### PR TITLE
Review data models and schemas for accuracy

### DIFF
--- a/farm/database/database.py
+++ b/farm/database/database.py
@@ -889,6 +889,8 @@ class SimulationDatabase:
                 return
 
             formatted_state = format_agent_state(agent_id, step_number, state_data)
+            # Ensure simulation_id is set on the state for multi-simulation databases
+            formatted_state["simulation_id"] = self.simulation_id
             agent_state = AgentStateModel(**formatted_state)
             session.add(agent_state)
 

--- a/farm/database/models.py
+++ b/farm/database/models.py
@@ -164,8 +164,8 @@ class AgentStateModel(Base):
         Current health level
     starting_health : float
         Maximum possible health
-    starvation_threshold : int
-        Resource level that triggers starvation
+    starvation_counter : int
+        Consecutive steps with zero resources (for starvation tracking)
     is_defending : bool
         Whether agent is in defensive stance
     total_reward : float
@@ -203,6 +203,8 @@ class AgentStateModel(Base):
     position_z = Column(Float)
     resource_level = Column(Float)
     current_health = Column(Float)
+    starting_health = Column(Float)
+    starvation_counter = Column(Integer)
     is_defending = Column(Boolean)
     total_reward = Column(Float)
     age = Column(Integer)
@@ -237,6 +239,8 @@ class AgentStateModel(Base):
             "position_z": self.position_z,
             "resource_level": self.resource_level,
             "current_health": self.current_health,
+            "starting_health": self.starting_health,
+            "starvation_counter": self.starvation_counter,
             "is_defending": self.is_defending,
             "total_reward": self.total_reward,
             "age": self.age,

--- a/tests/test_data_logger_log_step.py
+++ b/tests/test_data_logger_log_step.py
@@ -1,0 +1,121 @@
+import os
+import time
+from datetime import datetime, timezone
+
+from farm.database.database import SimulationDatabase
+from farm.database.models import AgentModel, AgentStateModel, SimulationStepModel
+
+
+def test_log_step_inserts_agent_state_with_new_columns():
+    db_path = f"test_log_step_{time.time()}.db"
+    db = SimulationDatabase(db_path, simulation_id="simX")
+    try:
+        # Ensure simulation exists
+        db.add_simulation_record(
+            simulation_id="simX",
+            start_time=datetime.now(timezone.utc),
+            status="running",
+            parameters={},
+        )
+
+        # Seed one agent (FK for agent_states)
+        def _insert_agent(session):
+            session.add(
+                AgentModel(
+                    simulation_id="simX",
+                    agent_id="a1",
+                    birth_time=0,
+                    agent_type="BaseAgent",
+                    position_x=0.0,
+                    position_y=0.0,
+                    initial_resources=0.0,
+                    starting_health=100.0,
+                    starvation_counter=0,
+                    genome_id="g",
+                    generation=0,
+                )
+            )
+
+        db._execute_in_transaction(_insert_agent)
+
+        # Prepare agent state tuple per DataLogger.log_step expectations
+        agent_states = [
+            (
+                "a1",      # agent_id
+                1.0,        # position_x
+                2.0,        # position_y
+                5.0,        # resource_level
+                80.0,       # current_health
+                100.0,      # starting_health
+                1,          # starvation_counter
+                0,          # is_defending
+                0.5,        # total_reward
+                1,          # age
+            )
+        ]
+
+        metrics = {
+            "total_agents": 1,
+            "system_agents": 0,
+            "independent_agents": 1,
+            "control_agents": 0,
+            "total_resources": 5.0,
+            "average_agent_resources": 5.0,
+            "births": 0,
+            "deaths": 0,
+            "current_max_generation": 0,
+            "resource_efficiency": 0.0,
+            "resource_distribution_entropy": 0.0,
+            "average_agent_health": 80.0,
+            "average_agent_age": 1,
+            "average_reward": 0.5,
+            "combat_encounters": 0,
+            "successful_attacks": 0,
+            "resources_shared": 0.0,
+            "resources_shared_this_step": 0.0,
+            "combat_encounters_this_step": 0,
+            "successful_attacks_this_step": 0,
+            "genetic_diversity": 0.0,
+            "dominant_genome_ratio": 0.0,
+            # resources_consumed default ensured in logger
+        }
+
+        db.logger.log_step(
+            step_number=1,
+            agent_states=agent_states,
+            resource_states=[],
+            metrics=metrics,
+        )
+
+        # Query stored agent state
+        def _query(session):
+            return (
+                session.query(AgentStateModel)
+                .filter(AgentStateModel.agent_id == "a1")
+                .filter(AgentStateModel.step_number == 1)
+                .one()
+            )
+
+        st = db._execute_in_transaction(_query)
+        assert st.simulation_id == "simX"
+        assert st.starting_health == 100.0
+        assert st.starvation_counter == 1
+        assert st.current_health == 80.0
+
+        # Also ensure a step row exists for the metrics
+        def _query_step(session):
+            return (
+                session.query(SimulationStepModel)
+                .filter(SimulationStepModel.step_number == 1)
+                .filter(SimulationStepModel.simulation_id == "simX")
+                .one()
+            )
+
+        step = db._execute_in_transaction(_query_step)
+        assert step.total_agents == 1
+
+    finally:
+        db.close()
+        if os.path.exists(db_path):
+            os.remove(db_path)
+

