### PR TITLE
Optimize and cache configuration gui

### DIFF
--- a/docs/electron/config_explorer_architecture.md
+++ b/docs/electron/config_explorer_architecture.md
@@ -322,6 +322,14 @@ The IPC service seamlessly integrates with existing Zustand stores:
 - `validationStore`: Receives real-time validation results from server
 - State persistence through electron-store for UI preferences
 
+### Performance & Caching (Issue #25)
+
+- Search caching: flattened config cache per config object and query-level LRU per config reference.
+- Diff caching: WeakMap pair cache for current vs comparison configs to avoid recomputing unchanged diffs.
+- Validation caching: config-level result cache and field-level cache in validation service.
+- UI memoization: `LeftPanel`, `RightPanel`, and `ComparisonPanel` wrapped with React.memo to minimize re-renders.
+- Perf logging: `PERF_LOG=1` enables lightweight timing logs via `src/utils/perf.ts`.
+
 ## Notes on Current Implementation
 
 The current implementation provides a solid foundation for all IPC communication needs, with excellent error handling, performance monitoring, and seamless integration with the existing codebase architecture. The service layer is production-ready and includes comprehensive testing coverage.

--- a/src/components/ConfigExplorer/ComparisonPanel.tsx
+++ b/src/components/ConfigExplorer/ComparisonPanel.tsx
@@ -105,7 +105,7 @@ type ComparisonPanelProps = {
   errorMessage?: string
 }
 
-export const ComparisonPanel: React.FC<ComparisonPanelProps> = ({ compareConfig, comparisonFilePath, errorMessage }) => {
+export const ComparisonPanel: React.FC<ComparisonPanelProps> = React.memo(({ compareConfig, comparisonFilePath, errorMessage }) => {
   const diff = useConfigStore(configSelectors.getComparisonDiff)
   const copyFromComparison = useConfigStore(s => s.copyFromComparison)
   const removeConfigPath = useConfigStore(s => s.removeConfigPath)
@@ -233,5 +233,5 @@ export const ComparisonPanel: React.FC<ComparisonPanelProps> = ({ compareConfig,
       )}
     </div>
   )
-}
+})
 

--- a/src/components/ConfigExplorer/LeftPanel.tsx
+++ b/src/components/ConfigExplorer/LeftPanel.tsx
@@ -55,7 +55,7 @@ const ControlGroup = styled.div`
   border: 1px solid var(--border-subtle);
 `
 
-export const LeftPanel: React.FC = () => {
+export const LeftPanel: React.FC = React.memo(() => {
   const levaStore = useLevaStore()
   const configStore = useConfigStore()
   const { announceToScreenReader } = useAccessibility()
@@ -229,4 +229,4 @@ export const LeftPanel: React.FC = () => {
       </ScrollableArea>
     </LeftPanelContainer>
   )
-}
+})

--- a/src/components/ConfigExplorer/RightPanel.tsx
+++ b/src/components/ConfigExplorer/RightPanel.tsx
@@ -101,7 +101,7 @@ const Stats = styled.div`
   margin-top: 8px;
 `
 
