### PR TITLE
Fix agentfarm github issue 257

### DIFF
--- a/farm/core/environment.py
+++ b/farm/core/environment.py
@@ -986,6 +986,8 @@ class Environment(AECEnv):
             recent_damage_world=[],  # TODO: Implement if needed
             ally_signals_world=[],  # TODO: Implement if needed
             trails_world_points=[],  # TODO: Implement if needed
+            spatial_index=self.spatial_index,
+            agent_object=agent,
         )
 
         tensor = obs.tensor().cpu().numpy()

--- a/farm/core/observations.py
+++ b/farm/core/observations.py
@@ -360,9 +360,9 @@ class AgentObservation:
         ],  # world tensors: ("RESOURCES","OBSTACLES","TERRAIN_COST", optional others) shape (H,W), 0..1
         agent_world_pos: Tuple[int, int],  # (y,x) in world coordinates
         self_hp01: float,
-        allies: List[Tuple[int, int, float]],  # (y,x,hp01)
-        enemies: List[Tuple[int, int, float]],  # (y,x,hp01)
-        goal_world_pos: Optional[Tuple[int, int]],  # (y,x) or None
+        allies: Optional[List[Tuple[int, int, float]]] = None,  # (y,x,hp01)
+        enemies: Optional[List[Tuple[int, int, float]]] = None,  # (y,x,hp01)
+        goal_world_pos: Optional[Tuple[int, int]] = None,  # (y,x) or None
         recent_damage_world: Optional[
             List[Tuple[int, int, float]]
         ] = None,  # events within last tick
@@ -372,6 +372,8 @@ class AgentObservation:
         trails_world_points: Optional[
             List[Tuple[int, int, float]]
         ] = None,  # you can also auto-add from seen agents
+        spatial_index: Optional["SpatialIndex"] = None,
+        agent_object: Optional[object] = None,
         **kwargs,  # Additional data for custom channels
     ):
         """
@@ -398,20 +400,56 @@ class AgentObservation:
             recent_damage_world: List of (y, x, intensity) tuples for recent damage events
             ally_signals_world: List of (y, x, intensity01) tuples for ally signals
             trails_world_points: List of (y, x, intensity) tuples for agent trails
+            spatial_index: Optional spatial index to derive entities efficiently
+            agent_object: Optional agent instance used to determine ally/enemy types
         """
         self.decay_dynamics()
         self.clear_instant()
+
+        # Optionally derive allies/enemies from spatial index if not provided
+        final_allies = allies
+        final_enemies = enemies
+        if (final_allies is None or final_enemies is None) and spatial_index is not None and agent_object is not None:
+            ay, ax = agent_world_pos
+            query_position_xy = (float(ax), float(ay))
+            radius = float(self.config.fov_radius)
+            try:
+                nearby_agents = spatial_index.get_nearby_agents(query_position_xy, radius)
+            except Exception:
+                nearby_agents = []
+
+            computed_allies: List[Tuple[int, int, float]] = []
+            computed_enemies: List[Tuple[int, int, float]] = []
+            agent_cls = type(agent_object)
+            for other in nearby_agents:
+                if other is agent_object or not getattr(other, "alive", False):
+                    continue
+                ny = int(round(other.position[1]))
+                nx = int(round(other.position[0]))
+                # Ensure positions are within world bounds is handled later by handlers
+                hp01 = float(other.current_health) / float(other.starting_health) if getattr(other, "starting_health", 0) else 0.0
+                if isinstance(other, agent_cls):
+                    computed_allies.append((ny, nx, hp01))
+                else:
+                    computed_enemies.append((ny, nx, hp01))
+
+            if final_allies is None:
+                final_allies = computed_allies
+            if final_enemies is None:
+                final_enemies = computed_enemies
 
         # Process all channels using their registered handlers
         kwargs_for_handlers = {
             "world_layers": world_layers,
             "self_hp01": self_hp01,
-            "allies": allies,
-            "enemies": enemies,
+            "allies": final_allies or [],
+            "enemies": final_enemies or [],
             "goal_world_pos": goal_world_pos,
             "recent_damage_world": recent_damage_world,
             "ally_signals_world": ally_signals_world,
             "trails_world_points": trails_world_points,
+            "spatial_index": spatial_index,
+            "agent_object": agent_object,
             **kwargs,  # Include any additional custom channel data
         }
 


### PR DESCRIPTION
Enable `AgentObservation.perceive_world` to efficiently derive nearby agents using a spatial index, resolving #257.

---
<a href="https://cursor.com/background-agent?bcId=bc-72d5dc1a-8c1f-47ca-a523-2bd93e935059">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-72d5dc1a-8c1f-47ca-a523-2bd93e935059">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

