### PR TITLE
Add peak RAM and storage profiling harness for recombination pipeline

### DIFF
--- a/farm/core/decision/training/__init__.py
+++ b/farm/core/decision/training/__init__.py
@@ -72,6 +72,13 @@ from .sim_rollout_adapter import (
     SimRolloutConfig,
     SimRolloutResult,
 )
+from .memory_profiler import (
+    PeakRAMSample,
+    PipelineMemoryReport,
+    StageMemoryProfile,
+    profile_model_stage,
+    profile_peak_ram,
+)
 from .trainer_distill import (
     DistillationConfig,
     DistillationMetrics,
@@ -113,6 +120,11 @@ __all__ = [
     "QuantizedValidationReport",
     "QuantizedValidationThresholds",
     "QuantizedValidator",
+    "PeakRAMSample",
+    "PipelineMemoryReport",
+    "StageMemoryProfile",
+    "profile_model_stage",
+    "profile_peak_ram",
     "REPORT_SCHEMA_VERSION",
     "RecombinationEvaluator",
     "RecombinationReport",

--- a/farm/core/decision/training/memory_profiler.py
+++ b/farm/core/decision/training/memory_profiler.py
@@ -86,6 +86,8 @@ import torch.nn as nn
 
 from farm.utils.logging import get_logger
 
+from .quantize_ptq import _estimate_tensor_bytes
+
 logger = get_logger(__name__)
 
 
@@ -123,22 +125,6 @@ def _reset_cuda_peak(device: torch.device) -> None:
         torch.cuda.reset_peak_memory_stats(device)
 
 
-def _estimate_obj_bytes(obj: Any) -> int:
-    """Recursively estimate tensor bytes in an arbitrarily nested object.
-
-    Quantized model state dicts may contain non-tensor entries (e.g.
-    ``torch.dtype`` scalars inside ``PackedParams``).  This function skips
-    non-tensor values so as not to raise ``AttributeError``.
-    """
-    if torch.is_tensor(obj):
-        return int(obj.numel() * obj.element_size())
-    if isinstance(obj, dict):
-        return sum(_estimate_obj_bytes(v) for v in obj.values())
-    if isinstance(obj, (tuple, list)):
-        return sum(_estimate_obj_bytes(v) for v in obj)
-    return 0
-
-
 def _state_dict_bytes(model: nn.Module) -> int:
     """Estimate in-memory byte footprint of all tensors in *model*'s state dict.
 
@@ -149,7 +135,7 @@ def _state_dict_bytes(model: nn.Module) -> int:
     across keys still contribute once per key, so totals can exceed unique
     backing storage in edge cases.
     """
-    return _estimate_obj_bytes(model.state_dict())
+    return _estimate_tensor_bytes(model.state_dict())
 
 
 # ---------------------------------------------------------------------------

--- a/farm/core/decision/training/memory_profiler.py
+++ b/farm/core/decision/training/memory_profiler.py
@@ -1,0 +1,454 @@
+"""Peak RAM and storage profiling harness for the recombination pipeline.
+
+This module provides a lightweight, cross-platform harness for measuring
+**peak resident memory** (RAM) during forward passes and **storage** (on-disk
+/ state-dict byte footprints) for each stage of the recombination pipeline:
+parent → student → quantized → child.
+
+Two RAM tracking back-ends are supported and composed automatically:
+
+* **CPU** – ``tracemalloc`` (Python allocator delta) and ``psutil`` process
+  RSS snapshots.  The *tracemalloc peak* is the more reliable signal because
+  it captures only the net Python heap delta introduced inside the measured
+  block rather than the accumulated process lifetime peak.
+* **GPU** – ``torch.cuda.max_memory_allocated`` / ``torch.cuda.reset_peak_memory_stats``
+  when a CUDA device is present.
+
+Quick start
+-----------
+::
+
+    import numpy as np
+    import torch
+    from farm.core.decision.base_dqn import StudentQNetwork
+    from farm.core.decision.training.memory_profiler import (
+        profile_model_stage,
+        PipelineMemoryReport,
+    )
+
+    model = StudentQNetwork(input_dim=8, output_dim=4, parent_hidden_size=64)
+    states = np.random.standard_normal((256, 8)).astype("float32")
+
+    profile = profile_model_stage("student", model, states, batch_size=64)
+    print(profile.to_dict())
+
+    # Profile multiple stages in one shot
+    report = PipelineMemoryReport(stages=[profile])
+    print(report.to_dict())
+
+Known limitations
+-----------------
+* ``tracemalloc`` tracks only **Python-managed** allocations; it does not
+  capture memory allocated by PyTorch's C++ ATen allocator or BLAS
+  libraries.  Use process RSS as a complementary signal.
+* ``psutil`` RSS on Linux reads from ``/proc/<pid>/status``; it reports
+  virtual memory pages that are currently resident and may fluctuate due to
+  OS paging activity and the kernel's lazy-eviction policy.
+* ``resource.getrusage`` units differ by OS: bytes on Linux, kilobytes on
+  macOS.  The field ``process_peak_rss_kb`` is reported in the OS-native
+  units (see ``ru_maxrss`` man page); callers should note this in
+  publication tables.
+* GPU tracking with ``torch.cuda.max_memory_allocated`` reports the
+  **PyTorch caching allocator** high-watermark, not the true device
+  memory.  It resets to zero after ``reset_peak_memory_stats``; other
+  concurrent kernels may inflate the reading.
+* Allocator warm-up effects: on the first forward pass PyTorch may allocate
+  extra buffers.  Pass ``n_warmup`` > 0 to exclude these from measurements.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import tracemalloc
+from contextlib import contextmanager
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, Generator, List, Optional, Sequence
+
+try:
+    import resource as _resource
+except ImportError:  # Windows
+    _resource = None  # type: ignore[assignment]
+
+try:
+    import psutil as _psutil
+except ImportError:
+    _psutil = None  # type: ignore[assignment]
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Low-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _rss_bytes() -> Optional[int]:
+    """Return current process RSS in bytes, or ``None`` if psutil is absent."""
+    if _psutil is None:
+        return None
+    return int(_psutil.Process(os.getpid()).memory_info().rss)
+
+
+def _process_peak_rss_ru() -> Optional[int]:
+    """Return ``resource.getrusage`` peak RSS in OS-native units (see module notes)."""
+    if _resource is None:
+        return None
+    try:
+        return int(_resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss)
+    except (AttributeError, ValueError, OSError):
+        return None
+
+
+def _cuda_peak_bytes(device: torch.device) -> Optional[int]:
+    """Return peak CUDA memory (bytes) allocated since last reset, or ``None``."""
+    if device.type != "cuda" or not torch.cuda.is_available():
+        return None
+    return int(torch.cuda.max_memory_allocated(device))
+
+
+def _reset_cuda_peak(device: torch.device) -> None:
+    if device.type == "cuda" and torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats(device)
+
+
+def _estimate_obj_bytes(obj: Any) -> int:
+    """Recursively estimate tensor bytes in an arbitrarily nested object.
+
+    Quantized model state dicts may contain non-tensor entries (e.g.
+    ``torch.dtype`` scalars inside ``PackedParams``).  This function skips
+    non-tensor values so as not to raise ``AttributeError``.
+    """
+    if torch.is_tensor(obj):
+        return int(obj.numel() * obj.element_size())
+    if isinstance(obj, dict):
+        return sum(_estimate_obj_bytes(v) for v in obj.values())
+    if isinstance(obj, (tuple, list)):
+        return sum(_estimate_obj_bytes(v) for v in obj)
+    return 0
+
+
+def _state_dict_bytes(model: nn.Module) -> int:
+    """Estimate in-memory byte footprint of all tensors in *model*'s state dict.
+
+    Handles quantized model state dicts that contain non-tensor entries such
+    as ``torch.dtype`` objects inside ``PackedParams``.
+    """
+    return _estimate_obj_bytes(model.state_dict())
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PeakRAMSample:
+    """Peak RAM measurements captured inside a :func:`profile_peak_ram` block.
+
+    Attributes
+    ----------
+    tracemalloc_peak_bytes:
+        Peak Python heap delta (bytes) during the block as measured by
+        ``tracemalloc``.  ``None`` if tracing could not be started.
+    rss_bytes_before:
+        Process RSS (bytes) at block entry.  ``None`` if ``psutil`` absent.
+    rss_bytes_after:
+        Process RSS (bytes) at block exit.  ``None`` if ``psutil`` absent.
+    rss_delta_bytes:
+        ``rss_bytes_after - rss_bytes_before``.  May be negative due to GC.
+        ``None`` if either snapshot is unavailable.
+    process_peak_rss_ru:
+        ``resource.getrusage`` lifetime peak RSS in OS-native units (bytes on
+        Linux, kilobytes on macOS).  This is a *process lifetime* peak, not
+        limited to the block.
+    cuda_peak_bytes:
+        Peak CUDA allocator memory (bytes) since the last reset, or ``None``
+        on CPU.
+    elapsed_seconds:
+        Wall-clock duration of the measured block in seconds.
+    """
+
+    tracemalloc_peak_bytes: Optional[int] = None
+    rss_bytes_before: Optional[int] = None
+    rss_bytes_after: Optional[int] = None
+    rss_delta_bytes: Optional[int] = None
+    process_peak_rss_ru: Optional[int] = None
+    cuda_peak_bytes: Optional[int] = None
+    elapsed_seconds: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@contextmanager
+def profile_peak_ram(
+    device: Optional[torch.device] = None,
+) -> Generator[PeakRAMSample, None, None]:
+    """Context manager that measures peak RAM during an arbitrary code block.
+
+    Yields a :class:`PeakRAMSample` that is populated *after* the block exits.
+
+    Parameters
+    ----------
+    device:
+        Optional ``torch.device``.  When it is a CUDA device, peak GPU
+        memory is also recorded.
+
+    Example
+    -------
+    ::
+
+        with profile_peak_ram() as sample:
+            output = model(batch)
+        print(sample.tracemalloc_peak_bytes)
+    """
+    dev = device or torch.device("cpu")
+    sample = PeakRAMSample()
+
+    _reset_cuda_peak(dev)
+    rss_before = _rss_bytes()
+    tracemalloc.start()
+    t0 = time.perf_counter()
+
+    try:
+        yield sample
+    finally:
+        elapsed = time.perf_counter() - t0
+        _current, peak_tm = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        rss_after = _rss_bytes()
+        cuda_peak = _cuda_peak_bytes(dev)
+        peak_ru = _process_peak_rss_ru()
+
+        sample.tracemalloc_peak_bytes = int(peak_tm)
+        sample.rss_bytes_before = rss_before
+        sample.rss_bytes_after = rss_after
+        sample.rss_delta_bytes = (
+            (rss_after - rss_before) if (rss_before is not None and rss_after is not None) else None
+        )
+        sample.process_peak_rss_ru = peak_ru
+        sample.cuda_peak_bytes = cuda_peak
+        sample.elapsed_seconds = elapsed
+
+
+# ---------------------------------------------------------------------------
+# Per-stage profile
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StageMemoryProfile:
+    """Memory profile for a single pipeline stage (e.g. ``"parent"``).
+
+    Attributes
+    ----------
+    stage:
+        Human-readable label, e.g. ``"parent"``, ``"student"``,
+        ``"quantized"``, ``"child"``.
+    batch_size:
+        Number of samples used in each forward pass.
+    n_forward_passes:
+        Total number of measured forward passes (warmup excluded).
+    state_dict_bytes:
+        Estimated in-memory byte footprint of the model state dict.
+    checkpoint_bytes:
+        On-disk checkpoint size in bytes, or ``None`` if no path was given.
+    peak_ram:
+        :class:`PeakRAMSample` from the measured forward passes.
+    device:
+        Device string (e.g. ``"cpu"``, ``"cuda:0"``).
+    notes:
+        Free-form list of warnings or limitation notices.
+    """
+
+    stage: str
+    batch_size: int
+    n_forward_passes: int
+    state_dict_bytes: int
+    checkpoint_bytes: Optional[int]
+    peak_ram: PeakRAMSample
+    device: str
+    notes: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = asdict(self)
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Public profiling function
+# ---------------------------------------------------------------------------
+
+
+def profile_model_stage(
+    stage: str,
+    model: nn.Module,
+    states: np.ndarray,
+    batch_size: int = 64,
+    n_warmup: int = 3,
+    n_forward_passes: int = 5,
+    checkpoint_path: Optional[str] = None,
+    device: Optional[torch.device] = None,
+) -> StageMemoryProfile:
+    """Profile peak RAM and storage for one pipeline stage.
+
+    A *stage* is any ``eval``-mode ``nn.Module`` corresponding to a step in
+    the recombination pipeline: parent, student, quantized student, or child.
+    The function:
+
+    1. Runs ``n_warmup`` un-timed forward passes to prime allocator caches.
+    2. Measures peak RAM over ``n_forward_passes`` consecutive forward passes
+       (all batches in one :func:`profile_peak_ram` block).
+    3. Records state-dict byte footprint and optional on-disk size.
+
+    Parameters
+    ----------
+    stage:
+        Human-readable stage label (e.g. ``"parent"``, ``"student"``).
+    model:
+        The ``nn.Module`` to profile.  It is placed in ``eval()`` mode.
+    states:
+        NumPy array of shape ``(N, input_dim)`` with ``dtype=float32``.
+        Must contain at least ``batch_size`` rows.
+    batch_size:
+        Number of samples per forward pass.  Clamped to ``len(states)``.
+    n_warmup:
+        Number of un-timed forward passes before measurement.
+    n_forward_passes:
+        Number of timed forward passes to include in the measurement block.
+    checkpoint_path:
+        Optional path to an on-disk checkpoint file; when provided the file
+        size is recorded in :attr:`StageMemoryProfile.checkpoint_bytes`.
+    device:
+        Target device.  Defaults to ``torch.device("cpu")``.
+
+    Returns
+    -------
+    StageMemoryProfile
+    """
+    dev = device or torch.device("cpu")
+    model = model.to(dev)
+    model.eval()
+
+    states_arr = np.asarray(states, dtype=np.float32)
+    effective_bs = min(batch_size, len(states_arr))
+    batch_np = states_arr[:effective_bs]
+    batch_t = torch.from_numpy(batch_np).to(dev)
+
+    notes: List[str] = []
+
+    # Warmup
+    with torch.no_grad():
+        for _ in range(n_warmup):
+            out = model(batch_t)
+            if hasattr(out, "dequantize") and out.is_quantized:
+                out = out.dequantize()
+
+    if dev.type == "cuda" and torch.cuda.is_available():
+        torch.cuda.synchronize(dev)
+
+    # Measure
+    with profile_peak_ram(device=dev) as sample:
+        with torch.no_grad():
+            for _ in range(n_forward_passes):
+                out = model(batch_t)
+                if hasattr(out, "dequantize") and out.is_quantized:
+                    out = out.dequantize()
+        if dev.type == "cuda" and torch.cuda.is_available():
+            torch.cuda.synchronize(dev)
+
+    sd_bytes = _state_dict_bytes(model)
+    ckpt_bytes: Optional[int] = None
+    if checkpoint_path and os.path.isfile(checkpoint_path):
+        ckpt_bytes = os.path.getsize(checkpoint_path)
+
+    if _psutil is None:
+        notes.append("psutil not installed; RSS metrics unavailable.")
+    if _resource is None:
+        notes.append("resource module unavailable (Windows?); process_peak_rss_ru not recorded.")
+    if dev.type != "cuda":
+        notes.append(
+            "CUDA profiling skipped (CPU device). "
+            "tracemalloc captures Python heap only; ATen/BLAS allocations are not included."
+        )
+    else:
+        notes.append(
+            "cuda_peak_bytes reflects PyTorch caching allocator high-watermark "
+            "since last reset; concurrent kernels may inflate the reading."
+        )
+
+    logger.info(
+        "stage_profiled",
+        stage=stage,
+        batch_size=effective_bs,
+        n_forward_passes=n_forward_passes,
+        state_dict_bytes=sd_bytes,
+        tracemalloc_peak_bytes=sample.tracemalloc_peak_bytes,
+        rss_delta_bytes=sample.rss_delta_bytes,
+    )
+
+    return StageMemoryProfile(
+        stage=stage,
+        batch_size=effective_bs,
+        n_forward_passes=n_forward_passes,
+        state_dict_bytes=sd_bytes,
+        checkpoint_bytes=ckpt_bytes,
+        peak_ram=sample,
+        device=str(dev),
+        notes=notes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Multi-stage report
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PipelineMemoryReport:
+    """Aggregate peak-RAM and storage report for all pipeline stages.
+
+    Parameters
+    ----------
+    stages:
+        List of :class:`StageMemoryProfile` instances, one per stage.
+
+    Example
+    -------
+    ::
+
+        report = PipelineMemoryReport(stages=[parent_profile, student_profile])
+        import json
+        print(json.dumps(report.to_dict(), indent=2))
+    """
+
+    stages: List[StageMemoryProfile] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise to a plain Python dict suitable for ``json.dump``."""
+        return {
+            "stages": [s.to_dict() for s in self.stages],
+            "summary": self._build_summary(),
+        }
+
+    def _build_summary(self) -> Dict[str, Any]:
+        summary: Dict[str, Any] = {}
+        for s in self.stages:
+            entry: Dict[str, Any] = {
+                "state_dict_bytes": s.state_dict_bytes,
+                "checkpoint_bytes": s.checkpoint_bytes,
+                "tracemalloc_peak_bytes": s.peak_ram.tracemalloc_peak_bytes,
+                "rss_delta_bytes": s.peak_ram.rss_delta_bytes,
+            }
+            if s.peak_ram.cuda_peak_bytes is not None:
+                entry["cuda_peak_bytes"] = s.peak_ram.cuda_peak_bytes
+            summary[s.stage] = entry
+        return summary

--- a/farm/core/decision/training/memory_profiler.py
+++ b/farm/core/decision/training/memory_profiler.py
@@ -45,7 +45,7 @@ Known limitations
   virtual memory pages that are currently resident and may fluctuate due to
   OS paging activity and the kernel's lazy-eviction policy.
 * ``resource.getrusage`` units differ by OS: bytes on Linux, kilobytes on
-  macOS.  The field ``process_peak_rss_kb`` is reported in the OS-native
+  macOS.  The field ``process_peak_rss_ru`` is reported in the OS-native
   units (see ``ru_maxrss`` man page); callers should note this in
   publication tables.
 * GPU tracking with ``torch.cuda.max_memory_allocated`` reports the

--- a/farm/core/decision/training/memory_profiler.py
+++ b/farm/core/decision/training/memory_profiler.py
@@ -57,6 +57,9 @@ Known limitations
 * Nested :func:`profile_peak_ram`: if ``tracemalloc`` was already tracing
   before entry, ``tracemalloc_peak_bytes`` is the peak since tracing began
   (process-wide), not isolated to the inner block alone.
+* **Quantized** ``nn.Module`` trees (``torch.nn.quantized`` /
+  ``torch.ao.nn.quantized``) are profiled on **CPU** only; a non-CPU
+  ``device`` request is overridden and noted in :attr:`StageMemoryProfile.notes`.
 * ``state_dict_bytes`` sums tensor element counts per ``state_dict`` entry;
   unusual parameter sharing can make the sum exceed unique physical storage.
 """
@@ -123,6 +126,16 @@ def _cuda_peak_bytes(device: torch.device) -> Optional[int]:
 def _reset_cuda_peak(device: torch.device) -> None:
     if device.type == "cuda" and torch.cuda.is_available():
         torch.cuda.reset_peak_memory_stats(device)
+
+
+def _model_requires_cpu_profiling(model: nn.Module) -> bool:
+    """Return True if *model* uses PyTorch quantized modules (CPU-only for .to(cuda))."""
+    prefixes = ("torch.nn.quantized", "torch.ao.nn.quantized")
+    for mod in model.modules():
+        mod_name = getattr(mod.__class__, "__module__", "") or ""
+        if any(mod_name.startswith(p) for p in prefixes):
+            return True
+    return False
 
 
 def _state_dict_bytes(model: nn.Module) -> int:
@@ -332,24 +345,41 @@ def profile_model_stage(
         Optional path to an on-disk checkpoint file; when provided the file
         size is recorded in :attr:`StageMemoryProfile.checkpoint_bytes`.
     device:
-        Target device.  Defaults to ``torch.device("cpu")``.
+        Target device.  Defaults to ``torch.device("cpu")``.  Models that
+        contain quantized submodules are always profiled on CPU; the
+        requested device is overridden and a note is recorded.
 
     Returns
     -------
     StageMemoryProfile
     """
-    dev = device or torch.device("cpu")
-    model = model.to(dev)
-    model.eval()
+    if batch_size < 1:
+        raise ValueError("batch_size must be >= 1.")
+    if n_warmup < 0:
+        raise ValueError("n_warmup must be >= 0.")
+    if n_forward_passes < 1:
+        raise ValueError("n_forward_passes must be >= 1.")
 
     states_arr = np.asarray(states, dtype=np.float32)
     if states_arr.size == 0:
         raise ValueError("states must be non-empty (at least one row).")
+
+    requested = device or torch.device("cpu")
+    dev = requested
+    notes: List[str] = []
+    if _model_requires_cpu_profiling(model) and dev.type != "cpu":
+        dev = torch.device("cpu")
+        notes.append(
+            f"Quantized modules are CPU-only in this profiler; device was pinned to cpu "
+            f"(requested {requested!s})."
+        )
+
+    model = model.to(dev)
+    model.eval()
+
     effective_bs = min(batch_size, len(states_arr))
     batch_np = states_arr[:effective_bs]
     batch_t = torch.from_numpy(batch_np).to(dev)
-
-    notes: List[str] = []
 
     # Warmup
     with torch.no_grad():
@@ -375,7 +405,14 @@ def profile_model_stage(
     ckpt_bytes: Optional[int] = None
     if checkpoint_path:
         if os.path.isfile(checkpoint_path):
-            ckpt_bytes = os.path.getsize(checkpoint_path)
+            try:
+                ckpt_bytes = os.path.getsize(checkpoint_path)
+            except OSError as exc:
+                ckpt_bytes = None
+                notes.append(
+                    f"could not read checkpoint size for {checkpoint_path!r} ({exc!s}); "
+                    "checkpoint_bytes omitted."
+                )
         else:
             notes.append(
                 f"checkpoint_path {checkpoint_path!r} is not a readable file; checkpoint_bytes omitted."

--- a/farm/core/decision/training/memory_profiler.py
+++ b/farm/core/decision/training/memory_profiler.py
@@ -54,6 +54,11 @@ Known limitations
   concurrent kernels may inflate the reading.
 * Allocator warm-up effects: on the first forward pass PyTorch may allocate
   extra buffers.  Pass ``n_warmup`` > 0 to exclude these from measurements.
+* Nested :func:`profile_peak_ram`: if ``tracemalloc`` was already tracing
+  before entry, ``tracemalloc_peak_bytes`` is the peak since tracing began
+  (process-wide), not isolated to the inner block alone.
+* ``state_dict_bytes`` sums tensor element counts per ``state_dict`` entry;
+  unusual parameter sharing can make the sum exceed unique physical storage.
 """
 
 from __future__ import annotations
@@ -63,7 +68,7 @@ import time
 import tracemalloc
 from contextlib import contextmanager
 from dataclasses import dataclass, field, asdict
-from typing import Any, Dict, Generator, List, Optional, Sequence
+from typing import Any, Dict, Generator, List, Optional
 
 try:
     import resource as _resource
@@ -139,6 +144,10 @@ def _state_dict_bytes(model: nn.Module) -> int:
 
     Handles quantized model state dicts that contain non-tensor entries such
     as ``torch.dtype`` objects inside ``PackedParams``.
+
+    Each ``state_dict`` key is summed separately; tensors that share storage
+    across keys still contribute once per key, so totals can exceed unique
+    backing storage in edge cases.
     """
     return _estimate_obj_bytes(model.state_dict())
 
@@ -155,8 +164,9 @@ class PeakRAMSample:
     Attributes
     ----------
     tracemalloc_peak_bytes:
-        Peak Python heap delta (bytes) during the block as measured by
-        ``tracemalloc``.  ``None`` if tracing could not be started.
+        Peak Python heap (bytes) from ``tracemalloc.get_traced_memory`` at
+        block exit.  If tracing was already active before this block, the
+        value is the peak since tracing began, not block-local.
     rss_bytes_before:
         Process RSS (bytes) at block entry.  ``None`` if ``psutil`` absent.
     rss_bytes_after:
@@ -195,6 +205,12 @@ def profile_peak_ram(
 
     Yields a :class:`PeakRAMSample` that is populated *after* the block exits.
 
+    If ``tracemalloc`` is already tracing when the block is entered, this
+    context manager does **not** call ``stop()`` on exit, so outer tracing
+    stays enabled.  In that case ``tracemalloc_peak_bytes`` reflects the
+    process-wide peak since tracing started, not allocations confined to
+    this block.
+
     Parameters
     ----------
     device:
@@ -214,7 +230,9 @@ def profile_peak_ram(
 
     _reset_cuda_peak(dev)
     rss_before = _rss_bytes()
-    tracemalloc.start()
+    already_tracing = tracemalloc.is_tracing()
+    if not already_tracing:
+        tracemalloc.start()
     t0 = time.perf_counter()
 
     try:
@@ -222,7 +240,8 @@ def profile_peak_ram(
     finally:
         elapsed = time.perf_counter() - t0
         _current, peak_tm = tracemalloc.get_traced_memory()
-        tracemalloc.stop()
+        if not already_tracing:
+            tracemalloc.stop()
 
         rss_after = _rss_bytes()
         cuda_peak = _cuda_peak_bytes(dev)
@@ -279,8 +298,7 @@ class StageMemoryProfile:
     notes: List[str] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
-        d = asdict(self)
-        return d
+        return asdict(self)
 
 
 # ---------------------------------------------------------------------------
@@ -317,7 +335,7 @@ def profile_model_stage(
         The ``nn.Module`` to profile.  It is placed in ``eval()`` mode.
     states:
         NumPy array of shape ``(N, input_dim)`` with ``dtype=float32``.
-        Must contain at least ``batch_size`` rows.
+        Must be non-empty.  ``batch_size`` is clamped to ``N``.
     batch_size:
         Number of samples per forward pass.  Clamped to ``len(states)``.
     n_warmup:
@@ -339,6 +357,8 @@ def profile_model_stage(
     model.eval()
 
     states_arr = np.asarray(states, dtype=np.float32)
+    if states_arr.size == 0:
+        raise ValueError("states must be non-empty (at least one row).")
     effective_bs = min(batch_size, len(states_arr))
     batch_np = states_arr[:effective_bs]
     batch_t = torch.from_numpy(batch_np).to(dev)
@@ -367,8 +387,13 @@ def profile_model_stage(
 
     sd_bytes = _state_dict_bytes(model)
     ckpt_bytes: Optional[int] = None
-    if checkpoint_path and os.path.isfile(checkpoint_path):
-        ckpt_bytes = os.path.getsize(checkpoint_path)
+    if checkpoint_path:
+        if os.path.isfile(checkpoint_path):
+            ckpt_bytes = os.path.getsize(checkpoint_path)
+        else:
+            notes.append(
+                f"checkpoint_path {checkpoint_path!r} is not a readable file; checkpoint_bytes omitted."
+            )
 
     if _psutil is None:
         notes.append("psutil not installed; RSS metrics unavailable.")

--- a/scripts/profile_memory.py
+++ b/scripts/profile_memory.py
@@ -48,8 +48,10 @@ used when the checkpoints were created (see ``run_distillation.py``).
 
 Device
 ------
-Use ``--device cuda`` or ``--device cuda:0`` to profile on GPU (CUDA must be
-available).  The default is ``cpu``.
+Use ``--device cuda`` or ``--device cuda:0`` to profile float stages on GPU
+(CUDA must be available).  The default is ``cpu``.  The **quantized** stage
+always loads and profiles on **CPU** (PyTorch quantized ops are not used on
+CUDA in this pipeline); the JSON report lists the actual device per stage.
 
 Interpreting the report
 -----------------------
@@ -332,17 +334,19 @@ def main() -> None:
     else:
         print("Skipping student stage (no --student-ckpt).")
 
-    # Quantized stage
+    # Quantized stage (CPU-only: dynamic/static quantized modules are not CUDA-moved here)
     if args.quant_ckpt:
         _ensure_unsafe_unpickle_allowed(args.allow_unsafe_unpickle)
-        print(f"\nProfiling quantized: {args.quant_ckpt}")
-        q_model, _meta = load_quantized_checkpoint(args.quant_ckpt, device=device)
+        quant_device = torch.device("cpu")
+        print(f"\nProfiling quantized: {args.quant_ckpt} (device={quant_device}, float stages use {device})")
+        q_model, _meta = load_quantized_checkpoint(args.quant_ckpt, device=quant_device)
+        quant_kwargs = {**common_kwargs, "device": quant_device}
         stages.append(
             profile_model_stage(
                 "quantized",
                 q_model,
                 checkpoint_path=args.quant_ckpt,
-                **common_kwargs,
+                **quant_kwargs,
             )
         )
     else:

--- a/scripts/profile_memory.py
+++ b/scripts/profile_memory.py
@@ -30,6 +30,7 @@ How to run
     python scripts/profile_memory.py \\
         --input-dim 16 --output-dim 8 --parent-hidden 128 \\
         --batch-size 128 --n-forward-passes 10 \\
+        --device cuda:0 \\
         --parent-ckpt   checkpoints/parent_A.pt \\
         --student-ckpt  checkpoints/student_A.pt \\
         --report-dir    reports/memory
@@ -44,6 +45,11 @@ Architecture flags
 ------------------
 ``--input-dim``, ``--output-dim``, ``--parent-hidden`` must match the values
 used when the checkpoints were created (see ``run_distillation.py``).
+
+Device
+------
+Use ``--device cuda`` or ``--device cuda:0`` to profile on GPU (CUDA must be
+available).  The default is ``cpu``.
 
 Interpreting the report
 -----------------------
@@ -221,6 +227,11 @@ def _parse_args() -> argparse.Namespace:
         default=64,
         help="Hidden size of the parent (BaseQNetwork) and student networks.",
     )
+    p.add_argument(
+        "--device",
+        default="cpu",
+        help="Torch device for models and profiling (e.g. cpu, cuda, cuda:0).",
+    )
 
     # States
     p.add_argument("--states-file", default="", help="NumPy .npy file of shape (N, input_dim).")
@@ -260,15 +271,23 @@ def main() -> None:
     args = _parse_args()
     rng = np.random.default_rng(args.seed)
 
+    device = torch.device(args.device)
+    if device.type == "cuda" and not torch.cuda.is_available():
+        raise SystemExit("CUDA device requested but torch.cuda.is_available() is False.")
+
     # Load or generate states
     if args.states_file:
         states = np.load(args.states_file).astype("float32")
+        if states.ndim != 2:
+            raise SystemExit(f"States file must be 2-D (N, input_dim), got shape {states.shape}.")
+        if states.shape[1] != args.input_dim:
+            raise SystemExit(
+                f"States second dimension {states.shape[1]} does not match --input-dim {args.input_dim}."
+            )
         print(f"Loaded states from {args.states_file}: {states.shape}")
     else:
         states = rng.standard_normal((args.n_states, args.input_dim)).astype("float32")
         print(f"Using {args.n_states} synthetic states (shape {states.shape})")
-
-    device = torch.device("cpu")
     stages: list[StageMemoryProfile] = []
 
     common_kwargs = dict(

--- a/scripts/profile_memory.py
+++ b/scripts/profile_memory.py
@@ -376,7 +376,7 @@ def main() -> None:
         "device": str(device),
     }
     with open(out_path, "w", encoding="utf-8") as fh:
-        json.dump(report_dict, fh, indent=2, allow_nan=False)
+        json.dump(report_dict, fh, indent=2)
     print(f"\nJSON report written: {out_path}")
 
 

--- a/scripts/profile_memory.py
+++ b/scripts/profile_memory.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python
+"""Profile peak RAM and storage for every stage of the recombination pipeline.
+
+This script produces **comparable** peak resident-memory and storage numbers
+for each stage—parent, student, quantized student, and child—using a common
+batch size and state distribution.  Results are printed to stdout and written
+to a JSON report file.
+
+Profiling back-ends
+-------------------
+* **CPU** – ``tracemalloc`` (Python heap delta) + ``psutil`` process RSS.
+* **GPU** – ``torch.cuda.max_memory_allocated`` (PyTorch caching allocator).
+
+Both are captured automatically; only the ones available on the current
+platform appear in the report.
+
+How to run
+----------
+::
+
+    # Minimal: profile the stages you have checkpoints for.
+    python scripts/profile_memory.py \\
+        --parent-ckpt   checkpoints/parent_A.pt \\
+        --student-ckpt  checkpoints/student_A.pt \\
+        --quant-ckpt    checkpoints/student_A_int8.pt \\
+        --allow-unsafe-unpickle \\
+        --report-dir    reports/memory
+
+    # Override architecture if your models differ from the defaults.
+    python scripts/profile_memory.py \\
+        --input-dim 16 --output-dim 8 --parent-hidden 128 \\
+        --batch-size 128 --n-forward-passes 10 \\
+        --parent-ckpt   checkpoints/parent_A.pt \\
+        --student-ckpt  checkpoints/student_A.pt \\
+        --report-dir    reports/memory
+
+    # Provide synthetic states without checkpoint files (quick sanity check).
+    python scripts/profile_memory.py \\
+        --parent-ckpt   checkpoints/parent_A.pt \\
+        --n-states 500 \\
+        --report-dir    reports/memory
+
+Architecture flags
+------------------
+``--input-dim``, ``--output-dim``, ``--parent-hidden`` must match the values
+used when the checkpoints were created (see ``run_distillation.py``).
+
+Interpreting the report
+-----------------------
+``state_dict_bytes``
+    Sum of ``nelement() * element_size()`` for every tensor in the model's
+    state dict.  This is the **in-memory** weight footprint, not the
+    on-disk pickle size.
+``checkpoint_bytes``
+    On-disk file size in bytes (includes Python pickle / metadata overhead).
+``tracemalloc_peak_bytes``
+    Peak Python heap delta during the measured forward passes.  Captures only
+    Python-managed allocations; does not include ATen/BLAS C++ buffers.
+``rss_delta_bytes``
+    RSS change (bytes) between block entry and exit.  May be negative due to
+    OS page reclamation.  Use as a *directional* signal.
+``process_peak_rss_ru``
+    Lifetime process peak RSS in OS-native units (bytes on Linux, kilobytes
+    on macOS).  Not limited to the measured block.
+``cuda_peak_bytes``
+    PyTorch caching-allocator high-watermark since the last reset.  Present
+    only for CUDA device runs.
+
+Known limitations
+-----------------
+* tracemalloc captures only Python heap; native C++ ATen buffers are invisible
+  to it.
+* ``psutil`` RSS on Linux is affected by OS paging noise.
+* ``resource.getrusage`` units are OS-dependent (bytes/Linux, KB/macOS).
+* Quantized checkpoints (``weights_only=False``) require explicit opt-in via
+  ``--allow-unsafe-unpickle`` because they are full-model pickles.
+* CUDA peak reflects the PyTorch allocator watermark; concurrent GPU work may
+  inflate it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+import numpy as np
+import torch
+
+# Allow running directly from repo root
+_repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+from farm.core.decision.base_dqn import BaseQNetwork, StudentQNetwork  # noqa: E402
+from farm.core.decision.training.distillation_script_helpers import (  # noqa: E402
+    load_base_qnetwork_checkpoint,
+    load_float_student_checkpoint,
+)
+from farm.core.decision.training.memory_profiler import (  # noqa: E402
+    PipelineMemoryReport,
+    StageMemoryProfile,
+    profile_model_stage,
+)
+from farm.core.decision.training.quantize_ptq import (  # noqa: E402
+    load_quantized_checkpoint,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_parent(path: str, input_dim: int, output_dim: int, hidden: int) -> BaseQNetwork:
+    return load_base_qnetwork_checkpoint(path, input_dim, output_dim, hidden)
+
+
+def _load_student(path: str, input_dim: int, output_dim: int, hidden: int) -> StudentQNetwork:
+    return load_float_student_checkpoint(
+        path,
+        input_dim,
+        output_dim,
+        hidden,
+        not_found_template="Student checkpoint not found: {path}",
+        bad_state_template="Expected a state dict at {path!r}, got {type_name}.",
+    )
+
+
+def _ensure_unsafe_unpickle_allowed(allow_flag: bool) -> None:
+    if not allow_flag:
+        raise ValueError(
+            "Loading quantized checkpoints requires full-model unpickling "
+            "(weights_only=False), which can execute arbitrary code. "
+            "Re-run with --allow-unsafe-unpickle only for trusted checkpoints."
+        )
+
+
+def _print_stage(profile: StageMemoryProfile) -> None:
+    sep = "-" * 60
+    print(f"\n{sep}")
+    print(f"Stage: {profile.stage}")
+    print(f"  Device                  : {profile.device}")
+    print(f"  Batch size              : {profile.batch_size}")
+    print(f"  Forward passes measured : {profile.n_forward_passes}")
+    print(f"  State-dict bytes        : {profile.state_dict_bytes:,}")
+    if profile.checkpoint_bytes is not None:
+        print(f"  Checkpoint bytes (disk) : {profile.checkpoint_bytes:,}")
+    ram = profile.peak_ram
+    print(f"  tracemalloc peak (bytes): {ram.tracemalloc_peak_bytes}")
+    if ram.rss_bytes_before is not None:
+        print(f"  RSS before (bytes)      : {ram.rss_bytes_before:,}")
+    if ram.rss_bytes_after is not None:
+        print(f"  RSS after (bytes)       : {ram.rss_bytes_after:,}")
+    if ram.rss_delta_bytes is not None:
+        print(f"  RSS delta (bytes)       : {ram.rss_delta_bytes:,}")
+    if ram.process_peak_rss_ru is not None:
+        print(f"  Process peak RSS (ru)   : {ram.process_peak_rss_ru:,}  (OS-native units)")
+    if ram.cuda_peak_bytes is not None:
+        print(f"  CUDA peak (bytes)       : {ram.cuda_peak_bytes:,}")
+    print(f"  Elapsed (s)             : {ram.elapsed_seconds:.4f}")
+    for note in profile.notes:
+        print(f"  NOTE: {note}")
+
+
+def _print_summary(report: PipelineMemoryReport) -> None:
+    sep = "=" * 72
+    print(f"\n{sep}")
+    print("Pipeline memory summary")
+    print(sep)
+    header = f"{'Stage':<14} {'StateDict(B)':>14} {'Ckpt(B)':>12} {'TMalloc peak(B)':>17} {'RSS delta(B)':>14}"
+    print(header)
+    print("-" * len(header))
+    for s in report.stages:
+        ckpt = f"{s.checkpoint_bytes:,}" if s.checkpoint_bytes is not None else "n/a"
+        tm = f"{s.peak_ram.tracemalloc_peak_bytes}" if s.peak_ram.tracemalloc_peak_bytes is not None else "n/a"
+        rss = f"{s.peak_ram.rss_delta_bytes:,}" if s.peak_ram.rss_delta_bytes is not None else "n/a"
+        print(f"{s.stage:<14} {s.state_dict_bytes:>14,} {ckpt:>12} {tm:>17} {rss:>14}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Profile peak RAM and storage for each recombination pipeline stage.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # Checkpoints (all optional—skip stages you don't have)
+    p.add_argument("--parent-ckpt", default="", help="Path to parent (teacher) checkpoint.")
+    p.add_argument("--student-ckpt", default="", help="Path to float student checkpoint.")
+    p.add_argument(
+        "--quant-ckpt",
+        default="",
+        help="Path to quantized student checkpoint (full-model pickle).",
+    )
+    p.add_argument(
+        "--child-ckpt",
+        default="",
+        help="Path to child (crossover / fine-tuned) checkpoint.",
+    )
+    p.add_argument(
+        "--allow-unsafe-unpickle",
+        action="store_true",
+        help=(
+            "Allow torch.load(weights_only=False) for quantized full-model pickles. "
+            "Use only for trusted checkpoints."
+        ),
+    )
+
+    # Architecture
+    p.add_argument("--input-dim", type=int, default=8)
+    p.add_argument("--output-dim", type=int, default=4)
+    p.add_argument(
+        "--parent-hidden",
+        type=int,
+        default=64,
+        help="Hidden size of the parent (BaseQNetwork) and student networks.",
+    )
+
+    # States
+    p.add_argument("--states-file", default="", help="NumPy .npy file of shape (N, input_dim).")
+    p.add_argument("--n-states", type=int, default=512, help="Synthetic states when --states-file absent.")
+    p.add_argument("--seed", type=int, default=42)
+
+    # Profiling knobs
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=64,
+        help="Batch size for forward passes (aligned across all stages).",
+    )
+    p.add_argument("--n-warmup", type=int, default=3, help="Un-timed warmup passes.")
+    p.add_argument(
+        "--n-forward-passes",
+        type=int,
+        default=5,
+        help="Timed forward passes per stage.",
+    )
+
+    # Output
+    p.add_argument(
+        "--report-dir",
+        default="reports/memory_profiling",
+        help="Directory for JSON output.",
+    )
+    p.add_argument(
+        "--report-file",
+        default="",
+        help="Explicit JSON output path (overrides --report-dir).",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    rng = np.random.default_rng(args.seed)
+
+    # Load or generate states
+    if args.states_file:
+        states = np.load(args.states_file).astype("float32")
+        print(f"Loaded states from {args.states_file}: {states.shape}")
+    else:
+        states = rng.standard_normal((args.n_states, args.input_dim)).astype("float32")
+        print(f"Using {args.n_states} synthetic states (shape {states.shape})")
+
+    device = torch.device("cpu")
+    stages: list[StageMemoryProfile] = []
+
+    common_kwargs = dict(
+        states=states,
+        batch_size=args.batch_size,
+        n_warmup=args.n_warmup,
+        n_forward_passes=args.n_forward_passes,
+        device=device,
+    )
+
+    # Parent stage
+    if args.parent_ckpt:
+        print(f"\nProfiling parent: {args.parent_ckpt}")
+        parent_model = _load_parent(
+            args.parent_ckpt, args.input_dim, args.output_dim, args.parent_hidden
+        )
+        stages.append(
+            profile_model_stage(
+                "parent",
+                parent_model,
+                checkpoint_path=args.parent_ckpt,
+                **common_kwargs,
+            )
+        )
+    else:
+        print("Skipping parent stage (no --parent-ckpt).")
+
+    # Student stage
+    if args.student_ckpt:
+        print(f"\nProfiling student: {args.student_ckpt}")
+        student_model = _load_student(
+            args.student_ckpt, args.input_dim, args.output_dim, args.parent_hidden
+        )
+        stages.append(
+            profile_model_stage(
+                "student",
+                student_model,
+                checkpoint_path=args.student_ckpt,
+                **common_kwargs,
+            )
+        )
+    else:
+        print("Skipping student stage (no --student-ckpt).")
+
+    # Quantized stage
+    if args.quant_ckpt:
+        _ensure_unsafe_unpickle_allowed(args.allow_unsafe_unpickle)
+        print(f"\nProfiling quantized: {args.quant_ckpt}")
+        q_model, _meta = load_quantized_checkpoint(args.quant_ckpt, device=device)
+        stages.append(
+            profile_model_stage(
+                "quantized",
+                q_model,
+                checkpoint_path=args.quant_ckpt,
+                **common_kwargs,
+            )
+        )
+    else:
+        print("Skipping quantized stage (no --quant-ckpt).")
+
+    # Child stage (float student architecture)
+    if args.child_ckpt:
+        print(f"\nProfiling child: {args.child_ckpt}")
+        child_model = _load_student(
+            args.child_ckpt, args.input_dim, args.output_dim, args.parent_hidden
+        )
+        stages.append(
+            profile_model_stage(
+                "child",
+                child_model,
+                checkpoint_path=args.child_ckpt,
+                **common_kwargs,
+            )
+        )
+    else:
+        print("Skipping child stage (no --child-ckpt).")
+
+    if not stages:
+        print("\nNo stages profiled—supply at least one checkpoint flag.")
+        return
+
+    # Print per-stage detail
+    for profile in stages:
+        _print_stage(profile)
+
+    report = PipelineMemoryReport(stages=stages)
+    _print_summary(report)
+
+    # Write JSON
+    if args.report_file:
+        out_path = args.report_file
+    else:
+        os.makedirs(args.report_dir, exist_ok=True)
+        out_path = os.path.join(args.report_dir, "memory_profile.json")
+
+    report_dict = report.to_dict()
+    report_dict["meta"] = {
+        "batch_size": args.batch_size,
+        "n_warmup": args.n_warmup,
+        "n_forward_passes": args.n_forward_passes,
+        "n_states": int(states.shape[0]),
+        "input_dim": int(states.shape[1]),
+        "states_source": args.states_file or "synthetic_standard_normal",
+        "seed": args.seed,
+        "device": str(device),
+    }
+    with open(out_path, "w", encoding="utf-8") as fh:
+        json.dump(report_dict, fh, indent=2, allow_nan=False)
+    print(f"\nJSON report written: {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/decision/test_decision_subpackages_import.py
+++ b/tests/decision/test_decision_subpackages_import.py
@@ -32,6 +32,8 @@ class TestDecisionSubpackagesImport(unittest.TestCase):
                 "LEADERBOARD_COLUMNS",
                 "ManifestEntry",
                 "PairwiseComparison",
+                "PeakRAMSample",
+                "PipelineMemoryReport",
                 "PolicyRolloutAdapter",
                 "PostTrainingQuantizer",
                 "QATConfig",
@@ -72,9 +74,12 @@ class TestDecisionSubpackagesImport(unittest.TestCase):
                 "make_shifted_states",
                 "run_crossover_search",
                 "SHIFT_TYPES",
+                "StageMemoryProfile",
                 "split_replay_buffer",
                 "apply_gaussian_noise",
                 "apply_input_scaling",
+                "profile_model_stage",
+                "profile_peak_ram",
             },
         )
 

--- a/tests/decision/test_memory_profiler.py
+++ b/tests/decision/test_memory_profiler.py
@@ -59,7 +59,7 @@ def _make_states(n: int = 100, seed: int = 0) -> np.ndarray:
 class TestProfilePeakRam:
     def test_yields_peak_ram_sample(self):
         with profile_peak_ram() as sample:
-            _data = [0] * 1000  # allocate something
+            _unused = [0] * 1000  # allocate something
         assert isinstance(sample, PeakRAMSample)
 
     def test_elapsed_seconds_positive(self):

--- a/tests/decision/test_memory_profiler.py
+++ b/tests/decision/test_memory_profiler.py
@@ -16,6 +16,7 @@ import json
 import os
 import tempfile
 import tracemalloc
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -199,6 +200,38 @@ class TestProfileModelStage:
         with pytest.raises(ValueError, match="non-empty"):
             profile_model_stage("student", model, states)
 
+    def test_batch_size_below_one_raises(self):
+        model = _make_student()
+        states = _make_states()
+        with pytest.raises(ValueError, match="batch_size must be >= 1"):
+            profile_model_stage("student", model, states, batch_size=0)
+
+    def test_n_warmup_negative_raises(self):
+        model = _make_student()
+        states = _make_states()
+        with pytest.raises(ValueError, match="n_warmup must be >= 0"):
+            profile_model_stage("student", model, states, n_warmup=-1)
+
+    def test_n_forward_passes_below_one_raises(self):
+        model = _make_student()
+        states = _make_states()
+        with pytest.raises(ValueError, match="n_forward_passes must be >= 1"):
+            profile_model_stage("student", model, states, n_forward_passes=0)
+
+    def test_checkpoint_getsize_oserror_adds_note(self):
+        model = _make_student()
+        states = _make_states()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ckpt_path = os.path.join(tmpdir, "student.pt")
+            torch.save(model.state_dict(), ckpt_path)
+            with mock.patch(
+                "farm.core.decision.training.memory_profiler.os.path.getsize",
+                side_effect=OSError("simulated stat failure"),
+            ):
+                profile = profile_model_stage("student", model, states, checkpoint_path=ckpt_path)
+        assert profile.checkpoint_bytes is None
+        assert any("could not read checkpoint size" in n for n in profile.notes)
+
     def test_batch_size_clamped_to_state_count(self):
         model = _make_student()
         states = _make_states(n=10)
@@ -322,6 +355,18 @@ class TestProfileQuantizedStage:
         qp = profile_model_stage("quantized", quantized_model, states)
         # int8 weight packing → quantized state dict ≤ float state dict
         assert qp.state_dict_bytes <= fp.state_dict_bytes
+
+    def test_quantized_non_cpu_device_request_pinned_to_cpu(self, quantized_model):
+        """Dynamic quantized modules cannot move to CUDA; profiler pins to CPU."""
+        states = _make_states()
+        profile = profile_model_stage(
+            "quantized",
+            quantized_model,
+            states,
+            device=torch.device("cuda:0"),
+        )
+        assert profile.device == "cpu"
+        assert any("Quantized modules are CPU-only" in n for n in profile.notes)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/decision/test_memory_profiler.py
+++ b/tests/decision/test_memory_profiler.py
@@ -1,0 +1,338 @@
+"""Tests for farm/core/decision/training/memory_profiler.py.
+
+Covers:
+- profile_peak_ram context manager: tracemalloc tracking, RSS snapshots, elapsed time.
+- profile_model_stage: state_dict_bytes, checkpoint_bytes, peak_ram population.
+- PipelineMemoryReport: to_dict schema and summary aggregation.
+- profile_model_stage with a dynamically-quantized model.
+- Edge cases: batch_size larger than states, zero warmup.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+from farm.core.decision.base_dqn import StudentQNetwork
+from farm.core.decision.training.memory_profiler import (
+    PeakRAMSample,
+    PipelineMemoryReport,
+    StageMemoryProfile,
+    profile_model_stage,
+    profile_peak_ram,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+INPUT_DIM = 8
+OUTPUT_DIM = 4
+PARENT_HIDDEN = 32  # → student hidden = max(16, 16) = 16
+
+
+def _make_student(seed: int = 0) -> StudentQNetwork:
+    torch.manual_seed(seed)
+    return StudentQNetwork(
+        input_dim=INPUT_DIM,
+        output_dim=OUTPUT_DIM,
+        parent_hidden_size=PARENT_HIDDEN,
+    )
+
+
+def _make_states(n: int = 100, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal((n, INPUT_DIM)).astype("float32")
+
+
+# ---------------------------------------------------------------------------
+# profile_peak_ram context manager
+# ---------------------------------------------------------------------------
+
+
+class TestProfilePeakRam:
+    def test_yields_peak_ram_sample(self):
+        with profile_peak_ram() as sample:
+            _data = [0] * 1000  # allocate something
+        assert isinstance(sample, PeakRAMSample)
+
+    def test_elapsed_seconds_positive(self):
+        with profile_peak_ram() as sample:
+            pass
+        assert sample.elapsed_seconds >= 0.0
+
+    def test_tracemalloc_peak_bytes_non_negative(self):
+        with profile_peak_ram() as sample:
+            _buf = bytearray(1024 * 1024)  # 1 MiB Python allocation
+        assert sample.tracemalloc_peak_bytes is not None
+        assert sample.tracemalloc_peak_bytes >= 0
+
+    def test_tracemalloc_peak_bytes_captures_large_allocation(self):
+        # Allocate ≥ 512 KiB inside the block; tracemalloc peak must be > 0.
+        with profile_peak_ram() as sample:
+            _buf = bytearray(512 * 1024)
+        assert sample.tracemalloc_peak_bytes is not None
+        assert sample.tracemalloc_peak_bytes > 0
+
+    def test_rss_fields_populated_or_none(self):
+        with profile_peak_ram() as sample:
+            pass
+        # Both are either both None (psutil absent) or both int
+        if sample.rss_bytes_before is not None:
+            assert isinstance(sample.rss_bytes_before, int)
+            assert isinstance(sample.rss_bytes_after, int)
+
+    def test_rss_delta_consistent(self):
+        with profile_peak_ram() as sample:
+            pass
+        if sample.rss_bytes_before is not None and sample.rss_bytes_after is not None:
+            assert sample.rss_delta_bytes == sample.rss_bytes_after - sample.rss_bytes_before
+
+    def test_to_dict_keys(self):
+        with profile_peak_ram() as sample:
+            pass
+        d = sample.to_dict()
+        assert "tracemalloc_peak_bytes" in d
+        assert "rss_bytes_before" in d
+        assert "rss_bytes_after" in d
+        assert "rss_delta_bytes" in d
+        assert "process_peak_rss_ru" in d
+        assert "cuda_peak_bytes" in d
+        assert "elapsed_seconds" in d
+
+    def test_cuda_peak_none_on_cpu(self):
+        with profile_peak_ram(device=torch.device("cpu")) as sample:
+            pass
+        assert sample.cuda_peak_bytes is None
+
+    def test_json_serialisable(self):
+        with profile_peak_ram() as sample:
+            pass
+        # Should not raise
+        json.dumps(sample.to_dict())
+
+
+# ---------------------------------------------------------------------------
+# profile_model_stage
+# ---------------------------------------------------------------------------
+
+
+class TestProfileModelStage:
+    def test_returns_stage_profile(self):
+        model = _make_student()
+        states = _make_states()
+        profile = profile_model_stage("student", model, states)
+        assert isinstance(profile, StageMemoryProfile)
+        assert profile.stage == "student"
+
+    def test_state_dict_bytes_positive(self):
+        model = _make_student()
+        states = _make_states()
+        profile = profile_model_stage("student", model, states)
+        assert profile.state_dict_bytes > 0
+
+    def test_state_dict_bytes_matches_manual_count(self):
+        model = _make_student()
+        states = _make_states()
+        expected = sum(t.nelement() * t.element_size() for t in model.state_dict().values())
+        profile = profile_model_stage("student", model, states)
+        assert profile.state_dict_bytes == expected
+
+    def test_checkpoint_bytes_none_when_no_path(self):
+        model = _make_student()
+        states = _make_states()
+        profile = profile_model_stage("student", model, states)
+        assert profile.checkpoint_bytes is None
+
+    def test_checkpoint_bytes_from_file(self):
+        model = _make_student()
+        states = _make_states()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ckpt_path = os.path.join(tmpdir, "student.pt")
+            torch.save(model.state_dict(), ckpt_path)
+            profile = profile_model_stage("student", model, states, checkpoint_path=ckpt_path)
+        assert profile.checkpoint_bytes is not None
+        assert profile.checkpoint_bytes > 0
+
+    def test_batch_size_clamped_to_state_count(self):
+        model = _make_student()
+        states = _make_states(n=10)
+        profile = profile_model_stage("student", model, states, batch_size=100)
+        assert profile.batch_size == 10
+
+    def test_batch_size_respected(self):
+        model = _make_student()
+        states = _make_states(n=200)
+        profile = profile_model_stage("student", model, states, batch_size=32)
+        assert profile.batch_size == 32
+
+    def test_n_forward_passes_stored(self):
+        model = _make_student()
+        states = _make_states()
+        profile = profile_model_stage("student", model, states, n_forward_passes=7)
+        assert profile.n_forward_passes == 7
+
+    def test_device_cpu(self):
+        model = _make_student()
+        states = _make_states()
+        profile = profile_model_stage("student", model, states, device=torch.device("cpu"))
+        assert profile.device == "cpu"
+
+    def test_peak_ram_populated(self):
+        model = _make_student()
+        states = _make_states()
+        profile = profile_model_stage("student", model, states)
+        assert isinstance(profile.peak_ram, PeakRAMSample)
+        assert profile.peak_ram.elapsed_seconds >= 0.0
+        assert profile.peak_ram.tracemalloc_peak_bytes is not None
+
+    def test_zero_warmup_passes(self):
+        model = _make_student()
+        states = _make_states()
+        # Should not raise with n_warmup=0
+        profile = profile_model_stage("student", model, states, n_warmup=0)
+        assert profile.stage == "student"
+
+    def test_notes_populated(self):
+        model = _make_student()
+        states = _make_states()
+        profile = profile_model_stage("student", model, states)
+        assert isinstance(profile.notes, list)
+
+    def test_to_dict_schema(self):
+        model = _make_student()
+        states = _make_states()
+        profile = profile_model_stage("student", model, states)
+        d = profile.to_dict()
+        assert "stage" in d
+        assert "batch_size" in d
+        assert "state_dict_bytes" in d
+        assert "checkpoint_bytes" in d
+        assert "peak_ram" in d
+        assert "device" in d
+        assert "notes" in d
+
+    def test_json_serialisable(self):
+        model = _make_student()
+        states = _make_states()
+        profile = profile_model_stage("student", model, states)
+        json.dumps(profile.to_dict())
+
+    def test_different_stages_same_architecture(self):
+        """Parent and student profiles on the same architecture should both succeed."""
+        model_a = _make_student(seed=0)
+        model_b = _make_student(seed=1)
+        states = _make_states()
+        p_a = profile_model_stage("parent", model_a, states)
+        p_b = profile_model_stage("student", model_b, states)
+        assert p_a.stage == "parent"
+        assert p_b.stage == "student"
+        # Both should have positive state-dict bytes
+        assert p_a.state_dict_bytes > 0
+        assert p_b.state_dict_bytes > 0
+
+
+# ---------------------------------------------------------------------------
+# Quantized model stage
+# ---------------------------------------------------------------------------
+
+
+class TestProfileQuantizedStage:
+    """Profile a dynamically-quantized model to ensure it works end-to-end."""
+
+    @pytest.fixture
+    def quantized_model(self):
+        from farm.core.decision.training.quantize_ptq import (
+            PostTrainingQuantizer,
+            QuantizationConfig,
+        )
+
+        student = _make_student()
+        quantizer = PostTrainingQuantizer(QuantizationConfig(mode="dynamic"))
+        q_model, _ = quantizer.quantize(student)
+        return q_model
+
+    def test_quantized_stage_profile(self, quantized_model):
+        states = _make_states()
+        profile = profile_model_stage("quantized", quantized_model, states)
+        assert profile.stage == "quantized"
+        assert profile.state_dict_bytes > 0
+        assert profile.peak_ram.tracemalloc_peak_bytes is not None
+
+    def test_quantized_smaller_state_dict_than_float(self, quantized_model):
+        float_model = _make_student()
+        states = _make_states()
+        fp = profile_model_stage("float", float_model, states)
+        qp = profile_model_stage("quantized", quantized_model, states)
+        # int8 weight packing → quantized state dict ≤ float state dict
+        assert qp.state_dict_bytes <= fp.state_dict_bytes
+
+
+# ---------------------------------------------------------------------------
+# PipelineMemoryReport
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineMemoryReport:
+    def _make_profiles(self) -> list[StageMemoryProfile]:
+        states = _make_states()
+        profiles = []
+        for i, stage in enumerate(["parent", "student"]):
+            model = _make_student(seed=i)
+            profiles.append(profile_model_stage(stage, model, states))
+        return profiles
+
+    def test_empty_report(self):
+        report = PipelineMemoryReport(stages=[])
+        d = report.to_dict()
+        assert d["stages"] == []
+        assert d["summary"] == {}
+
+    def test_to_dict_has_stages_and_summary(self):
+        profiles = self._make_profiles()
+        report = PipelineMemoryReport(stages=profiles)
+        d = report.to_dict()
+        assert "stages" in d
+        assert "summary" in d
+
+    def test_summary_contains_all_stage_keys(self):
+        profiles = self._make_profiles()
+        report = PipelineMemoryReport(stages=profiles)
+        summary = report.to_dict()["summary"]
+        for p in profiles:
+            assert p.stage in summary
+
+    def test_summary_values(self):
+        profiles = self._make_profiles()
+        report = PipelineMemoryReport(stages=profiles)
+        summary = report.to_dict()["summary"]
+        for p in profiles:
+            entry = summary[p.stage]
+            assert "state_dict_bytes" in entry
+            assert "checkpoint_bytes" in entry
+            assert "tracemalloc_peak_bytes" in entry
+            assert "rss_delta_bytes" in entry
+
+    def test_json_serialisable(self):
+        profiles = self._make_profiles()
+        report = PipelineMemoryReport(stages=profiles)
+        json.dumps(report.to_dict())
+
+    def test_stages_list_length(self):
+        profiles = self._make_profiles()
+        report = PipelineMemoryReport(stages=profiles)
+        d = report.to_dict()
+        assert len(d["stages"]) == len(profiles)
+
+    def test_summary_state_dict_bytes_matches_profile(self):
+        profiles = self._make_profiles()
+        report = PipelineMemoryReport(stages=profiles)
+        d = report.to_dict()
+        for p in profiles:
+            assert d["summary"][p.stage]["state_dict_bytes"] == p.state_dict_bytes

--- a/tests/decision/test_memory_profiler.py
+++ b/tests/decision/test_memory_profiler.py
@@ -6,6 +6,8 @@ Covers:
 - PipelineMemoryReport: to_dict schema and summary aggregation.
 - profile_model_stage with a dynamically-quantized model.
 - Edge cases: batch_size larger than states, zero warmup.
+- Tracemalloc: preserves outer tracing; nested contexts complete.
+- Empty states, missing checkpoint path note; optional CUDA device.
 """
 
 from __future__ import annotations
@@ -13,6 +15,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+import tracemalloc
 
 import numpy as np
 import pytest
@@ -117,6 +120,24 @@ class TestProfilePeakRam:
         # Should not raise
         json.dumps(sample.to_dict())
 
+    def test_preserves_tracing_when_already_tracing(self):
+        tracemalloc.start()
+        try:
+            assert tracemalloc.is_tracing()
+            with profile_peak_ram() as sample:
+                _buf = bytearray(128 * 1024)
+            assert tracemalloc.is_tracing()
+            assert sample.tracemalloc_peak_bytes is not None
+        finally:
+            tracemalloc.stop()
+
+    def test_nested_contexts_complete(self):
+        with profile_peak_ram() as outer:
+            with profile_peak_ram() as inner:
+                _buf = bytearray(64 * 1024)
+        assert isinstance(outer, PeakRAMSample)
+        assert isinstance(inner, PeakRAMSample)
+
 
 # ---------------------------------------------------------------------------
 # profile_model_stage
@@ -159,6 +180,24 @@ class TestProfileModelStage:
             profile = profile_model_stage("student", model, states, checkpoint_path=ckpt_path)
         assert profile.checkpoint_bytes is not None
         assert profile.checkpoint_bytes > 0
+
+    def test_checkpoint_missing_path_adds_note(self):
+        model = _make_student()
+        states = _make_states()
+        profile = profile_model_stage(
+            "student",
+            model,
+            states,
+            checkpoint_path="/nonexistent/checkpoint/missing.pt",
+        )
+        assert profile.checkpoint_bytes is None
+        assert any("not a readable file" in n for n in profile.notes)
+
+    def test_empty_states_raises(self):
+        model = _make_student()
+        states = np.zeros((0, INPUT_DIM), dtype=np.float32)
+        with pytest.raises(ValueError, match="non-empty"):
+            profile_model_stage("student", model, states)
 
     def test_batch_size_clamped_to_state_count(self):
         model = _make_student()
@@ -236,6 +275,17 @@ class TestProfileModelStage:
         # Both should have positive state-dict bytes
         assert p_a.state_dict_bytes > 0
         assert p_b.state_dict_bytes > 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestProfileModelStageCuda:
+    def test_cuda_device_reports_cuda_peak(self):
+        model = _make_student()
+        states = _make_states()
+        profile = profile_model_stage("student", model, states, device=torch.device("cuda"))
+        assert profile.device.startswith("cuda")
+        assert profile.peak_ram.cuda_peak_bytes is not None
+        assert not any("CUDA profiling skipped" in n for n in profile.notes)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces a comprehensive suite of memory profiling utilities and their corresponding tests for the training pipeline. The main focus is on profiling RAM usage, including peak memory, during model operations and providing structured reports. The changes include adding new memory profiling classes and functions, updating the module exports, and introducing thorough tests to ensure correctness and robustness.

**Memory Profiling Utilities:**

- Added `PeakRAMSample`, `PipelineMemoryReport`, `StageMemoryProfile`, `profile_model_stage`, and `profile_peak_ram` to the `farm.core.decision.training` package, making them available for import and use in other modules. [[1]](diffhunk://#diff-ab3cacf04dba95036814f258617148c29776f07eb95c26db571f9bbaf7c2e0e9R75-R81) [[2]](diffhunk://#diff-ab3cacf04dba95036814f258617148c29776f07eb95c26db571f9bbaf7c2e0e9R145-R149)

**Testing and Validation:**

- Added a new test module `test_memory_profiler.py` containing extensive tests for all aspects of the new memory profiling utilities, including context manager behavior, model stage profiling, quantized model handling, and pipeline-level reporting.
- Updated the training package import tests to verify that the new classes and functions are correctly exposed and importable. [[1]](diffhunk://#diff-28f4aec4897c84959c96e54b7895261812eeac60a8d69130a7c8639085c7fa68R35-R36) [[2]](diffhunk://#diff-28f4aec4897c84959c96e54b7895261812eeac60a8d69130a7c8639085c7fa68R88-R93)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new profiling utilities and a CLI script without changing training/quantization behavior; risk is mainly around optional dependencies (`psutil`) and environment-specific memory metrics causing flaky expectations (covered by tests/skip guards).
> 
> **Overview**
> Adds a new `memory_profiler` module to measure per-stage peak memory (CPU `tracemalloc` + optional RSS via `psutil`, and optional CUDA peak) and storage footprints (`state_dict_bytes` and checkpoint file size) via `profile_peak_ram` and `profile_model_stage`, with structured outputs in `StageMemoryProfile` and `PipelineMemoryReport`.
> 
> Exposes these new profiling APIs from `farm.core.decision.training.__init__`, adds a `scripts/profile_memory.py` CLI to profile parent/student/quantized/child checkpoints (including an explicit `--allow-unsafe-unpickle` gate for quantized full-model pickles), and extends/import-smoke + new unit tests to cover CPU/GPU/quantized and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 019b28c56c7f0d49dee5503360d1c21d30bbdeec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->