### PR TITLE
Review api module from multiple engineering viewpoints

### DIFF
--- a/farm/api/unified_adapter.py
+++ b/farm/api/unified_adapter.py
@@ -22,8 +22,10 @@ from farm.api.models import (
     EventSubscription,
     ExperimentResults,
     ExperimentStatus,
+    ExperimentStatusInfo,
     SimulationResults,
     SimulationStatus,
+    SimulationStatusInfo,
 )
 from farm.api.simulation_controller import SimulationController
 from farm.core.analysis import SimulationAnalyzer
@@ -224,7 +226,7 @@ class UnifiedAdapter:
 
         return self.get_simulation_status(simulation_id)
 
-    def get_simulation_status(self, simulation_id: str) -> SimulationStatus:
+    def get_simulation_status(self, simulation_id: str) -> SimulationStatusInfo:
         """Get simulation status.
 
         Args:
@@ -249,7 +251,7 @@ class UnifiedAdapter:
             else 0
         )
 
-        return SimulationStatus(
+        return SimulationStatusInfo(
             simulation_id=simulation_id,
             status=sim_info["status"],
             current_step=sim_info["current_step"],
@@ -436,7 +438,7 @@ class UnifiedAdapter:
 
         return self.get_experiment_status(experiment_id)
 
-    def get_experiment_status(self, experiment_id: str) -> ExperimentStatus:
+    def get_experiment_status(self, experiment_id: str) -> ExperimentStatusInfo:
         """Get experiment status.
 
         Args:
@@ -461,7 +463,7 @@ class UnifiedAdapter:
             else 0
         )
 
-        return ExperimentStatus(
+        return ExperimentStatusInfo(
             experiment_id=experiment_id,
             status=exp_info["status"],
             current_iteration=state["current_iteration"],


### PR DESCRIPTION
Update `UnifiedAdapter` to return `SimulationStatusInfo` and `ExperimentStatusInfo` dataclasses to fix a critical runtime error.

The previous implementation incorrectly instantiated `SimulationStatus` and `ExperimentStatus` (which are Enums) as if they were dataclasses, leading to runtime errors. This change corrects the return types and instantiation to use the dedicated `SimulationStatusInfo` and `ExperimentStatusInfo` dataclasses.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3803781-cd3a-4d7f-93c2-dbd09c2986bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3803781-cd3a-4d7f-93c2-dbd09c2986bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

