### PR TITLE
Fix share.py target_id logging inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ For detailed documentation and advanced usage:
 - [Simulation Guide](docs/SimulationQuickStart.md)
 - [Experiment Guide](docs/ExperimentQuickStart.md)
 - [Data System Architecture](docs/data/data_api.md)
+- [Interaction Edge Logging](docs/data/interaction_edges.md)
 - [Full Documentation](docs/README.md)
 
 ## Contributing

--- a/docs/data/interaction_edges.md
+++ b/docs/data/interaction_edges.md
@@ -1,0 +1,47 @@
+# Interaction Edge Logging
+
+AgentFarm logs interactions as edges between environment nodes to enable social network analysis, lineage tracing, and resource interaction analytics.
+
+## Table: `interactions`
+
+Columns:
+- `interaction_id` (PK)
+- `simulation_id` (FK simulations.simulation_id)
+- `step_number` (int)
+- `source_type` (str): one of `agent`, `resource`
+- `source_id` (str)
+- `target_type` (str): one of `agent`, `resource`
+- `target_id` (str)
+- `interaction_type` (str): semantic type such as `share`, `attack`, `gather`, `reproduce`, and their `_attempt`/`_failed` variants
+- `action_type` (str, optional): action grouping
+- `details` (JSON, optional)
+- `timestamp` (datetime)
+
+Indexes are provided on `(step_number)`, `(source_type, source_id)`, `(target_type, target_id)`, and `(interaction_type)`.
+
+## Programmatic API
+
+Use the environment helper to log edges:
+
+```python
+env.log_interaction_edge(
+    source_type="agent", source_id="A1",
+    target_type="resource", target_id="42",
+    interaction_type="gather", action_type="gather",
+    details={"amount": 3}
+)
+```
+
+Under the hood this calls `DataLogger.log_interaction_edge`, which buffers and batch-writes to the `interactions` table.
+
+## Automatic Instrumentation
+
+The following actions now log interaction edges automatically:
+- Share: `agent -> agent` (`share`, `share_attempt`)
+- Attack: `agent -> agent` (`attack`, `attack_failed`, `attack_attempt`)
+- Gather: `agent -> resource` (`gather`, `gather_attempt`, `gather_failed`)
+- Reproduce: `agent -> agent` parent→offspring (`reproduce`), plus attempts/failures as self-edges
+
+## Notes
+- Interaction logs include the current simulation step and optional metadata in `details`.
+- Edge logging is a supplement to existing `agent_actions` records and does not replace them.

--- a/farm/actions/attack.py
+++ b/farm/actions/attack.py
@@ -123,6 +123,21 @@ def _log_no_targets_attempt(
         targets_found=0,
         reason=reason,
     )
+    # Log interaction edge (attempt with no target)
+    agent.environment.log_interaction_edge(
+        source_type="agent",
+        source_id=agent.agent_id,
+        target_type="agent",
+        target_id="none",
+        interaction_type="attack_attempt",
+        action_type="attack",
+        details={
+            "success": False,
+            "reason": reason,
+            "targets_found": 0,
+            "target_position": target_position,
+        },
+    )
 
 
 def _apply_attack_cost(agent: "BaseAgent") -> None:
@@ -217,6 +232,21 @@ def _log_attack_outcome(
         targets_found=valid_targets_count,
         damage_dealt=total_damage_dealt,
         reason="hit" if successful_hits > 0 else "missed",
+    )
+    # Log interaction edge for attack outcome
+    agent.environment.log_interaction_edge(
+        source_type="agent",
+        source_id=agent.agent_id,
+        target_type="agent",
+        target_id=target.agent_id,
+        interaction_type="attack" if successful_hits > 0 else "attack_failed",
+        action_type="attack",
+        details={
+            "success": successful_hits > 0,
+            "damage_dealt": total_damage_dealt,
+            "targets_found": valid_targets_count,
+            "target_position": target_position,
+        },
     )
 
 

--- a/farm/actions/gather.py
+++ b/farm/actions/gather.py
@@ -493,6 +493,21 @@ def gather_action(agent: "BaseAgent") -> None:
                     ),
                 },
             )
+        # Log interaction edge (attempt)
+        agent.environment.log_interaction_edge(
+            source_type="agent",
+            source_id=agent.agent_id,
+            target_type="resource",
+            target_id=str(target_resource.resource_id) if target_resource else "none",
+            interaction_type="gather_attempt",
+            action_type="gather",
+            details={
+                "success": False,
+                "reason": (
+                    "decided_not_to_gather" if not should_gather else "no_target_resource"
+                ),
+            },
+        )
         return
 
     # Record initial resource amount
