### PR TITLE
Enhance electron configuration explorer feature

### DIFF
--- a/docs/config_schema_endpoint.md
+++ b/docs/config_schema_endpoint.md
@@ -1,0 +1,67 @@
+## Electron Configuration Explorer: Backend Support (Issue #356)
+
+### Summary
+- **Added schema generator**: `farm/core/config_schema.py` produces a combined, JSON-serializable schema for configuration sections.
+- **New API endpoint**: `GET /config/schema` via `server/backend/app/routers/config.py` exposes the schema to the Electron app.
+- **App wiring**: Router included in `server/backend/app/main.py`.
+- **Basic test**: `tests/test_config_schema_endpoint.py` validates endpoint structure.
+
+### What’s Included
+- **Schema generator** (`farm/core/config_schema.py`):
+  - Introspects these sources:
+    - `SimulationConfig` (dataclass)
+    - `VisualizationConfig` (dataclass)
+    - `RedisMemoryConfig` (dataclass)
+    - `ObservationConfig` (Pydantic model)
+  - Emits a merged schema with:
+    - Field `type` (integer, number, boolean, string, object, array)
+    - `default` values
+    - `enum` choices where known (e.g., storage mode, certain strings)
+    - Range constraints for Pydantic fields when available (minimum/maximum)
+  - Output is organized into four sections: `simulation`, `visualization`, `redis`, `observation`.
+
+- **API** (`server/backend/app/routers/config.py`):
+  - `GET /config/schema` returns a payload like:
+
+```json
+{
+  "version": 1,
+  "generated_at": "2025-09-25T12:34:56Z",
+  "sections": {
+    "simulation": { "title": "Simulation", "properties": { /* ... */ } },
+    "visualization": { "title": "Visualization", "properties": { /* ... */ } },
+    "redis": { "title": "Redis", "properties": { /* ... */ } },
+    "observation": {
+      "title": "Observation",
+      "properties": { /* Pydantic-derived with descriptions and ranges where present */ },
+      "enums": { "storage_mode": ["hybrid", "dense"] }
+    }
+  }
+}
+```
+
+### How the Electron App Can Use This
+- **Fetch schema**: Call `GET /config/schema` on app load or when refreshing settings.
+- **Build UI**: For each section, iterate `properties` and render appropriate controls based on `type`, `default`, and `enum`.
+- **Hints/validation**:
+  - Use `enum` to render select inputs.
+  - Use `minimum`/`maximum` when present to set numeric control ranges.
+  - Defaults can seed initial field values.
+
+### Design Notes and Limitations
+- Dataclass-based fields do not carry numeric range metadata; only defaults and known enums are emitted.
+- Known string enums for `SimulationConfig` (e.g., `position_discretization_method`, `db_*` pragmas, `device_preference`) are provided via a curated list.
+- `ObservationConfig` includes descriptions and constraints from Pydantic `Field` definitions.
+- The generator emphasizes stability and JSON compatibility; complex Python types are surfaced as `object` with sensible defaults.
+
+### Files Changed/Added
+- Added: `farm/core/config_schema.py`
+- Added: `server/backend/app/routers/config.py`
+- Updated: `server/backend/app/main.py` (included config router)
+- Added: `tests/test_config_schema_endpoint.py`
+
+### Testing
+- Run tests (example):
+  - Create a virtualenv and install dependencies, then `pytest -q`.
+  - The test `tests/test_config_schema_endpoint.py` checks structure and a few representative fields.
+