--- a/tests/test_database_state_updates.py
+++ b/tests/test_database_state_updates.py
@@ -1,0 +1,104 @@
+import os
+import time
+from datetime import datetime
+
+import sqlalchemy
+
+from farm.database.database import SimulationDatabase
+from farm.database.models import AgentModel, AgentStateModel, Simulation
+
+
+def _make_db(tmp_name: str = None) -> tuple[SimulationDatabase, str]:
+    db_path = tmp_name or f"test_state_updates_{time.time()}.db"
+    db = SimulationDatabase(db_path, simulation_id="sim_test")
+    # Ensure a simulation record exists for FK
+    db.add_simulation_record(
+        simulation_id="sim_test",
+        start_time=datetime.now(),
+        status="running",
+        parameters={},
+    )
+    return db, db_path
+
+
+def test_update_agent_state_persists_simulation_id_and_columns():
+    db, path = _make_db()
+    try:
+        # Seed an agent (required for FK on agent_states.agent_id)
+        def _insert_agent(session):
+            agent = AgentModel(
+                simulation_id="sim_test",
+                agent_id="agent_a",
+                birth_time=0,
+                agent_type="BaseAgent",
+                position_x=0.0,
+                position_y=0.0,
+                initial_resources=10.0,
+                starting_health=100.0,
+                starvation_counter=0,
+                genome_id="g1",
+                generation=0,
+            )
+            session.add(agent)
+
+        db._execute_in_transaction(_insert_agent)
+
+        # Update agent state
+        state = {
+            "current_health": 95.0,
+            "starting_health": 100.0,
+            "resource_level": 5.0,
+            "position": (1.0, 2.0),
+            "is_defending": False,
+            "total_reward": 1.5,
+            "starvation_counter": 3,
+        }
+        db.update_agent_state("agent_a", 1, state)
+
+        # Verify persisted row includes simulation_id and new columns
+        def _query_state(session):
+            return (
+                session.query(AgentStateModel)
+                .filter(AgentStateModel.agent_id == "agent_a")
+                .filter(AgentStateModel.step_number == 1)
+                .one()
+            )
+
+        row = db._execute_in_transaction(_query_state)
+        assert row.simulation_id == "sim_test"
+        assert row.current_health == 95.0
+        assert row.starting_health == 100.0
+        assert row.starvation_counter == 3
+        assert row.resource_level == 5.0
+        assert row.position_x == 1.0 and row.position_y == 2.0
+
+    finally:
+        db.close()
+        if os.path.exists(path):
+            os.remove(path)
+
+
+def test_agent_state_as_dict_includes_new_keys():
+    # Construct a model instance directly and ensure keys present
+    row = AgentStateModel(
+        id="a-1",
+        simulation_id="sim_test",
+        step_number=1,
+        agent_id="a",
+        position_x=0.0,
+        position_y=0.0,
+        position_z=0.0,
+        resource_level=1.0,
+        current_health=50.0,
+        starting_health=100.0,
+        starvation_counter=2,
+        is_defending=False,
+        total_reward=0.0,
+        age=1,
+    )
+    d = row.as_dict()
+    assert "starting_health" in d
+    assert "starvation_counter" in d
+    assert d["starting_health"] == 100.0
+    assert d["starvation_counter"] == 2
+


### PR DESCRIPTION
Add `starting_health` and `starvation_counter` to `AgentStateModel` and ensure `simulation_id` is set during agent state creation to align with logging and multi-simulation requirements.

The `AgentStateModel` was missing `starting_health` and `starvation_counter` columns, causing a mismatch with how `DataLogger.log_step` and `utilities.format_agent_state` expected agent state data. Explicitly setting `simulation_id` during `AgentStateModel` creation ensures proper data scoping for multi-simulation databases.

---
<a href="https://cursor.com/background-agent?bcId=bc-24cc2d5d-b3b4-4d86-b432-4f6d49478dc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-24cc2d5d-b3b4-4d86-b432-4f6d49478dc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

