### PR TITLE
Restore module registration error handling and fallback

### DIFF
--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -1,0 +1,119 @@
+## Dependency Injection Improvements
+
+This document explains recent refactors that introduce dependency injection (DI) for configuration and improve service injection patterns across the project. The primary goal is to reduce direct environment and concrete dependency coupling, improving testability, modularity, and maintainability.
+
+### What Changed
+
+- Added `IConfigService` interface and a default `EnvConfigService` implementation.
+  - Location: `farm/core/services/interfaces.py`, `farm/core/services/implementations.py`
+  - Exported via `farm/core/services/__init__.py`
+- Refactored modules that previously read environment variables directly to accept a `config_service` (or use `EnvConfigService` by default):
+  - `farm/charts/llm_client.py` now accepts `config_service` and no longer reads `OPENAI_API_KEY` directly.
+  - `farm/analysis/registry.register_modules` accepts `config_service` and no longer reads `FARM_ANALYSIS_MODULES` directly.
+  - `farm/analysis/service.AnalysisService` injects `EnvConfigService` into `register_modules`.
+  - `scripts/analysis_config.py` injects `EnvConfigService` into `register_modules`.
+  - `farm/utils/run_analysis.setup_environment` uses `IConfigService` to validate existence of `OPENAI_API_KEY`.
+- A lightweight singleton `farm.analysis.null_module.null_module` was exposed to make testing the registry easier.
+
+These changes align with SRP, DIP, and KISS principles and prefactor the codebase for broader DI adoption.
+
+### New Interfaces and Implementations
+
+- `IConfigService`
+  - Methods:
+    - `get(key: str, default: Optional[str] = None) -> Optional[str]`
+    - `get_analysis_module_paths(env_var: str = "FARM_ANALYSIS_MODULES") -> List[str]`
+    - `get_openai_api_key() -> Optional[str]`
+- `EnvConfigService` (default)
+  - Reads from environment variables via `os.getenv` and implements `IConfigService`.
+
+### Updated APIs
+
+- `LLMClient`
+  - Before: `LLMClient(api_key: Optional[str] = None)` reads env directly when `api_key` not provided.
+  - Now: `LLMClient(api_key: Optional[str] = None, config_service: Optional[IConfigService] = None)`
+    - If `api_key` is `None`, the client uses `config_service.get_openai_api_key()`.
+    - Defaults to `EnvConfigService()` when not provided.
+
+- `farm.analysis.registry.register_modules`
+  - Before: `register_modules(config_env_var: str = "FARM_ANALYSIS_MODULES")` reads env directly.
+  - Now: `register_modules(config_env_var: str = "FARM_ANALYSIS_MODULES", *, config_service: Optional[IConfigService] = None)`
+    - Uses `config_service.get_analysis_module_paths(config_env_var)`.
+    - Defaults to `EnvConfigService()` when not provided.
+    - Will attempt to register all configured modules; if none successfully register, it falls back to the built-in dominance module.
+
+- `AnalysisService` and `scripts/analysis_config.py`
+  - Both now call `register_modules(config_service=EnvConfigService())`.
+
+- `utils/run_analysis.setup_environment`
+  - Before: validated `OPENAI_API_KEY` via `os.getenv`.
+  - Now: validates via `config_service.get_openai_api_key()` and defaults to `EnvConfigService()`.
+
+### Example Usage
+
+Injecting a custom config service for testing or alternative configuration sources:
+
+```python
+from farm.core.services import IConfigService
+from farm.charts.llm_client import LLMClient
+from farm.analysis.registry import register_modules
+
+
+class StaticConfig(IConfigService):
+    def __init__(self, api_key: str, modules: list[str] = None):
+        self._api_key = api_key
+        self._modules = modules or []
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return default
+
+    def get_analysis_module_paths(self, env_var: str = "FARM_ANALYSIS_MODULES") -> list[str]:
+        return list(self._modules)
+
+    def get_openai_api_key(self) -> str | None:
+        return self._api_key
+
+
+cfg = StaticConfig(api_key="sk-test", modules=["farm.analysis.null_module.null_module"])
+register_modules(config_service=cfg)
+client = LLMClient(config_service=cfg)
+```
+
+### Backward Compatibility
+
+- Existing code that did not pass a `config_service` continues to work due to defaulting to `EnvConfigService`.
+- `register_modules` still loads the built-in dominance module if no configured modules register successfully.
+
+### Testing
+
+New tests validate the DI behavior:
+- `tests/test_config_service.py` covers `EnvConfigService` behaviors.
+- `tests/test_analysis_registry_di.py` ensures the registry uses an injected module list provider.
+
+To run only the new tests:
+
+```bash
+python3 -m pytest -q tests/test_config_service.py tests/test_analysis_registry_di.py
+```
+
+Note: The full test suite depends on additional packages (e.g., `pydantic`, `psutil`, `stable_baselines3`). Those are unrelated to these DI changes.
+
+### Migration Notes
+
+- If you previously relied on direct environment variable reads for:
+  - `OPENAI_API_KEY` in `LLMClient`: prefer passing `api_key` directly or provide a custom `IConfigService`.
+  - `FARM_ANALYSIS_MODULES` in analysis registry: pass module paths via a custom `IConfigService` or set the env var as before (default service will use it).
+- For other modules, prefer adding an optional `config_service: IConfigService | None = None` parameter and default to `EnvConfigService()` internally when needed.
+
+### Related Files
+
+- `farm/core/services/interfaces.py`
+- `farm/core/services/implementations.py`
+- `farm/core/services/__init__.py`
+- `farm/charts/llm_client.py`
+- `farm/charts/chart_analyzer.py`
+- `farm/analysis/registry.py`
+- `farm/analysis/service.py`
+- `farm/utils/run_analysis.py`
+- `scripts/analysis_config.py`
+