@@ -537,6 +552,20 @@ def gather_action(agent: "BaseAgent") -> None:
                     ),
                 },
             )
+        # Log interaction edge (success)
+        agent.environment.log_interaction_edge(
+            source_type="agent",
+            source_id=agent.agent_id,
+            target_type="resource",
+            target_id=str(target_resource.resource_id),
+            interaction_type="gather",
+            action_type="gather",
+            details={
+                "amount_gathered": gather_amount,
+                "resource_before": resource_amount_before,
+                "resource_after": target_resource.amount,
+            },
+        )
     else:
         # Log failed gather action due to depleted resource
         if agent.environment.db is not None:
@@ -552,6 +581,18 @@ def gather_action(agent: "BaseAgent") -> None:
                     "reason": "resource_depleted",
                 },
             )
+        # Log interaction edge (failed)
+        agent.environment.log_interaction_edge(
+            source_type="agent",
+            source_id=agent.agent_id,
+            target_type="resource",
+            target_id=str(target_resource.resource_id),
+            interaction_type="gather_failed",
+            action_type="gather",
+            details={
+                "reason": "resource_depleted",
+            },
+        )
 
 
 # Default configuration instance

--- a/farm/actions/reproduce.py
+++ b/farm/actions/reproduce.py
@@ -242,6 +242,20 @@ def reproduce_action(agent: "BaseAgent") -> None:
                     "confidence": confidence if should_reproduce else 0.0,
                 },
             )
+        # Reproduction is a self-contained action; log as self-edge for lineage attempt
+        agent.environment.log_interaction_edge(
+            source_type="agent",
+            source_id=agent.agent_id,
+            target_type="agent",
+            target_id=agent.agent_id,
+            interaction_type="reproduce_attempt",
+            action_type="reproduce",
+            details={
+                "success": False,
+                "reason": "conditions_not_met",
+                "confidence": confidence if should_reproduce else 0.0,
+            },
+        )
         return
 
     # Attempt reproduction
@@ -266,6 +280,20 @@ def reproduce_action(agent: "BaseAgent") -> None:
                     "reward": reward,
                 },
             )
+        # Log lineage interaction edge parent -> offspring
+        agent.environment.log_interaction_edge(
+            source_type="agent",
+            source_id=agent.agent_id,
+            target_type="agent",
+            target_id=offspring.agent_id,
+            interaction_type="reproduce",
+            action_type="reproduce",
+            details={
+                "success": True,
+                "reward": reward,
+                "confidence": confidence,
+            },
+        )
 
     except Exception as e:
         logger.error(f"Reproduction failed for agent {agent.agent_id}: {str(e)}")
@@ -281,6 +309,19 @@ def reproduce_action(agent: "BaseAgent") -> None:
                     "error": str(e),
                 },
             )
+        agent.environment.log_interaction_edge(
+            source_type="agent",
+            source_id=agent.agent_id,
+            target_type="agent",
+            target_id=agent.agent_id,
+            interaction_type="reproduce_failed",
+            action_type="reproduce",
+            details={
+                "success": False,
+                "reason": "reproduction_error",
+                "error": str(e),
+            },
+        )
 
 
 def _get_reproduce_state(agent: "BaseAgent") -> torch.Tensor:

--- a/farm/actions/share.py
+++ b/farm/actions/share.py
@@ -406,8 +406,8 @@ def share_action(agent: "BaseAgent") -> None:
         agent.environment.log_interaction_edge(
             source_type="agent",
             source_id=agent.agent_id,
-            target_type="agent" if target else "agent",
-            target_id=target.agent_id if target else agent.agent_id,
+            target_type="agent" if target else "none",
+            target_id=target.agent_id if target else None,
             interaction_type="share_attempt",
             action_type="share",
             details={

--- a/farm/actions/share.py
+++ b/farm/actions/share.py
@@ -407,7 +407,7 @@ def share_action(agent: "BaseAgent") -> None:
             source_type="agent",
             source_id=agent.agent_id,
             target_type="agent" if target else "none",
-            target_id=target.agent_id if target else None,
+            target_id=target.agent_id if target else "none",
             interaction_type="share_attempt",
             action_type="share",
             details={

--- a/farm/actions/share.py
+++ b/farm/actions/share.py
@@ -407,7 +407,7 @@ def share_action(agent: "BaseAgent") -> None:
             source_type="agent",
             source_id=agent.agent_id,
             target_type="agent" if target else "none",
-            target_id=target.agent_id if target else "none",
+            target_id="none" if not target else target.agent_id,
             interaction_type="share_attempt",
             action_type="share",
             details={

--- a/farm/actions/share.py
+++ b/farm/actions/share.py
@@ -402,6 +402,20 @@ def share_action(agent: "BaseAgent") -> None:
                     "attempted_amount": share_amount,
                 },
             )
+        # Log interaction edge (attempt)
+        agent.environment.log_interaction_edge(
+            source_type="agent",
+            source_id=agent.agent_id,
+            target_type="agent" if target else "agent",
+            target_id=target.agent_id if target else agent.agent_id,
+            interaction_type="share_attempt",
+            action_type="share",
+            details={
+                "success": False,
+                "attempted_amount": share_amount,
+                "reason": "invalid_share_conditions",
+            },
+        )
         return
 
     # Execute sharing
@@ -439,6 +453,20 @@ def share_action(agent: "BaseAgent") -> None:
                 and target_initial_resources < target.config.starvation_threshold,
             },
         )