-export const RightPanel: React.FC = () => {
+export const RightPanel: React.FC = React.memo(() => {
   const runSearch = useSearchStore((s) => s.runSearch)
   const isSearching = useSearchStore((s) => s.isSearching)
   const { announceToScreenReader } = useAccessibility()
@@ -170,7 +170,7 @@ export const RightPanel: React.FC = () => {
   return (
     <RightPanelContainer role="complementary" aria-label="Configuration comparison and validation panel">
       <PanelHeader>
-        <PanelTitle>Configuration Tools</PanelTitle>
+        <PanelTitle>Configuration Comparison</PanelTitle>
       </PanelHeader>
 
       <ContentArea id="comparison-content" tabIndex={-1}>
@@ -274,4 +274,4 @@ export const RightPanel: React.FC = () => {
       </ContentArea>
     </RightPanelContainer>
   )
-}
+})

--- a/src/services/validationService.ts
+++ b/src/services/validationService.ts
@@ -14,22 +14,32 @@ export interface ValidationService {
 }
 
 export class ZodValidationService implements ValidationService {
+  private configCache = new WeakMap<SimulationConfigType, ValidationResult>()
+  private fieldCache = new Map<string, ValidationError[]>()
+
   async validateConfig(config: SimulationConfigType): Promise<ValidationResult> {
+    const cached = this.configCache.get(config)
+    if (cached) return cached
     // Use the Zod-based validation utility
     const zodResult = await validateSimulationConfig(config)
 
     // Add any additional business logic validation if needed
     const { errors: additionalErrors, warnings: additionalWarnings } = this.validateBusinessRules(config)
 
-    return {
+    const result: ValidationResult = {
       success: zodResult.success && additionalErrors.length === 0,
       errors: [...zodResult.errors, ...additionalErrors],
       warnings: [...zodResult.warnings, ...additionalWarnings]
     }
+    this.configCache.set(config, result)
+    return result
   }
 
   validateField(path: string, value: any): ValidationResult {
-    const errors = zodValidateField(path, value)
+    const key = `${path}|${tryStringify(value)}`
+    const cached = this.fieldCache.get(key)
+    const errors = cached ?? zodValidateField(path, value)
+    if (!cached) this.fieldCache.set(key, errors)
 
     return {
       success: errors.length === 0,
@@ -105,3 +115,7 @@ export class ZodValidationService implements ValidationService {
 
 // Create singleton instance
 export const validationService = new ZodValidationService()
+
+function tryStringify(v: unknown): string {
+  try { return JSON.stringify(v) } catch { return String(v) }
+}

--- a/src/services/validationService.ts
+++ b/src/services/validationService.ts
@@ -1,4 +1,5 @@
 import { ValidationError, ValidationResult } from '@/types/validation'
+import { safeStringify } from '@/utils/stringify'
 import { SimulationConfigType } from '@/types/config'
 import { validateSimulationConfig, validateField as zodValidateField } from '@/utils/validationUtils'
 
@@ -36,7 +37,7 @@ export class ZodValidationService implements ValidationService {
   }
 
   validateField(path: string, value: any): ValidationResult {
-    const key = `${path}|${tryStringify(value)}`
+    const key = `${path}|${safeStringify(value)}`
     const cached = this.fieldCache.get(key)
     const errors = cached ?? zodValidateField(path, value)
     if (!cached) this.fieldCache.set(key, errors)
@@ -115,7 +116,3 @@ export class ZodValidationService implements ValidationService {
 
 // Create singleton instance
 export const validationService = new ZodValidationService()
-
-function tryStringify(v: unknown): string {
-  try { return JSON.stringify(v) } catch { return String(v) }
-}

--- a/src/utils/perf.ts
+++ b/src/utils/perf.ts
@@ -1,0 +1,21 @@
+export function time<T>(label: string, fn: () => T): T {
+  const shouldLog = typeof process !== 'undefined' && (process.env?.PERF_LOG === '1' || process.env?.PERF_LOG === 'true')
+  if (!shouldLog) return fn()
+  const start = (globalThis.performance && performance.now) ? performance.now() : Date.now()
+  try {
+    return fn()
+  } finally {
+    const end = (globalThis.performance && performance.now) ? performance.now() : Date.now()
+    // eslint-disable-next-line no-console
+    console.log(`[perf] ${label}: ${Math.round((end as number) - (start as number))}ms`)
+  }
+}
+
+export function mark(label: string): void {
+  const shouldLog = typeof process !== 'undefined' && (process.env?.PERF_LOG === '1' || process.env?.PERF_LOG === 'true')
+  if (!shouldLog) return
+  const now = (globalThis.performance && performance.now) ? performance.now() : Date.now()
+  // eslint-disable-next-line no-console
+  console.log(`[perf] ${label}: ${Math.round(now as number)}ms`)
+}
+

--- a/src/utils/stringify.ts
+++ b/src/utils/stringify.ts
@@ -1,0 +1,10 @@
+export function safeStringify(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+


### PR DESCRIPTION
Add caching for flattened configurations and search query results in `searchService` to improve search performance.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c2367b7-0fca-47f2-ad63-f9b8f96ae15c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c2367b7-0fca-47f2-ad63-f9b8f96ae15c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces caching for search, validation, and diff computations, memoizes key panels, tweaks a panel title, and adds lightweight performance logging.
> 
> - **Performance & Caching**:
>   - **Search**: Cache flattened configs (WeakMap) and query results (per-config LRU) in `src/services/searchService.ts`.
>   - **Validation**: Add config-level and field-level caches in `src/services/validationService.ts`.
>   - **Diff**: Cache comparison diffs via WeakMap pairs in `src/stores/configStore.ts`.
>   - **Perf logs**: New `src/utils/perf.ts` with `time`/`mark` gated by `PERF_LOG`.
> - **UI**:
>   - Memoize `ComparisonPanel`, `LeftPanel`, `RightPanel` with `React.memo`.
>   - Rename `RightPanel` header to "Configuration Comparison".
> - **Docs**:
>   - Add "Performance & Caching (Issue #25)" section detailing search, diff, validation caching, UI memoization, and perf logging in `docs/electron/config_explorer_architecture.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d27f842964bc87d93077717802fc19d8a7549b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->