### PR TITLE
chore: Upgrade upload-artifact action version in Redis benchmark work…

### DIFF
--- a/.github/workflows/redis_benchmark.yml
+++ b/.github/workflows/redis_benchmark.yml
@@ -60,7 +60,7 @@ jobs:
           python track_performance.py plot
       
       - name: Archive benchmark results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
           path: |


### PR DESCRIPTION
…flow

- Updated the GitHub Actions workflow for Redis benchmarking to use version 4 of the upload-artifact action, ensuring compatibility and access to the latest features.