### PR TITLE
Implement agent farm gui feature

### DIFF
--- a/docs/electron/config_explorer_architecture.md
+++ b/docs/electron/config_explorer_architecture.md
@@ -147,6 +147,16 @@ Channel names are namespaced as `config:*` and `explorer:*`.
 - preview:progress (event)
   - payload: `{ runId: string, percent: number, message?: string }`
 
+### Native File Dialogs (Renderer-triggered)
+
+- dialog:openConfig
+  - req: none
+  - res: `{ canceled: boolean, filePath?: string }`
+
+- dialog:saveConfig
+  - req: `{ suggestedPath?: string }`
+  - res: `{ canceled: boolean, filePath?: string }`
+
 Diagnostic shape:
 
 Diagnostic shape:
@@ -182,6 +192,8 @@ Selectors compute derived views (e.g., visible nodes) and keep components simple
 - Long-running tasks (preview) are cancellable and emit progress events
 - Watchers are debounced and coalesced to avoid floods
 
+Note: Until the preload boundary is introduced, a temporary renderer service (`window.dialogService`) wraps `ipcRenderer.invoke` calls for `dialog:openConfig` and `dialog:saveConfig`. This will be migrated behind a typed preload API in a future phase.
+
 ---
 
 ## Migration Plan (Phased)
@@ -190,6 +202,7 @@ Phase 1: Architecture & Skeleton
 - Add `ipcRoutes`, `configStore`, `fileSystemService` in main; `ipcClient` in renderer
 - Implement read-only features: `config:listRoots`, `config:listTree`, `config:get`
 - Introduce `ConfigExplorer` panel behind a feature flag while keeping existing sidebar
+ - Add native file dialogs for open/save and basic toolbar controls (Open, Save, Save As)
 
 Phase 2: Editing & Validation
 - Implement `config:update`, `config:validate`, `config:save`

--- a/farm/editor/components/config-explorer/Explorer.js
+++ b/farm/editor/components/config-explorer/Explorer.js
@@ -97,12 +97,22 @@
 					<span id="unsaved-indicator" class="unsaved-indicator" style="display:none;"><span class="dot"></span> Unsaved</span>
 				</div>
 				<div class="right">
+					<button id="open-config" class="btn">Open…</button>
+					<span class="sep"></span>
 					<input id="save-path" class="search" placeholder="Save path (optional)" />
+					<button id="browse-save" class="btn" title="Choose save location">Browse…</button>
 					<button id="save-config" class="btn">Save</button>
+					<button id="save-as" class="btn">Save As…</button>
 				</div>
 			`
 			bar.querySelector('#back-to-legacy').onclick = () => window.hideConfigExplorer()
 			bar.querySelector('#save-config').onclick = () => this.onSave()
+			const openBtn = bar.querySelector('#open-config')
+			if (openBtn) openBtn.onclick = () => this.onOpen()
+			const browseBtn = bar.querySelector('#browse-save')
+			if (browseBtn) browseBtn.onclick = () => this.onBrowseSave()
+			const saveAsBtn = bar.querySelector('#save-as')
+			if (saveAsBtn) saveAsBtn.onclick = () => this.onSaveAs()
 			return bar
 		}
 
@@ -492,6 +502,50 @@
 				this.showGlobalValidation('error', 'Save failed')
 			} finally {
 				if (btn) { btn.disabled = !this.state.unsaved; btn.textContent = 'Save' }
+			}
+		}
+
+		async onBrowseSave() {
+			try {
+				const suggested = this.root.querySelector('#save-path')?.value || undefined
+				const res = await (window.dialogService && window.dialogService.saveConfigDialog ? window.dialogService.saveConfigDialog(suggested) : Promise.resolve({ canceled: true }))
+				if (!res || res.canceled) return
+				const input = this.root.querySelector('#save-path')
+				if (input) input.value = res.filePath
+			} catch (_) {}
+		}
+
+		async onSaveAs() {
+			try {
+				const res = await (window.dialogService && window.dialogService.saveConfigDialog ? window.dialogService.saveConfigDialog(undefined) : Promise.resolve({ canceled: true }))
+				if (!res || res.canceled) return
+				const input = this.root.querySelector('#save-path')
+				if (input) input.value = res.filePath
+				await this.onSave()
+			} catch (e) {
+				this.showGlobalValidation('error', 'Save As failed')
+			}
+		}
+
+		async onOpen() {
+			try {
+				const res = await (window.dialogService && window.dialogService.openConfigDialog ? window.dialogService.openConfigDialog() : Promise.resolve({ canceled: true }))
+				if (!res || res.canceled) return
+				const load = await window.configSchemaService.loadConfig(res.filePath)
+				if (load && load.success && load.config) {
+					this.state.config = load.config
+					this.state.lastSavedConfig = JSON.parse(JSON.stringify(load.config))
+					this.markUnsaved(false)
+					this.renderDetailsContent(this.state.selectedSectionKey || (this.state.sections[0] && this.state.sections[0].key))
+					this.updateYamlPreview()
+					const input = this.root.querySelector('#save-path')
+					if (input) input.value = res.filePath
+					this.showGlobalValidation('valid', 'Configuration loaded')
+				} else {
+					this.showGlobalValidation('error', (load && load.message) || 'Open failed')
+				}
+			} catch (e) {
+				this.showGlobalValidation('error', 'Open failed')
 			}
 		}
 	}

--- a/farm/editor/index.html
+++ b/farm/editor/index.html
@@ -19,6 +19,7 @@
     <script src="components/sidebar.js"></script>
     <script src="components/editor.js"></script>
     <script src="services/schema.js"></script>
+    <script src="services/dialog.js"></script>
     <script src="components/config-explorer/SplitPane.js"></script>
     <script src="components/config-explorer/Explorer.js"></script>
 </body>

--- a/farm/editor/services/dialog.js
+++ b/farm/editor/services/dialog.js
@@ -1,4 +1,4 @@
-;(function() {
+(function() {
     const { ipcRenderer } = require('electron')
 
     async function openConfigDialog() {

--- a/farm/editor/services/dialog.js
+++ b/farm/editor/services/dialog.js
@@ -1,0 +1,27 @@
+;(function() {
+    const { ipcRenderer } = require('electron')
+
+    async function openConfigDialog() {
+        try {
+            const res = await ipcRenderer.invoke('dialog:openConfig')
+            return res || { canceled: true }
+        } catch (e) {
+            return { canceled: true, error: String(e && e.message ? e.message : e) }
+        }
+    }
+
+    async function saveConfigDialog(suggestedPath) {
+        try {
+            const res = await ipcRenderer.invoke('dialog:saveConfig', suggestedPath)
+            return res || { canceled: true }
+        } catch (e) {
+            return { canceled: true, error: String(e && e.message ? e.message : e) }
+        }
+    }
+
+    window.dialogService = {
+        openConfigDialog,
+        saveConfigDialog,
+    }
+})()
+


### PR DESCRIPTION
Add native file dialog support (Open, Save As, Browse) to the Electron configuration GUI to allow users to manage config files directly from the UI, as requested in #360.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e83ca27-8e5c-420b-9129-250eab261723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8e83ca27-8e5c-420b-9129-250eab261723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