+    # Log interaction edge (success)
+    agent.environment.log_interaction_edge(
+        source_type="agent",
+        source_id=agent.agent_id,
+        target_type="agent",
+        target_id=target.agent_id,
+        interaction_type="share",
+        action_type="share",
+        details={
+            "amount_shared": share_amount,
+            "target_resources_before": target_initial_resources,
+            "target_resources_after": target.resource_level,
+        },
+    )
 
 
 def _get_share_state(agent: "BaseAgent") -> List[float]:

--- a/farm/core/environment.py
+++ b/farm/core/environment.py
@@ -256,6 +256,33 @@ class Environment(AECEnv):
                 details=action_data.get("details"),
             )
 
+    def log_interaction_edge(
+        self,
+        source_type,
+        source_id,
+        target_type,
+        target_id,
+        interaction_type,
+        action_type=None,
+        details=None,
+    ):
+        """Log an interaction as an edge between nodes if database is enabled."""
+        if self.db is None:
+            return
+        try:
+            self.db.logger.log_interaction_edge(
+                step_number=self.time,
+                source_type=source_type,
+                source_id=str(source_id),
+                target_type=target_type,
+                target_id=str(target_id),
+                interaction_type=interaction_type,
+                action_type=action_type,
+                details=details,
+            )
+        except Exception as e:
+            logger.error(f"Failed to log interaction edge: {e}")
+
     def update(self):
         """Update environment state for current time step."""
         try:

--- a/farm/database/models.py
+++ b/farm/database/models.py
@@ -288,6 +288,40 @@ class ResourceModel(Base):
         }
 
 
+class InteractionModel(Base):
+    """Generic interaction edges between nodes in the environment.
+
+    This table captures interactions as edges between source and target nodes
+    (e.g., agent->agent, agent->resource) with consistent metadata for
+    downstream analytics and visualization.
+    """
+
+    __tablename__ = "interactions"
+    __table_args__ = (
+        Index("idx_interactions_step_number", "step_number"),
+        Index("idx_interactions_source", "source_type", "source_id"),
+        Index("idx_interactions_target", "target_type", "target_id"),
+        Index("idx_interactions_type", "interaction_type"),
+    )
+
+    interaction_id = Column(Integer, primary_key=True)
+    simulation_id = Column(String(64), ForeignKey("simulations.simulation_id"))
+    step_number = Column(Integer, nullable=False)
+
+    # Source node
+    source_type = Column(String(32), nullable=False)  # e.g., 'agent', 'resource'
+    source_id = Column(String(64), nullable=False)
+
+    # Target node
+    target_type = Column(String(32), nullable=False)  # e.g., 'agent', 'resource'
+    target_id = Column(String(64), nullable=False)
+
+    # Semantics
+    interaction_type = Column(String(50), nullable=False)  # e.g., 'share', 'attack', 'gather', 'reproduce'
+    action_type = Column(String(50), nullable=True)  # Optional action grouping
+    details = Column(JSON, nullable=True)
+    timestamp = Column(DateTime, default=func.now(), nullable=False)
+
 class SimulationStepModel(Base):
     """Records simulation-wide metrics for each time step.
 


### PR DESCRIPTION
Fix `log_interaction_edge` calls to use "none" for `target_id` when no target is present.

This change ensures consistency in logged `target_id` values across all action modules, which previously used "None" in `share.py` while others used "none".

---
<a href="https://cursor.com/background-agent?bcId=bc-ee99a996-1ac8-4cf4-8a49-679b86bbc66f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee99a996-1ac8-4cf4-8a49-679b86bbc66f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