--- a/farm/core/config_schema.py
+++ b/farm/core/config_schema.py
@@ -1,0 +1,199 @@
+import dataclasses
+import datetime
+from dataclasses import is_dataclass, fields
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple, get_args, get_origin
+
+from pydantic import BaseModel
+
+from farm.core.config import (
+    SimulationConfig,
+    VisualizationConfig,
+    RedisMemoryConfig,
+)
+from farm.core.observations import ObservationConfig, StorageMode
+
+
+def _python_type_to_schema_type(annotation: Any) -> str:
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+
+    if origin is list or origin is List:
+        return "array"
+    if origin is dict or origin is Dict:
+        return "object"
+    if origin is tuple or origin is Tuple:
+        return "array"
+    if origin is Optional:
+        return _python_type_to_schema_type(args[0]) if args else "string"
+
+    if annotation in (int, Optional[int]):
+        return "integer"
+    if annotation in (float, Optional[float]):
+        return "number"
+    if annotation in (bool, Optional[bool]):
+        return "boolean"
+    if annotation in (str, Optional[str]):
+        return "string"
+
+    # Enums
+    try:
+        if issubclass(annotation, Enum):
+            return "string"
+    except Exception:
+        pass
+
+    # Fallback
+    return "object"
+
+
+def _enum_values(annotation: Any) -> Optional[List[Any]]:
+    try:
+        if issubclass(annotation, Enum):
+            return [e.value for e in annotation]
+    except Exception:
+        pass
+    return None
+
+
+def _get_default_from_instance(instance: Any, name: str) -> Any:
+    try:
+        return getattr(instance, name)
+    except Exception:
+        return None
+
+
+def _dataclass_to_properties(dc_cls: type, known_enums: Dict[str, List[Any]] | None = None) -> Dict[str, Dict[str, Any]]:
+    instance = dc_cls()  # relies on defaults in dataclass
+    props: Dict[str, Dict[str, Any]] = {}
+
+    for f in fields(dc_cls):
+        # Skip nested dataclass fields; these are split into their own sections
+        if is_dataclass(f.type):
+            continue
+
+        schema_entry: Dict[str, Any] = {
+            "type": _python_type_to_schema_type(f.type),
+            "default": _get_default_from_instance(instance, f.name),
+        }
+
+        # Add enums if known by name
+        if known_enums and f.name in known_enums:
+            schema_entry["enum"] = list(known_enums[f.name])
+
+        # Add enums if type itself is Enum
+        enum_vals = _enum_values(f.type)
+        if enum_vals:
+            schema_entry["enum"] = enum_vals
+
+        props[f.name] = schema_entry
+
+    return props
+
+
+def _pydantic_model_to_properties(model_cls: type[BaseModel]) -> Dict[str, Dict[str, Any]]:
+    schema = model_cls.model_json_schema()
+    properties = schema.get("properties", {})
+    result: Dict[str, Dict[str, Any]] = {}
+
+    # Build a default instance to pull resolved defaults when missing
+    try:
+        default_instance = model_cls()  # type: ignore[call-arg]
+    except Exception:
+        default_instance = None
+
+    for name, meta in properties.items():
+        entry: Dict[str, Any] = {}
+        # Normalize type
+        if "type" in meta:
+            entry["type"] = meta["type"]
+        elif "anyOf" in meta:
+            # Optional fields often appear as anyOf [type,null]
+            types = [t.get("type") for t in meta["anyOf"] if isinstance(t, dict)]
+            entry["type"] = next((t for t in types if t != "null"), types[0] if types else "object")
+        else:
+            entry["type"] = "object"
+
+        # Defaults
+        if "default" in meta:
+            entry["default"] = meta["default"]
+        elif default_instance is not None:
+            entry["default"] = getattr(default_instance, name, None)
+
+        # Description
+        if "description" in meta:
+            entry["description"] = meta["description"]
+
+        # Enum
+        if "enum" in meta:
+            entry["enum"] = meta["enum"]
+
+        # Ranges/constraints
+        for key_src, key_dst in (
+            ("minimum", "minimum"),
+            ("maximum", "maximum"),
+            ("exclusiveMinimum", "exclusiveMinimum"),
+            ("exclusiveMaximum", "exclusiveMaximum"),
+        ):
+            if key_src in meta:
+                entry[key_dst] = meta[key_src]
+
+        result[name] = entry
+
+    return result
+
+
+def generate_combined_config_schema() -> Dict[str, Any]:
+    """Generate a combined configuration schema for the Electron explorer.
+
+    Sections:
+      - simulation: top-level simulation parameters (excludes nested sections)
+      - visualization: nested visualization parameters
+      - redis: nested Redis memory parameters
+      - observation: observation system parameters
+    """
+
+    # Known enum-like choices present as strings in dataclasses
+    simulation_known_enums: Dict[str, List[Any]] = {
+        "position_discretization_method": ["floor", "round", "ceil"],
+        "db_pragma_profile": ["balanced", "performance", "safety", "memory"],
+        "db_synchronous_mode": ["OFF", "NORMAL", "FULL"],
+        "db_journal_mode": ["DELETE", "TRUNCATE", "PERSIST", "MEMORY", "WAL", "OFF"],
+        "device_preference": ["auto", "cpu", "cuda"],
+    }
+
+    sim_props = _dataclass_to_properties(SimulationConfig, known_enums=simulation_known_enums)
+    # Remove nested sections from simulation section
+    for nested in ("visualization", "redis", "observation"):
+        sim_props.pop(nested, None)
+
+    vis_props = _dataclass_to_properties(VisualizationConfig)
+    redis_props = _dataclass_to_properties(RedisMemoryConfig)
+    obs_props = _pydantic_model_to_properties(ObservationConfig)
+
+    return {
+        "version": 1,
+        "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
+        "sections": {
+            "simulation": {
+                "title": "Simulation",
+                "properties": sim_props,
+            },
+            "visualization": {
+                "title": "Visualization",
+                "properties": vis_props,
+            },
+            "redis": {
+                "title": "Redis",
+                "properties": redis_props,
+            },
+            "observation": {
+                "title": "Observation",
+                "properties": obs_props,
+                "enums": {
+                    "storage_mode": [e.value for e in StorageMode],
+                },
+            },
+        },
+    }
+

