### PR TITLE
Implement dual spatial indexing with KD-tree and Quadtree for enhance…

### DIFF
--- a/docs/core_architecture.md
+++ b/docs/core_architecture.md
@@ -29,7 +29,7 @@ farm.core/
 ├── resources.py           # Resource definitions and types
 ├── senses.py              # Sensory input processing
 ├── simulation.py          # Simulation orchestration
-├── spatial_index.py       # Spatial indexing for performance
+├── spatial_index.py       # Dual spatial indexing (KD-tree + Quadtree) for performance
 ├── state.py               # Environment state management
 └── visualization.py       # Core visualization components
 ```

--- a/docs/perception_system.md
+++ b/docs/perception_system.md
@@ -82,7 +82,12 @@ The system uses **13 default channels** (indices 0-12) that can be extended:
 
 ### Spatial Reasoning & Efficiency
 
-**KD-Tree Spatial Indexing**: Uses scipy.spatial.cKDTree for O(log n) proximity queries with smart change detection to minimize rebuilds.
+**Dual Spatial Indexing**: The system uses both KD-tree and Quadtree indexing strategies for optimal performance across different query patterns:
+
+- **KD-Tree Indexing**: scipy.spatial.cKDTree for O(log n) radial and nearest-neighbor queries
+- **Quadtree Indexing**: Hierarchical partitioning for efficient rectangular range queries and dynamic updates
+
+**Smart Index Selection**: The system automatically chooses the most efficient indexing strategy based on query type and entity movement patterns.
 
 **Key Features**:
 

--- a/farm/core/environment.py
+++ b/farm/core/environment.py
@@ -480,9 +480,9 @@ class Environment(AECEnv):
         # Register Quadtree versions of the default indices
         self.spatial_index.register_index(
             name="agents_quadtree",
-            data_reference=self._agent_objects,
-            position_getter=lambda aid: self._agent_objects[aid].position,
-            filter_func=lambda aid: getattr(self._agent_objects[aid], "alive", True),
+            data_getter=lambda: list(self._agent_objects.values()),
+            position_getter=lambda a: a.position,
+            filter_func=lambda a: getattr(a, "alive", True),
             index_type="quadtree",
         )
 

--- a/scripts/quadtree_demo.py
+++ b/scripts/quadtree_demo.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+Quadtree Spatial Indexing Demo
+
+This script demonstrates the Quadtree spatial indexing functionality
+added to AgentFarm. It shows how Quadtrees provide efficient range
+queries and dynamic updates compared to KD-trees.
+
+Usage:
+    python scripts/quadtree_demo.py
+"""
+
+import time
+import numpy as np
+from farm.core.spatial_index import SpatialIndex
+
+
+class MockAgent:
+    """Simple mock agent for demonstration."""
+    def __init__(self, agent_id, position):
+        self.agent_id = agent_id
+        self.position = position
+        self.alive = True
+
+
+def demo_basic_quadtree():
+    """Demonstrate basic Quadtree operations."""
+    print("Basic Quadtree Operations Demo")
+    print("=" * 50)
+
+    # Create spatial index
+    spatial_index = SpatialIndex(width=100, height=100)
+
+    # Create some test agents
+    agents = []
+    for i in range(20):
+        position = (np.random.uniform(0, 100), np.random.uniform(0, 100))
+        agent = MockAgent(f"agent_{i}", position)
+        agents.append(agent)
+
+    # Register Quadtree index
+    spatial_index.register_index(
+        name="demo_quadtree",
+        data_reference=agents,
+        position_getter=lambda a: a.position,
+        index_type="quadtree"
+    )
+
+    # Build the index
+    spatial_index.update()
+
+    print(f"Created Quadtree with {len(agents)} agents")
+
+    # Test range query
+    query_bounds = (25, 25, 50, 50)  # 50x50 rectangle centered at (50,50)
+    results = spatial_index.get_nearby_range(query_bounds, ["demo_quadtree"])
+    entities_in_range = results["demo_quadtree"]
+
+    print(f"Range query {query_bounds}: found {len(entities_in_range)} agents")
+
+    # Show Quadtree stats
+    stats = spatial_index.get_quadtree_stats("demo_quadtree")
+    print(f"Quadtree stats: {stats}")
+
+    print()
+
+
+def demo_performance_comparison():
+    """Compare KD-tree vs Quadtree performance."""
+    print("Performance Comparison: KD-tree vs Quadtree")
+    print("=" * 50)
+
+    # Create test data
+    num_agents = 1000
+    agents = []
+    for i in range(num_agents):
+        position = (np.random.uniform(0, 100), np.random.uniform(0, 100))
+        agent = MockAgent(f"perf_agent_{i}", position)
+        agents.append(agent)
+
+    # Create spatial index
+    spatial_index = SpatialIndex(width=100, height=100)
+
+    # Register both index types
+    spatial_index.register_index(
+        name="perf_kdtree",
+        data_reference=agents,
+        position_getter=lambda a: a.position,
+        index_type="kdtree"
+    )
+
+    spatial_index.register_index(
+        name="perf_quadtree",
+        data_reference=agents,
+        position_getter=lambda a: a.position,
+        index_type="quadtree"
+    )
+
+    spatial_index.update()
+
+    # Test radial queries (KD-tree advantage)
+    print("Testing radial queries (KD-tree optimized)...")
+    radial_positions = [(np.random.uniform(0, 100), np.random.uniform(0, 100)) for _ in range(50)]
+
+    # KD-tree radial queries
+    start_time = time.time()
+    for pos in radial_positions:
+        spatial_index.get_nearby(pos, 10, ["perf_kdtree"])
+    kdtree_radial_time = time.time() - start_time
+
+    # Quadtree radial queries
+    start_time = time.time()
+    for pos in radial_positions:
+        spatial_index.get_nearby(pos, 10, ["perf_quadtree"])
+    quadtree_radial_time = time.time() - start_time
+
+    print(".3f")
+    print(".3f")
+
+    # Test rectangular queries (Quadtree advantage)
+    print("\nTesting rectangular range queries (Quadtree optimized)...")
+    rect_queries = [(np.random.uniform(0, 80), np.random.uniform(0, 80), 20, 20) for _ in range(50)]
+
+    # KD-tree rectangular queries
+    start_time = time.time()
+    for bounds in rect_queries:
+        spatial_index.get_nearby_range(bounds, ["perf_kdtree"])
+    kdtree_rect_time = time.time() - start_time
+
+    # Quadtree rectangular queries
+    start_time = time.time()
+    for bounds in rect_queries:
+        spatial_index.get_nearby_range(bounds, ["perf_quadtree"])
+    quadtree_rect_time = time.time() - start_time
+
+    print(".3f")
+    print(".3f")
+
+    # Calculate speedups
+    if quadtree_rect_time < kdtree_rect_time:
+        rect_speedup = kdtree_rect_time / quadtree_rect_time
+        print(".1f")
+
+    print()
+
+
+def demo_dynamic_updates():
+    """Demonstrate dynamic position updates."""
+    print("Dynamic Position Updates Demo")
+    print("=" * 50)
+
+    # Create spatial index with Quadtree
+    spatial_index = SpatialIndex(width=100, height=100)
+
+    # Create a moving agent
+    agent = MockAgent("moving_agent", (50, 50))
+    spatial_index.register_index(
+        name="moving_quadtree",
+        data_reference=[agent],
+        position_getter=lambda a: a.position,
+        index_type="quadtree"
+    )
+    spatial_index.update()
+
+    print("Agent starting at position (50, 50)")
+
+    # Simulate movement
+    for i in range(5):
+        old_pos = agent.position
+        new_pos = (old_pos[0] + np.random.uniform(-5, 5),
+                  old_pos[1] + np.random.uniform(-5, 5))
+        new_pos = (max(0, min(100, new_pos[0])), max(0, min(100, new_pos[1])))
+
+        # Update position efficiently
+        agent.position = new_pos
+        spatial_index.update_entity_position(agent, old_pos, new_pos)
+
+        # Verify agent is still findable at new position
+        nearby = spatial_index.get_nearby(new_pos, 1, ["moving_quadtree"])
+        found = len(nearby["moving_quadtree"]) > 0
+
+        print(f"Move {i+1}: {old_pos} -> {new_pos} | Found: {found}")
+
+    print()
+
+
+def demo_quadtree_statistics():
+    """Demonstrate Quadtree statistics and structure."""
+    print("Statistics and Structure Demo")
+    print("=" * 50)
+
+    # Create spatial index with many agents
+    spatial_index = SpatialIndex(width=100, height=100)
+
+    # Create agents in a grid pattern to show subdivision
+    agents = []
+    for x in range(0, 100, 10):
+        for y in range(0, 100, 10):
+            agent = MockAgent(f"grid_agent_{x}_{y}", (x, y))
+            agents.append(agent)
+
+    spatial_index.register_index(
+        name="stats_quadtree",
+        data_reference=agents,
+        position_getter=lambda a: a.position,
+        index_type="quadtree"
+    )
+    spatial_index.update()
+
+    # Get detailed statistics
+    stats = spatial_index.get_quadtree_stats("stats_quadtree")
+    print(f"Quadtree Statistics:")
+    print(f"  Total entities: {stats['total_entities']}")
+    print(f"  Local entities (root): {stats['local_entities']}")
+    print(f"  Is divided: {stats['is_divided']}")
+    print(f"  Children count: {stats['children_count']}")
+    print(f"  Bounds: {stats['bounds']}")
+
+    print()
+
+
+def main():
+    """Run all demonstrations."""
+    print("AgentFarm Quadtree Spatial Indexing Demo")
+    print("=" * 60)
+    print()
+
+    try:
+        demo_basic_quadtree()
+        demo_performance_comparison()
+        demo_dynamic_updates()
+        demo_quadtree_statistics()
+
+        print("All demonstrations completed successfully!")
+        print("\nKey Takeaways:")
+        print("- Quadtrees excel at rectangular range queries")
+        print("- KD-trees excel at radial and nearest-neighbor queries")
+        print("- Quadtrees provide hierarchical spatial subdivision")
+        print("- Both indexing strategies work together for optimal performance")
+
+    except Exception as e:
+        print(f"Demo failed with error: {e}")
+        import traceback
+        traceback.print_exc()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/quadtree_demo.py
+++ b/scripts/quadtree_demo.py
@@ -114,8 +114,8 @@ def demo_performance_comparison():
         spatial_index.get_nearby(pos, 10, ["perf_quadtree"])
     quadtree_radial_time = time.time() - start_time
 
-    print(".3f")
-    print(".3f")
+    print(f"KD-tree radial queries: {kdtree_radial_time:.3f} seconds")
+    print(f"Quadtree radial queries: {quadtree_radial_time:.3f} seconds")
 
     # Test rectangular queries (Quadtree advantage)
     print("\nTesting rectangular range queries (Quadtree optimized)...")
@@ -133,13 +133,13 @@ def demo_performance_comparison():
         spatial_index.get_nearby_range(bounds, ["perf_quadtree"])
     quadtree_rect_time = time.time() - start_time
 
-    print(".3f")
-    print(".3f")
+    print(f"KD-tree rectangular query time: {kdtree_rect_time:.3f} s")
+    print(f"Quadtree rectangular query time: {quadtree_rect_time:.3f} s")
 
     # Calculate speedups
     if quadtree_rect_time < kdtree_rect_time:
         rect_speedup = kdtree_rect_time / quadtree_rect_time
-        print(".1f")
+        print(f"Rectangular query speedup (KD-tree / Quadtree): {rect_speedup:.1f}x")
 
     print()
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -357,6 +357,31 @@ class TestEnvironment(unittest.TestCase):
         if nearest_resource:
             self.assertIsInstance(nearest_resource.position, tuple)
 
+    def test_quadtree_indices(self):
+        """Test Quadtree index functionality"""
+        # Enable Quadtree indices
+        self.env.enable_quadtree_indices()
+
+        # Check that Quadtree indices were registered
+        stats = self.env.spatial_index.get_stats()
+        self.assertIn("quadtree_indices", stats)
+        self.assertGreater(len(stats["quadtree_indices"]), 0)
+
+        # Test Quadtree-specific queries
+        if self.env.agent_objects:
+            agent = self.env.agent_objects[0]
+            position = agent.position
+
+            # Test range queries (Quadtree optimized)
+            bounds = (position[0]-5, position[1]-5, 10, 10)
+            nearby_in_range = self.env.spatial_index.get_nearby_range(bounds, ["agents_quadtree"])
+            self.assertIsInstance(nearby_in_range, dict)
+
+            # Test Quadtree stats
+            quadtree_stats = self.env.spatial_index.get_quadtree_stats("agents_quadtree")
+            self.assertIsNotNone(quadtree_stats)
+            self.assertIn("total_entities", quadtree_stats)
+
     def test_position_validation(self):
         """Test position validation logic"""
         # Valid positions


### PR DESCRIPTION
…d performance in proximity queries. Update documentation to reflect new indexing strategies and add Quadtree support for dynamic updates. Introduce tests for Quadtree functionality and performance comparisons against KD-tree.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce Quadtree alongside KD-tree for dual spatial indexing, adding range-query and dynamic-update APIs, env enablement, docs, demo, and tests.
> 
> - **Core (spatial indexing)**:
>   - Add `QuadtreeNode` and `Quadtree` implementations in `farm/core/spatial_index.py`.
>   - Extend `SpatialIndex` with dual indices (`index_type: "kdtree"|"quadtree"`), supporting:
>     - `get_nearby` and `get_nearest` across index types
>     - `get_nearby_range(bounds, index_names)` for rectangular queries
>     - `update_entity_position(entity, old_position, new_position)` for efficient Quadtree updates
>     - `get_quadtree_stats(name)` and expanded `get_stats()` output
> - **Environment**:
>   - Add `enable_quadtree_indices()` to register `agents_quadtree` and `resources_quadtree`.
>   - Initialize Quadtree toggle plumbing.
> - **Docs**:
>   - Update `docs/*` to document dual KD-tree/Quadtree strategy, smart selection, performance, and usage examples.
> - **Scripts**:
>   - Add `scripts/quadtree_demo.py` showcasing basic use, performance comparison, dynamic updates, and stats.
> - **Tests**:
>   - Add Quadtree unit tests in `tests/test_spatial_index.py` and `tests/test_environment.py` (basic ops, range queries, dynamic updates, performance comparisons).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a61d4e762545a5ccc75b1631c84bfb23c187cce5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->