### PR TITLE
Optimize frequent channel construction

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -183,20 +183,41 @@ Configuration class for the observation system.
 #### Constructor
 
 ```python
-ObservationConfig(R: int = 6, fov_radius: int = 5,
-                 decay_factors: Dict[str, float] = None)
+ObservationConfig(
+    R: int = 6,
+    fov_radius: int = 5,
+    device: str = "cpu",
+    dtype: str = "float32",
+    gamma_trail: float = 0.90,
+    gamma_dmg: float = 0.85,
+    gamma_sig: float = 0.92,
+    gamma_known: float = 0.98,
+    initialization: str = "zeros",
+    random_min: float = 0.0,
+    random_max: float = 1.0,
+    storage_mode: StorageMode = StorageMode.HYBRID,
+    enable_metrics: bool = True,
+    high_frequency_channels: List[str] = []
+)
 ```
 
 **Parameters:**
 - `R` (int): Observation radius in cells
 - `fov_radius` (int): Field-of-view radius
-- `decay_factors` (Dict[str, float]): Channel-specific decay rates
+- `device` (str): Torch device
+- `dtype` (str): Torch dtype string (e.g., "float32")
+- `gamma_trail/gamma_dmg/gamma_sig/gamma_known` (float): Decay rates for dynamic channels
+- `initialization` (str): Tensor init method ("zeros" or "random")
+- `random_min/random_max` (float): Random initialization range
+- `storage_mode` (StorageMode): HYBRID or DENSE
+- `enable_metrics` (bool): Enable metrics collection
+- `high_frequency_channels` (List[str]): Channels to prebuild densely for faster dense construction
 
 #### Properties
 
 - `R` (int): Observation radius
 - `fov_radius` (int): Field-of-view radius
-- `decay_factors` (Dict[str, float]): Decay factors for dynamic channels
+- `high_frequency_channels` (List[str]): Prebuilt channel names for frequent access
 
 ### AgentObservation Class
 