--- a/server/backend/app/main.py
+++ b/server/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi.staticfiles import StaticFiles
 
 from . import models
 from .db import engine
-from .routers import simulation
+from .routers import simulation, config
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -44,6 +44,7 @@ app.mount("/static", StaticFiles(directory="static"), name="static")
 
 # Include routers
 app.include_router(simulation.router)
+app.include_router(config.router)
 
 
 @app.get("/")

--- a/server/backend/app/routers/config.py
+++ b/server/backend/app/routers/config.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter
+
+from farm.core.config_schema import generate_combined_config_schema
+
+
+router = APIRouter(prefix="/config", tags=["config"])
+
+
+@router.get("/schema")
+def get_config_schema():
+    return generate_combined_config_schema()
+

--- a/tests/test_config_schema_endpoint.py
+++ b/tests/test_config_schema_endpoint.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+
+from server.backend.app.main import app
+
+
+client = TestClient(app)
+
+
+def test_config_schema_endpoint_basic_structure():
+    resp = client.get("/config/schema")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "version" in data
+    assert "sections" in data
+    sections = data["sections"]
+    for key in ["simulation", "visualization", "redis", "observation"]:
+        assert key in sections
+        assert "properties" in sections[key]
+        assert isinstance(sections[key]["properties"], dict)
+
+    # Spot-check a few expected fields
+    sim_props = sections["simulation"]["properties"]
+    assert "width" in sim_props
+    assert sim_props["width"]["type"] in ["integer", "number"]
+    obs_props = sections["observation"]["properties"]
+    assert "R" in obs_props
+    assert obs_props["R"]["type"] in ["integer", "number"]
+


### PR DESCRIPTION
Add a `/config/schema` API endpoint to expose the backend's configuration schema for the Electron app, addressing issue #356.

---
<a href="https://cursor.com/background-agent?bcId=bc-8588803c-ad02-4d9f-80ff-8cef1a6d7403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8588803c-ad02-4d9f-80ff-8cef1a6d7403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

