### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,3 +56,24 @@ Run these from the repository root unless noted.
 | `benchmarks/` | Performance benchmarks |
 
 When changing behavior, locate the closest existing patterns in `farm/` and mirror their structure, typing, and logging (`structlog` via `farm.utils` logging helpers where applicable).
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | How to run | Notes |
+|---------|-----------|-------|
+| Simulation (CLI) | `source venv/bin/activate && python run_simulation.py --environment development --steps N` | Produces a `.db` file in `simulations/` |
+| API server | `source venv/bin/activate && uvicorn farm.api.server:app --host 0.0.0.0 --port 5000` | Do **not** use `python -m farm.api.server` — the `reload=True` flag in `__main__` requires import-string mode and may crash. Use the `uvicorn` command directly. |
+| Pytest | `source venv/bin/activate && pytest` | See `AGENTS.md > Commands` table for variants. 2 pre-existing failures in `tests/analysis/test_dominance.py` (pandas `LossySetitemError`). |
+| Jest (editor) | `cd farm/editor && npm test -- --runInBand` | Requires Node 20 (`nvm use 20`). |
+| Lint | `source venv/bin/activate && ruff check .` | 136 pre-existing warnings; these are in the repo, not regressions. |
+
+### Gotchas
+
+- **API server startup**: Always use `uvicorn farm.api.server:app` instead of `python -m farm.api.server`. The latter's `reload=True` flag causes `WARNING: You must pass the application as an import string to enable 'reload' or 'workers'` and silently exits.
+- **Node version**: The editor tests require Node 20. Run `source /home/ubuntu/.nvm/nvm.sh && nvm use 20` before `npm test`.
+- **`python3.12-venv` and `python3-tk`**: Must be installed via `apt` — they are not in `requirements.txt`. The update script handles this.
+- **Ruff/Pylint not in `requirements.txt`**: `ruff` and `pylint` must be `pip install`-ed separately; the update script handles this.
+- **Simulation determinism**: `run_simulation.py` automatically restarts itself with `PYTHONHASHSEED=0` if not set. This is normal behavior, not an error.
+- **Pytest logging noise**: Some tests trigger `structlog` memory-monitor warnings on stderr (`CRITICAL: Memory usage at …`). This is cosmetic and does not indicate test failure — check the actual pass/fail summary line.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious development caveats discovered during environment setup.

### Changes

- **Services overview table**: Documents how to run the simulation CLI, API server, pytest, Jest editor tests, and linting
- **API server gotcha**: Use `uvicorn farm.api.server:app` directly instead of `python -m farm.api.server` (the `reload=True` flag in `__main__` causes silent exit)
- **Node version requirement**: Editor tests require Node 20 via nvm
- **Pre-existing issues**: Documents 2 pre-existing test failures in `tests/analysis/test_dominance.py` and 136 pre-existing ruff lint warnings
- **Other caveats**: Simulation determinism auto-restart behavior, pytest logging noise from structlog memory monitor

### Verification

All services verified working:

| Service | Status | Command |
|---------|--------|---------|
| Simulation (CLI) | ✅ 100 steps completed, 88 agents | `python run_simulation.py --environment development --steps 100` |
| API Server | ✅ Accepted and completed simulation | `uvicorn farm.api.server:app --host 0.0.0.0 --port 5000` |
| Pytest | ✅ All pass (2 pre-existing failures) | `pytest` |
| Jest (editor) | ✅ 16/16 passed | `cd farm/editor && npm test -- --runInBand` |
| Ruff lint | ✅ Runs (136 pre-existing warnings) | `ruff check .` |

Evidence log:
[environment_setup.log](https://cursor.com/agents/bc-220f4467-ac26-4111-abc8-b8156711be49/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenvironment_setup.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-220f4467-ac26-4111-abc8-b8156711be49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-220f4467-ac26-4111-abc8-b8156711be49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

