### PR TITLE
Add unified publication-style ablation runner with tests and refactor

### DIFF
--- a/docs/howto/neural_recombination_runbook.md
+++ b/docs/howto/neural_recombination_runbook.md
@@ -849,9 +849,12 @@ more than ~5 pp below the ID score.  If this happens, consider:
 For reproducible paper tables and CI-style regression of the full pipeline,
 use the unified ablation runner.  A single invocation sweeps multiple
 **conditions** (e.g. distill-only, distill+quantize, or the full pipeline)
-across a list of **seeds**, shares the same state buffer across all runs, and
-writes every result into a structured `results/` tree together with a
-consolidated CSV and Markdown summary table.
+across a list of **seeds** and writes every result into a structured
+`results/` tree together with a consolidated CSV and Markdown summary
+table.  If you provide a shared `states_file`, that same state buffer is
+reused across seeds and conditions.  If `states_file` is omitted, the
+runner generates synthetic states per seed, so cross-seed results are not
+directly comparable unless you supply a common state buffer.
 
 ### Quick start (no config file needed)
 
@@ -874,7 +877,7 @@ The config file is YAML (recommended) or JSON.  A minimal example:
 ```yaml
 seeds: [0, 1, 2]
 n_states: 2000
-states_file: ""           # leave empty to synthesise from seed
+states_file: ""           # leave empty to synthesise per-seed (supply a .npy path for comparable cross-seed results)
 input_dim: 8
 output_dim: 4
 hidden_size: 64
@@ -949,8 +952,8 @@ conditions:
 | `compare` | `RecombinationEvaluator` (child vs students); writes `compare_child_vs_students.json` |
 
 Stages are always applied in the order listed above regardless of declaration
-order in the config.  A `quantize` stage without a preceding `distill` stage
-will log a warning and skip.
+order in the config.  A `quantize` or `crossover` stage without a preceding
+`distill` stage will be rejected at config-parse time with a clear error.
 
 ### Dry-run mode
 

--- a/docs/howto/neural_recombination_runbook.md
+++ b/docs/howto/neural_recombination_runbook.md
@@ -921,8 +921,8 @@ results/ablation/
     seed_0/student_A.pt  student_B.pt  student_A_int8.pt  student_B_int8.pt
     ...
   full_pipeline/
-    seed_0/student_A.pt  student_B.pt  child_finetuned.pt
-             compare_child_vs_students.json
+    seed_0/student_A.pt  student_B.pt  student_A_int8.pt  student_B_int8.pt
+             child_finetuned.pt  compare_child_vs_students.json
     ...
   ablation_summary.csv          ← consolidated table (paste into spreadsheet)
   ablation_summary.md           ← Markdown version (paste into GitHub issues)
@@ -948,12 +948,12 @@ conditions:
 |-------|-------------|
 | `distill` | `DistillationTrainer` for both A and B pairs; writes `student_A.pt`, `student_B.pt` |
 | `quantize` | `PostTrainingQuantizer` on both students; writes `student_A_int8.pt`, `student_B_int8.pt` |
-| `crossover` | `crossover_quantized_state_dict` + `FineTuner`; writes `child_finetuned.pt` |
-| `compare` | `RecombinationEvaluator` (child vs students); writes `compare_child_vs_students.json` |
+| `crossover` | When `quantize` is included, int8 parents are loaded and **dequantized** to float weights, then `crossover_quantized_state_dict` blends them into a float child; otherwise float `student_*.pt` parents are blended. `FineTuner` always uses float student A as KD teacher. Writes `child_finetuned.pt`. |
+| `compare` | `RecombinationEvaluator` (float child vs float or int8 parents matching the pipeline); writes `compare_child_vs_students.json` |
 
 Stages are always applied in the order listed above regardless of declaration
-order in the config.  A `quantize` or `crossover` stage without a preceding
-`distill` stage will be rejected at config-parse time with a clear error.
+order in the config.  Parse-time rules: `quantize` and `crossover` require
+`distill`; **`compare` requires `crossover`** (there must be a child to score).
 
 ### Dry-run mode
 
@@ -982,8 +982,8 @@ The Markdown summary table (`ablation_summary.md`) contains one row per
 
 | Column | Meaning |
 |--------|---------|
-| `child_vs_ref_a_agreement` | Top-1 action agreement of child vs student A |
-| `child_vs_ref_b_agreement` | Top-1 action agreement of child vs student B |
+| `child_vs_ref_a_agreement` | Top-1 action agreement of child vs parent A (float student, or int8 checkpoint when the condition includes `quantize`) |
+| `child_vs_ref_b_agreement` | Top-1 action agreement of child vs parent B (same rule) |
 | `oracle_agreement` | Fraction where child matches *at least one* reference |
 | `elapsed_s` | Wall-clock seconds for the (condition, seed) run |
 

--- a/docs/howto/neural_recombination_runbook.md
+++ b/docs/howto/neural_recombination_runbook.md
@@ -18,6 +18,7 @@
 10. [Tuning Guide](#10-tuning-guide)
 11. [Copy-Paste Recipes](#11-copy-paste-recipes)
 12. [Generalization: Holdout & Domain-Shift Evaluation](#12-generalization-holdout--domain-shift-evaluation)
+13. [Publication Ablations](#13-publication-ablations)
 
 ---
 
@@ -836,6 +837,153 @@ more than ~5 pp below the ID score.  If this happens, consider:
 - Training on a larger or more diverse replay buffer.
 - Increasing the holdout fraction to detect over-fitting earlier in development.
 - Tuning the crossover alpha or fine-tuning LR to reduce ID–holdout gap.
+
+---
+
+## 13. Publication Ablations
+
+**Script:** `scripts/run_recombination_ablation.py`
+
+For reproducible paper tables and CI-style regression of the full pipeline,
+use the unified ablation runner.  A single invocation sweeps multiple
+**conditions** (e.g. distill-only, distill+quantize, or the full pipeline)
+across a list of **seeds**, shares the same state buffer across all runs, and
+writes every result into a structured `results/` tree together with a
+consolidated CSV and Markdown summary table.
+
+### Quick start (no config file needed)
+
+```bash
+# Dry-run: validate plan, write stub summary, no training
+python scripts/run_recombination_ablation.py --smoke-test --dry-run
+
+# Smoke-test: tiny synthetic run (2 seeds × 3 conditions, 50 states, 2 epochs)
+python scripts/run_recombination_ablation.py --smoke-test --results-dir /tmp/ablation_smoke
+```
+
+### Full run from a config file
+
+```bash
+python scripts/run_recombination_ablation.py --config ablation.yaml
+```
+
+The config file is YAML (recommended) or JSON.  A minimal example:
+
+```yaml
+seeds: [0, 1, 2]
+n_states: 2000
+states_file: ""           # leave empty to synthesise from seed
+input_dim: 8
+output_dim: 4
+hidden_size: 64
+results_dir: results/ablation
+
+conditions:
+  - name: distill_only
+    stages: [distill]
+  - name: distill_quantize
+    stages: [distill, quantize]
+  - name: full_pipeline
+    stages: [distill, quantize, crossover, compare]
+
+distillation:
+  epochs: 20
+  temperature: 3.0
+  alpha: 1.0
+  lr: 0.001
+  batch_size: 32
+
+quantization:
+  mode: dynamic
+
+crossover:
+  mode: weighted
+  alpha: 0.5
+
+comparison:
+  report_only: true
+```
+
+### Output layout
+
+```
+results/ablation/
+  distill_only/
+    seed_0/student_A.pt  student_B.pt
+    seed_1/...
+    seed_2/...
+  distill_quantize/
+    seed_0/student_A.pt  student_B.pt  student_A_int8.pt  student_B_int8.pt
+    ...
+  full_pipeline/
+    seed_0/student_A.pt  student_B.pt  child_finetuned.pt
+             compare_child_vs_students.json
+    ...
+  ablation_summary.csv          ← consolidated table (paste into spreadsheet)
+  ablation_summary.md           ← Markdown version (paste into GitHub issues)
+```
+
+### Per-condition stage overrides
+
+Each condition can override any global distillation / quantization /
+crossover / comparison setting:
+
+```yaml
+conditions:
+  - name: high_temp_distill
+    stages: [distill, crossover, compare]
+    distillation:
+      temperature: 6.0   # overrides global temperature: 3.0
+      epochs: 30
+```
+
+### Valid stages
+
+| Stage | What it runs |
+|-------|-------------|
+| `distill` | `DistillationTrainer` for both A and B pairs; writes `student_A.pt`, `student_B.pt` |
+| `quantize` | `PostTrainingQuantizer` on both students; writes `student_A_int8.pt`, `student_B_int8.pt` |
+| `crossover` | `crossover_quantized_state_dict` + `FineTuner`; writes `child_finetuned.pt` |
+| `compare` | `RecombinationEvaluator` (child vs students); writes `compare_child_vs_students.json` |
+
+Stages are always applied in the order listed above regardless of declaration
+order in the config.  A `quantize` stage without a preceding `distill` stage
+will log a warning and skip.
+
+### Dry-run mode
+
+```bash
+python scripts/run_recombination_ablation.py --config ablation.yaml --dry-run
+```
+
+Prints the full execution plan (conditions × seeds × stages × directories)
+and writes a stub `ablation_summary.md` / `ablation_summary.csv` without
+running any training.  Use this to verify the config before a long run.
+
+### Using a shared real replay buffer
+
+Set `states_file` in the config to a `.npy` file of shape `(N, input_dim)`
+float32.  All seeds and conditions will use **the same** state file, ensuring
+metrics are comparable across the ablation.
+
+```yaml
+states_file: data/replay_states.npy
+```
+
+### Reading the summary table
+
+The Markdown summary table (`ablation_summary.md`) contains one row per
+(condition, seed) pair.  Key columns:
+
+| Column | Meaning |
+|--------|---------|
+| `child_vs_ref_a_agreement` | Top-1 action agreement of child vs student A |
+| `child_vs_ref_b_agreement` | Top-1 action agreement of child vs student B |
+| `oracle_agreement` | Fraction where child matches *at least one* reference |
+| `elapsed_s` | Wall-clock seconds for the (condition, seed) run |
+
+`child_vs_ref_*_agreement` columns are populated only when the `compare`
+stage is included.  Conditions without a `compare` stage show `n/a`.
 
 ---
 

--- a/scripts/run_recombination_ablation.py
+++ b/scripts/run_recombination_ablation.py
@@ -56,6 +56,11 @@ Valid stages
 ------------
 ``distill``, ``quantize``, ``crossover``, ``compare``
 
+``compare`` must include ``crossover`` (it evaluates a crossover child).  When
+``quantize`` is present, crossover blends **dequantized** weights extracted from
+the int8 checkpoints; ``compare`` loads the same int8 modules as parent
+references when reporting agreement against the float fine-tuned child.
+
 Each stage writes its outputs into a per-seed sub-directory under
 ``<results_dir>/<condition_name>/seed_<seed>/``.
 
@@ -243,6 +248,11 @@ def _parse_config(raw: Dict[str, Any], results_dir_override: str = "") -> _Ablat
                 f"Condition '{name}' includes 'crossover' but is missing required "
                 "'distill' stage."
             )
+        if "compare" in stages and "crossover" not in stages:
+            raise ValueError(
+                f"Condition '{name}' includes 'compare' but is missing required "
+                "'crossover' stage (compare evaluates a crossover child)."
+            )
         conditions.append(
             _ConditionConfig(
                 name=name,
@@ -396,20 +406,34 @@ def _run_crossover_stage(
     cond: _ConditionConfig,
     seed: int,
     student_ckpts: Dict[str, str],
+    int8_ckpts: Dict[str, str],
     states: np.ndarray,
     work_dir: str,
 ) -> str:
-    """Run crossover + fine-tuning and return the child checkpoint path."""
+    """Run crossover + fine-tuning and return the child checkpoint path.
+
+    When ``quantize`` is in the condition's stages and both int8 checkpoints
+    exist, parents are loaded as dynamic PTQ modules and converted to float
+    parameter dicts (same helper as ``crossover`` training code) before
+    :func:`crossover_quantized_state_dict` blends them.  Otherwise float
+    ``student_*.pt`` checkpoints from distillation are blended.
+
+    Fine-tuning still uses the float distilled student A as the soft-label
+    teacher so KD targets stay in full precision.
+    """
     import torch
     from farm.core.decision.base_dqn import StudentQNetwork
-    from farm.core.decision.training.crossover import crossover_quantized_state_dict
+    from farm.core.decision.training.crossover import (
+        _float_state_dict_from_dynamic_quantized_module,
+        crossover_quantized_state_dict,
+    )
     from farm.core.decision.training.finetune import FineTuner, FineTuningConfig
+    from farm.core.decision.training.quantize_ptq import load_quantized_checkpoint
 
     xcfg_raw = _merged(cfg.crossover, cond.crossover)
     dcfg_raw = _merged(cfg.distillation, cond.distillation)
 
-    # Load students as parents (produced by the distill stage).
-    def _load_student(path: str) -> StudentQNetwork:
+    def _load_float_student(path: str) -> StudentQNetwork:
         net = StudentQNetwork(
             input_dim=cfg.input_dim,
             output_dim=cfg.output_dim,
@@ -426,8 +450,29 @@ def _run_crossover_stage(
     if not parent_a_path or not parent_b_path:
         raise RuntimeError("crossover stage requires 'distill' stage to run first.")
 
-    parent_a = _load_student(parent_a_path)
-    parent_b = _load_student(parent_b_path)
+    parent_a_float = _load_float_student(parent_a_path)
+
+    use_quantized_parents = (
+        "quantize" in cond.stages
+        and bool(int8_ckpts.get("A"))
+        and bool(int8_ckpts.get("B"))
+    )
+    if "quantize" in cond.stages and "crossover" in cond.stages and not use_quantized_parents:
+        raise RuntimeError(
+            f"Condition {cond.name!r}: crossover after quantize requires both "
+            "student_A_int8.pt and student_B_int8.pt; quantize stage did not produce them."
+        )
+
+    if use_quantized_parents:
+        parent_a_q, _ = load_quantized_checkpoint(int8_ckpts["A"])
+        parent_b_q, _ = load_quantized_checkpoint(int8_ckpts["B"])
+        # Dynamic PTQ modules use packed params; extract float weights for crossover.
+        sd_a = _float_state_dict_from_dynamic_quantized_module(parent_a_q)
+        sd_b = _float_state_dict_from_dynamic_quantized_module(parent_b_q)
+    else:
+        parent_b_float = _load_float_student(parent_b_path)
+        sd_a = parent_a_float.state_dict()
+        sd_b = parent_b_float.state_dict()
 
     # Crossover
     crossover_mode = str(xcfg_raw.get("mode", "weighted"))
@@ -435,8 +480,8 @@ def _run_crossover_stage(
     crossover_seed = int(xcfg_raw.get("seed", seed))
 
     child_state = crossover_quantized_state_dict(
-        parent_a.state_dict(),
-        parent_b.state_dict(),
+        sd_a,
+        sd_b,
         mode=crossover_mode,
         alpha=crossover_alpha,
         seed=crossover_seed,
@@ -460,8 +505,8 @@ def _run_crossover_stage(
         alpha=float(dcfg_raw.get("alpha", 1.0)),
         seed=seed,
     )
-    # FineTuner(reference, child, config) — parent_a acts as soft-label teacher.
-    tuner = FineTuner(parent_a, child, ft_config)
+    # FineTuner(reference, child, config) — float parent A as soft-label teacher.
+    tuner = FineTuner(parent_a_float, child, ft_config)
     child_path = os.path.join(work_dir, "child_finetuned.pt")
     tuner.finetune(states, checkpoint_path=child_path)
     print(f"    [crossover] child -> {child_path}")
@@ -471,20 +516,33 @@ def _run_crossover_stage(
 def _run_compare_stage(
     cfg: _AblationConfig,
     cond: _ConditionConfig,
-    seed: int,
     student_ckpts: Dict[str, str],
     int8_ckpts: Dict[str, str],
     child_path: str,
     states: np.ndarray,
     work_dir: str,
 ) -> Dict[str, Any]:
-    """Run comparison matrix and return a summary dict."""
+    """Run comparison matrix and return a summary dict.
+
+    Parents are loaded from int8 checkpoints when ``quantize`` ran and both
+    ``student_*_int8.pt`` paths exist; otherwise float ``student_*.pt`` parents
+    are used.  The child is always the fine-tuned float checkpoint from
+    crossover.
+    """
     import torch
     from farm.core.decision.base_dqn import StudentQNetwork
+    from farm.core.decision.training.quantize_ptq import load_quantized_checkpoint
     from farm.core.decision.training.recombination_eval import (
         RecombinationEvaluator,
         RecombinationThresholds,
     )
+
+    if not child_path:
+        raise RuntimeError(
+            "compare stage requires a crossover child checkpoint (run crossover first)."
+        )
+    if not student_ckpts.get("A") or not student_ckpts.get("B"):
+        raise RuntimeError("compare requires distilled student_A.pt and student_B.pt.")
 
     cmpcfg_raw = _merged(cfg.comparison, cond.comparison)
     report_only = bool(cmpcfg_raw.get("report_only", True))
@@ -508,29 +566,53 @@ def _run_compare_stage(
         net.eval()
         return net
 
-    summary: Dict[str, Any] = {}
+    use_quantized_refs = (
+        "quantize" in cond.stages
+        and bool(int8_ckpts.get("A"))
+        and bool(int8_ckpts.get("B"))
+    )
+    if "quantize" in cond.stages and not use_quantized_refs:
+        raise RuntimeError(
+            f"Condition {cond.name!r}: compare after quantize requires int8 checkpoints "
+            "for both students."
+        )
 
-    # Child vs students comparison (child is fine-tuned StudentQNetwork)
-    if child_path and student_ckpts.get("A") and student_ckpts.get("B"):
-        child_net = _load_student_net(child_path)
+    child_net = _load_student_net(child_path)
+    if use_quantized_refs:
+        ref_a, _ = load_quantized_checkpoint(int8_ckpts["A"])
+        ref_b, _ = load_quantized_checkpoint(int8_ckpts["B"])
+        model_paths = {
+            "parent_a": int8_ckpts["A"],
+            "parent_b": int8_ckpts["B"],
+            "child": child_path,
+        }
+        model_formats = {
+            "parent_a": "quantized_full_model",
+            "parent_b": "quantized_full_model",
+            "child": "float_state_dict",
+        }
+    else:
         ref_a = _load_student_net(student_ckpts["A"])
         ref_b = _load_student_net(student_ckpts["B"])
-        evaluator = RecombinationEvaluator(ref_a, ref_b, child_net, thresholds)
-        report = evaluator.evaluate(states)
-        report_dict = report.to_dict()
-        report_path = os.path.join(work_dir, "compare_child_vs_students.json")
-        with open(report_path, "w", encoding="utf-8") as fh:
-            json.dump(report_dict, fh, indent=2)
-        summary["child_vs_students"] = report_dict.get("summary", {})
-        print(f"    [compare] child vs students -> {report_path}")
-    elif student_ckpts.get("A") and student_ckpts.get("B") and not child_path:
-        # No child — just record student-vs-student similarity as a check
-        ref_a = _load_student_net(student_ckpts["A"])
-        ref_b = _load_student_net(student_ckpts["B"])
-        evaluator = RecombinationEvaluator(ref_a, ref_b, ref_a, thresholds)
-        report = evaluator.evaluate(states)
-        summary["student_self_check"] = report.to_dict().get("summary", {})
+        model_paths = {
+            "parent_a": student_ckpts["A"],
+            "parent_b": student_ckpts["B"],
+            "child": child_path,
+        }
+        model_formats = {
+            "parent_a": "float_state_dict",
+            "parent_b": "float_state_dict",
+            "child": "float_state_dict",
+        }
 
+    evaluator = RecombinationEvaluator(ref_a, ref_b, child_net, thresholds)
+    report = evaluator.evaluate(states, model_paths=model_paths, model_formats=model_formats)
+    report_dict = report.to_dict()
+    report_path = os.path.join(work_dir, "compare_child_vs_students.json")
+    with open(report_path, "w", encoding="utf-8") as fh:
+        json.dump(report_dict, fh, indent=2)
+    summary: Dict[str, Any] = {"child_vs_students": report_dict.get("summary", {})}
+    print(f"    [compare] child vs students -> {report_path}")
     return summary
 
 
@@ -583,11 +665,13 @@ def _run_condition_seed(
             int8_ckpts = _run_quantize_stage(cfg, cond, student_ckpts, states, work_dir)
 
     if "crossover" in cond.stages:
-        child_path = _run_crossover_stage(cfg, cond, seed, student_ckpts, states, work_dir)
+        child_path = _run_crossover_stage(
+            cfg, cond, seed, student_ckpts, int8_ckpts, states, work_dir
+        )
 
     if "compare" in cond.stages:
         compare_summary = _run_compare_stage(
-            cfg, cond, seed, student_ckpts, int8_ckpts, child_path, states, work_dir
+            cfg, cond, student_ckpts, int8_ckpts, child_path, states, work_dir
         )
         cvs = compare_summary.get("child_vs_students", {})
         row["child_vs_ref_a_agreement"] = cvs.get("child_agrees_with_parent_a", "n/a")
@@ -672,6 +756,7 @@ def _write_summary(rows: List[Dict[str, Any]], results_dir: str, dry_run: bool) 
         "- Offline metrics only (action agreement, KL, MSE, cosine); no online rollout.",
         "- `child_vs_ref_a/b_agreement` are populated only when the `compare` stage runs.",
         "- Stage order: `distill` → `quantize` → `crossover` → `compare`.",
+        "- `compare` requires `crossover`. With `quantize`, crossover and compare use int8 parents.",
         "",
     ]
     with open(md_path, "w", encoding="utf-8") as fh:
@@ -804,6 +889,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     # Real run
     # ------------------------------------------------------------------
     all_rows: List[Dict[str, Any]] = []
+    shared_states: Optional[np.ndarray] = None
 
     for cond in cfg.conditions:
         print(f"\n{'=' * 70}")
@@ -811,7 +897,12 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         print("=" * 70)
         for seed in cfg.seeds:
             print(f"\n  Seed {seed} …")
-            states = _make_states(cfg, seed)
+            if cfg.states_file:
+                if shared_states is None:
+                    shared_states = _make_states(cfg, seed)
+                states = shared_states
+            else:
+                states = _make_states(cfg, seed)
             row = _run_condition_seed(cfg, cond, seed, states, dry_run=False)
             all_rows.append(row)
             print(f"  Done. elapsed={row.get('elapsed_s', '?')}s")

--- a/scripts/run_recombination_ablation.py
+++ b/scripts/run_recombination_ablation.py
@@ -168,9 +168,31 @@ def _load_raw_config(path: str) -> Dict[str, Any]:
         content = fh.read()
     # Try YAML first (superset of JSON).
     if _YAML_AVAILABLE:
-        return _yaml.safe_load(content)  # type: ignore[return-value]
-    # Fallback to JSON.
-    return json.loads(content)  # type: ignore[return-value]
+        try:
+            raw = _yaml.safe_load(content)
+        except Exception as exc:
+            raise ValueError(
+                f"Failed to parse config file '{path}' as YAML. "
+                "Expected a YAML or JSON object at the top level."
+            ) from exc
+    else:
+        # Fallback to JSON.
+        try:
+            raw = json.loads(content)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Failed to parse config file '{path}' as JSON. "
+                "Expected a YAML or JSON object at the top level."
+            ) from exc
+
+    if not isinstance(raw, dict):
+        parsed_type = type(raw).__name__
+        raise ValueError(
+            f"Config file '{path}' must contain a top-level YAML/JSON object, "
+            f"got {parsed_type}."
+        )
+
+    return raw
 
 
 def _parse_config(raw: Dict[str, Any], results_dir_override: str = "") -> _AblationConfig:
@@ -209,6 +231,17 @@ def _parse_config(raw: Dict[str, Any], results_dir_override: str = "") -> _Ablat
             raise ValueError(
                 f"Condition '{name}' has unknown stages: {sorted(invalid)}. "
                 f"Valid stages are: {sorted(_VALID_STAGES)}."
+            )
+        stages = set(stages_raw)
+        if "quantize" in stages and "distill" not in stages:
+            raise ValueError(
+                f"Condition '{name}' includes 'quantize' but is missing required "
+                "'distill' stage."
+            )
+        if "crossover" in stages and "distill" not in stages:
+            raise ValueError(
+                f"Condition '{name}' includes 'crossover' but is missing required "
+                "'distill' stage."
             )
         conditions.append(
             _ConditionConfig(
@@ -633,7 +666,9 @@ def _write_summary(rows: List[Dict[str, Any]], results_dir: str, dry_run: bool) 
         "",
         "## Notes",
         "",
-        "- All seeds used the same state buffer (synthetic or from `states_file`).",
+        "- When `states_file` is set, all seeds share the same state buffer.",
+        "  When omitted, synthetic states are generated per seed (cross-seed results",
+        "  are not directly comparable without a shared `states_file`).",
         "- Offline metrics only (action agreement, KL, MSE, cosine); no online rollout.",
         "- `child_vs_ref_a/b_agreement` are populated only when the `compare` stage runs.",
         "- Stage order: `distill` → `quantize` → `crossover` → `compare`.",

--- a/scripts/run_recombination_ablation.py
+++ b/scripts/run_recombination_ablation.py
@@ -299,14 +299,15 @@ def _run_distill_stage(
     ckpts: Dict[str, str] = {}
     _pair_offset = {"A": 0, "B": 1}
 
+    import torch
+
     for pair in ("A", "B"):
+        torch.manual_seed(seed + _pair_offset[pair])
         teacher = BaseQNetwork(
             input_dim=cfg.input_dim,
             output_dim=cfg.output_dim,
             hidden_size=cfg.hidden_size,
         )
-        import torch
-        torch.manual_seed(seed + _pair_offset[pair])
         student = StudentQNetwork(
             input_dim=cfg.input_dim,
             output_dim=cfg.output_dim,
@@ -682,7 +683,7 @@ def _print_plan(cfg: _AblationConfig) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _parse_args() -> argparse.Namespace:
+def _build_arg_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         description="Unified ablation runner: seeds × conditions → results/ tree + summary.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -711,7 +712,11 @@ def _parse_args() -> argparse.Namespace:
         default="",
         help="Override the results directory from the config (or the smoke-test default).",
     )
-    return p.parse_args()
+    return p
+
+
+def _parse_args() -> argparse.Namespace:
+    return _build_arg_parser().parse_args()
 
 
 def main(argv: Optional[Sequence[str]] = None) -> None:
@@ -787,16 +792,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
 
 def _parse_args_from(argv: Sequence[str]) -> argparse.Namespace:
     """Parse *argv* using the same parser as ``_parse_args``."""
-    p = argparse.ArgumentParser(
-        description="Unified ablation runner: seeds × conditions → results/ tree + summary.",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
-    source = p.add_mutually_exclusive_group()
-    source.add_argument("--config", default="")
-    source.add_argument("--smoke-test", action="store_true")
-    p.add_argument("--dry-run", action="store_true")
-    p.add_argument("--results-dir", default="")
-    return p.parse_args(list(argv))
+    return _build_arg_parser().parse_args(list(argv))
 
 
 if __name__ == "__main__":

--- a/scripts/run_recombination_ablation.py
+++ b/scripts/run_recombination_ablation.py
@@ -297,6 +297,8 @@ def _run_distill_stage(
     )
 
     ckpts: Dict[str, str] = {}
+    _pair_offset = {"A": 0, "B": 1}
+
     for pair in ("A", "B"):
         teacher = BaseQNetwork(
             input_dim=cfg.input_dim,
@@ -304,7 +306,7 @@ def _run_distill_stage(
             hidden_size=cfg.hidden_size,
         )
         import torch
-        torch.manual_seed(seed + ord(pair))
+        torch.manual_seed(seed + _pair_offset[pair])
         student = StudentQNetwork(
             input_dim=cfg.input_dim,
             output_dim=cfg.output_dim,

--- a/scripts/run_recombination_ablation.py
+++ b/scripts/run_recombination_ablation.py
@@ -1,0 +1,801 @@
+#!/usr/bin/env python3
+"""Unified publication-style ablation runner for recombination experiments.
+
+This script orchestrates a full ablation study across multiple conditions
+(crossover-only, distill-only, quantize-only, or the full pipeline), a list
+of random seeds, and optional shared state buffers.  All results land in a
+single ``results/`` tree together with CSV and Markdown summary tables suitable
+for paper tables and CI regression.
+
+How to run
+----------
+::
+
+    # Dry-run (validate config, print plan, no training)
+    python scripts/run_recombination_ablation.py --config ablation.yaml --dry-run
+
+    # Tiny synthetic run for smoke-testing (no config file needed)
+    python scripts/run_recombination_ablation.py --smoke-test --results-dir /tmp/ablation_smoke
+
+    # Full run from a config file
+    python scripts/run_recombination_ablation.py --config ablation.yaml
+
+Config format
+-------------
+YAML (recommended) or JSON.  Example::
+
+    seeds: [0, 1, 2]
+    n_states: 2000
+    states_file: ""          # leave empty to synthesise from seed
+    input_dim: 8
+    output_dim: 4
+    hidden_size: 64
+    results_dir: results/ablation
+    conditions:
+      - name: distill_only
+        stages: [distill]
+      - name: distill_quantize
+        stages: [distill, quantize]
+      - name: full_pipeline
+        stages: [distill, quantize, crossover, compare]
+    distillation:
+      epochs: 10
+      temperature: 3.0
+      alpha: 1.0
+      lr: 0.001
+      batch_size: 32
+    quantization:
+      mode: dynamic
+    crossover:
+      mode: weighted
+      alpha: 0.5
+    comparison:
+      report_only: true
+
+Valid stages
+------------
+``distill``, ``quantize``, ``crossover``, ``compare``
+
+Each stage writes its outputs into a per-seed sub-directory under
+``<results_dir>/<condition_name>/seed_<seed>/``.
+
+The final summary CSV and Markdown table are written to
+``<results_dir>/ablation_summary.csv`` and
+``<results_dir>/ablation_summary.md``.
+
+Dry-run / smoke-test mode
+--------------------------
+Pass ``--dry-run`` to validate the config and print the full execution plan
+without running any training.  Pass ``--smoke-test`` to run a tiny end-to-end
+exercise using 50 synthetic states and 2 epochs with no checkpoints required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Allow running from repo root without pip install -e .
+# ---------------------------------------------------------------------------
+_repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+# ---------------------------------------------------------------------------
+# Optional YAML support (falls back to JSON if PyYAML is absent)
+# ---------------------------------------------------------------------------
+try:
+    import yaml as _yaml  # type: ignore[import]
+
+    _YAML_AVAILABLE = True
+except ModuleNotFoundError:
+    _YAML_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Config dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ConditionConfig:
+    name: str
+    stages: List[str]  # subset of ["distill", "quantize", "crossover", "compare"]
+    # Per-condition overrides (merged on top of global settings)
+    distillation: Dict[str, Any] = field(default_factory=dict)
+    quantization: Dict[str, Any] = field(default_factory=dict)
+    crossover: Dict[str, Any] = field(default_factory=dict)
+    comparison: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _AblationConfig:
+    seeds: List[int]
+    n_states: int
+    states_file: str
+    input_dim: int
+    output_dim: int
+    hidden_size: int
+    results_dir: str
+    conditions: List[_ConditionConfig]
+    # Global stage defaults
+    distillation: Dict[str, Any] = field(default_factory=dict)
+    quantization: Dict[str, Any] = field(default_factory=dict)
+    crossover: Dict[str, Any] = field(default_factory=dict)
+    comparison: Dict[str, Any] = field(default_factory=dict)
+
+
+_VALID_STAGES = {"distill", "quantize", "crossover", "compare"}
+
+_SMOKE_CONFIG_DICT: Dict[str, Any] = {
+    "seeds": [0, 1],
+    "n_states": 50,
+    "states_file": "",
+    "input_dim": 8,
+    "output_dim": 4,
+    "hidden_size": 64,
+    "conditions": [
+        {"name": "distill_only", "stages": ["distill"]},
+        {"name": "distill_quantize", "stages": ["distill", "quantize"]},
+        {"name": "full_pipeline", "stages": ["distill", "quantize", "crossover", "compare"]},
+    ],
+    "distillation": {"epochs": 2, "temperature": 3.0, "alpha": 1.0, "lr": 1e-3, "batch_size": 16},
+    "quantization": {"mode": "dynamic"},
+    "crossover": {"mode": "weighted", "alpha": 0.5},
+    "comparison": {"report_only": True},
+}
+
+
+# ---------------------------------------------------------------------------
+# Config loading / validation
+# ---------------------------------------------------------------------------
+
+
+def _load_raw_config(path: str) -> Dict[str, Any]:
+    """Load a YAML or JSON config file and return a raw dict."""
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"Config file not found: {path}")
+    with open(path, encoding="utf-8") as fh:
+        content = fh.read()
+    # Try YAML first (superset of JSON).
+    if _YAML_AVAILABLE:
+        return _yaml.safe_load(content)  # type: ignore[return-value]
+    # Fallback to JSON.
+    return json.loads(content)  # type: ignore[return-value]
+
+
+def _parse_config(raw: Dict[str, Any], results_dir_override: str = "") -> _AblationConfig:
+    """Parse and validate a raw config dict into an ``_AblationConfig``."""
+    seeds = list(raw.get("seeds", [0]))
+    if not seeds:
+        raise ValueError("'seeds' must be a non-empty list.")
+    if not all(isinstance(s, int) for s in seeds):
+        raise ValueError("All values in 'seeds' must be integers.")
+
+    n_states = int(raw.get("n_states", 500))
+    if n_states < 1:
+        raise ValueError(f"'n_states' must be >= 1, got {n_states}.")
+
+    states_file = str(raw.get("states_file", "") or "")
+    input_dim = int(raw.get("input_dim", 8))
+    output_dim = int(raw.get("output_dim", 4))
+    hidden_size = int(raw.get("hidden_size", 64))
+    if input_dim < 1 or output_dim < 1 or hidden_size < 1:
+        raise ValueError("input_dim, output_dim, hidden_size must all be >= 1.")
+
+    results_dir = results_dir_override or str(raw.get("results_dir", "results/ablation"))
+
+    raw_conditions = raw.get("conditions", [])
+    if not raw_conditions:
+        raise ValueError("'conditions' must be a non-empty list.")
+
+    conditions: List[_ConditionConfig] = []
+    for i, rc in enumerate(raw_conditions):
+        name = str(rc.get("name", f"condition_{i}"))
+        stages_raw = list(rc.get("stages", []))
+        if not stages_raw:
+            raise ValueError(f"Condition '{name}' must declare at least one stage.")
+        invalid = set(stages_raw) - _VALID_STAGES
+        if invalid:
+            raise ValueError(
+                f"Condition '{name}' has unknown stages: {sorted(invalid)}. "
+                f"Valid stages are: {sorted(_VALID_STAGES)}."
+            )
+        conditions.append(
+            _ConditionConfig(
+                name=name,
+                stages=stages_raw,
+                distillation=dict(rc.get("distillation", {})),
+                quantization=dict(rc.get("quantization", {})),
+                crossover=dict(rc.get("crossover", {})),
+                comparison=dict(rc.get("comparison", {})),
+            )
+        )
+
+    return _AblationConfig(
+        seeds=seeds,
+        n_states=n_states,
+        states_file=states_file,
+        input_dim=input_dim,
+        output_dim=output_dim,
+        hidden_size=hidden_size,
+        results_dir=results_dir,
+        conditions=conditions,
+        distillation=dict(raw.get("distillation", {})),
+        quantization=dict(raw.get("quantization", {})),
+        crossover=dict(raw.get("crossover", {})),
+        comparison=dict(raw.get("comparison", {})),
+    )
+
+
+# ---------------------------------------------------------------------------
+# States generation
+# ---------------------------------------------------------------------------
+
+
+def _make_states(cfg: _AblationConfig, seed: int) -> np.ndarray:
+    """Return the shared state buffer for *seed*.
+
+    If ``cfg.states_file`` is set the file is loaded (every seed uses the same
+    file).  Otherwise ``cfg.n_states`` synthetic states are drawn from a seeded
+    standard-normal distribution.
+    """
+    if cfg.states_file:
+        states = np.load(cfg.states_file).astype("float32")
+        if states.ndim != 2 or states.shape[1] != cfg.input_dim:
+            raise ValueError(
+                f"States file {cfg.states_file!r} has unexpected shape {states.shape}; "
+                f"expected (N, {cfg.input_dim})."
+            )
+        return states
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal((cfg.n_states, cfg.input_dim)).astype("float32")
+
+
+# ---------------------------------------------------------------------------
+# Stage runners
+# ---------------------------------------------------------------------------
+
+
+def _merged(global_dict: Dict[str, Any], override_dict: Dict[str, Any]) -> Dict[str, Any]:
+    merged = dict(global_dict)
+    merged.update(override_dict)
+    return merged
+
+
+def _run_distill_stage(
+    cfg: _AblationConfig,
+    cond: _ConditionConfig,
+    seed: int,
+    states: np.ndarray,
+    work_dir: str,
+) -> Dict[str, str]:
+    """Run distillation for both pairs and return a dict of checkpoint paths."""
+    from farm.core.decision.base_dqn import BaseQNetwork, StudentQNetwork
+    from farm.core.decision.training.trainer_distill import DistillationConfig, DistillationTrainer
+
+    dcfg_raw = _merged(cfg.distillation, cond.distillation)
+    dist_cfg = DistillationConfig(
+        temperature=float(dcfg_raw.get("temperature", 3.0)),
+        alpha=float(dcfg_raw.get("alpha", 1.0)),
+        learning_rate=float(dcfg_raw.get("lr", 1e-3)),
+        epochs=int(dcfg_raw.get("epochs", 10)),
+        batch_size=int(dcfg_raw.get("batch_size", 32)),
+        max_grad_norm=float(dcfg_raw.get("max_grad_norm", 1.0)),
+        val_fraction=float(dcfg_raw.get("val_fraction", 0.1)),
+        loss_fn=str(dcfg_raw.get("loss_fn", "kl")),
+        seed=seed,
+    )
+
+    ckpts: Dict[str, str] = {}
+    for pair in ("A", "B"):
+        teacher = BaseQNetwork(
+            input_dim=cfg.input_dim,
+            output_dim=cfg.output_dim,
+            hidden_size=cfg.hidden_size,
+        )
+        import torch
+        torch.manual_seed(seed + ord(pair))
+        student = StudentQNetwork(
+            input_dim=cfg.input_dim,
+            output_dim=cfg.output_dim,
+            parent_hidden_size=cfg.hidden_size,
+        )
+        ckpt_path = os.path.join(work_dir, f"student_{pair}.pt")
+        trainer = DistillationTrainer(teacher, student, dist_cfg)
+        trainer.train(states, checkpoint_path=ckpt_path)
+        ckpts[pair] = ckpt_path
+        print(f"    [distill] pair {pair} -> {ckpt_path}")
+    return ckpts
+
+
+def _run_quantize_stage(
+    cfg: _AblationConfig,
+    cond: _ConditionConfig,
+    student_ckpts: Dict[str, str],
+    states: np.ndarray,
+    work_dir: str,
+) -> Dict[str, str]:
+    """Quantize both students and return a dict of int8 checkpoint paths."""
+    import torch
+    from farm.core.decision.base_dqn import StudentQNetwork
+    from farm.core.decision.training.quantize_ptq import PostTrainingQuantizer, QuantizationConfig
+
+    qcfg_raw = _merged(cfg.quantization, cond.quantization)
+    q_config = QuantizationConfig(
+        mode=str(qcfg_raw.get("mode", "dynamic")),
+    )
+
+    int8_ckpts: Dict[str, str] = {}
+    for pair, ckpt_path in student_ckpts.items():
+        float_student = StudentQNetwork(
+            input_dim=cfg.input_dim,
+            output_dim=cfg.output_dim,
+            parent_hidden_size=cfg.hidden_size,
+        )
+        state = torch.load(ckpt_path, map_location="cpu", weights_only=True)
+        float_student.load_state_dict(state)
+        float_student.eval()
+
+        quantizer = PostTrainingQuantizer(q_config)
+        q_model, q_result = quantizer.quantize(float_student, calibration_states=states)
+        int8_path = os.path.join(work_dir, f"student_{pair}_int8.pt")
+        quantizer.save_checkpoint(q_model, int8_path, q_result)
+        int8_ckpts[pair] = int8_path
+        print(f"    [quantize] pair {pair} -> {int8_path}")
+    return int8_ckpts
+
+
+def _run_crossover_stage(
+    cfg: _AblationConfig,
+    cond: _ConditionConfig,
+    seed: int,
+    student_ckpts: Dict[str, str],
+    states: np.ndarray,
+    work_dir: str,
+) -> str:
+    """Run crossover + fine-tuning and return the child checkpoint path."""
+    import torch
+    from farm.core.decision.base_dqn import StudentQNetwork
+    from farm.core.decision.training.crossover import crossover_quantized_state_dict
+    from farm.core.decision.training.finetune import FineTuner, FineTuningConfig
+
+    xcfg_raw = _merged(cfg.crossover, cond.crossover)
+    dcfg_raw = _merged(cfg.distillation, cond.distillation)
+
+    # Load students as parents (produced by the distill stage).
+    def _load_student(path: str) -> StudentQNetwork:
+        net = StudentQNetwork(
+            input_dim=cfg.input_dim,
+            output_dim=cfg.output_dim,
+            parent_hidden_size=cfg.hidden_size,
+        )
+        state = torch.load(path, map_location="cpu", weights_only=True)
+        net.load_state_dict(state)
+        net.eval()
+        return net
+
+    parent_a_path = student_ckpts.get("A", "")
+    parent_b_path = student_ckpts.get("B", "")
+
+    if not parent_a_path or not parent_b_path:
+        raise RuntimeError("crossover stage requires 'distill' stage to run first.")
+
+    parent_a = _load_student(parent_a_path)
+    parent_b = _load_student(parent_b_path)
+
+    # Crossover
+    crossover_mode = str(xcfg_raw.get("mode", "weighted"))
+    crossover_alpha = float(xcfg_raw.get("alpha", 0.5))
+    crossover_seed = int(xcfg_raw.get("seed", seed))
+
+    child_state = crossover_quantized_state_dict(
+        parent_a.state_dict(),
+        parent_b.state_dict(),
+        mode=crossover_mode,
+        alpha=crossover_alpha,
+        seed=crossover_seed,
+    )
+    child = StudentQNetwork(
+        input_dim=cfg.input_dim,
+        output_dim=cfg.output_dim,
+        parent_hidden_size=cfg.hidden_size,
+    )
+    child.load_state_dict(child_state)
+
+    # Fine-tune child against parent A acting as soft-label teacher.
+    ft_config = FineTuningConfig(
+        learning_rate=float(dcfg_raw.get("lr", 1e-3)),
+        epochs=int(dcfg_raw.get("epochs", 10)),
+        batch_size=int(dcfg_raw.get("batch_size", 32)),
+        max_grad_norm=float(dcfg_raw.get("max_grad_norm", 1.0)),
+        val_fraction=float(dcfg_raw.get("val_fraction", 0.1)),
+        loss_fn=str(dcfg_raw.get("loss_fn", "kl")),
+        temperature=float(dcfg_raw.get("temperature", 3.0)),
+        alpha=float(dcfg_raw.get("alpha", 1.0)),
+        seed=seed,
+    )
+    # FineTuner(reference, child, config) — parent_a acts as soft-label teacher.
+    tuner = FineTuner(parent_a, child, ft_config)
+    child_path = os.path.join(work_dir, "child_finetuned.pt")
+    tuner.finetune(states, checkpoint_path=child_path)
+    print(f"    [crossover] child -> {child_path}")
+    return child_path
+
+
+def _run_compare_stage(
+    cfg: _AblationConfig,
+    cond: _ConditionConfig,
+    seed: int,
+    student_ckpts: Dict[str, str],
+    int8_ckpts: Dict[str, str],
+    child_path: str,
+    states: np.ndarray,
+    work_dir: str,
+) -> Dict[str, Any]:
+    """Run comparison matrix and return a summary dict."""
+    import torch
+    from farm.core.decision.base_dqn import StudentQNetwork
+    from farm.core.decision.training.recombination_eval import (
+        RecombinationEvaluator,
+        RecombinationThresholds,
+    )
+
+    cmpcfg_raw = _merged(cfg.comparison, cond.comparison)
+    report_only = bool(cmpcfg_raw.get("report_only", True))
+
+    thresholds = RecombinationThresholds(
+        min_action_agreement=float(cmpcfg_raw.get("min_action_agreement", 0.70)),
+        max_kl_divergence=float(cmpcfg_raw.get("max_kl_divergence", 1.0)),
+        max_mse=float(cmpcfg_raw.get("max_mse", 5.0)),
+        min_cosine_similarity=float(cmpcfg_raw.get("min_cosine_similarity", 0.70)),
+        report_only=report_only,
+    )
+
+    def _load_student_net(path: str) -> StudentQNetwork:
+        net = StudentQNetwork(
+            input_dim=cfg.input_dim,
+            output_dim=cfg.output_dim,
+            parent_hidden_size=cfg.hidden_size,
+        )
+        state = torch.load(path, map_location="cpu", weights_only=True)
+        net.load_state_dict(state)
+        net.eval()
+        return net
+
+    summary: Dict[str, Any] = {}
+
+    # Child vs students comparison (child is fine-tuned StudentQNetwork)
+    if child_path and student_ckpts.get("A") and student_ckpts.get("B"):
+        child_net = _load_student_net(child_path)
+        ref_a = _load_student_net(student_ckpts["A"])
+        ref_b = _load_student_net(student_ckpts["B"])
+        evaluator = RecombinationEvaluator(ref_a, ref_b, child_net, thresholds)
+        report = evaluator.evaluate(states)
+        report_dict = report.to_dict()
+        report_path = os.path.join(work_dir, "compare_child_vs_students.json")
+        with open(report_path, "w", encoding="utf-8") as fh:
+            json.dump(report_dict, fh, indent=2)
+        summary["child_vs_students"] = report_dict.get("summary", {})
+        print(f"    [compare] child vs students -> {report_path}")
+    elif student_ckpts.get("A") and student_ckpts.get("B") and not child_path:
+        # No child — just record student-vs-student similarity as a check
+        ref_a = _load_student_net(student_ckpts["A"])
+        ref_b = _load_student_net(student_ckpts["B"])
+        evaluator = RecombinationEvaluator(ref_a, ref_b, ref_a, thresholds)
+        report = evaluator.evaluate(states)
+        summary["student_self_check"] = report.to_dict().get("summary", {})
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Per-seed condition runner
+# ---------------------------------------------------------------------------
+
+
+def _run_condition_seed(
+    cfg: _AblationConfig,
+    cond: _ConditionConfig,
+    seed: int,
+    states: np.ndarray,
+    dry_run: bool,
+) -> Dict[str, Any]:
+    """Run all stages for one (condition, seed) pair.
+
+    Returns a flat metrics dict for the summary table.
+    """
+    work_dir = os.path.join(cfg.results_dir, cond.name, f"seed_{seed}")
+    if not dry_run:
+        os.makedirs(work_dir, exist_ok=True)
+
+    row: Dict[str, Any] = {
+        "condition": cond.name,
+        "seed": seed,
+        "stages": ",".join(cond.stages),
+        "work_dir": work_dir,
+    }
+
+    if dry_run:
+        return row
+
+    student_ckpts: Dict[str, str] = {}
+    int8_ckpts: Dict[str, str] = {}
+    child_path: str = ""
+
+    t_start = time.perf_counter()
+
+    if "distill" in cond.stages:
+        student_ckpts = _run_distill_stage(cfg, cond, seed, states, work_dir)
+
+    if "quantize" in cond.stages:
+        if not student_ckpts:
+            print(
+                f"    [quantize] WARNING: no student checkpoints for condition "
+                f"'{cond.name}' seed {seed} – skipping quantize stage."
+            )
+        else:
+            int8_ckpts = _run_quantize_stage(cfg, cond, student_ckpts, states, work_dir)
+
+    if "crossover" in cond.stages:
+        child_path = _run_crossover_stage(cfg, cond, seed, student_ckpts, states, work_dir)
+
+    if "compare" in cond.stages:
+        compare_summary = _run_compare_stage(
+            cfg, cond, seed, student_ckpts, int8_ckpts, child_path, states, work_dir
+        )
+        cvs = compare_summary.get("child_vs_students", {})
+        row["child_vs_ref_a_agreement"] = cvs.get("child_agrees_with_parent_a", "n/a")
+        row["child_vs_ref_b_agreement"] = cvs.get("child_agrees_with_parent_b", "n/a")
+        row["oracle_agreement"] = cvs.get("oracle_agreement", "n/a")
+
+    row["elapsed_s"] = round(time.perf_counter() - t_start, 2)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Summary writing
+# ---------------------------------------------------------------------------
+
+
+_SUMMARY_COLUMNS = [
+    "condition",
+    "seed",
+    "stages",
+    "child_vs_ref_a_agreement",
+    "child_vs_ref_b_agreement",
+    "oracle_agreement",
+    "elapsed_s",
+    "work_dir",
+]
+
+
+def _fmt_cell(v: Any) -> str:
+    if v is None:
+        return "n/a"
+    if isinstance(v, float):
+        return f"{v:.4f}"
+    return str(v)
+
+
+def _write_summary(rows: List[Dict[str, Any]], results_dir: str, dry_run: bool) -> None:
+    """Write CSV and Markdown summary tables under *results_dir*."""
+    os.makedirs(results_dir, exist_ok=True)
+
+    csv_path = os.path.join(results_dir, "ablation_summary.csv")
+    md_path = os.path.join(results_dir, "ablation_summary.md")
+
+    # Collect all keys (some rows may have extra keys)
+    all_keys: List[str] = list(_SUMMARY_COLUMNS)
+    seen = set(all_keys)
+    for r in rows:
+        for k in r:
+            if k not in seen:
+                all_keys.append(k)
+                seen.add(k)
+
+    with open(csv_path, "w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=all_keys, extrasaction="ignore")
+        writer.writeheader()
+        for r in rows:
+            writer.writerow({k: r.get(k, "") for k in all_keys})
+
+    prefix = "[DRY-RUN] " if dry_run else ""
+    md_lines = [
+        "# Recombination Ablation Summary",
+        "",
+        f"> {prefix}Generated by `scripts/run_recombination_ablation.py`.",
+        "",
+        "## Results",
+        "",
+    ]
+    header = " | ".join(_SUMMARY_COLUMNS)
+    sep = " | ".join(["---"] * len(_SUMMARY_COLUMNS))
+    md_lines.append(f"| {header} |")
+    md_lines.append(f"| {sep} |")
+    for r in rows:
+        cells = " | ".join(_fmt_cell(r.get(c)) for c in _SUMMARY_COLUMNS)
+        md_lines.append(f"| {cells} |")
+
+    md_lines += [
+        "",
+        "## Notes",
+        "",
+        "- All seeds used the same state buffer (synthetic or from `states_file`).",
+        "- Offline metrics only (action agreement, KL, MSE, cosine); no online rollout.",
+        "- `child_vs_ref_a/b_agreement` are populated only when the `compare` stage runs.",
+        "- Stage order: `distill` → `quantize` → `crossover` → `compare`.",
+        "",
+    ]
+    with open(md_path, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(md_lines) + "\n")
+
+    print(f"\nSummary CSV      : {csv_path}")
+    print(f"Summary Markdown : {md_path}")
+
+
+# ---------------------------------------------------------------------------
+# Dry-run plan printer
+# ---------------------------------------------------------------------------
+
+
+def _print_plan(cfg: _AblationConfig) -> None:
+    total = len(cfg.conditions) * len(cfg.seeds)
+    print("=" * 70)
+    print("Recombination Ablation — Execution Plan (DRY-RUN)")
+    print("=" * 70)
+    print(f"  Seeds              : {cfg.seeds}")
+    print(f"  States             : {cfg.n_states} synthetic" if not cfg.states_file
+          else f"  States             : {cfg.states_file}")
+    print(f"  Input / output dim : {cfg.input_dim} / {cfg.output_dim}")
+    print(f"  Hidden size        : {cfg.hidden_size}")
+    print(f"  Results dir        : {cfg.results_dir}")
+    print(f"  Conditions ({len(cfg.conditions)}):")
+    for cond in cfg.conditions:
+        print(f"    [{cond.name}] stages: {cond.stages}")
+    print(f"  Total runs         : {total}")
+    print("=" * 70)
+    print()
+    for cond in cfg.conditions:
+        for seed in cfg.seeds:
+            work_dir = os.path.join(cfg.results_dir, cond.name, f"seed_{seed}")
+            print(f"  {cond.name} / seed={seed}")
+            print(f"    Work dir : {work_dir}")
+            for stage in cond.stages:
+                print(f"    Stage    : {stage}")
+            print()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Unified ablation runner: seeds × conditions → results/ tree + summary.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    source = p.add_mutually_exclusive_group()
+    source.add_argument(
+        "--config",
+        default="",
+        help="Path to YAML or JSON ablation config file.",
+    )
+    source.add_argument(
+        "--smoke-test",
+        action="store_true",
+        help=(
+            "Run a tiny built-in smoke-test config (2 seeds, 50 states, 2 epochs). "
+            "No config file required."
+        ),
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate config and print execution plan without running any training.",
+    )
+    p.add_argument(
+        "--results-dir",
+        default="",
+        help="Override the results directory from the config (or the smoke-test default).",
+    )
+    return p.parse_args()
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    args = _parse_args() if argv is None else _parse_args_from(argv)
+
+    # ------------------------------------------------------------------
+    # Resolve config
+    # ------------------------------------------------------------------
+    if args.smoke_test:
+        raw = dict(_SMOKE_CONFIG_DICT)
+        if not args.results_dir:
+            args.results_dir = os.path.join(
+                os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                "results",
+                "ablation_smoke",
+            )
+        print("Running smoke-test config (tiny synthetic run).")
+    elif args.config:
+        raw = _load_raw_config(args.config)
+    else:
+        print(
+            "Error: provide --config <file> or --smoke-test.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    cfg = _parse_config(raw, results_dir_override=args.results_dir)
+
+    # ------------------------------------------------------------------
+    # Dry-run: print plan and exit
+    # ------------------------------------------------------------------
+    if args.dry_run:
+        _print_plan(cfg)
+        print("[DRY-RUN] No training was performed.")
+        # Write stub summary so tests can verify the files exist.
+        stub_rows = [
+            {
+                "condition": cond.name,
+                "seed": seed,
+                "stages": ",".join(cond.stages),
+                "work_dir": os.path.join(cfg.results_dir, cond.name, f"seed_{seed}"),
+            }
+            for cond in cfg.conditions
+            for seed in cfg.seeds
+        ]
+        _write_summary(stub_rows, cfg.results_dir, dry_run=True)
+        return
+
+    # ------------------------------------------------------------------
+    # Real run
+    # ------------------------------------------------------------------
+    all_rows: List[Dict[str, Any]] = []
+
+    for cond in cfg.conditions:
+        print(f"\n{'=' * 70}")
+        print(f"Condition: {cond.name}  (stages: {cond.stages})")
+        print("=" * 70)
+        for seed in cfg.seeds:
+            print(f"\n  Seed {seed} …")
+            states = _make_states(cfg, seed)
+            row = _run_condition_seed(cfg, cond, seed, states, dry_run=False)
+            all_rows.append(row)
+            print(f"  Done. elapsed={row.get('elapsed_s', '?')}s")
+
+    _write_summary(all_rows, cfg.results_dir, dry_run=False)
+    print("\nAblation complete.")
+
+
+# ---------------------------------------------------------------------------
+# Internal helper: parse args from an explicit list (for testing)
+# ---------------------------------------------------------------------------
+
+
+def _parse_args_from(argv: Sequence[str]) -> argparse.Namespace:
+    """Parse *argv* using the same parser as ``_parse_args``."""
+    p = argparse.ArgumentParser(
+        description="Unified ablation runner: seeds × conditions → results/ tree + summary.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    source = p.add_mutually_exclusive_group()
+    source.add_argument("--config", default="")
+    source.add_argument("--smoke-test", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--results-dir", default="")
+    return p.parse_args(list(argv))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/decision/test_ablation_runner.py
+++ b/tests/decision/test_ablation_runner.py
@@ -209,7 +209,7 @@ def test_load_raw_config_invalid_json_raises(tmp_path):
         raw = mod._load_raw_config(str(cfg_file))
         # If YAML parsed it as a dict that's acceptable; otherwise should have raised.
         assert isinstance(raw, dict)
-    except (ValueError, Exception):
+    except Exception:
         pass  # Any clear exception is acceptable for invalid input
 
 

--- a/tests/decision/test_ablation_runner.py
+++ b/tests/decision/test_ablation_runner.py
@@ -258,9 +258,7 @@ def test_dry_run_writes_summary(tmp_path):
     assert os.path.isfile(os.path.join(results_dir, "ablation_summary.csv"))
     assert os.path.isfile(os.path.join(results_dir, "ablation_summary.md"))
     # No model checkpoint should be created
-    assert not any(
-        f.endswith(".pt") for _, _, files in os.walk(results_dir) for f in files
-    )
+    assert not any(f.endswith(".pt") for f in _find_pt_files(results_dir))
 
 
 def test_dry_run_with_config_file(tmp_path):
@@ -290,6 +288,16 @@ def test_no_args_exits(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+def _find_pt_files(root: str) -> list:
+    """Return a list of all .pt file paths under *root*."""
+    return [
+        os.path.join(dirpath, fname)
+        for dirpath, _, fnames in os.walk(root)
+        for fname in fnames
+        if fname.endswith(".pt")
+    ]
+
+
 @pytest.mark.slow
 def test_smoke_test_end_to_end(tmp_path):
     """Full smoke-test run: tiny config, real training, check outputs."""
@@ -303,13 +311,7 @@ def test_smoke_test_end_to_end(tmp_path):
     md_path = os.path.join(results_dir, "ablation_summary.md")
     assert os.path.isfile(md_path)
     # At least one student checkpoint produced
-    pt_files = [
-        f
-        for _, _, files in os.walk(results_dir)
-        for f in files
-        if f.endswith(".pt")
-    ]
-    assert len(pt_files) >= 1
+    assert len(_find_pt_files(results_dir)) >= 1
 
 
 @pytest.mark.slow

--- a/tests/decision/test_ablation_runner.py
+++ b/tests/decision/test_ablation_runner.py
@@ -1,0 +1,382 @@
+"""Tests for scripts/run_recombination_ablation.py.
+
+Covers:
+- Config loading and validation (_parse_config / _load_raw_config)
+- Dry-run mode (main with --dry-run)
+- Smoke-test mode (main with --smoke-test)
+- State buffer generation (_make_states)
+- Summary writing (_write_summary)
+- End-to-end integration smoke test (full_pipeline condition, 1 seed)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module loading
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "run_recombination_ablation.py"
+
+
+def _load_ablation_module():
+    spec = importlib.util.spec_from_file_location("run_recombination_ablation_mod", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclass decorator can resolve the module namespace.
+    sys.modules["run_recombination_ablation_mod"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = None
+
+
+def _get_mod():
+    global _mod
+    if _mod is None:
+        _mod = _load_ablation_module()
+    return _mod
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_MINIMAL_RAW: Dict[str, Any] = {
+    "seeds": [0],
+    "n_states": 30,
+    "states_file": "",
+    "input_dim": 8,
+    "output_dim": 4,
+    "hidden_size": 64,
+    "conditions": [
+        {"name": "distill_only", "stages": ["distill"]},
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# _parse_config
+# ---------------------------------------------------------------------------
+
+
+def test_parse_config_minimal():
+    mod = _get_mod()
+    cfg = mod._parse_config(_MINIMAL_RAW)
+    assert cfg.seeds == [0]
+    assert cfg.n_states == 30
+    assert len(cfg.conditions) == 1
+    assert cfg.conditions[0].name == "distill_only"
+    assert cfg.conditions[0].stages == ["distill"]
+
+
+def test_parse_config_results_dir_override():
+    mod = _get_mod()
+    cfg = mod._parse_config(_MINIMAL_RAW, results_dir_override="/tmp/my_results")
+    assert cfg.results_dir == "/tmp/my_results"
+
+
+def test_parse_config_empty_seeds_raises():
+    mod = _get_mod()
+    raw = dict(_MINIMAL_RAW, seeds=[])
+    with pytest.raises(ValueError, match="seeds"):
+        mod._parse_config(raw)
+
+
+def test_parse_config_bad_n_states_raises():
+    mod = _get_mod()
+    raw = dict(_MINIMAL_RAW, n_states=0)
+    with pytest.raises(ValueError, match="n_states"):
+        mod._parse_config(raw)
+
+
+def test_parse_config_invalid_stage_raises():
+    mod = _get_mod()
+    raw = dict(
+        _MINIMAL_RAW,
+        conditions=[{"name": "bad", "stages": ["distill", "fly_to_mars"]}],
+    )
+    with pytest.raises(ValueError, match="fly_to_mars"):
+        mod._parse_config(raw)
+
+
+def test_parse_config_empty_conditions_raises():
+    mod = _get_mod()
+    raw = dict(_MINIMAL_RAW, conditions=[])
+    with pytest.raises(ValueError, match="conditions"):
+        mod._parse_config(raw)
+
+
+def test_parse_config_empty_stages_raises():
+    mod = _get_mod()
+    raw = dict(_MINIMAL_RAW, conditions=[{"name": "empty", "stages": []}])
+    with pytest.raises(ValueError, match="stage"):
+        mod._parse_config(raw)
+
+
+def test_parse_config_invalid_dim_raises():
+    mod = _get_mod()
+    raw = dict(_MINIMAL_RAW, input_dim=0)
+    with pytest.raises(ValueError, match="input_dim"):
+        mod._parse_config(raw)
+
+
+def test_parse_config_global_and_condition_dicts():
+    mod = _get_mod()
+    raw = dict(
+        _MINIMAL_RAW,
+        distillation={"epochs": 5, "lr": 1e-4},
+        conditions=[
+            {
+                "name": "custom",
+                "stages": ["distill"],
+                "distillation": {"epochs": 3},
+            }
+        ],
+    )
+    cfg = mod._parse_config(raw)
+    assert cfg.distillation["epochs"] == 5
+    assert cfg.conditions[0].distillation["epochs"] == 3
+
+
+# ---------------------------------------------------------------------------
+# _load_raw_config
+# ---------------------------------------------------------------------------
+
+
+def test_load_raw_config_json(tmp_path):
+    mod = _get_mod()
+    cfg_dict = {"seeds": [1, 2], "n_states": 10, "conditions": [{"name": "x", "stages": ["distill"]}]}
+    cfg_file = tmp_path / "cfg.json"
+    cfg_file.write_text(json.dumps(cfg_dict))
+    raw = mod._load_raw_config(str(cfg_file))
+    assert raw["seeds"] == [1, 2]
+
+
+def test_load_raw_config_missing_raises(tmp_path):
+    mod = _get_mod()
+    with pytest.raises(FileNotFoundError):
+        mod._load_raw_config(str(tmp_path / "nonexistent.yaml"))
+
+
+# ---------------------------------------------------------------------------
+# _make_states
+# ---------------------------------------------------------------------------
+
+
+def test_make_states_synthetic():
+    mod = _get_mod()
+    cfg = mod._parse_config(_MINIMAL_RAW)
+    states = mod._make_states(cfg, seed=0)
+    assert states.shape == (cfg.n_states, cfg.input_dim)
+    assert states.dtype == np.float32
+
+
+def test_make_states_synthetic_reproducible():
+    mod = _get_mod()
+    cfg = mod._parse_config(_MINIMAL_RAW)
+    s0a = mod._make_states(cfg, seed=0)
+    s0b = mod._make_states(cfg, seed=0)
+    assert np.allclose(s0a, s0b)
+
+
+def test_make_states_different_seeds_differ():
+    mod = _get_mod()
+    cfg = mod._parse_config(_MINIMAL_RAW)
+    s0 = mod._make_states(cfg, seed=0)
+    s1 = mod._make_states(cfg, seed=1)
+    assert not np.allclose(s0, s1)
+
+
+def test_make_states_from_file(tmp_path):
+    mod = _get_mod()
+    arr = np.random.default_rng(42).standard_normal((20, 8)).astype("float32")
+    npy_path = str(tmp_path / "states.npy")
+    np.save(npy_path, arr)
+    raw = dict(_MINIMAL_RAW, states_file=npy_path)
+    cfg = mod._parse_config(raw)
+    states = mod._make_states(cfg, seed=0)
+    assert states.shape == (20, 8)
+    assert np.allclose(states, arr)
+
+
+# ---------------------------------------------------------------------------
+# _write_summary
+# ---------------------------------------------------------------------------
+
+
+def test_write_summary_creates_files(tmp_path):
+    mod = _get_mod()
+    rows = [
+        {"condition": "distill_only", "seed": 0, "stages": "distill", "elapsed_s": 1.5},
+        {"condition": "distill_only", "seed": 1, "stages": "distill", "elapsed_s": 1.2},
+    ]
+    mod._write_summary(rows, str(tmp_path), dry_run=False)
+    assert (tmp_path / "ablation_summary.csv").exists()
+    assert (tmp_path / "ablation_summary.md").exists()
+
+
+def test_write_summary_dry_run_marker(tmp_path):
+    mod = _get_mod()
+    rows = [{"condition": "c", "seed": 0, "stages": "distill"}]
+    mod._write_summary(rows, str(tmp_path), dry_run=True)
+    md = (tmp_path / "ablation_summary.md").read_text()
+    assert "DRY-RUN" in md
+
+
+def test_write_summary_csv_has_header(tmp_path):
+    mod = _get_mod()
+    rows = [{"condition": "c", "seed": 0, "stages": "distill", "elapsed_s": 0.5}]
+    mod._write_summary(rows, str(tmp_path), dry_run=False)
+    csv_text = (tmp_path / "ablation_summary.csv").read_text()
+    assert "condition" in csv_text
+    assert "seed" in csv_text
+
+
+# ---------------------------------------------------------------------------
+# Dry-run mode
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_writes_summary(tmp_path):
+    """--dry-run must write stub summary files without training."""
+    mod = _get_mod()
+    results_dir = str(tmp_path / "dry_results")
+    mod.main(["--smoke-test", "--dry-run", "--results-dir", results_dir])
+    assert os.path.isfile(os.path.join(results_dir, "ablation_summary.csv"))
+    assert os.path.isfile(os.path.join(results_dir, "ablation_summary.md"))
+    # No model checkpoint should be created
+    assert not any(
+        f.endswith(".pt") for _, _, files in os.walk(results_dir) for f in files
+    )
+
+
+def test_dry_run_with_config_file(tmp_path):
+    mod = _get_mod()
+    cfg_data = {
+        "seeds": [42],
+        "n_states": 20,
+        "conditions": [{"name": "distill_only", "stages": ["distill"]}],
+    }
+    cfg_file = tmp_path / "ab.json"
+    cfg_file.write_text(json.dumps(cfg_data))
+    results_dir = str(tmp_path / "res")
+    mod.main(["--config", str(cfg_file), "--dry-run", "--results-dir", results_dir])
+    assert os.path.isfile(os.path.join(results_dir, "ablation_summary.csv"))
+
+
+def test_no_args_exits(monkeypatch):
+    """Calling main without --config or --smoke-test should sys.exit(1)."""
+    mod = _get_mod()
+    with pytest.raises(SystemExit) as exc_info:
+        mod.main([])
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Smoke-test mode (end-to-end, fast)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_smoke_test_end_to_end(tmp_path):
+    """Full smoke-test run: tiny config, real training, check outputs."""
+    mod = _get_mod()
+    results_dir = str(tmp_path / "smoke")
+    mod.main(["--smoke-test", "--results-dir", results_dir])
+    # CSV summary
+    csv_path = os.path.join(results_dir, "ablation_summary.csv")
+    assert os.path.isfile(csv_path)
+    # Markdown summary
+    md_path = os.path.join(results_dir, "ablation_summary.md")
+    assert os.path.isfile(md_path)
+    # At least one student checkpoint produced
+    pt_files = [
+        f
+        for _, _, files in os.walk(results_dir)
+        for f in files
+        if f.endswith(".pt")
+    ]
+    assert len(pt_files) >= 1
+
+
+@pytest.mark.slow
+def test_smoke_test_distill_only_produces_student_checkpoints(tmp_path):
+    """distill_only condition must write student_A.pt and student_B.pt."""
+    mod = _get_mod()
+    raw = {
+        "seeds": [7],
+        "n_states": 30,
+        "input_dim": 8,
+        "output_dim": 4,
+        "hidden_size": 64,
+        "conditions": [{"name": "distill_only", "stages": ["distill"]}],
+        "distillation": {"epochs": 1, "batch_size": 16},
+    }
+    results_dir = str(tmp_path / "res")
+    cfg = mod._parse_config(raw, results_dir_override=results_dir)
+    states = mod._make_states(cfg, seed=7)
+    row = mod._run_condition_seed(cfg, cfg.conditions[0], seed=7, states=states, dry_run=False)
+    work_dir = row["work_dir"]
+    assert os.path.isfile(os.path.join(work_dir, "student_A.pt"))
+    assert os.path.isfile(os.path.join(work_dir, "student_B.pt"))
+
+
+@pytest.mark.slow
+def test_smoke_test_distill_quantize_produces_int8_checkpoints(tmp_path):
+    """distill + quantize stages must produce student_A_int8.pt."""
+    mod = _get_mod()
+    raw = {
+        "seeds": [3],
+        "n_states": 30,
+        "input_dim": 8,
+        "output_dim": 4,
+        "hidden_size": 64,
+        "conditions": [{"name": "dq", "stages": ["distill", "quantize"]}],
+        "distillation": {"epochs": 1, "batch_size": 16},
+        "quantization": {"mode": "dynamic"},
+    }
+    results_dir = str(tmp_path / "res")
+    cfg = mod._parse_config(raw, results_dir_override=results_dir)
+    states = mod._make_states(cfg, seed=3)
+    row = mod._run_condition_seed(cfg, cfg.conditions[0], seed=3, states=states, dry_run=False)
+    work_dir = row["work_dir"]
+    assert os.path.isfile(os.path.join(work_dir, "student_A_int8.pt"))
+    assert os.path.isfile(os.path.join(work_dir, "student_B_int8.pt"))
+
+
+@pytest.mark.slow
+def test_smoke_test_full_pipeline_produces_child(tmp_path):
+    """Full pipeline must produce a child_finetuned.pt checkpoint."""
+    mod = _get_mod()
+    raw = {
+        "seeds": [5],
+        "n_states": 40,
+        "input_dim": 8,
+        "output_dim": 4,
+        "hidden_size": 64,
+        "conditions": [{"name": "full", "stages": ["distill", "quantize", "crossover", "compare"]}],
+        "distillation": {"epochs": 1, "batch_size": 16},
+        "quantization": {"mode": "dynamic"},
+        "crossover": {"mode": "weighted", "alpha": 0.5},
+        "comparison": {"report_only": True},
+    }
+    results_dir = str(tmp_path / "res")
+    cfg = mod._parse_config(raw, results_dir_override=results_dir)
+    states = mod._make_states(cfg, seed=5)
+    row = mod._run_condition_seed(cfg, cfg.conditions[0], seed=5, states=states, dry_run=False)
+    work_dir = row["work_dir"]
+    assert os.path.isfile(os.path.join(work_dir, "child_finetuned.pt"))
+    assert os.path.isfile(os.path.join(work_dir, "compare_child_vs_students.json"))

--- a/tests/decision/test_ablation_runner.py
+++ b/tests/decision/test_ablation_runner.py
@@ -132,6 +132,26 @@ def test_parse_config_crossover_without_distill_raises():
         mod._parse_config(raw)
 
 
+def test_parse_config_compare_without_crossover_raises():
+    mod = _get_mod()
+    raw = dict(
+        _MINIMAL_RAW,
+        conditions=[{"name": "bad", "stages": ["distill", "compare"]}],
+    )
+    with pytest.raises(ValueError, match="crossover"):
+        mod._parse_config(raw)
+
+
+def test_parse_config_compare_only_raises():
+    mod = _get_mod()
+    raw = dict(
+        _MINIMAL_RAW,
+        conditions=[{"name": "bad", "stages": ["compare"]}],
+    )
+    with pytest.raises(ValueError, match="crossover"):
+        mod._parse_config(raw)
+
+
 def test_parse_config_empty_conditions_raises():
     mod = _get_mod()
     raw = dict(_MINIMAL_RAW, conditions=[])

--- a/tests/decision/test_ablation_runner.py
+++ b/tests/decision/test_ablation_runner.py
@@ -112,6 +112,26 @@ def test_parse_config_invalid_stage_raises():
         mod._parse_config(raw)
 
 
+def test_parse_config_quantize_without_distill_raises():
+    mod = _get_mod()
+    raw = dict(
+        _MINIMAL_RAW,
+        conditions=[{"name": "bad", "stages": ["quantize"]}],
+    )
+    with pytest.raises(ValueError, match="distill"):
+        mod._parse_config(raw)
+
+
+def test_parse_config_crossover_without_distill_raises():
+    mod = _get_mod()
+    raw = dict(
+        _MINIMAL_RAW,
+        conditions=[{"name": "bad", "stages": ["crossover"]}],
+    )
+    with pytest.raises(ValueError, match="distill"):
+        mod._parse_config(raw)
+
+
 def test_parse_config_empty_conditions_raises():
     mod = _get_mod()
     raw = dict(_MINIMAL_RAW, conditions=[])
@@ -169,6 +189,28 @@ def test_load_raw_config_missing_raises(tmp_path):
     mod = _get_mod()
     with pytest.raises(FileNotFoundError):
         mod._load_raw_config(str(tmp_path / "nonexistent.yaml"))
+
+
+def test_load_raw_config_non_dict_raises(tmp_path):
+    mod = _get_mod()
+    cfg_file = tmp_path / "cfg.json"
+    cfg_file.write_text(json.dumps([1, 2, 3]))  # top-level list, not dict
+    with pytest.raises(ValueError, match="top-level"):
+        mod._load_raw_config(str(cfg_file))
+
+
+def test_load_raw_config_invalid_json_raises(tmp_path):
+    mod = _get_mod()
+    cfg_file = tmp_path / "cfg.json"
+    cfg_file.write_text("{not: valid json!!!}")
+    # Module may use YAML (which would parse this differently) or JSON fallback.
+    # Either way it must not silently succeed with a non-dict or raise an unhelpful error.
+    try:
+        raw = mod._load_raw_config(str(cfg_file))
+        # If YAML parsed it as a dict that's acceptable; otherwise should have raised.
+        assert isinstance(raw, dict)
+    except (ValueError, Exception):
+        pass  # Any clear exception is acceptable for invalid input
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request adds comprehensive documentation and end-to-end tests for the neural recombination ablation runner. The documentation now includes a detailed section on how to use the unified ablation script for reproducible experiments, while the new test suite ensures robust coverage of configuration, dry-run and smoke-test modes, state buffer generation, summary writing, and integration across all pipeline stages.

**Documentation improvements:**

* Added a new "Publication Ablations" section to `neural_recombination_runbook.md`, detailing usage, configuration, and output of the `run_recombination_ablation.py` script, including quickstart examples, config file usage, output layout, stage descriptions, dry-run mode, and summary table interpretation. [[1]](diffhunk://#diff-744e9f7504e9f73ded4402ec309148dc666ad50f940482bd0395d39e1c5179e0R21) [[2]](diffhunk://#diff-744e9f7504e9f73ded4402ec309148dc666ad50f940482bd0395d39e1c5179e0R845-R991)

**Testing and quality assurance:**

* Introduced a comprehensive test suite in `test_ablation_runner.py` covering:
  - Config loading and validation, including error cases and per-condition overrides.
  - State buffer generation and reproducibility.
  - Summary file writing for both normal and dry-run modes.
  - End-to-end dry-run and smoke-test execution, checking for correct outputs and checkpoint files.
  - Integration tests for all major ablation pipeline conditions (distill, quantize, crossover, compare).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new standalone orchestration script plus documentation/tests without modifying core training logic; main risk is CI/runtime flakiness from the new slow end-to-end tests and filesystem outputs.
> 
> **Overview**
> Adds a unified ablation runner (`scripts/run_recombination_ablation.py`) that executes recombination experiments across multiple **conditions × seeds**, optionally using a shared `.npy` state buffer, and writes per-run artifacts plus consolidated `ablation_summary.csv`/`ablation_summary.md` (with `--dry-run` and `--smoke-test` support).
> 
> Updates `docs/howto/neural_recombination_runbook.md` with a new **Publication Ablations** section describing config format, stage semantics (`distill`/`quantize`/`crossover`/`compare`), output layout, and usage patterns.
> 
> Introduces `tests/decision/test_ablation_runner.py` covering config validation, state generation, summary writing, dry-run behavior, and slow end-to-end smoke tests that assert expected checkpoints/reports are produced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8af019b34818b917a014f5c0d64a8cb3d6bd77f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->