### PR TITLE
Add timeout protection to GitHub Actions workflows

### DIFF
--- a/.github/workflows/deterministic-simulation.yml
+++ b/.github/workflows/deterministic-simulation.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   deterministic-test:
     runs-on: ubuntu-latest
-    
+    timeout-minutes: 30
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   python:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -34,6 +35,7 @@ jobs:
 
   js-ui:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: farm/editor


### PR DESCRIPTION
## Summary
- Added `timeout-minutes` to all workflow jobs to prevent runaway processes
- Deterministic simulation tests: 30 minutes timeout
- Python pytest with coverage: 20 minutes timeout
- JavaScript Jest tests: 10 minutes timeout

## Test plan
- Workflows will continue to run as before
- Added protection against hanging processes
- Timeouts are appropriate for each job type

Generated with [Claude Code](https://claude.com/claude-code)