### PR TITLE
Implement comparison panel for config explorer gui

### DIFF
--- a/LIVE_SIMULATION_CONFIG_EXPLORER_PROJECT_SUMMARY.md
+++ b/LIVE_SIMULATION_CONFIG_EXPLORER_PROJECT_SUMMARY.md
@@ -37,6 +37,7 @@ Create a cinematic, professional configuration tool that feels like editing a Jo
 ### 🔧 Dual Side Editing Interface
 - **Primary Panel** - Live Leva controls with real-time validation
 - **Comparison Panel** - Read-only comparison view with diff highlighting
+  - Implemented base comparison panel: toggle, file load with validation, clear, synchronized scroll, and file path display. Read-only rendering of key fields in `ComparisonPanel`.
 - **Resizable Layouts** - Smooth, animated panel resizing with persistence
 - **Live YAML Preview** - Real-time YAML generation with syntax highlighting
 - **Diff Highlighting** - Visual differences with one-click field copying

--- a/phase3_github_issues.md
+++ b/phase3_github_issues.md
@@ -46,6 +46,13 @@ Build the comparison panel system that allows users to load and compare two diff
 - ✅ Performance remains good with large configurations
 - ✅ Error handling works for invalid files
 
+Implementation Notes (Sept 2025):
+- Added comparison state/actions in `src/stores/configStore.ts` and types in `src/types/config.ts` (`showComparison`, `comparisonFilePath`, `toggleComparison`, `clearComparison`, `setComparisonPath`, `setComparison`).
+- Created read-only `ComparisonPanel` in `src/components/ConfigExplorer/ComparisonPanel.tsx`.
+- Integrated comparison controls into `RightPanel` with toggle, file load (JSON), Zod validation, error messaging, and file path display.
+- Added synchronized scrolling between left control area (`left-scroll-area`) and `comparison-scroll-area`.
+- Resizing persists via `ResizablePanels` and store; no changes required.
+
 **Dependencies:** Phase 2 completion
 **Estimated Time:** 3-4 days
 

--- a/src/components/ConfigExplorer/ComparisonPanel.tsx
+++ b/src/components/ConfigExplorer/ComparisonPanel.tsx
@@ -1,0 +1,76 @@
+import React, { useMemo } from 'react'
+import styled from 'styled-components'
+import { SimulationConfigType } from '@/types/config'
+
+const ContentSection = styled.div`
+  margin-bottom: 24px;
+  padding: 16px;
+  background: var(--background-primary);
+  border-radius: 8px;
+  border: 1px solid var(--border-subtle);
+`
+
+const ConfigItem = styled.div`
+  margin-bottom: 12px;
+  padding: 8px;
+  background: var(--background-secondary);
+  border-radius: 4px;
+  border-left: 3px solid var(--accent-primary);
+`
+
+const ConfigLabel = styled.span`
+  font-weight: 600;
+  color: var(--text-primary);
+`
+
+const ConfigValue = styled.span`
+  color: var(--text-secondary);
+  margin-left: 8px;
+`
+
+type ComparisonPanelProps = {
+  compareConfig: SimulationConfigType | null
+  comparisonFilePath?: string
+  errorMessage?: string
+}
+
+export const ComparisonPanel: React.FC<ComparisonPanelProps> = ({ compareConfig, comparisonFilePath, errorMessage }) => {
+  const comparisonSummary = useMemo(() => {
+    if (!compareConfig) return null
+    return [
+      { label: 'Environment Settings', value: `Grid: ${compareConfig.width}x${compareConfig.height}, ${compareConfig.position_discretization_method} discretization` },
+      { label: 'Agent Counts', value: `System: ${compareConfig.system_agents}, Independent: ${compareConfig.independent_agents}, Control: ${compareConfig.control_agents}` },
+      { label: 'Learning Rate', value: String(compareConfig.learning_rate) },
+      { label: 'Visualization', value: `Canvas: ${compareConfig.visualization.canvas_width}x${compareConfig.visualization.canvas_height}, Metrics: ${compareConfig.visualization.show_metrics ? 'Enabled' : 'Disabled'}` }
+    ]
+  }, [compareConfig])
+
+  return (
+    <div>
+      <div style={{ margin: '4px 0', color: 'var(--text-secondary)', fontSize: '12px' }}>
+        {comparisonFilePath ? `Loaded from: ${comparisonFilePath}` : 'No file selected'}
+      </div>
+      {errorMessage && (
+        <div role="alert" style={{ color: 'var(--error-text)', background: 'var(--error-bg)', border: '1px solid var(--error-border)', padding: '8px', borderRadius: '4px', marginBottom: '8px' }}>
+          {errorMessage}
+        </div>
+      )}
+      <ContentSection>
+        {!compareConfig && (
+          <div style={{ color: 'var(--text-secondary)' }}>No comparison configuration loaded.</div>
+        )}
+        {compareConfig && (
+          <div role="list" aria-label="Comparison configuration parameters">
+            {comparisonSummary?.map((row) => (
+              <ConfigItem role="listitem" key={row.label} aria-readonly="true">
+                <ConfigLabel>{row.label}:</ConfigLabel>
+                <ConfigValue>{row.value}</ConfigValue>
+              </ConfigItem>
+            ))}
+          </div>
+        )}
+      </ContentSection>
+    </div>
+  )
+}
+