--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -81,8 +81,9 @@ client = LLMClient(config_service=cfg)
 
 ### Backward Compatibility
 
-- Existing code that did not pass a `config_service` continues to work due to defaulting to `EnvConfigService`.
-- `register_modules` still loads the built-in dominance module if no configured modules register successfully.
+- Backward-compatibility fallbacks have been removed to enforce explicit DI usage:
+  - `LLMClient` now requires an `IConfigService` (and optional explicit `api_key`).
+  - `register_modules` requires an `IConfigService` and no longer falls back to a built-in module.
 
 ### Testing
 
@@ -100,10 +101,10 @@ Note: The full test suite depends on additional packages (e.g., `pydantic`, `psu
 
 ### Migration Notes
 
-- If you previously relied on direct environment variable reads for:
-  - `OPENAI_API_KEY` in `LLMClient`: prefer passing `api_key` directly or provide a custom `IConfigService`.
-  - `FARM_ANALYSIS_MODULES` in analysis registry: pass module paths via a custom `IConfigService` or set the env var as before (default service will use it).
-- For other modules, prefer adding an optional `config_service: IConfigService | None = None` parameter and default to `EnvConfigService()` internally when needed.
+- Code must now inject `IConfigService` explicitly:
+  - For `LLMClient`, pass `config_service` and optionally `api_key`.
+  - For analysis registration, call `register_modules(config_service=...)` with module paths supplied by your service.
+  - Replace any remaining direct env reads with `IConfigService` accessors.
 
 ### Related Files
 

--- a/farm/analysis/null_module.py
+++ b/farm/analysis/null_module.py
@@ -22,3 +22,7 @@ class NullModule(AnalysisModule):
 
     def get_db_filename(self) -> Optional[str]:
         return None
+
+
+# Provide a lightweight singleton for registry-based discovery
+null_module = NullModule()

--- a/farm/analysis/registry.py
+++ b/farm/analysis/registry.py
@@ -8,6 +8,7 @@ import os
 from typing import Dict, List, Optional
 
 from farm.analysis.base_module import AnalysisModule
+from farm.core.services import IConfigService, EnvConfigService
 
 
 class ModuleRegistry:
@@ -76,7 +77,7 @@ class ModuleRegistry:
 registry = ModuleRegistry()
 
 
-def register_modules(config_env_var: str = "FARM_ANALYSIS_MODULES"):
+def register_modules(config_env_var: str = "FARM_ANALYSIS_MODULES", *, config_service: Optional[IConfigService] = None):
     """
     Register available analysis modules.
 
@@ -85,18 +86,22 @@ def register_modules(config_env_var: str = "FARM_ANALYSIS_MODULES"):
        e.g., "farm.analysis.dominance.module.dominance_module, farm.analysis.template.module.template_module"
     2) Fallback to built-in dominance module if env is not set.
     """
-    module_paths = os.getenv(config_env_var, "").strip()
-    if module_paths:
-        for path in [p.strip() for p in module_paths.split(",") if p.strip()]:
+    cfg = config_service or EnvConfigService()
+    module_paths_list = cfg.get_analysis_module_paths(config_env_var)
+    if module_paths_list:
+        registered_any = False
+        for path in module_paths_list:
             try:
                 module_path, attr = path.rsplit(".", 1)
                 mod = importlib.import_module(module_path)
                 instance = getattr(mod, attr)
                 if instance:
                     registry.register_module(instance)
+                    registered_any = True
             except Exception:
                 continue
-        return
+        if registered_any:
+            return
 
     # Fallback registration
     try:

--- a/farm/analysis/registry.py
+++ b/farm/analysis/registry.py
@@ -5,6 +5,7 @@ This module provides a central registry for all analysis modules.
 
 import importlib
 import os
+import logging
 from typing import Dict, List, Optional
 
 from farm.analysis.base_module import AnalysisModule
@@ -87,12 +88,46 @@ def register_modules(config_env_var: str = "FARM_ANALYSIS_MODULES", *, config_se
     2) Fallback to built-in dominance module if env is not set.
     """
     module_paths_list = config_service.get_analysis_module_paths(config_env_var)
+
+    successfully_registered = 0
+
     for path in module_paths_list:
-        module_path, attr = path.rsplit(".", 1)
-        mod = importlib.import_module(module_path)
-        instance = getattr(mod, attr)
-        if instance:
+        try:
+            module_path, attr = path.rsplit(".", 1)
+        except ValueError:
+            logging.warning("Invalid analysis module path (no attribute specified): %s", path)
+            continue
+
+        try:
+            mod = importlib.import_module(module_path)
+            instance = getattr(mod, attr)
+        except (ImportError, AttributeError) as err:
+            logging.warning("Failed to import analysis module '%s': %s", path, err)
+            continue
+        except Exception as err:
+            logging.warning("Unexpected error loading analysis module '%s': %s", path, err)
+            continue
+
+        if isinstance(instance, AnalysisModule):
             registry.register_module(instance)
+            successfully_registered += 1
+        else:
+            logging.warning(
+                "Configured object at '%s' is not an AnalysisModule instance; skipping.",
+                path,
+            )
+
+    # Fallback to built-in dominance module if nothing was registered
+    if successfully_registered == 0:
+        try:
+            from farm.analysis.dominance.module import dominance_module
+
+            registry.register_module(dominance_module)
+            successfully_registered = 1
+        except Exception as err:
+            logging.warning(
+                "Failed to register fallback dominance module: %s", err
+            )
 
 
 def get_module(name: str) -> Optional[AnalysisModule]:

--- a/farm/analysis/service.py
+++ b/farm/analysis/service.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 from farm.analysis.registry import get_module, register_modules
-from farm.core.services import EnvConfigService
+from farm.core.services import IConfigService
 
 
 @dataclass
@@ -16,9 +16,8 @@ class AnalysisRequest:
 
 
 class AnalysisService:
-    def __init__(self):
-        # Use config service to register modules
-        register_modules(config_service=EnvConfigService())
+    def __init__(self, config_service: IConfigService):
+        register_modules(config_service=config_service)
 
     def run(self, request: AnalysisRequest):
         module = get_module(request.module_name)

--- a/farm/analysis/service.py
+++ b/farm/analysis/service.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 from farm.analysis.registry import get_module, register_modules
+from farm.core.services import EnvConfigService
 
 
 @dataclass
@@ -16,7 +17,8 @@ class AnalysisRequest:
 
 class AnalysisService:
     def __init__(self):
-        register_modules()
+        # Use config service to register modules
+        register_modules(config_service=EnvConfigService())
 
     def run(self, request: AnalysisRequest):
         module = get_module(request.module_name)

--- a/farm/api/server.py
+++ b/farm/api/server.py
@@ -9,6 +9,7 @@ from flask_socketio import SocketIO, emit
 
 from farm.core.analysis import analyze_simulation
 from farm.analysis.service import AnalysisRequest, AnalysisService
+from farm.core.services import EnvConfigService
 from farm.core.config import SimulationConfig
 from farm.core.simulation import run_simulation
 from farm.database.database import SimulationDatabase
@@ -135,7 +136,7 @@ def run_analysis_module(module_name):
         processor_kwargs = payload.get("processor_kwargs")
         analysis_kwargs = payload.get("analysis_kwargs")
 
-        service = AnalysisService()
+        service = AnalysisService(config_service=EnvConfigService())
         req = AnalysisRequest(
             module_name=module_name,
             experiment_path=experiment_path,

--- a/farm/charts/chart_analyzer.py
+++ b/farm/charts/chart_analyzer.py
@@ -65,8 +65,9 @@ class ChartAnalyzer:
         self.db = database
         self.output_dir = output_dir if output_dir else Path("example_output")
         self.save_charts = save_charts
-        # Inject config service for dependency inversion
-        self.llm_client = LLMClient(config_service=EnvConfigService())
+        # Inject config service explicitly (no implicit fallbacks)
+        cfg = EnvConfigService()
+        self.llm_client = LLMClient(api_key=None, config_service=cfg)
 
     def analyze_all_charts(self, output_path: Optional[Path] = None) -> Dict[str, str]:
         """Generate and analyze all charts, returning a dictionary of analyses."""

--- a/farm/charts/chart_analyzer.py
+++ b/farm/charts/chart_analyzer.py
@@ -44,6 +44,7 @@ from .chart_simulation import (
 )
 from .chart_utils import save_plot  # Import from utilities module
 from .llm_client import LLMClient
+from farm.core.services import EnvConfigService
 
 
 class ChartAnalyzer:
@@ -64,7 +65,8 @@ class ChartAnalyzer:
         self.db = database
         self.output_dir = output_dir if output_dir else Path("example_output")
         self.save_charts = save_charts
-        self.llm_client = LLMClient()
+        # Inject config service for dependency inversion
+        self.llm_client = LLMClient(config_service=EnvConfigService())
 
     def analyze_all_charts(self, output_path: Optional[Path] = None) -> Dict[str, str]:
         """Generate and analyze all charts, returning a dictionary of analyses."""

--- a/farm/charts/llm_client.py
+++ b/farm/charts/llm_client.py
@@ -7,14 +7,23 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 from openai import OpenAI
+from farm.core.services import IConfigService, EnvConfigService
 
 logger = logging.getLogger(__name__)
 
 
 class LLMClient:
-    def __init__(self, api_key: Optional[str] = None):
-        """Initialize OpenAI client with API key from env or passed directly."""
-        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        config_service: Optional[IConfigService] = None,
+    ):
+        """Initialize OpenAI client with API key from injected config or env.
+
+        Prefer dependency-injected configuration to avoid direct env access.
+        """
+        self._config = config_service or EnvConfigService()
+        self.api_key = api_key or self._config.get_openai_api_key()
         if not self.api_key:
             raise ValueError(
                 "OpenAI API key must be provided or set in OPENAI_API_KEY environment variable"

--- a/farm/charts/llm_client.py
+++ b/farm/charts/llm_client.py
@@ -15,19 +15,14 @@ logger = logging.getLogger(__name__)
 class LLMClient:
     def __init__(
         self,
-        api_key: Optional[str] = None,
-        config_service: Optional[IConfigService] = None,
+        api_key: Optional[str],
+        config_service: IConfigService,
     ):
-        """Initialize OpenAI client with API key from injected config or env.
-
-        Prefer dependency-injected configuration to avoid direct env access.
-        """
-        self._config = config_service or EnvConfigService()
+        """Initialize OpenAI client with API key from injected config service."""
+        self._config = config_service
         self.api_key = api_key or self._config.get_openai_api_key()
         if not self.api_key:
-            raise ValueError(
-                "OpenAI API key must be provided or set in OPENAI_API_KEY environment variable"
-            )
+            raise ValueError("OpenAI API key must be provided via IConfigService or explicitly")
         self.client = OpenAI(api_key=self.api_key)
         self.analyses = {}
         self.actions_df = None

--- a/farm/core/services/__init__.py
+++ b/farm/core/services/__init__.py
@@ -1,5 +1,6 @@
 from farm.core.services.implementations import (
     EnvironmentAgentLifecycleService,
+    EnvConfigService,
     EnvironmentLoggingService,
     EnvironmentMetricsService,
     EnvironmentTimeService,
@@ -7,6 +8,7 @@ from farm.core.services.implementations import (
 )
 from farm.core.services.interfaces import (
     IAgentLifecycleService,
+    IConfigService,
     ILoggingService,
     IMetricsService,
     ISpatialQueryService,
@@ -22,10 +24,12 @@ __all__ = [
     "IAgentLifecycleService",
     "ITimeService",
     "ILoggingService",
+    "IConfigService",
     # Implementations
     "EnvironmentValidationService",
     "EnvironmentMetricsService",
     "EnvironmentAgentLifecycleService",
     "EnvironmentTimeService",
     "EnvironmentLoggingService",
+    "EnvConfigService",
 ]

--- a/farm/core/services/implementations.py
+++ b/farm/core/services/implementations.py
@@ -255,19 +255,6 @@ class EnvConfigService(IConfigService):
     def get_openai_api_key(self) -> Optional[str]:
         return self.get("OPENAI_API_KEY", None)
 
-    def update_agent_death(
-        self, agent_id: str, death_time: int, cause: str = "starvation"
-    ) -> None:
-        """Update the death information for an agent in the database.
-
-        Args:
-            agent_id: The identifier of the agent that died.
-            death_time: The simulation step when the agent died.
-            cause: The cause of death (default: "starvation").
-        """
-        # delegate to environment's method which already checks DB presence
-        self._env.update_agent_death(agent_id, death_time, cause)
-
 
 class SpatialIndexAdapter(ISpatialQueryService):
     """Adapter that exposes `SpatialIndex` as an `ISpatialQueryService`.

--- a/farm/core/services/implementations.py
+++ b/farm/core/services/implementations.py
@@ -234,6 +234,19 @@ class EnvironmentLoggingService(ILoggingService):
             offspring_generation=offspring_generation,
         )
 
+    def update_agent_death(
+        self, agent_id: str, death_time: int, cause: str = "starvation"
+    ) -> None:
+        """Log or update the death of an agent in the database if available.
+
+        Delegates to the environment's database to persist the death event. If
+        no database is configured on the environment, this is a no-op.
+        """
+        db = getattr(self._env, "db", None)
+        if db is None:
+            return
+        db.update_agent_death(agent_id=agent_id, death_time=death_time, cause=cause)
+
 
 class EnvConfigService(IConfigService):
     """Configuration service that reads from environment variables.
@@ -243,10 +256,7 @@ class EnvConfigService(IConfigService):
     """
 
     def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
-        value = os.getenv(key, default if default is not None else None)
-        if value is None:
-            return default
-        return value
+        return os.getenv(key, default)
 
     def get_analysis_module_paths(self, env_var: str = "FARM_ANALYSIS_MODULES") -> List[str]:
         raw = self.get(env_var, "") or ""

--- a/farm/core/services/interfaces.py
+++ b/farm/core/services/interfaces.py
@@ -81,6 +81,45 @@ class ISpatialQueryService(ABC):
         pass
 
 
+class IConfigService(ABC):
+    """Interface for accessing configuration values and environment settings.
+
+    Centralizes configuration lookup to enable dependency injection and
+    improve testability by avoiding direct environment access in modules.
+    """
+
+    @abstractmethod
+    def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
+        """Retrieve a configuration value by key.
+
+        Args:
+            key: Configuration or environment variable name
+            default: Value to return if the key is not found
+
+        Returns:
+            The configuration value as a string if found, otherwise default.
+        """
+        pass
+
+    @abstractmethod
+    def get_analysis_module_paths(self, env_var: str = "FARM_ANALYSIS_MODULES") -> List[str]:
+        """Get analysis module import paths from configuration.
+
+        Args:
+            env_var: Name of the configuration/environment variable containing
+                     a comma-separated list of import paths
+
+        Returns:
+            List of import path strings. Empty if none configured.
+        """
+        pass
+
+    @abstractmethod
+    def get_openai_api_key(self) -> Optional[str]:
+        """Return the OpenAI API key from configuration if available."""
+        pass
+
+
 class IValidationService(ABC):
     """Interface for common validation checks related to the environment.
 

--- a/farm/utils/run_analysis.py
+++ b/farm/utils/run_analysis.py
@@ -8,14 +8,16 @@ from sqlalchemy import create_engine
 
 from farm.charts.chart_analyzer import ChartAnalyzer
 from farm.database.database import SimulationDatabase
+from farm.core.services import IConfigService, EnvConfigService
 
 
-def setup_environment():
+def setup_environment(config_service: IConfigService | None = None):
     """Load environment variables from .env file and check required variables."""
     # Load environment variables from .env file
     load_dotenv()
 
-    if not os.getenv("OPENAI_API_KEY"):
+    cfg = config_service or EnvConfigService()
+    if not cfg.get_openai_api_key():
         raise EnvironmentError(
             "OPENAI_API_KEY environment variable is not set in .env file. "
             "Please check your .env file contains the API key."

--- a/farm/utils/run_analysis.py
+++ b/farm/utils/run_analysis.py
@@ -11,13 +11,12 @@ from farm.database.database import SimulationDatabase
 from farm.core.services import IConfigService, EnvConfigService
 
 
-def setup_environment(config_service: IConfigService | None = None):
+def setup_environment(config_service: IConfigService):
     """Load environment variables from .env file and check required variables."""
     # Load environment variables from .env file
     load_dotenv()
 
-    cfg = config_service or EnvConfigService()
-    if not cfg.get_openai_api_key():
+    if not config_service.get_openai_api_key():
         raise EnvironmentError(
             "OPENAI_API_KEY environment variable is not set in .env file. "
             "Please check your .env file contains the API key."

--- a/scripts/analysis_config.py
+++ b/scripts/analysis_config.py
@@ -442,7 +442,7 @@ def run_analysis(
         from farm.analysis.registry import get_module, register_modules
         from farm.core.services import EnvConfigService
 
-        # Register all modules using config service
+        # Register all modules using config service (explicit)
         register_modules(config_service=EnvConfigService())
 
         # Get the module for this analysis type

--- a/scripts/analysis_config.py
+++ b/scripts/analysis_config.py
@@ -440,9 +440,10 @@ def run_analysis(
     # Try to use the module system first
     try:
         from farm.analysis.registry import get_module, register_modules
+        from farm.core.services import EnvConfigService
 
-        # Register all modules
-        register_modules()
+        # Register all modules using config service
+        register_modules(config_service=EnvConfigService())
 
         # Get the module for this analysis type
         module = get_module(analysis_type)

--- a/tests/test_analysis_registry_di.py
+++ b/tests/test_analysis_registry_di.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+from farm.analysis.registry import registry, register_modules
+
+
+class DummyConfigService:
+    def __init__(self, paths):
+        self._paths = paths
+
+    def get(self, key, default=None):
+        return default
+
+    def get_analysis_module_paths(self, env_var: str = "FARM_ANALYSIS_MODULES"):
+        return list(self._paths)
+
+    def get_openai_api_key(self):
+        return None
+
+
+def test_register_modules_with_injected_paths(monkeypatch):
+    # Clear existing registry state for this test by reinitializing its dict
+    registry._modules.clear()
+
+    # Provide a known good lightweight module path
+    paths = ["farm.analysis.null_module.null_module"]
+    cfg = DummyConfigService(paths)
+
+    register_modules(config_service=cfg)
+
+    # The registry should now contain the null module by its name
+    assert "null" in registry.get_module_names()
+

--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -1,0 +1,30 @@
+import os
+
+from farm.core.services import EnvConfigService
+
+
+def test_env_config_service_basic_get(monkeypatch):
+    monkeypatch.setenv("TEST_KEY_X", "value123")
+    cfg = EnvConfigService()
+    assert cfg.get("TEST_KEY_X") == "value123"
+    assert cfg.get("MISSING_KEY", "default") == "default"
+
+
+def test_env_config_service_analysis_paths(monkeypatch):
+    monkeypatch.setenv(
+        "FARM_ANALYSIS_MODULES",
+        " farm.analysis.dominance.module.dominance_module ,farm.analysis.template.module.template_module ",
+    )
+    cfg = EnvConfigService()
+    paths = cfg.get_analysis_module_paths()
+    assert paths[0] == "farm.analysis.dominance.module.dominance_module"
+    assert paths[1] == "farm.analysis.template.module.template_module"
+
+
+def test_env_config_service_openai_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    cfg = EnvConfigService()
+    assert cfg.get_openai_api_key() is None
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    assert cfg.get_openai_api_key() == "sk-test"
+


### PR DESCRIPTION
Reintroduce robust error handling and fallback registration in `register_modules` to prevent crashes on module loading failures and ensure the analysis registry is never empty.

---
<a href="https://cursor.com/background-agent?bcId=bc-56631c60-7653-4e3a-8706-4c55798d0bf2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-56631c60-7653-4e3a-8706-4c55798d0bf2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