@@ -235,6 +256,19 @@ Clear instant channels for new data.
 apply_decay() -> None
 ```
 Apply temporal decay to dynamic channels.
+
+```python
+get_metrics() -> Dict
+```
+
+Returns metrics related to dense construction and sparse storage, including:
+- `dense_bytes`
+- `sparse_points`
+- `sparse_logical_bytes`
+- `memory_reduction_percent`
+- `cache_hits`, `cache_misses`, `cache_hit_rate`
+- `dense_rebuilds`, `dense_rebuild_time_s_total`
+- `grid_population_ops`, `vectorized_point_assign_ops`, `prebuilt_channel_copies`, `prebuilt_channels_active`
 
 ## Agents Module (`farm.core.agent`)
 

--- a/docs/perception_system.md
+++ b/docs/perception_system.md
@@ -35,8 +35,8 @@ The perception system provides:
 The system combines:
 
 - **Sparse internal storage** for memory efficiency
-- **Lazy dense construction** for computational performance
-- **Channel-specific optimization** strategies
+- **Lazy dense construction** for computational performance, with optional prebuilding of high-frequency channels (`high_frequency_channels`) for fast O(1) copies during dense builds
+- **Channel-specific optimization** strategies (including prebuilt high-frequency channels and vectorized sparse population)
 - **Spatial indexing** for efficient proximity queries
 
 ---
@@ -173,7 +173,8 @@ obs_config = ObservationConfig(
     gamma_known=0.98,             # Decay rate for known empty cells (default: 0.98)
     device="cpu",                 # Device for tensor operations (default: "cpu")
     dtype="float32",              # PyTorch dtype as string (default: "float32")
-    initialization="zeros"        # Tensor initialization method (default: "zeros")
+    initialization="zeros",       # Tensor initialization method (default: "zeros")
+    high_frequency_channels=["RESOURCES", "VISIBILITY"]  # Optional optimization
 )
 
 # Create simulation configuration with observation settings
@@ -256,6 +257,7 @@ config = SimulationConfig.from_yaml("config.yaml")
 | **Retrieval** | O(1) | O(1) | Cached construction |
 | **Decay** | O(grid_size) | O(active_elements) | Sparse much faster |
 | **NN Processing** | O(grid_size) | O(grid_size) | Same dense tensor |
+| **Dense Build (hybrid)** | — | — | Prebuilt channels copied O(S²), other sparse channels vectorized |
 
 ### Scalability Analysis
 

--- a/docs/usage_examples.md
+++ b/docs/usage_examples.md
@@ -29,7 +29,9 @@ def create_basic_simulation():
         R=6,                    # Observation radius (6 cells in each direction)
         fov_radius=5,           # Field-of-view radius
         gamma_trail=0.95,       # Movement trails decay slowly
-        gamma_dmg=0.90          # Combat heat decays moderately
+        gamma_dmg=0.90,         # Combat heat decays moderately
+        # Optional: prebuild frequently accessed channels for speed
+        high_frequency_channels=["RESOURCES", "VISIBILITY"]
     )
 
     # 2. Create simulation configuration
@@ -265,6 +267,8 @@ def create_mixed_simulation():
     """Create simulation with different agent types."""
 
     obs_config = ObservationConfig(R=6, fov_radius=5)
+    # Tip: For frequent access workloads, consider:
+    # obs_config.high_frequency_channels = ["RESOURCES", "VISIBILITY"]
     
     config = SimulationConfig(
         width=60, height=60,
@@ -571,6 +575,8 @@ def create_weather_simulation():
 
     # Configure observations
     obs_config = ObservationConfig(R=8, fov_radius=6)
+    # Optional optimization for frequent world layers
+    # obs_config.high_frequency_channels = ["RESOURCES", "VISIBILITY"]
     
     config = SimulationConfig(
         width=50, height=50,

--- a/farm/core/observations.py
+++ b/farm/core/observations.py
@@ -515,7 +515,7 @@ class AgentObservation:
             self.cache_dirty = False
 
         # High-frequency channel prebuild support
-        high_freq_names: Set[str] = set(getattr(config, "high_frequency_channels", []) or [])
+        high_freq_names: Set[str] = set(config.high_frequency_channels or [])
         self._high_freq_indices: Set[int] = set()
         for name in high_freq_names:
             try:
@@ -609,7 +609,7 @@ class AgentObservation:
                 ys, xs, vals = zip(*points)
                 ys_t = torch.as_tensor(ys, device=self.config.device, dtype=torch.long)
                 xs_t = torch.as_tensor(xs, device=self.config.device, dtype=torch.long)
-                vals_t = torch.as_tensor(points, device=self.config.device, dtype=self.config.torch_dtype)[:, 2]
+                vals_t = torch.as_tensor(vals, device=self.config.device, dtype=self.config.torch_dtype)
                 # Clamp valid indices
                 mask = (ys_t >= 0) & (ys_t < S) & (xs_t >= 0) & (xs_t < S)
                 if mask.any().item():

--- a/tests/test_observations_highfreq.py
+++ b/tests/test_observations_highfreq.py
@@ -1,0 +1,83 @@
+import torch
+import pytest
+
+from farm.core.observations import AgentObservation, ObservationConfig
+from farm.core.channels import Channel
+
+
+@pytest.fixture
+def config_with_highfreq():
+    # Mark RESOURCES and ALLIES_HP as high-frequency
+    return ObservationConfig(R=3, device="cpu", dtype="float32", high_frequency_channels=["RESOURCES", "ALLIES_HP"])
+
+
+def test_prebuilt_grid_copy_and_points_update(config_with_highfreq):
+    obs = AgentObservation(config_with_highfreq)
+
+    # Store full grid for RESOURCES (high-frequency)
+    grid = torch.zeros(2 * config_with_highfreq.R + 1, 2 * config_with_highfreq.R + 1, dtype=config_with_highfreq.torch_dtype)
+    grid[1:3, 1:3] = 0.7
+    res_idx = 3  # Channel.RESOURCES
+    obs._store_sparse_grid(res_idx, grid)
+
+    # Store points for ALLIES_HP (high-frequency) via public handler-style method
+    # Use direct sparse API to simulate handler behavior
+    allies_idx = int(Channel.ALLIES_HP)
+    obs._store_sparse_points(allies_idx, [(2, 3, 0.5), (4, 3, 0.8)], accumulate=False)
+
+    dense = obs.tensor()
+    # Grid should copy exactly
+    assert torch.allclose(dense[res_idx], grid)
+    # Points should be reflected
+    assert dense[allies_idx, 2, 3] == pytest.approx(0.5)
+    assert dense[allies_idx, 4, 3] == pytest.approx(0.8)
+
+
+def test_vectorized_sparse_population_and_metrics():
+    config = ObservationConfig(R=3, device="cpu", dtype="float32")
+    obs = AgentObservation(config)
+
+    enemies_idx = int(Channel.ENEMIES_HP)
+    # Populate a bunch of points in dict-based sparse storage path
+    # Ensure this channel is NOT high-frequency so it uses dict path
+    points = []
+    for y in range(0, 2 * config.R + 1):
+        for x in range(0, 2 * config.R + 1):
+            val = (y + x) / 100.0
+            points.append((y, x, val))
+    obs._store_sparse_points(enemies_idx, points, accumulate=False)
+
+    dense = obs.tensor()
+    # Validate a few positions
+    assert dense[enemies_idx, 0, 0] == pytest.approx(0.0)
+    assert dense[enemies_idx, 3, 4] == pytest.approx((3 + 4) / 100.0)
+    assert dense[enemies_idx, 6, 6] == pytest.approx((6 + 6) / 100.0)
+
+    # Metrics should reflect vectorized assignment at least once
+    metrics = obs.get_metrics()
+    assert metrics["vectorized_point_assign_ops"] >= 1
+
+
+def test_decay_and_clear_on_prebuilt_channel(config_with_highfreq):
+    obs = AgentObservation(config_with_highfreq)
+
+    # Use ALLY_SIGNAL as dynamic but not prebuilt; then check ALLIES_HP prebuilt clear
+    allies_idx = int(Channel.ALLIES_HP)
+    # Seed values
+    obs._store_sparse_points(allies_idx, [(2, 2, 1.0), (3, 3, 0.4)], accumulate=False)
+
+    # Clear should zero prebuilt slice
+    obs._clear_sparse_channel(allies_idx)
+    dense = obs.tensor()
+    assert torch.all(dense[allies_idx] == 0.0)
+
+    # Now test decay on prebuilt grid channel RESOURCES by writing grid, then decaying via decay helper
+    res_idx = int(Channel.RESOURCES)
+    S = 2 * config_with_highfreq.R + 1
+    grid = torch.ones(S, S, dtype=config_with_highfreq.torch_dtype)
+    obs._store_sparse_grid(res_idx, grid)
+    # Apply decay path that hits prebuilt
+    obs._decay_sparse_channel(res_idx, 0.5)
+    dense = obs.tensor()
+    assert torch.allclose(dense[res_idx], torch.full((S, S), 0.5, dtype=config_with_highfreq.torch_dtype))
+

--- a/tests/test_observations_highfreq.py
+++ b/tests/test_observations_highfreq.py
@@ -22,7 +22,7 @@ def test_prebuilt_grid_copy_and_points_update(config_with_highfreq):
 
     # Store points for ALLIES_HP (high-frequency) via public handler-style method
     # Use direct sparse API to simulate handler behavior
-    allies_idx = int(Channel.ALLIES_HP)
+    allies_idx = Channel.ALLIES_HP
     obs._store_sparse_points(allies_idx, [(2, 3, 0.5), (4, 3, 0.8)], accumulate=False)
 
     dense = obs.tensor()
@@ -37,7 +37,7 @@ def test_vectorized_sparse_population_and_metrics():
     config = ObservationConfig(R=3, device="cpu", dtype="float32")
     obs = AgentObservation(config)
 
-    enemies_idx = int(Channel.ENEMIES_HP)
+    enemies_idx = Channel.ENEMIES_HP
     # Populate a bunch of points in dict-based sparse storage path
     # Ensure this channel is NOT high-frequency so it uses dict path
     points = []
@@ -62,7 +62,7 @@ def test_decay_and_clear_on_prebuilt_channel(config_with_highfreq):
     obs = AgentObservation(config_with_highfreq)
 
     # Use ALLY_SIGNAL as dynamic but not prebuilt; then check ALLIES_HP prebuilt clear
-    allies_idx = int(Channel.ALLIES_HP)
+    allies_idx = Channel.ALLIES_HP
     # Seed values
     obs._store_sparse_points(allies_idx, [(2, 2, 1.0), (3, 3, 0.4)], accumulate=False)
 
@@ -72,7 +72,7 @@ def test_decay_and_clear_on_prebuilt_channel(config_with_highfreq):
     assert torch.all(dense[allies_idx] == 0.0)
 
     # Now test decay on prebuilt grid channel RESOURCES by writing grid, then decaying via decay helper
-    res_idx = int(Channel.RESOURCES)
+    res_idx = Channel.RESOURCES
     S = 2 * config_with_highfreq.R + 1
     grid = torch.ones(S, S, dtype=config_with_highfreq.torch_dtype)
     obs._store_sparse_grid(res_idx, grid)


### PR DESCRIPTION
Optimize lazy construction by implementing pre-building for high-frequency channels and vectorizing sparse data population in `_build_dense_tensor` to avoid bottlenecks.

The `_build_dense_tensor` method can be a bottleneck in frequent access scenarios due to O(grid_size) population for each sparse channel. This PR introduces a mechanism to pre-build high-frequency channels into dense tensors, allowing for O(1) copy operations during `_build_dense_tensor`. Additionally, it vectorizes the population of other sparse channels from dictionaries, replacing slow Python loops with efficient tensor operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-17379745-e85e-4c47-89b0-7af32c697769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-17379745-e85e-4c47-89b0-7af32c697769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