--- a/src/components/ConfigExplorer/LeftPanel.tsx
+++ b/src/components/ConfigExplorer/LeftPanel.tsx
@@ -88,9 +88,19 @@ export const LeftPanel: React.FC = () => {
     )
   }
 
+  const containerRef = React.useRef<HTMLDivElement>(null)
+
   return (
     <LeftPanelContainer
-      ref={ref as unknown as React.RefObject<HTMLDivElement>}
+      ref={(node) => {
+        containerRef.current = node as HTMLDivElement | null
+        // Attach to keyboard nav ref if compatible
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const anyRef = ref as any
+        if (anyRef && typeof anyRef === 'object') {
+          anyRef.current = node
+        }
+      }}
       role="navigation"
       aria-label="Configuration sections navigation"
       tabIndex={-1}

--- a/src/components/ConfigExplorer/LeftPanel.tsx
+++ b/src/components/ConfigExplorer/LeftPanel.tsx
@@ -35,6 +35,9 @@ const ControlsSection = styled.div`
   overflow-y: auto;
 `
 
+// Expose an id for scroll sync
+const ScrollableArea = styled(ControlsSection).attrs({ id: 'left-scroll-area' })``
+
 const SectionTitle = styled.h3`
   margin: 0 0 12px 0;
   font-size: 14px;
@@ -87,7 +90,7 @@ export const LeftPanel: React.FC = () => {
 
   return (
     <LeftPanelContainer
-      ref={ref}
+      ref={ref as unknown as React.RefObject<HTMLDivElement>}
       role="navigation"
       aria-label="Configuration sections navigation"
       tabIndex={-1}
@@ -97,14 +100,14 @@ export const LeftPanel: React.FC = () => {
         <PanelTitle>Configuration Explorer</PanelTitle>
       </PanelHeader>
 
-      <ControlsSection>
+      <ScrollableArea>
         <SectionTitle>Leva Controls</SectionTitle>
 
         <ConfigFolder
           label="Environment Settings"
           collapsed={levaStore.isFolderCollapsed('environment')}
           onToggle={() => handleFolderToggle('environment', levaStore.isFolderCollapsed('environment'))}
-          folderId="environment"
+          id="environment"
         >
           <ControlGroup>
             <LevaControls />
@@ -120,7 +123,7 @@ export const LeftPanel: React.FC = () => {
           label="Agent Parameters"
           collapsed={levaStore.isFolderCollapsed('agents')}
           onToggle={() => handleFolderToggle('agents', levaStore.isFolderCollapsed('agents'))}
-          folderId="agents"
+          id="agents"
         >
           <ControlGroup>
             <div style={{ padding: '8px', color: 'var(--text-secondary)' }}>
@@ -138,7 +141,7 @@ export const LeftPanel: React.FC = () => {
           label="Learning Configuration"
           collapsed={levaStore.isFolderCollapsed('learning')}
           onToggle={() => handleFolderToggle('learning', levaStore.isFolderCollapsed('learning'))}
-          folderId="learning"
+          id="learning"
         >
           <ControlGroup>
             <div style={{ padding: '8px', color: 'var(--text-secondary)' }}>
@@ -156,7 +159,7 @@ export const LeftPanel: React.FC = () => {
           label="Visualization Settings"
           collapsed={levaStore.isFolderCollapsed('visualization')}
           onToggle={() => handleFolderToggle('visualization', levaStore.isFolderCollapsed('visualization'))}
-          folderId="visualization"
+          id="visualization"
         >
           <ControlGroup>
             <div style={{ padding: '8px', color: 'var(--text-secondary)' }}>
@@ -213,7 +216,7 @@ export const LeftPanel: React.FC = () => {
             {levaStore.isCollapsed ? 'Expand Panel' : 'Collapse Panel'}
           </button>
         </ControlGroup>
-      </ControlsSection>
+      </ScrollableArea>
     </LeftPanelContainer>
   )
 }

--- a/src/components/ConfigExplorer/RightPanel.tsx
+++ b/src/components/ConfigExplorer/RightPanel.tsx
@@ -89,23 +89,20 @@ export const RightPanel: React.FC = () => {
   const { announceToScreenReader } = useAccessibility()
   const showComparison = useConfigStore(configSelectors.getShowComparison)
   const compareConfig = useConfigStore(configSelectors.getCompareConfig)
-  const comparisonFilePath = useConfigStore((s: any) => s.comparisonFilePath)
-  const clearComparison = useConfigStore((s: any) => s.clearComparison)
-  const toggleComparison = useConfigStore((s: any) => s.toggleComparison)
-  const setComparison = useConfigStore((s: any) => s.setComparison)
-  const setComparisonPath = useConfigStore((s: any) => s.setComparisonPath)
+  const comparisonFilePath = useConfigStore((s) => s.comparisonFilePath)
+  const clearComparison = useConfigStore((s) => s.clearComparison)
+  const toggleComparison = useConfigStore((s) => s.toggleComparison)
+  const setComparison = useConfigStore((s) => s.setComparison)
+  const setComparisonPath = useConfigStore((s) => s.setComparisonPath)
 
   // File input handling for loading comparison config (JSON for now)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const onChooseFile = () => fileInputRef.current?.click()
   const [comparisonError, setComparisonError] = useState<string | undefined>(undefined)
-  const onFileSelected: React.ChangeEventHandler<HTMLInputElement> = async (e) => {
-    const file = e.target.files?.[0]
-    if (!file) return
+  const handleComparisonSelection = async (file: File) => {
     try {
       const text = await file.text()
       const parsed = JSON.parse(text)
-      // Validate parsed comparison config
       const result = await validationService.validateConfig(parsed)
       if (!result.success) {
         setComparison(null)
@@ -118,9 +115,17 @@ export const RightPanel: React.FC = () => {
         setComparisonError(undefined)
         announceToScreenReader('Comparison configuration loaded', 'polite')
       }
-    } catch (err) {
+    } catch {
       setComparisonError('Invalid comparison file: unable to parse JSON')
       announceToScreenReader('Invalid comparison file', 'assertive')
+    }
+  }
+
+  const onFileSelected: React.ChangeEventHandler<HTMLInputElement> = async (e) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    try {
+      await handleComparisonSelection(file)
     } finally {
       // reset input to allow re-select same file
       if (fileInputRef.current) fileInputRef.current.value = ''

--- a/src/components/ConfigExplorer/RightPanel.tsx
+++ b/src/components/ConfigExplorer/RightPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useEffect, useState } from 'react'
+import React, { useRef, useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { ValidationSummary } from '@/components/Validation/ValidationSummary'
 import { useAccessibility } from '@/components/UI/AccessibilityProvider'

--- a/src/components/__tests__/ConfigExplorer.test.tsx
+++ b/src/components/__tests__/ConfigExplorer.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { ThemeProvider } from '@/components/UI/ThemeProvider'
 import { ConfigExplorer } from '../ConfigExplorer/ConfigExplorer'
+import { useConfigStore } from '@/stores/configStore'
 
 // Mock the modules BEFORE importing the component
 vi.mock('@/services/ipcService', () => ({
@@ -52,5 +53,49 @@ describe('ConfigExplorer', () => {
       </ThemeProvider>
     )
     expect(screen.getByText(/Running in browser mode/)).toBeInTheDocument()
+  })
+
+  it('toggles comparison panel visibility', async () => {
+    render(
+      <ThemeProvider>
+        <ConfigExplorer />
+      </ThemeProvider>
+    )
+
+    // Initially hidden
+    expect(screen.queryByText(/Comparison Panel/)).not.toBeInTheDocument()
+
+    // Find and click the toggle button
+    const toggleBtn = await screen.findByRole('button', { name: /Show Comparison Panel/i })
+    fireEvent.click(toggleBtn)
+
+    // Panel now visible
+    await waitFor(() => expect(screen.getByText(/Comparison Panel/)).toBeInTheDocument())
+
+    // Click again to hide
+    fireEvent.click(screen.getByRole('button', { name: /Hide Comparison Panel/i }))
+    await waitFor(() => expect(screen.queryByText(/Comparison Panel/)).not.toBeInTheDocument())
+  })
+
+  it('handles invalid comparison file gracefully', async () => {
+    render(
+      <ThemeProvider>
+        <ConfigExplorer />
+      </ThemeProvider>
+    )
+
+    const toggleBtn = await screen.findByRole('button', { name: /Show Comparison Panel/i })
+    fireEvent.click(toggleBtn)
+
+    const loadBtn = await screen.findByRole('button', { name: /Load Comparison Config/i })
+    // Simulate a click on hidden input by dispatching change with invalid JSON
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(["{ invalid json"], 'bad.json', { type: 'application/json' })
+    Object.defineProperty(input, 'files', { value: [file] })
+    fireEvent.change(input)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Invalid comparison file/)).toBeInTheDocument()
+    })
   })
 })

--- a/src/stores/configStore.ts
+++ b/src/stores/configStore.ts
@@ -272,17 +272,20 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
   toggleComparison: () => {
     const current = get().showComparison
     set({ showComparison: !current })
-    get().persistUIState()
+    const persistUI = get().persistUIState
+    persistUI()
   },
 
   clearComparison: () => {
     set({ compareConfig: null, comparisonFilePath: undefined })
-    get().persistUIState()
+    const persistUI = get().persistUIState
+    persistUI()
   },
 
   setComparisonPath: (path?: string) => {
     set({ comparisonFilePath: path })
-    get().persistUIState()
+    const persistUI = get().persistUIState
+    persistUI()
   },
 
   toggleSection: (section: ConfigSection) => {

--- a/src/stores/configStore.ts
+++ b/src/stores/configStore.ts
@@ -151,6 +151,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
   isDirty: false,
   compareConfig: null,
   showComparison: false,
+  comparisonFilePath: undefined,
   selectedSection: 'environment',
   expandedFolders: new Set(['environment', 'agents', 'learning', 'visualization']),
   validationErrors: [],
@@ -268,6 +269,22 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     set({ compareConfig: config })
   },
 
+  toggleComparison: () => {
+    const current = get().showComparison
+    set({ showComparison: !current })
+    get().persistUIState()
+  },
+
+  clearComparison: () => {
+    set({ compareConfig: null, comparisonFilePath: undefined })
+    get().persistUIState()
+  },
+
+  setComparisonPath: (path?: string) => {
+    set({ comparisonFilePath: path })
+    get().persistUIState()
+  },
+
   toggleSection: (section: ConfigSection) => {
     const expandedFolders = new Set(get().expandedFolders)
     if (expandedFolders.has(section)) {
@@ -305,6 +322,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       selectedSection: state.selectedSection,
       expandedFolders: Array.from(state.expandedFolders),
       showComparison: state.showComparison,
+      comparisonFilePath: state.comparisonFilePath,
       leftPanelWidth: state.leftPanelWidth,
       rightPanelWidth: state.rightPanelWidth
     }
@@ -347,6 +365,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
         selectedSection: selectedSectionValid,
         expandedFolders: expandedFoldersValid,
         showComparison: (state.showComparison as boolean) || false,
+        comparisonFilePath: (state.comparisonFilePath as string | undefined) || undefined,
         leftPanelWidth: (state.leftPanelWidth as number) || 0.5,
         rightPanelWidth: (state.rightPanelWidth as number) || 0.5
       })

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -116,6 +116,7 @@ export interface ConfigState {
   isDirty: boolean
   compareConfig: SimulationConfigType | null
   showComparison: boolean
+  comparisonFilePath?: string
   selectedSection: ConfigSection
   expandedFolders: Set<ConfigSection>
   validationErrors: ValidationError[]
@@ -149,6 +150,7 @@ export interface ConfigActions {
   setComparison: (config: SimulationConfigType | null) => void
   toggleComparison: () => void
   clearComparison: () => void
+  setComparisonPath: (path?: string) => void
 
   // Navigation actions
   setSelectedSection: (section: ConfigSection) => void


### PR DESCRIPTION
Implement the comparison panel functionality for the config explorer GUI as specified in Issue #15.

---
<a href="https://cursor.com/background-agent?bcId=bc-03bd672a-ad40-4e8b-917b-63df9d0ab11d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-03bd672a-ad40-4e8b-917b-63df9d0ab11d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a toggleable, read-only comparison panel with JSON load + Zod validation, clear and file path display, synchronized scrolling, and corresponding store/types/tests updates.
> 
> - **UI**:
>   - **Comparison Panel**: New read-only `ComparisonPanel` rendering key fields; integrated into `RightPanel` with toggle, load JSON (validated), clear, error messaging, and file path display; adds synced scrolling via `left-scroll-area` and `comparison-scroll-area`.
>   - **Left Panel**: Exposes `id` `left-scroll-area`; adjusts refs and folder identifiers for scroll sync.
> - **State Management**:
>   - Store (`src/stores/configStore.ts`) and types (`src/types/config.ts`): add `showComparison`, `comparisonFilePath`, and actions `toggleComparison`, `clearComparison`, `setComparisonPath`, `setComparison`; persist/restore these in UI state.
> - **Testing**:
>   - Adds tests for toggling comparison panel and handling invalid comparison file input.
> - **Docs**:
>   - Updates project and phase issue summaries to document comparison panel implementation details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02cbba7f425ce18ed29606aa5340727245f14c9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->