### PR TITLE
Add CartPole training and neural recombination scripts

### DIFF
--- a/scripts/cartpole_dqn_training.py
+++ b/scripts/cartpole_dqn_training.py
@@ -1,0 +1,240 @@
+"""Shared CartPole-v1 DQN parent training for cartpole pipeline scripts."""
+
+from __future__ import annotations
+
+import collections
+import dataclasses
+import json
+import os
+import random
+from typing import Deque, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+try:
+    import gymnasium as gym
+except ImportError as exc:
+    raise SystemExit("gymnasium is required: pip install gymnasium") from exc
+
+from farm.core.decision.base_dqn import BaseQNetwork
+
+
+@dataclasses.dataclass(frozen=True)
+class CartPoleParentTrainResult:
+    """Paths and summary stats after training one parent."""
+
+    checkpoint_path: str
+    metadata_path: str
+    replay_states_path: str
+    mean_reward_last_50: float
+    replay_states_shape: Tuple[int, ...]
+
+
+class CartPoleDQN:
+    """Minimal DQN trainer wired to a ``BaseQNetwork`` for CartPole-v1.
+
+    Implements experience replay, epsilon-greedy exploration, Double Q-Learning
+    updates, and soft target-network updates.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        hidden_size: int,
+        lr: float,
+        gamma: float,
+        epsilon_start: float,
+        epsilon_min: float,
+        epsilon_decay: float,
+        tau: float,
+        memory_size: int,
+        batch_size: int,
+        seed: Optional[int],
+        device: torch.device,
+    ) -> None:
+        self.device = device
+        self.input_dim = input_dim
+        self.output_dim = output_dim
+        self.gamma = gamma
+        self.epsilon = epsilon_start
+        self.epsilon_min = epsilon_min
+        self.epsilon_decay = epsilon_decay
+        self.tau = tau
+        self.batch_size = batch_size
+
+        if seed is not None:
+            random.seed(seed)
+            np.random.seed(seed)
+            torch.manual_seed(seed)
+
+        self.q_net = BaseQNetwork(input_dim, output_dim, hidden_size).to(device)
+        self.target_net = BaseQNetwork(input_dim, output_dim, hidden_size).to(device)
+        self.target_net.load_state_dict(self.q_net.state_dict())
+        self.target_net.eval()
+
+        self.optimizer = optim.Adam(self.q_net.parameters(), lr=lr)
+        self.criterion = nn.SmoothL1Loss()
+        self.memory: Deque[Tuple] = collections.deque(maxlen=memory_size)
+        self._states_seen: List[np.ndarray] = []
+
+    def select_action(self, state: np.ndarray) -> int:
+        if random.random() < self.epsilon:
+            return random.randint(0, self.output_dim - 1)
+        s = torch.from_numpy(state).float().to(self.device)
+        self.q_net.eval()
+        with torch.no_grad():
+            q = self.q_net(s)
+        self.q_net.train()
+        return int(q.argmax().item())
+
+    def store(
+        self,
+        state: np.ndarray,
+        action: int,
+        reward: float,
+        next_state: np.ndarray,
+        done: bool,
+    ) -> None:
+        self.memory.append((state, action, reward, next_state, done))
+        self._states_seen.append(state.astype("float32"))
+
+    def train_step(self) -> Optional[float]:
+        if len(self.memory) < self.batch_size:
+            return None
+        batch = random.sample(self.memory, self.batch_size)
+        states = torch.from_numpy(np.stack([b[0] for b in batch])).float().to(self.device)
+        actions = torch.tensor([b[1] for b in batch], device=self.device).unsqueeze(1)
+        rewards = torch.tensor([b[2] for b in batch], dtype=torch.float32, device=self.device)
+        next_states = torch.from_numpy(np.stack([b[3] for b in batch])).float().to(self.device)
+        dones = torch.tensor([b[4] for b in batch], dtype=torch.float32, device=self.device)
+
+        self.q_net.eval()
+        current_q = self.q_net(states).gather(1, actions)
+        with torch.no_grad():
+            next_actions = self.q_net(next_states).argmax(1, keepdim=True)
+            next_q = self.target_net(next_states).gather(1, next_actions)
+            target_q = rewards.unsqueeze(1) + (1 - dones.unsqueeze(1)) * self.gamma * next_q
+        self.q_net.train()
+
+        loss = self.criterion(current_q, target_q)
+        self.optimizer.zero_grad()
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(self.q_net.parameters(), 1.0)
+        self.optimizer.step()
+
+        for tp, lp in zip(self.target_net.parameters(), self.q_net.parameters()):
+            tp.data.copy_(self.tau * lp.data + (1.0 - self.tau) * tp.data)
+
+        self.epsilon = max(self.epsilon_min, self.epsilon * self.epsilon_decay)
+        return float(loss.item())
+
+    def replay_states(self) -> np.ndarray:
+        if not self._states_seen:
+            return np.empty((0, self.input_dim), dtype="float32")
+        return np.stack(self._states_seen, axis=0).astype("float32")
+
+
+def train_cartpole_parent(
+    label: str,
+    episodes: int,
+    hidden_size: int,
+    lr: float,
+    gamma: float,
+    epsilon_start: float,
+    epsilon_min: float,
+    epsilon_decay: float,
+    tau: float,
+    memory_size: int,
+    batch_size: int,
+    seed: Optional[int],
+    output_dir: str,
+    log_every: int,
+    device: torch.device,
+    env_reset_seed: Optional[int] = None,
+) -> CartPoleParentTrainResult:
+    """Train one CartPole-v1 parent, write checkpoint/metadata/replay states."""
+    env = gym.make("CartPole-v1")
+    input_dim = int(env.observation_space.shape[0])
+    output_dim = int(env.action_space.n)
+
+    agent = CartPoleDQN(
+        input_dim=input_dim,
+        output_dim=output_dim,
+        hidden_size=hidden_size,
+        lr=lr,
+        gamma=gamma,
+        epsilon_start=epsilon_start,
+        epsilon_min=epsilon_min,
+        epsilon_decay=epsilon_decay,
+        tau=tau,
+        memory_size=memory_size,
+        batch_size=batch_size,
+        seed=seed,
+        device=device,
+    )
+
+    episode_rewards: List[float] = []
+    recent: Deque[float] = collections.deque(maxlen=100)
+
+    for ep in range(1, episodes + 1):
+        obs, _ = env.reset(seed=env_reset_seed)
+        state = np.array(obs, dtype="float32")
+        total_reward = 0.0
+        done = False
+        while not done:
+            action = agent.select_action(state)
+            obs2, reward, terminated, truncated, _ = env.step(action)
+            next_state = np.array(obs2, dtype="float32")
+            done = terminated or truncated
+            agent.store(state, action, float(reward), next_state, done)
+            agent.train_step()
+            state = next_state
+            total_reward += float(reward)
+        episode_rewards.append(total_reward)
+        recent.append(total_reward)
+        if ep % log_every == 0 or ep == episodes:
+            print(
+                f"  ep {ep:>5}/{episodes}  reward={total_reward:6.1f}"
+                f"  mean100={np.mean(recent):6.2f}  ε={agent.epsilon:.4f}"
+            )
+
+    env.close()
+
+    os.makedirs(output_dir, exist_ok=True)
+    ckpt_path = os.path.join(output_dir, f"parent_{label}.pt")
+    agent.q_net.eval()
+    torch.save(agent.q_net.state_dict(), ckpt_path)
+
+    mean_last50 = float(np.mean(episode_rewards[-50:])) if episode_rewards else 0.0
+    meta = {
+        "label": label,
+        "env": "CartPole-v1",
+        "input_dim": input_dim,
+        "output_dim": output_dim,
+        "hidden_size": hidden_size,
+        "episodes_trained": episodes,
+        "seed": seed,
+        "final_epsilon": round(agent.epsilon, 6),
+        "mean_reward_last_50_episodes": round(mean_last50, 4),
+        "episode_rewards": [round(r, 4) for r in episode_rewards],
+    }
+    meta_path = ckpt_path + ".json"
+    with open(meta_path, "w", encoding="utf-8") as fh:
+        json.dump(meta, fh, indent=2)
+
+    states_path = os.path.join(output_dir, "replay_states.npy")
+    replay = agent.replay_states()
+    np.save(states_path, replay)
+    replay_shape = tuple(int(x) for x in replay.shape)
+
+    return CartPoleParentTrainResult(
+        checkpoint_path=ckpt_path,
+        metadata_path=meta_path,
+        replay_states_path=states_path,
+        mean_reward_last_50=mean_last50,
+        replay_states_shape=replay_shape,
+    )

--- a/scripts/cartpole_dqn_training.py
+++ b/scripts/cartpole_dqn_training.py
@@ -22,6 +22,11 @@ except ImportError as exc:
 from farm.core.decision.base_dqn import BaseQNetwork
 
 
+def parse_torch_device(spec: str) -> torch.device:
+    """Parse a CLI device string (e.g. ``cpu``, ``cuda``, ``cuda:0``)."""
+    return torch.device(spec)
+
+
 @dataclasses.dataclass(frozen=True)
 class CartPoleParentTrainResult:
     """Paths and summary stats after training one parent."""
@@ -55,6 +60,7 @@ class CartPoleDQN:
         batch_size: int,
         seed: Optional[int],
         device: torch.device,
+        max_replay_states: Optional[int] = 200_000,
     ) -> None:
         self.device = device
         self.input_dim = input_dim
@@ -79,7 +85,11 @@ class CartPoleDQN:
         self.optimizer = optim.Adam(self.q_net.parameters(), lr=lr)
         self.criterion = nn.SmoothL1Loss()
         self.memory: Deque[Tuple] = collections.deque(maxlen=memory_size)
-        self._states_seen: List[np.ndarray] = []
+        self._states_seen: Deque[np.ndarray] = (
+            collections.deque(maxlen=max_replay_states)
+            if max_replay_states is not None
+            else collections.deque()
+        )
 
     def select_action(self, state: np.ndarray) -> int:
         if random.random() < self.epsilon:
@@ -135,7 +145,7 @@ class CartPoleDQN:
     def replay_states(self) -> np.ndarray:
         if not self._states_seen:
             return np.empty((0, self.input_dim), dtype="float32")
-        return np.stack(self._states_seen, axis=0).astype("float32")
+        return np.stack(list(self._states_seen), axis=0).astype("float32")
 
 
 def train_cartpole_parent(
@@ -155,86 +165,92 @@ def train_cartpole_parent(
     log_every: int,
     device: torch.device,
     env_reset_seed: Optional[int] = None,
+    max_replay_states: Optional[int] = 200_000,
 ) -> CartPoleParentTrainResult:
     """Train one CartPole-v1 parent, write checkpoint/metadata/replay states."""
     env = gym.make("CartPole-v1")
-    input_dim = int(env.observation_space.shape[0])
-    output_dim = int(env.action_space.n)
+    try:
+        input_dim = int(env.observation_space.shape[0])
+        output_dim = int(env.action_space.n)
 
-    agent = CartPoleDQN(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_size=hidden_size,
-        lr=lr,
-        gamma=gamma,
-        epsilon_start=epsilon_start,
-        epsilon_min=epsilon_min,
-        epsilon_decay=epsilon_decay,
-        tau=tau,
-        memory_size=memory_size,
-        batch_size=batch_size,
-        seed=seed,
-        device=device,
-    )
+        agent = CartPoleDQN(
+            input_dim=input_dim,
+            output_dim=output_dim,
+            hidden_size=hidden_size,
+            lr=lr,
+            gamma=gamma,
+            epsilon_start=epsilon_start,
+            epsilon_min=epsilon_min,
+            epsilon_decay=epsilon_decay,
+            tau=tau,
+            memory_size=memory_size,
+            batch_size=batch_size,
+            seed=seed,
+            device=device,
+            max_replay_states=max_replay_states,
+        )
 
-    episode_rewards: List[float] = []
-    recent: Deque[float] = collections.deque(maxlen=100)
+        episode_rewards: List[float] = []
+        recent: Deque[float] = collections.deque(maxlen=100)
 
-    for ep in range(1, episodes + 1):
-        obs, _ = env.reset(seed=env_reset_seed)
-        state = np.array(obs, dtype="float32")
-        total_reward = 0.0
-        done = False
-        while not done:
-            action = agent.select_action(state)
-            obs2, reward, terminated, truncated, _ = env.step(action)
-            next_state = np.array(obs2, dtype="float32")
-            done = terminated or truncated
-            agent.store(state, action, float(reward), next_state, done)
-            agent.train_step()
-            state = next_state
-            total_reward += float(reward)
-        episode_rewards.append(total_reward)
-        recent.append(total_reward)
-        if ep % log_every == 0 or ep == episodes:
-            print(
-                f"  ep {ep:>5}/{episodes}  reward={total_reward:6.1f}"
-                f"  mean100={np.mean(recent):6.2f}  ε={agent.epsilon:.4f}"
-            )
+        for ep in range(1, episodes + 1):
+            obs, _ = env.reset(seed=env_reset_seed)
+            state = np.array(obs, dtype="float32")
+            total_reward = 0.0
+            done = False
+            while not done:
+                action = agent.select_action(state)
+                obs2, reward, terminated, truncated, _ = env.step(action)
+                next_state = np.array(obs2, dtype="float32")
+                done = terminated or truncated
+                agent.store(state, action, float(reward), next_state, done)
+                agent.train_step()
+                state = next_state
+                total_reward += float(reward)
+            episode_rewards.append(total_reward)
+            recent.append(total_reward)
+            if ep % log_every == 0 or ep == episodes:
+                print(
+                    f"  ep {ep:>5}/{episodes}  reward={total_reward:6.1f}"
+                    f"  mean100={np.mean(recent):6.2f}  ε={agent.epsilon:.4f}"
+                )
 
-    env.close()
+        os.makedirs(output_dir, exist_ok=True)
+        ckpt_path = os.path.join(output_dir, f"parent_{label}.pt")
+        agent.q_net.eval()
+        torch.save(agent.q_net.state_dict(), ckpt_path)
 
-    os.makedirs(output_dir, exist_ok=True)
-    ckpt_path = os.path.join(output_dir, f"parent_{label}.pt")
-    agent.q_net.eval()
-    torch.save(agent.q_net.state_dict(), ckpt_path)
+        mean_last50 = float(np.mean(episode_rewards[-50:])) if episode_rewards else 0.0
+        meta = {
+            "label": label,
+            "env": "CartPole-v1",
+            "input_dim": input_dim,
+            "output_dim": output_dim,
+            "hidden_size": hidden_size,
+            "episodes_trained": episodes,
+            "seed": seed,
+            "final_epsilon": round(agent.epsilon, 6),
+            "mean_reward_last_50_episodes": round(mean_last50, 4),
+            "episode_rewards": [round(r, 4) for r in episode_rewards],
+            "max_replay_states_cap": max_replay_states,
+        }
+        meta_path = ckpt_path + ".json"
+        with open(meta_path, "w", encoding="utf-8") as fh:
+            json.dump(meta, fh, indent=2)
 
-    mean_last50 = float(np.mean(episode_rewards[-50:])) if episode_rewards else 0.0
-    meta = {
-        "label": label,
-        "env": "CartPole-v1",
-        "input_dim": input_dim,
-        "output_dim": output_dim,
-        "hidden_size": hidden_size,
-        "episodes_trained": episodes,
-        "seed": seed,
-        "final_epsilon": round(agent.epsilon, 6),
-        "mean_reward_last_50_episodes": round(mean_last50, 4),
-        "episode_rewards": [round(r, 4) for r in episode_rewards],
-    }
-    meta_path = ckpt_path + ".json"
-    with open(meta_path, "w", encoding="utf-8") as fh:
-        json.dump(meta, fh, indent=2)
+        states_path = os.path.join(output_dir, f"replay_states_{label}.npy")
+        replay = agent.replay_states()
+        np.save(states_path, replay)
+        replay_shape = tuple(int(x) for x in replay.shape)
 
-    states_path = os.path.join(output_dir, "replay_states.npy")
-    replay = agent.replay_states()
-    np.save(states_path, replay)
-    replay_shape = tuple(int(x) for x in replay.shape)
+        result = CartPoleParentTrainResult(
+            checkpoint_path=ckpt_path,
+            metadata_path=meta_path,
+            replay_states_path=states_path,
+            mean_reward_last_50=mean_last50,
+            replay_states_shape=replay_shape,
+        )
+    finally:
+        env.close()
 
-    return CartPoleParentTrainResult(
-        checkpoint_path=ckpt_path,
-        metadata_path=meta_path,
-        replay_states_path=states_path,
-        mean_reward_last_50=mean_last50,
-        replay_states_shape=replay_shape,
-    )
+    return result

--- a/scripts/run_cartpole_recombination.py
+++ b/scripts/run_cartpole_recombination.py
@@ -1,0 +1,633 @@
+#!/usr/bin/env python3
+"""Run the full recombination pipeline for two CartPole-v1 parents.
+
+This script orchestrates all steps of the neural recombination pipeline,
+starting from two trained ``BaseQNetwork`` parent checkpoints (``parent_A.pt``
+and ``parent_B.pt``) and finishing with a JSON validation report.
+
+Pipeline stages
+---------------
+1. **Train parents** (optional) — calls ``train_cartpole_parents.py`` logic
+   inline to produce ``parent_A.pt`` / ``parent_B.pt`` if they don't already
+   exist (or if ``--force-train`` is set).
+2. **Crossover + fine-tune child** — combines parent weights via
+   :func:`~farm.core.decision.training.crossover.crossover_quantized_state_dict`
+   and fine-tunes the resulting child against parent A using
+   :class:`~farm.core.decision.training.finetune.FineTuner`.
+3. **Validate recombination** — evaluates child vs both parents via
+   :class:`~farm.core.decision.training.recombination_eval.RecombinationEvaluator`
+   and writes a JSON report.
+
+How to run
+----------
+::
+
+    # Full pipeline from scratch (train + recombine + validate)
+    python scripts/run_cartpole_recombination.py
+
+    # Use existing parent checkpoints
+    python scripts/run_cartpole_recombination.py \\
+        --parent-a-ckpt checkpoints/cartpole/parent_A.pt \\
+        --parent-b-ckpt checkpoints/cartpole/parent_B.pt
+
+    # Custom training then weighted crossover
+    python scripts/run_cartpole_recombination.py \\
+        --train-episodes 300 \\
+        --crossover-mode weighted \\
+        --crossover-alpha 0.6 \\
+        --finetune-epochs 15 \\
+        --output-dir checkpoints/cartpole_run1
+
+    # Skip threshold enforcement (just produce the report)
+    python scripts/run_cartpole_recombination.py --report-only
+
+Outputs
+-------
+All files are written under ``<output-dir>/``:
+
+``parent_A.pt``, ``parent_A.pt.json``
+    Parent A checkpoint and metadata (training stage).
+``parent_B.pt``, ``parent_B.pt.json``
+    Parent B checkpoint and metadata (training stage).
+``replay_states.npy``
+    Replay buffer states collected during training (shape ``(N, 4)``).
+``child_finetuned.pt``, ``child_finetuned.pt.json``
+    Fine-tuned child checkpoint and metadata (recombination stage).
+``recombination_validation.json``
+    Full validation report (passed / comparison metrics / thresholds).
+
+CartPole dimensions
+-------------------
+``input_dim = 4``  (cart pos, cart vel, pole angle, pole angular vel)
+``output_dim = 2`` (push left / push right)
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import random
+import sys
+from typing import Deque, List, Optional
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+# Allow running directly from repo root without installing the package.
+_repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+try:
+    import gymnasium as gym
+except ImportError as exc:
+    raise SystemExit("gymnasium is required: pip install gymnasium") from exc
+
+from farm.core.decision.base_dqn import BaseQNetwork  # noqa: E402
+from farm.core.decision.training.crossover import (  # noqa: E402
+    CROSSOVER_MODES,
+    crossover_quantized_state_dict,
+)
+from farm.core.decision.training.distillation_script_helpers import (  # noqa: E402
+    load_distillation_states,
+)
+from farm.core.decision.training.finetune import (  # noqa: E402
+    FineTuner,
+    load_finetuning_config_from_yaml,
+)
+from farm.core.decision.training.recombination_eval import (  # noqa: E402
+    RecombinationEvaluator,
+    RecombinationThresholds,
+)
+
+# CartPole-v1 fixed dimensions
+_INPUT_DIM = 4
+_OUTPUT_DIM = 2
+
+
+# ---------------------------------------------------------------------------
+# Minimal DQN agent for CartPole training (self-contained)
+# ---------------------------------------------------------------------------
+
+
+class _DQNAgent:
+    """Lightweight DQN agent for single-environment training."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        lr: float,
+        gamma: float,
+        epsilon_start: float,
+        epsilon_min: float,
+        epsilon_decay: float,
+        tau: float,
+        memory_size: int,
+        batch_size: int,
+        seed: Optional[int],
+    ) -> None:
+        self.device = torch.device("cpu")
+        self.gamma = gamma
+        self.epsilon = epsilon_start
+        self.epsilon_min = epsilon_min
+        self.epsilon_decay = epsilon_decay
+        self.tau = tau
+        self.batch_size = batch_size
+
+        if seed is not None:
+            random.seed(seed)
+            np.random.seed(seed)
+            torch.manual_seed(seed)
+
+        self.q_net = BaseQNetwork(_INPUT_DIM, _OUTPUT_DIM, hidden_size).to(self.device)
+        self.target_net = BaseQNetwork(_INPUT_DIM, _OUTPUT_DIM, hidden_size).to(self.device)
+        self.target_net.load_state_dict(self.q_net.state_dict())
+        self.target_net.eval()
+        self.optimizer = optim.Adam(self.q_net.parameters(), lr=lr)
+        self.criterion = nn.SmoothL1Loss()
+        self.memory: Deque = collections.deque(maxlen=memory_size)
+        self._states_seen: List[np.ndarray] = []
+
+    def act(self, state: np.ndarray) -> int:
+        if random.random() < self.epsilon:
+            return random.randint(0, _OUTPUT_DIM - 1)
+        s = torch.from_numpy(state).float().to(self.device)
+        self.q_net.eval()
+        with torch.no_grad():
+            q = self.q_net(s)
+        self.q_net.train()
+        return int(q.argmax().item())
+
+    def store(self, state, action, reward, next_state, done):
+        self.memory.append((state, action, reward, next_state, done))
+        self._states_seen.append(state.astype("float32"))
+
+    def learn(self):
+        if len(self.memory) < self.batch_size:
+            return
+        batch = random.sample(self.memory, self.batch_size)
+        states = torch.from_numpy(np.stack([b[0] for b in batch])).float().to(self.device)
+        actions = torch.tensor([b[1] for b in batch], device=self.device).unsqueeze(1)
+        rewards = torch.tensor([b[2] for b in batch], dtype=torch.float32, device=self.device)
+        next_states = torch.from_numpy(np.stack([b[3] for b in batch])).float().to(self.device)
+        dones = torch.tensor([b[4] for b in batch], dtype=torch.float32, device=self.device)
+
+        self.q_net.eval()
+        current_q = self.q_net(states).gather(1, actions)
+        with torch.no_grad():
+            next_acts = self.q_net(next_states).argmax(1, keepdim=True)
+            next_q = self.target_net(next_states).gather(1, next_acts)
+            target_q = rewards.unsqueeze(1) + (1 - dones.unsqueeze(1)) * self.gamma * next_q
+        self.q_net.train()
+
+        loss = self.criterion(current_q, target_q)
+        self.optimizer.zero_grad()
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(self.q_net.parameters(), 1.0)
+        self.optimizer.step()
+
+        for tp, lp in zip(self.target_net.parameters(), self.q_net.parameters()):
+            tp.data.copy_(self.tau * lp.data + (1.0 - self.tau) * tp.data)
+
+        self.epsilon = max(self.epsilon_min, self.epsilon * self.epsilon_decay)
+
+    def replay_states(self) -> np.ndarray:
+        if not self._states_seen:
+            return np.empty((0, _INPUT_DIM), dtype="float32")
+        return np.stack(self._states_seen, axis=0).astype("float32")
+
+
+# ---------------------------------------------------------------------------
+# Stage 1: train parents
+# ---------------------------------------------------------------------------
+
+
+def _train_parent(
+    label: str,
+    episodes: int,
+    hidden_size: int,
+    lr: float,
+    gamma: float,
+    epsilon_start: float,
+    epsilon_min: float,
+    epsilon_decay: float,
+    tau: float,
+    memory_size: int,
+    batch_size: int,
+    seed: Optional[int],
+    output_dir: str,
+    log_every: int,
+) -> str:
+    """Train one CartPole parent and return its checkpoint path."""
+    print(f"\n[Stage 1] Training parent_{label}  ({episodes} episodes, seed={seed})")
+    env = gym.make("CartPole-v1")
+    agent = _DQNAgent(
+        hidden_size=hidden_size,
+        lr=lr,
+        gamma=gamma,
+        epsilon_start=epsilon_start,
+        epsilon_min=epsilon_min,
+        epsilon_decay=epsilon_decay,
+        tau=tau,
+        memory_size=memory_size,
+        batch_size=batch_size,
+        seed=seed,
+    )
+
+    episode_rewards: List[float] = []
+    recent: Deque[float] = collections.deque(maxlen=100)
+
+    for ep in range(1, episodes + 1):
+        obs, _ = env.reset()
+        state = np.array(obs, dtype="float32")
+        total_reward = 0.0
+        done = False
+        while not done:
+            action = agent.act(state)
+            obs2, reward, terminated, truncated, _ = env.step(action)
+            next_state = np.array(obs2, dtype="float32")
+            done = terminated or truncated
+            agent.store(state, action, float(reward), next_state, done)
+            agent.learn()
+            state = next_state
+            total_reward += float(reward)
+        episode_rewards.append(total_reward)
+        recent.append(total_reward)
+        if ep % log_every == 0 or ep == episodes:
+            print(
+                f"  ep {ep:>5}/{episodes}  reward={total_reward:6.1f}"
+                f"  mean100={np.mean(recent):6.2f}  ε={agent.epsilon:.4f}"
+            )
+
+    env.close()
+
+    os.makedirs(output_dir, exist_ok=True)
+    ckpt = os.path.join(output_dir, f"parent_{label}.pt")
+    agent.q_net.eval()
+    torch.save(agent.q_net.state_dict(), ckpt)
+
+    mean_last50 = float(np.mean(episode_rewards[-50:])) if episode_rewards else 0.0
+    meta = {
+        "label": label,
+        "env": "CartPole-v1",
+        "input_dim": _INPUT_DIM,
+        "output_dim": _OUTPUT_DIM,
+        "hidden_size": hidden_size,
+        "episodes_trained": episodes,
+        "seed": seed,
+        "final_epsilon": round(agent.epsilon, 6),
+        "mean_reward_last_50_episodes": round(mean_last50, 4),
+        "episode_rewards": [round(r, 4) for r in episode_rewards],
+    }
+    with open(ckpt + ".json", "w", encoding="utf-8") as fh:
+        json.dump(meta, fh, indent=2)
+
+    # Write replay states (always from the most recent parent)
+    states_path = os.path.join(output_dir, "replay_states.npy")
+    np.save(states_path, agent.replay_states())
+    print(f"  ✓ parent_{label} → {ckpt}  (mean last-50: {mean_last50:.1f})")
+    return ckpt
+
+
+# ---------------------------------------------------------------------------
+# Stage 2: crossover + fine-tune
+# ---------------------------------------------------------------------------
+
+
+def _load_parent(path: str, hidden_size: int) -> BaseQNetwork:
+    state = torch.load(path, map_location="cpu", weights_only=True)
+    # Infer hidden size from checkpoint if possible
+    key = "network.0.weight"
+    if key in state:
+        hidden_size = int(state[key].shape[0])
+    model = BaseQNetwork(_INPUT_DIM, _OUTPUT_DIM, hidden_size=hidden_size)
+    model.load_state_dict(state)
+    model.eval()
+    return model
+
+
+def _recombine(
+    parent_a_ckpt: str,
+    parent_b_ckpt: str,
+    states_file: str,
+    hidden_size: int,
+    crossover_mode: str,
+    crossover_alpha: float,
+    crossover_seed: Optional[int],
+    finetune_epochs: int,
+    finetune_lr: float,
+    finetune_batch: int,
+    finetune_seed: Optional[int],
+    output_dir: str,
+) -> str:
+    """Crossover two parents and fine-tune the child. Returns child ckpt path."""
+    print("\n[Stage 2] Crossover + fine-tune")
+    parent_a = _load_parent(parent_a_ckpt, hidden_size)
+    parent_b = _load_parent(parent_b_ckpt, hidden_size)
+    inferred_hidden = int(parent_a.network[0].out_features)
+    print(f"  parents loaded  (hidden={inferred_hidden})")
+
+    # Crossover
+    child_sd = crossover_quantized_state_dict(
+        parent_a.state_dict(),
+        parent_b.state_dict(),
+        mode=crossover_mode,
+        alpha=crossover_alpha,
+        seed=crossover_seed,
+    )
+    child = BaseQNetwork(_INPUT_DIM, _OUTPUT_DIM, hidden_size=inferred_hidden)
+    child.load_state_dict(child_sd)
+    print(f"  crossover done  (mode={crossover_mode!r}, alpha={crossover_alpha})")
+
+    # Load states
+    states = load_distillation_states(
+        states_file, n_states=2000, input_dim=_INPUT_DIM, seed=finetune_seed
+    )
+    print(f"  states shape    : {states.shape}")
+
+    # Fine-tune
+    base_cfg = load_finetuning_config_from_yaml(None)
+    import dataclasses
+    cfg = dataclasses.replace(
+        base_cfg,
+        epochs=finetune_epochs,
+        learning_rate=finetune_lr,
+        batch_size=finetune_batch,
+        seed=finetune_seed,
+    )
+    tuner = FineTuner(reference=parent_a, child=child, config=cfg)
+    os.makedirs(output_dir, exist_ok=True)
+    ckpt_path = os.path.join(output_dir, "child_finetuned.pt")
+    metrics = tuner.finetune(states, checkpoint_path=ckpt_path)
+
+    if metrics.train_losses:
+        print(f"  final train loss : {metrics.train_losses[-1]:.6f}")
+    if metrics.val_losses:
+        print(f"  best  val  loss  : {metrics.best_val_loss:.6f} (epoch {metrics.best_epoch})")
+        print(f"  final agreement  : {metrics.action_agreements[-1]*100:.1f}%")
+    print(f"  ✓ child → {ckpt_path}")
+    return ckpt_path
+
+
+# ---------------------------------------------------------------------------
+# Stage 3: validate recombination
+# ---------------------------------------------------------------------------
+
+
+def _validate(
+    parent_a_ckpt: str,
+    parent_b_ckpt: str,
+    child_ckpt: str,
+    states_file: str,
+    hidden_size: int,
+    report_dir: str,
+    include_parent_baseline: bool,
+    report_only: bool,
+    min_action_agreement: float,
+    max_kl: float,
+    max_mse: float,
+    min_cosine: float,
+) -> bool:
+    """Run RecombinationEvaluator and write the JSON report. Returns passed."""
+    print("\n[Stage 3] Recombination validation")
+    parent_a = _load_parent(parent_a_ckpt, hidden_size)
+    parent_b = _load_parent(parent_b_ckpt, hidden_size)
+    child = _load_parent(child_ckpt, hidden_size)
+
+    states = load_distillation_states(
+        states_file, n_states=2000, input_dim=_INPUT_DIM, seed=0
+    )
+    print(f"  evaluation states: {states.shape}")
+
+    thresholds = RecombinationThresholds(
+        min_action_agreement=min_action_agreement,
+        max_kl_divergence=max_kl,
+        max_mse=max_mse,
+        min_cosine_similarity=min_cosine,
+        report_only=report_only,
+    )
+    evaluator = RecombinationEvaluator(
+        parent_a, parent_b, child,
+        thresholds=thresholds,
+        device=torch.device("cpu"),
+    )
+    report = evaluator.evaluate(
+        states,
+        include_parent_baseline=include_parent_baseline,
+        k_values=[1, 2],
+        states_source=states_file if states_file else "synthetic_standard_normal",
+        model_paths={
+            "parent_a": parent_a_ckpt,
+            "parent_b": parent_b_ckpt,
+            "child": child_ckpt,
+        },
+    )
+
+    report_dict = report.to_dict()
+
+    # Print summary
+    sep = "=" * 60
+    summary = report_dict.get("summary", {})
+    print(f"\n  {sep}")
+    print("  Recombination report")
+    print(f"  {sep}")
+    print(f"  Child ↔ Parent A agreement : {summary.get('child_agrees_with_parent_a', 0):.4f}")
+    print(f"  Child ↔ Parent B agreement : {summary.get('child_agrees_with_parent_b', 0):.4f}")
+    oracle = summary.get("oracle_agreement")
+    if oracle is not None:
+        print(f"  Oracle agreement           : {oracle:.4f}")
+    print(f"  Overall passed             : {report_dict.get('passed', False)}")
+
+    os.makedirs(report_dir, exist_ok=True)
+    out_path = os.path.join(report_dir, "recombination_validation.json")
+    with open(out_path, "w", encoding="utf-8") as fh:
+        json.dump(report_dict, fh, indent=2, allow_nan=False)
+    print(f"\n  ✓ Report → {out_path}")
+    return bool(report.passed)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=(
+            "Run the full CartPole recombination pipeline: "
+            "train parents → crossover + fine-tune → validate."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    # Existing checkpoints (skip training if provided)
+    p.add_argument(
+        "--parent-a-ckpt", default="",
+        help="Existing parent A checkpoint. If absent, parent A is trained.",
+    )
+    p.add_argument(
+        "--parent-b-ckpt", default="",
+        help="Existing parent B checkpoint. If absent, parent B is trained.",
+    )
+    p.add_argument(
+        "--force-train", action="store_true",
+        help="Re-train parents even if checkpoints already exist.",
+    )
+    # Training
+    p.add_argument("--train-episodes", type=int, default=200, help="Episodes per parent.")
+    p.add_argument("--train-lr", type=float, default=1e-3, help="Adam LR for parent training.")
+    p.add_argument("--train-gamma", type=float, default=0.99)
+    p.add_argument("--train-epsilon-start", type=float, default=1.0)
+    p.add_argument("--train-epsilon-min", type=float, default=0.01)
+    p.add_argument("--train-epsilon-decay", type=float, default=0.995)
+    p.add_argument("--train-tau", type=float, default=0.005)
+    p.add_argument("--train-memory", type=int, default=10000)
+    p.add_argument("--train-batch", type=int, default=64)
+    p.add_argument("--seed-a", type=int, default=42, help="RNG seed for parent A training.")
+    p.add_argument("--seed-b", type=int, default=99, help="RNG seed for parent B training.")
+    p.add_argument("--log-every", type=int, default=50)
+    # Architecture
+    p.add_argument("--hidden-size", type=int, default=64)
+    # Crossover
+    p.add_argument(
+        "--crossover-mode", choices=list(CROSSOVER_MODES), default="weighted",
+    )
+    p.add_argument("--crossover-alpha", type=float, default=0.5)
+    p.add_argument("--crossover-seed", type=int, default=None)
+    # Fine-tuning
+    p.add_argument("--finetune-epochs", type=int, default=10)
+    p.add_argument("--finetune-lr", type=float, default=1e-3)
+    p.add_argument("--finetune-batch", type=int, default=64)
+    p.add_argument("--finetune-seed", type=int, default=0)
+    # States
+    p.add_argument(
+        "--states-file", default="",
+        help="Path to replay_states.npy. Defaults to <output-dir>/replay_states.npy.",
+    )
+    # Validation thresholds
+    p.add_argument("--min-action-agreement", type=float, default=0.50)
+    p.add_argument("--max-kl-divergence", type=float, default=2.0)
+    p.add_argument("--max-mse", type=float, default=10.0)
+    p.add_argument("--min-cosine-similarity", type=float, default=0.50)
+    p.add_argument(
+        "--include-parent-baseline", action="store_true",
+        help="Also compute parent A vs parent B comparison.",
+    )
+    p.add_argument(
+        "--report-only", action="store_true",
+        help="Write validation report without applying pass/fail thresholds.",
+    )
+    # Output
+    p.add_argument("--output-dir", default="checkpoints/cartpole")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    out = args.output_dir
+    os.makedirs(out, exist_ok=True)
+
+    sep = "=" * 60
+    print(f"\n{sep}")
+    print("CartPole recombination pipeline")
+    print(f"Output directory : {out}")
+    print(f"Crossover mode   : {args.crossover_mode}  (alpha={args.crossover_alpha})")
+    print(f"{sep}")
+
+    # -----------------------------------------------------------------------
+    # Stage 1: train parents (skip if checkpoints exist and --force-train not set)
+    # -----------------------------------------------------------------------
+    parent_a_ckpt = args.parent_a_ckpt
+    parent_b_ckpt = args.parent_b_ckpt
+
+    default_a = os.path.join(out, "parent_A.pt")
+    default_b = os.path.join(out, "parent_B.pt")
+
+    train_common = dict(
+        hidden_size=args.hidden_size,
+        lr=args.train_lr,
+        gamma=args.train_gamma,
+        epsilon_start=args.train_epsilon_start,
+        epsilon_min=args.train_epsilon_min,
+        epsilon_decay=args.train_epsilon_decay,
+        tau=args.train_tau,
+        memory_size=args.train_memory,
+        batch_size=args.train_batch,
+        output_dir=out,
+        log_every=args.log_every,
+    )
+
+    need_a = not parent_a_ckpt or args.force_train
+    need_b = not parent_b_ckpt or args.force_train
+
+    if need_a and (not os.path.isfile(default_a) or args.force_train):
+        parent_a_ckpt = _train_parent(
+            "A", episodes=args.train_episodes, seed=args.seed_a, **train_common
+        )
+    elif not parent_a_ckpt:
+        parent_a_ckpt = default_a
+        print(f"\n[Stage 1] Skipping parent A training — using {parent_a_ckpt}")
+
+    if need_b and (not os.path.isfile(default_b) or args.force_train):
+        parent_b_ckpt = _train_parent(
+            "B", episodes=args.train_episodes, seed=args.seed_b, **train_common
+        )
+    elif not parent_b_ckpt:
+        parent_b_ckpt = default_b
+        print(f"[Stage 1] Skipping parent B training — using {parent_b_ckpt}")
+
+    # -----------------------------------------------------------------------
+    # Stage 2: crossover + fine-tune
+    # -----------------------------------------------------------------------
+    states_file = args.states_file or os.path.join(out, "replay_states.npy")
+    if not os.path.isfile(states_file):
+        states_file = ""   # fall back to synthetic states
+
+    child_ckpt = _recombine(
+        parent_a_ckpt=parent_a_ckpt,
+        parent_b_ckpt=parent_b_ckpt,
+        states_file=states_file,
+        hidden_size=args.hidden_size,
+        crossover_mode=args.crossover_mode,
+        crossover_alpha=args.crossover_alpha,
+        crossover_seed=args.crossover_seed,
+        finetune_epochs=args.finetune_epochs,
+        finetune_lr=args.finetune_lr,
+        finetune_batch=args.finetune_batch,
+        finetune_seed=args.finetune_seed,
+        output_dir=out,
+    )
+
+    # -----------------------------------------------------------------------
+    # Stage 3: validate
+    # -----------------------------------------------------------------------
+    passed = _validate(
+        parent_a_ckpt=parent_a_ckpt,
+        parent_b_ckpt=parent_b_ckpt,
+        child_ckpt=child_ckpt,
+        states_file=states_file,
+        hidden_size=args.hidden_size,
+        report_dir=out,
+        include_parent_baseline=args.include_parent_baseline,
+        report_only=args.report_only,
+        min_action_agreement=args.min_action_agreement,
+        max_kl=args.max_kl_divergence,
+        max_mse=args.max_mse,
+        min_cosine=args.min_cosine_similarity,
+    )
+
+    print(f"\n{sep}")
+    print("Pipeline complete.")
+    print(f"All outputs in    : {out}")
+    print(f"Validation passed : {passed}")
+    print(f"{sep}\n")
+
+    if not passed and not args.report_only:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_cartpole_recombination.py
+++ b/scripts/run_cartpole_recombination.py
@@ -66,6 +66,7 @@ from __future__ import annotations
 
 import argparse
 import collections
+import dataclasses
 import json
 import os
 import random
@@ -351,7 +352,6 @@ def _recombine(
 
     # Fine-tune
     base_cfg = load_finetuning_config_from_yaml(None)
-    import dataclasses
     cfg = dataclasses.replace(
         base_cfg,
         epochs=finetune_epochs,
@@ -577,7 +577,7 @@ def main() -> None:
         )
     elif not parent_b_ckpt:
         parent_b_ckpt = default_b
-        print(f"[Stage 1] Skipping parent B training — using {parent_b_ckpt}")
+        print(f"\n[Stage 1] Skipping parent B training — using {parent_b_ckpt}")
 
     # -----------------------------------------------------------------------
     # Stage 2: crossover + fine-tune

--- a/scripts/run_cartpole_recombination.py
+++ b/scripts/run_cartpole_recombination.py
@@ -49,8 +49,9 @@ All files are written under ``<output-dir>/``:
     Parent A checkpoint and metadata (training stage).
 ``parent_B.pt``, ``parent_B.pt.json``
     Parent B checkpoint and metadata (training stage).
-``replay_states.npy``
-    Replay buffer states collected during training (shape ``(N, 4)``).
+``replay_states_A.npy``, ``replay_states_B.npy`` (and legacy ``replay_states.npy``)
+    Per-parent replay state exports (shape ``(N, 4)``). The pipeline prefers B,
+    then A, then the legacy single file when choosing a default states path.
 ``child_finetuned.pt``, ``child_finetuned.pt.json``
     Fine-tuned child checkpoint and metadata (recombination stage).
 ``recombination_validation.json``
@@ -71,7 +72,6 @@ import os
 import sys
 from typing import Optional
 
-import numpy as np
 import torch
 
 # Allow running directly from repo root without installing the package.
@@ -87,6 +87,7 @@ from farm.core.decision.training.crossover import (  # noqa: E402
     crossover_quantized_state_dict,
 )
 from farm.core.decision.training.distillation_script_helpers import (  # noqa: E402
+    load_base_qnetwork_checkpoint,
     load_distillation_states,
 )
 from farm.core.decision.training.finetune import (  # noqa: E402
@@ -98,7 +99,7 @@ from farm.core.decision.training.recombination_eval import (  # noqa: E402
     RecombinationThresholds,
 )
 
-from cartpole_dqn_training import train_cartpole_parent  # noqa: E402
+from cartpole_dqn_training import parse_torch_device, train_cartpole_parent  # noqa: E402
 
 # CartPole-v1 fixed dimensions
 _INPUT_DIM = 4
@@ -125,6 +126,8 @@ def _train_parent(
     seed: Optional[int],
     output_dir: str,
     log_every: int,
+    device: torch.device,
+    max_replay_states: Optional[int],
 ) -> str:
     """Train one CartPole parent and return its checkpoint path."""
     print(f"\n[Stage 1] Training parent_{label}  ({episodes} episodes, seed={seed})")
@@ -143,7 +146,8 @@ def _train_parent(
         seed=seed,
         output_dir=output_dir,
         log_every=log_every,
-        device=torch.device("cpu"),
+        device=device,
+        max_replay_states=max_replay_states,
     )
     print(
         f"  ✓ parent_{label} → {result.checkpoint_path}  "
@@ -157,16 +161,55 @@ def _train_parent(
 # ---------------------------------------------------------------------------
 
 
-def _load_parent(path: str, hidden_size: int) -> BaseQNetwork:
+def _infer_hidden_size(path: str, fallback: int) -> int:
+    """Read first-layer width from a ``BaseQNetwork`` state dict checkpoint."""
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"Parent checkpoint not found: {path!r}")
     state = torch.load(path, map_location="cpu", weights_only=True)
-    # Infer hidden size from checkpoint if possible
+    if not isinstance(state, dict):
+        raise ValueError(
+            f"Checkpoint at {path!r} does not contain a state dict (got {type(state).__name__})."
+        )
     key = "network.0.weight"
     if key in state:
-        hidden_size = int(state[key].shape[0])
-    model = BaseQNetwork(_INPUT_DIM, _OUTPUT_DIM, hidden_size=hidden_size)
-    model.load_state_dict(state)
-    model.eval()
-    return model
+        return int(state[key].shape[0])
+    return fallback
+
+
+def _load_parent_network(path: str, hidden_fallback: int) -> BaseQNetwork:
+    """Load a parent ``BaseQNetwork`` with the same validation as distillation scripts."""
+    hidden = _infer_hidden_size(path, hidden_fallback)
+    net = load_base_qnetwork_checkpoint(
+        path,
+        _INPUT_DIM,
+        _OUTPUT_DIM,
+        hidden,
+        loaded_template="  Loaded parent network from: {path}",
+    )
+    net.eval()
+    return net
+
+
+def _assert_parent_state_dicts_compatible(
+    sd_a: dict,
+    sd_b: dict,
+    path_a: str,
+    path_b: str,
+) -> None:
+    """Crossover requires identical keys and tensor shapes between parents."""
+    keys_a = set(sd_a.keys())
+    keys_b = set(sd_b.keys())
+    if keys_a != keys_b:
+        raise ValueError(
+            f"Parent checkpoints have different state-dict keys ({path_a!r} vs {path_b!r})."
+        )
+    for key in keys_a:
+        ta, tb = sd_a[key], sd_b[key]
+        if ta.shape != tb.shape:
+            raise ValueError(
+                f"Parent checkpoints shape mismatch on {key!r}: "
+                f"{tuple(ta.shape)} vs {tuple(tb.shape)} ({path_a!r} vs {path_b!r})."
+            )
 
 
 def _recombine(
@@ -182,11 +225,18 @@ def _recombine(
     finetune_batch: int,
     finetune_seed: Optional[int],
     output_dir: str,
+    device: torch.device,
 ) -> str:
     """Crossover two parents and fine-tune the child. Returns child ckpt path."""
     print("\n[Stage 2] Crossover + fine-tune")
-    parent_a = _load_parent(parent_a_ckpt, hidden_size)
-    parent_b = _load_parent(parent_b_ckpt, hidden_size)
+    parent_a = _load_parent_network(parent_a_ckpt, hidden_size)
+    parent_b = _load_parent_network(parent_b_ckpt, hidden_size)
+    _assert_parent_state_dicts_compatible(
+        parent_a.state_dict(),
+        parent_b.state_dict(),
+        parent_a_ckpt,
+        parent_b_ckpt,
+    )
     inferred_hidden = int(parent_a.network[0].out_features)
     print(f"  parents loaded  (hidden={inferred_hidden})")
 
@@ -217,7 +267,7 @@ def _recombine(
         batch_size=finetune_batch,
         seed=finetune_seed,
     )
-    tuner = FineTuner(reference=parent_a, child=child, config=cfg)
+    tuner = FineTuner(reference=parent_a, child=child, config=cfg, device=device)
     os.makedirs(output_dir, exist_ok=True)
     ckpt_path = os.path.join(output_dir, "child_finetuned.pt")
     metrics = tuner.finetune(states, checkpoint_path=ckpt_path)
@@ -249,12 +299,13 @@ def _validate(
     max_kl: float,
     max_mse: float,
     min_cosine: float,
+    device: torch.device,
 ) -> bool:
     """Run RecombinationEvaluator and write the JSON report. Returns passed."""
     print("\n[Stage 3] Recombination validation")
-    parent_a = _load_parent(parent_a_ckpt, hidden_size)
-    parent_b = _load_parent(parent_b_ckpt, hidden_size)
-    child = _load_parent(child_ckpt, hidden_size)
+    parent_a = _load_parent_network(parent_a_ckpt, hidden_size)
+    parent_b = _load_parent_network(parent_b_ckpt, hidden_size)
+    child = _load_parent_network(child_ckpt, hidden_size)
 
     states = load_distillation_states(
         states_file, n_states=2000, input_dim=_INPUT_DIM, seed=0
@@ -271,7 +322,7 @@ def _validate(
     evaluator = RecombinationEvaluator(
         parent_a, parent_b, child,
         thresholds=thresholds,
-        device=torch.device("cpu"),
+        device=device,
     )
     report = evaluator.evaluate(
         states,
@@ -306,6 +357,23 @@ def _validate(
         json.dump(report_dict, fh, indent=2, allow_nan=False)
     print(f"\n  ✓ Report → {out_path}")
     return bool(report.passed)
+
+
+def _default_replay_states_path(output_dir: str) -> str:
+    """Prefer B's replay export, then A's, then legacy single file."""
+    for name in ("replay_states_B.npy", "replay_states_A.npy", "replay_states.npy"):
+        candidate = os.path.join(output_dir, name)
+        if os.path.isfile(candidate):
+            return candidate
+    return os.path.join(output_dir, "replay_states_B.npy")
+
+
+def _require_parent_checkpoint(path: str, which: str) -> None:
+    if not os.path.isfile(path):
+        raise FileNotFoundError(
+            f"Parent {which} checkpoint is not a readable file: {path!r}. "
+            "Omit --parent-*-ckpt to train defaults under --output-dir, or fix the path."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -347,6 +415,17 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("--seed-a", type=int, default=42, help="RNG seed for parent A training.")
     p.add_argument("--seed-b", type=int, default=99, help="RNG seed for parent B training.")
     p.add_argument("--log-every", type=int, default=50)
+    p.add_argument(
+        "--device",
+        default="cpu",
+        help="Torch device for parent training, fine-tuning, and validation (cpu, cuda, …).",
+    )
+    p.add_argument(
+        "--max-replay-states",
+        type=int,
+        default=200_000,
+        help="Max replay-state rows kept per parent (-1 = unlimited; caps RAM and .npy size).",
+    )
     # Architecture
     p.add_argument("--hidden-size", type=int, default=64)
     # Crossover
@@ -363,7 +442,10 @@ def _parse_args() -> argparse.Namespace:
     # States
     p.add_argument(
         "--states-file", default="",
-        help="Path to replay_states.npy. Defaults to <output-dir>/replay_states.npy.",
+        help=(
+            "Path to replay states .npy. Default: first existing among "
+            "replay_states_B.npy, replay_states_A.npy, replay_states.npy under --output-dir."
+        ),
     )
     # Validation thresholds
     p.add_argument("--min-action-agreement", type=float, default=0.50)
@@ -387,11 +469,16 @@ def main() -> None:
     args = _parse_args()
     out = args.output_dir
     os.makedirs(out, exist_ok=True)
+    device = parse_torch_device(args.device)
+    max_replay_states: Optional[int] = (
+        None if args.max_replay_states < 0 else args.max_replay_states
+    )
 
     sep = "=" * 60
     print(f"\n{sep}")
     print("CartPole recombination pipeline")
     print(f"Output directory : {out}")
+    print(f"Device           : {device}")
     print(f"Crossover mode   : {args.crossover_mode}  (alpha={args.crossover_alpha})")
     print(f"{sep}")
 
@@ -416,6 +503,8 @@ def main() -> None:
         batch_size=args.train_batch,
         output_dir=out,
         log_every=args.log_every,
+        device=device,
+        max_replay_states=max_replay_states,
     )
 
     need_a = not parent_a_ckpt or args.force_train
@@ -437,12 +526,19 @@ def main() -> None:
         parent_b_ckpt = default_b
         print(f"\n[Stage 1] Skipping parent B training — using {parent_b_ckpt}")
 
+    _require_parent_checkpoint(parent_a_ckpt, "A")
+    _require_parent_checkpoint(parent_b_ckpt, "B")
+
     # -----------------------------------------------------------------------
     # Stage 2: crossover + fine-tune
     # -----------------------------------------------------------------------
-    states_file = args.states_file or os.path.join(out, "replay_states.npy")
+    states_file = args.states_file or _default_replay_states_path(out)
     if not os.path.isfile(states_file):
-        states_file = ""   # fall back to synthetic states
+        print(
+            f"\n[States] No replay states file at {states_file!r} — "
+            "using synthetic Gaussian states for fine-tune and validation."
+        )
+        states_file = ""
 
     child_ckpt = _recombine(
         parent_a_ckpt=parent_a_ckpt,
@@ -457,6 +553,7 @@ def main() -> None:
         finetune_batch=args.finetune_batch,
         finetune_seed=args.finetune_seed,
         output_dir=out,
+        device=device,
     )
 
     # -----------------------------------------------------------------------
@@ -475,6 +572,7 @@ def main() -> None:
         max_kl=args.max_kl_divergence,
         max_mse=args.max_mse,
         min_cosine=args.min_cosine_similarity,
+        device=device,
     )
 
     print(f"\n{sep}")

--- a/scripts/run_cartpole_recombination.py
+++ b/scripts/run_cartpole_recombination.py
@@ -7,8 +7,8 @@ and ``parent_B.pt``) and finishing with a JSON validation report.
 
 Pipeline stages
 ---------------
-1. **Train parents** (optional) — calls ``train_cartpole_parents.py`` logic
-   inline to produce ``parent_A.pt`` / ``parent_B.pt`` if they don't already
+1. **Train parents** (optional) — uses shared ``cartpole_dqn_training`` logic
+   to produce ``parent_A.pt`` / ``parent_B.pt`` if they don't already
    exist (or if ``--force-train`` is set).
 2. **Crossover + fine-tune child** — combines parent weights via
    :func:`~farm.core.decision.training.crossover.crossover_quantized_state_dict`
@@ -65,28 +65,21 @@ CartPole dimensions
 from __future__ import annotations
 
 import argparse
-import collections
 import dataclasses
 import json
 import os
-import random
 import sys
-from typing import Deque, List, Optional
+from typing import Optional
 
 import numpy as np
 import torch
-import torch.nn as nn
-import torch.optim as optim
 
 # Allow running directly from repo root without installing the package.
 _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _repo_root not in sys.path:
-    sys.path.insert(0, _repo_root)
-
-try:
-    import gymnasium as gym
-except ImportError as exc:
-    raise SystemExit("gymnasium is required: pip install gymnasium") from exc
+_scripts_dir = os.path.join(_repo_root, "scripts")
+for _p in (_repo_root, _scripts_dir):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
 
 from farm.core.decision.base_dqn import BaseQNetwork  # noqa: E402
 from farm.core.decision.training.crossover import (  # noqa: E402
@@ -105,101 +98,11 @@ from farm.core.decision.training.recombination_eval import (  # noqa: E402
     RecombinationThresholds,
 )
 
+from cartpole_dqn_training import train_cartpole_parent  # noqa: E402
+
 # CartPole-v1 fixed dimensions
 _INPUT_DIM = 4
 _OUTPUT_DIM = 2
-
-
-# ---------------------------------------------------------------------------
-# Minimal DQN agent for CartPole training (self-contained)
-# ---------------------------------------------------------------------------
-
-
-class _DQNAgent:
-    """Lightweight DQN agent for single-environment training."""
-
-    def __init__(
-        self,
-        hidden_size: int,
-        lr: float,
-        gamma: float,
-        epsilon_start: float,
-        epsilon_min: float,
-        epsilon_decay: float,
-        tau: float,
-        memory_size: int,
-        batch_size: int,
-        seed: Optional[int],
-    ) -> None:
-        self.device = torch.device("cpu")
-        self.gamma = gamma
-        self.epsilon = epsilon_start
-        self.epsilon_min = epsilon_min
-        self.epsilon_decay = epsilon_decay
-        self.tau = tau
-        self.batch_size = batch_size
-
-        if seed is not None:
-            random.seed(seed)
-            np.random.seed(seed)
-            torch.manual_seed(seed)
-
-        self.q_net = BaseQNetwork(_INPUT_DIM, _OUTPUT_DIM, hidden_size).to(self.device)
-        self.target_net = BaseQNetwork(_INPUT_DIM, _OUTPUT_DIM, hidden_size).to(self.device)
-        self.target_net.load_state_dict(self.q_net.state_dict())
-        self.target_net.eval()
-        self.optimizer = optim.Adam(self.q_net.parameters(), lr=lr)
-        self.criterion = nn.SmoothL1Loss()
-        self.memory: Deque = collections.deque(maxlen=memory_size)
-        self._states_seen: List[np.ndarray] = []
-
-    def act(self, state: np.ndarray) -> int:
-        if random.random() < self.epsilon:
-            return random.randint(0, _OUTPUT_DIM - 1)
-        s = torch.from_numpy(state).float().to(self.device)
-        self.q_net.eval()
-        with torch.no_grad():
-            q = self.q_net(s)
-        self.q_net.train()
-        return int(q.argmax().item())
-
-    def store(self, state, action, reward, next_state, done):
-        self.memory.append((state, action, reward, next_state, done))
-        self._states_seen.append(state.astype("float32"))
-
-    def learn(self):
-        if len(self.memory) < self.batch_size:
-            return
-        batch = random.sample(self.memory, self.batch_size)
-        states = torch.from_numpy(np.stack([b[0] for b in batch])).float().to(self.device)
-        actions = torch.tensor([b[1] for b in batch], device=self.device).unsqueeze(1)
-        rewards = torch.tensor([b[2] for b in batch], dtype=torch.float32, device=self.device)
-        next_states = torch.from_numpy(np.stack([b[3] for b in batch])).float().to(self.device)
-        dones = torch.tensor([b[4] for b in batch], dtype=torch.float32, device=self.device)
-
-        self.q_net.eval()
-        current_q = self.q_net(states).gather(1, actions)
-        with torch.no_grad():
-            next_acts = self.q_net(next_states).argmax(1, keepdim=True)
-            next_q = self.target_net(next_states).gather(1, next_acts)
-            target_q = rewards.unsqueeze(1) + (1 - dones.unsqueeze(1)) * self.gamma * next_q
-        self.q_net.train()
-
-        loss = self.criterion(current_q, target_q)
-        self.optimizer.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(self.q_net.parameters(), 1.0)
-        self.optimizer.step()
-
-        for tp, lp in zip(self.target_net.parameters(), self.q_net.parameters()):
-            tp.data.copy_(self.tau * lp.data + (1.0 - self.tau) * tp.data)
-
-        self.epsilon = max(self.epsilon_min, self.epsilon * self.epsilon_decay)
-
-    def replay_states(self) -> np.ndarray:
-        if not self._states_seen:
-            return np.empty((0, _INPUT_DIM), dtype="float32")
-        return np.stack(self._states_seen, axis=0).astype("float32")
 
 
 # ---------------------------------------------------------------------------
@@ -225,8 +128,9 @@ def _train_parent(
 ) -> str:
     """Train one CartPole parent and return its checkpoint path."""
     print(f"\n[Stage 1] Training parent_{label}  ({episodes} episodes, seed={seed})")
-    env = gym.make("CartPole-v1")
-    agent = _DQNAgent(
+    result = train_cartpole_parent(
+        label=label,
+        episodes=episodes,
         hidden_size=hidden_size,
         lr=lr,
         gamma=gamma,
@@ -237,61 +141,15 @@ def _train_parent(
         memory_size=memory_size,
         batch_size=batch_size,
         seed=seed,
+        output_dir=output_dir,
+        log_every=log_every,
+        device=torch.device("cpu"),
     )
-
-    episode_rewards: List[float] = []
-    recent: Deque[float] = collections.deque(maxlen=100)
-
-    for ep in range(1, episodes + 1):
-        obs, _ = env.reset()
-        state = np.array(obs, dtype="float32")
-        total_reward = 0.0
-        done = False
-        while not done:
-            action = agent.act(state)
-            obs2, reward, terminated, truncated, _ = env.step(action)
-            next_state = np.array(obs2, dtype="float32")
-            done = terminated or truncated
-            agent.store(state, action, float(reward), next_state, done)
-            agent.learn()
-            state = next_state
-            total_reward += float(reward)
-        episode_rewards.append(total_reward)
-        recent.append(total_reward)
-        if ep % log_every == 0 or ep == episodes:
-            print(
-                f"  ep {ep:>5}/{episodes}  reward={total_reward:6.1f}"
-                f"  mean100={np.mean(recent):6.2f}  ε={agent.epsilon:.4f}"
-            )
-
-    env.close()
-
-    os.makedirs(output_dir, exist_ok=True)
-    ckpt = os.path.join(output_dir, f"parent_{label}.pt")
-    agent.q_net.eval()
-    torch.save(agent.q_net.state_dict(), ckpt)
-
-    mean_last50 = float(np.mean(episode_rewards[-50:])) if episode_rewards else 0.0
-    meta = {
-        "label": label,
-        "env": "CartPole-v1",
-        "input_dim": _INPUT_DIM,
-        "output_dim": _OUTPUT_DIM,
-        "hidden_size": hidden_size,
-        "episodes_trained": episodes,
-        "seed": seed,
-        "final_epsilon": round(agent.epsilon, 6),
-        "mean_reward_last_50_episodes": round(mean_last50, 4),
-        "episode_rewards": [round(r, 4) for r in episode_rewards],
-    }
-    with open(ckpt + ".json", "w", encoding="utf-8") as fh:
-        json.dump(meta, fh, indent=2)
-
-    # Write replay states (always from the most recent parent)
-    states_path = os.path.join(output_dir, "replay_states.npy")
-    np.save(states_path, agent.replay_states())
-    print(f"  ✓ parent_{label} → {ckpt}  (mean last-50: {mean_last50:.1f})")
-    return ckpt
+    print(
+        f"  ✓ parent_{label} → {result.checkpoint_path}  "
+        f"(mean last-50: {result.mean_reward_last_50:.1f})"
+    )
+    return result.checkpoint_path
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/train_cartpole_parents.py
+++ b/scripts/train_cartpole_parents.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Train two parent BaseQNetwork models on the CartPole-v1 task.
+
+Each parent is trained independently via DQN with epsilon-greedy exploration.
+Their ``q_network`` state dicts are saved as ``parent_A.pt`` and ``parent_B.pt``
+(plus companion metadata JSON files) in the output directory.
+
+CartPole-v1 state space
+-----------------------
+4-dimensional observation: cart position, cart velocity, pole angle, pole
+angular velocity.  Two discrete actions: push left (0) or push right (1).
+
+Episode ends when the pole tilts beyond ±12°, the cart moves more than ±2.4
+units from the centre, or after 500 timesteps.  A reward of +1 is given each
+step the pole stays upright.
+
+How to run
+----------
+::
+
+    # Train both parents with defaults (200 episodes each)
+    python scripts/train_cartpole_parents.py
+
+    # Custom run
+    python scripts/train_cartpole_parents.py \\
+        --episodes 500 \\
+        --hidden-size 64 \\
+        --seed-a 1 --seed-b 2 \\
+        --output-dir checkpoints/cartpole
+
+    # Train only one parent
+    python scripts/train_cartpole_parents.py --pair A --episodes 300
+
+Outputs
+-------
+``<output-dir>/parent_A.pt``
+    ``BaseQNetwork`` state dict saved with ``torch.save(model.state_dict(), …)``.
+``<output-dir>/parent_A.pt.json``
+    Companion metadata: input/output dims, hidden size, seed, final epsilon,
+    mean reward of the last 50 episodes.
+``<output-dir>/parent_B.pt``  (and ``.pt.json``) — same for parent B.
+``<output-dir>/replay_states.npy``
+    Concatenated experience states (float32, shape ``(N, 4)``) collected during
+    the *last* training run (parent B, or parent A if only pair A is trained).
+    Useful as a real-distribution state buffer for downstream pipeline stages.
+
+The script also writes per-episode rewards to stdout so progress can be
+monitored in real time.
+
+Architecture
+------------
+Both parents share the same architecture (``BaseQNetwork`` with configurable
+``hidden_size``), but are trained independently from different random seeds.
+This intentional diversity means the two parents will have learnt slightly
+different policies, providing meaningful signal for the crossover stage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import random
+import sys
+from typing import Deque, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+# Allow running directly from repo root without installing the package.
+_repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+try:
+    import gymnasium as gym
+except ImportError as exc:
+    raise SystemExit(
+        "gymnasium is required: pip install gymnasium"
+    ) from exc
+
+from farm.core.decision.base_dqn import BaseQNetwork  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# DQN trainer (self-contained, no SimulationDatabase dependency)
+# ---------------------------------------------------------------------------
+
+
+class _CartPoleDQN:
+    """Minimal DQN trainer wired to a ``BaseQNetwork`` for CartPole-v1.
+
+    Implements:
+    - Experience replay buffer
+    - Epsilon-greedy exploration with linear/exponential decay
+    - Double Q-Learning updates
+    - Soft target-network updates
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        hidden_size: int,
+        lr: float,
+        gamma: float,
+        epsilon_start: float,
+        epsilon_min: float,
+        epsilon_decay: float,
+        tau: float,
+        memory_size: int,
+        batch_size: int,
+        seed: Optional[int],
+        device: torch.device,
+    ) -> None:
+        self.device = device
+        self.output_dim = output_dim
+        self.gamma = gamma
+        self.epsilon = epsilon_start
+        self.epsilon_min = epsilon_min
+        self.epsilon_decay = epsilon_decay
+        self.tau = tau
+        self.batch_size = batch_size
+
+        if seed is not None:
+            random.seed(seed)
+            np.random.seed(seed)
+            torch.manual_seed(seed)
+
+        self.q_net = BaseQNetwork(input_dim, output_dim, hidden_size).to(device)
+        self.target_net = BaseQNetwork(input_dim, output_dim, hidden_size).to(device)
+        self.target_net.load_state_dict(self.q_net.state_dict())
+        self.target_net.eval()
+
+        self.optimizer = optim.Adam(self.q_net.parameters(), lr=lr)
+        self.criterion = nn.SmoothL1Loss()
+        self.memory: Deque[Tuple] = collections.deque(maxlen=memory_size)
+
+        # Collected states for replay buffer export
+        self._states_seen: List[np.ndarray] = []
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def select_action(self, state: np.ndarray) -> int:
+        if random.random() < self.epsilon:
+            return random.randint(0, self.output_dim - 1)
+        s = torch.from_numpy(state).float().to(self.device)
+        self.q_net.eval()
+        with torch.no_grad():
+            q = self.q_net(s)
+        self.q_net.train()
+        return int(q.argmax().item())
+
+    def store(
+        self,
+        state: np.ndarray,
+        action: int,
+        reward: float,
+        next_state: np.ndarray,
+        done: bool,
+    ) -> None:
+        self.memory.append((state, action, reward, next_state, done))
+        self._states_seen.append(state.astype("float32"))
+
+    def train_step(self) -> Optional[float]:
+        if len(self.memory) < self.batch_size:
+            return None
+        batch = random.sample(self.memory, self.batch_size)
+        states = torch.from_numpy(np.stack([b[0] for b in batch])).float().to(self.device)
+        actions = torch.tensor([b[1] for b in batch], device=self.device).unsqueeze(1)
+        rewards = torch.tensor([b[2] for b in batch], dtype=torch.float32, device=self.device)
+        next_states = torch.from_numpy(np.stack([b[3] for b in batch])).float().to(self.device)
+        dones = torch.tensor([b[4] for b in batch], dtype=torch.float32, device=self.device)
+
+        self.q_net.eval()
+        current_q = self.q_net(states).gather(1, actions)
+        with torch.no_grad():
+            next_actions = self.q_net(next_states).argmax(1, keepdim=True)
+            next_q = self.target_net(next_states).gather(1, next_actions)
+            target_q = rewards.unsqueeze(1) + (1 - dones.unsqueeze(1)) * self.gamma * next_q
+        self.q_net.train()
+
+        loss = self.criterion(current_q, target_q)
+        self.optimizer.zero_grad()
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(self.q_net.parameters(), 1.0)
+        self.optimizer.step()
+
+        # Soft target update
+        for tp, lp in zip(self.target_net.parameters(), self.q_net.parameters()):
+            tp.data.copy_(self.tau * lp.data + (1.0 - self.tau) * tp.data)
+
+        # Decay epsilon
+        self.epsilon = max(self.epsilon_min, self.epsilon * self.epsilon_decay)
+        return float(loss.item())
+
+    def replay_states(self) -> np.ndarray:
+        """Return all states seen during training as float32 (N, input_dim)."""
+        if not self._states_seen:
+            return np.empty((0, 4), dtype="float32")
+        return np.stack(self._states_seen, axis=0).astype("float32")
+
+
+# ---------------------------------------------------------------------------
+# Training loop
+# ---------------------------------------------------------------------------
+
+
+def _train_one_parent(
+    label: str,
+    episodes: int,
+    hidden_size: int,
+    lr: float,
+    gamma: float,
+    epsilon_start: float,
+    epsilon_min: float,
+    epsilon_decay: float,
+    tau: float,
+    memory_size: int,
+    batch_size: int,
+    seed: Optional[int],
+    output_dir: str,
+    log_every: int,
+    device: torch.device,
+) -> None:
+    """Run a full DQN training loop for one parent and save the checkpoint."""
+    print(f"\n{'=' * 60}")
+    print(f"Training parent_{label}  (CartPole-v1, {episodes} episodes)")
+    if seed is not None:
+        print(f"  Seed       : {seed}")
+    print(f"  Hidden     : {hidden_size}")
+    print(f"  lr         : {lr}  gamma={gamma}  eps_decay={epsilon_decay}")
+    print(f"{'=' * 60}")
+
+    env = gym.make("CartPole-v1")
+    input_dim = int(env.observation_space.shape[0])   # 4
+    output_dim = int(env.action_space.n)               # 2
+
+    agent = _CartPoleDQN(
+        input_dim=input_dim,
+        output_dim=output_dim,
+        hidden_size=hidden_size,
+        lr=lr,
+        gamma=gamma,
+        epsilon_start=epsilon_start,
+        epsilon_min=epsilon_min,
+        epsilon_decay=epsilon_decay,
+        tau=tau,
+        memory_size=memory_size,
+        batch_size=batch_size,
+        seed=seed,
+        device=device,
+    )
+
+    episode_rewards: List[float] = []
+    recent: Deque[float] = collections.deque(maxlen=100)
+
+    for ep in range(1, episodes + 1):
+        obs, _ = env.reset(seed=None)
+        state = np.array(obs, dtype="float32")
+        total_reward = 0.0
+        done = False
+
+        while not done:
+            action = agent.select_action(state)
+            obs2, reward, terminated, truncated, _ = env.step(action)
+            next_state = np.array(obs2, dtype="float32")
+            done = terminated or truncated
+            agent.store(state, action, float(reward), next_state, done)
+            agent.train_step()
+            state = next_state
+            total_reward += float(reward)
+
+        episode_rewards.append(total_reward)
+        recent.append(total_reward)
+
+        if ep % log_every == 0 or ep == episodes:
+            mean100 = float(np.mean(recent))
+            print(
+                f"  ep {ep:>5}/{episodes}  reward={total_reward:6.1f}"
+                f"  mean100={mean100:6.2f}  ε={agent.epsilon:.4f}"
+            )
+
+    env.close()
+
+    # Save state dict checkpoint
+    os.makedirs(output_dir, exist_ok=True)
+    ckpt_path = os.path.join(output_dir, f"parent_{label}.pt")
+    agent.q_net.eval()
+    torch.save(agent.q_net.state_dict(), ckpt_path)
+
+    # Companion metadata
+    mean_last50 = float(np.mean(episode_rewards[-50:])) if episode_rewards else 0.0
+    meta = {
+        "label": label,
+        "env": "CartPole-v1",
+        "input_dim": input_dim,
+        "output_dim": output_dim,
+        "hidden_size": hidden_size,
+        "episodes_trained": episodes,
+        "seed": seed,
+        "final_epsilon": round(agent.epsilon, 6),
+        "mean_reward_last_50_episodes": round(mean_last50, 4),
+        "episode_rewards": [round(r, 4) for r in episode_rewards],
+    }
+    meta_path = ckpt_path + ".json"
+    with open(meta_path, "w", encoding="utf-8") as fh:
+        json.dump(meta, fh, indent=2)
+
+    print(f"\n  ✓ Checkpoint   : {ckpt_path}")
+    print(f"  ✓ Metadata     : {meta_path}")
+    print(f"  Mean reward (last 50 eps): {mean_last50:.2f}")
+
+    # Save replay states (overwritten each time – caller picks up the last one)
+    states_path = os.path.join(output_dir, "replay_states.npy")
+    replay = agent.replay_states()
+    np.save(states_path, replay)
+    print(f"  ✓ Replay states: {states_path}  shape={replay.shape}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Train two parent BaseQNetwork models on CartPole-v1.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--pair",
+        choices=["A", "B", "both"],
+        default="both",
+        help="Which parent(s) to train.",
+    )
+    # Architecture
+    p.add_argument("--hidden-size", type=int, default=64, help="Hidden layer width.")
+    # Training
+    p.add_argument("--episodes", type=int, default=200, help="Training episodes per parent.")
+    p.add_argument("--lr", type=float, default=1e-3, help="Adam learning rate.")
+    p.add_argument("--gamma", type=float, default=0.99, help="Discount factor.")
+    p.add_argument("--epsilon-start", type=float, default=1.0, help="Initial epsilon.")
+    p.add_argument("--epsilon-min", type=float, default=0.01, help="Minimum epsilon.")
+    p.add_argument(
+        "--epsilon-decay",
+        type=float,
+        default=0.995,
+        help="Per-step epsilon decay factor.",
+    )
+    p.add_argument("--tau", type=float, default=0.005, help="Soft target-update rate.")
+    p.add_argument("--memory-size", type=int, default=10000, help="Replay buffer capacity.")
+    p.add_argument("--batch-size", type=int, default=64, help="Training mini-batch size.")
+    # Seeds (each parent gets its own seed so policies diverge)
+    p.add_argument("--seed-a", type=int, default=42, help="RNG seed for parent A.")
+    p.add_argument("--seed-b", type=int, default=99, help="RNG seed for parent B.")
+    # Output
+    p.add_argument(
+        "--output-dir",
+        default="checkpoints/cartpole",
+        help="Directory to write parent checkpoints.",
+    )
+    p.add_argument(
+        "--log-every",
+        type=int,
+        default=50,
+        help="Print progress every N episodes.",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    device = torch.device("cpu")
+
+    common = dict(
+        hidden_size=args.hidden_size,
+        lr=args.lr,
+        gamma=args.gamma,
+        epsilon_start=args.epsilon_start,
+        epsilon_min=args.epsilon_min,
+        epsilon_decay=args.epsilon_decay,
+        tau=args.tau,
+        memory_size=args.memory_size,
+        batch_size=args.batch_size,
+        output_dir=args.output_dir,
+        log_every=args.log_every,
+        device=device,
+    )
+
+    if args.pair in ("A", "both"):
+        _train_one_parent(
+            label="A",
+            episodes=args.episodes,
+            seed=args.seed_a,
+            **common,
+        )
+
+    if args.pair in ("B", "both"):
+        _train_one_parent(
+            label="B",
+            episodes=args.episodes,
+            seed=args.seed_b,
+            **common,
+        )
+
+    print("\nDone.  Parent checkpoints written to:", args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_cartpole_parents.py
+++ b/scripts/train_cartpole_parents.py
@@ -58,156 +58,20 @@ different policies, providing meaningful signal for the crossover stage.
 from __future__ import annotations
 
 import argparse
-import collections
-import json
 import os
-import random
 import sys
-from typing import Deque, List, Optional, Tuple
+from typing import Optional
 
-import numpy as np
 import torch
-import torch.nn as nn
-import torch.optim as optim
 
 # Allow running directly from repo root without installing the package.
 _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _repo_root not in sys.path:
-    sys.path.insert(0, _repo_root)
+_scripts_dir = os.path.join(_repo_root, "scripts")
+for _p in (_repo_root, _scripts_dir):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
 
-try:
-    import gymnasium as gym
-except ImportError as exc:
-    raise SystemExit(
-        "gymnasium is required: pip install gymnasium"
-    ) from exc
-
-from farm.core.decision.base_dqn import BaseQNetwork  # noqa: E402
-
-# CartPole-v1 dimensions used as fallback (inferred at runtime from environment).
-_CARTPOLE_INPUT_DIM = 4
-_CARTPOLE_OUTPUT_DIM = 2
-
-
-# ---------------------------------------------------------------------------
-# DQN trainer (self-contained, no SimulationDatabase dependency)
-# ---------------------------------------------------------------------------
-
-
-class _CartPoleDQN:
-    """Minimal DQN trainer wired to a ``BaseQNetwork`` for CartPole-v1.
-
-    Implements:
-    - Experience replay buffer
-    - Epsilon-greedy exploration with linear/exponential decay
-    - Double Q-Learning updates
-    - Soft target-network updates
-    """
-
-    def __init__(
-        self,
-        input_dim: int,
-        output_dim: int,
-        hidden_size: int,
-        lr: float,
-        gamma: float,
-        epsilon_start: float,
-        epsilon_min: float,
-        epsilon_decay: float,
-        tau: float,
-        memory_size: int,
-        batch_size: int,
-        seed: Optional[int],
-        device: torch.device,
-    ) -> None:
-        self.device = device
-        self.output_dim = output_dim
-        self.gamma = gamma
-        self.epsilon = epsilon_start
-        self.epsilon_min = epsilon_min
-        self.epsilon_decay = epsilon_decay
-        self.tau = tau
-        self.batch_size = batch_size
-
-        if seed is not None:
-            random.seed(seed)
-            np.random.seed(seed)
-            torch.manual_seed(seed)
-
-        self.q_net = BaseQNetwork(input_dim, output_dim, hidden_size).to(device)
-        self.target_net = BaseQNetwork(input_dim, output_dim, hidden_size).to(device)
-        self.target_net.load_state_dict(self.q_net.state_dict())
-        self.target_net.eval()
-
-        self.optimizer = optim.Adam(self.q_net.parameters(), lr=lr)
-        self.criterion = nn.SmoothL1Loss()
-        self.memory: Deque[Tuple] = collections.deque(maxlen=memory_size)
-
-        # Collected states for replay buffer export
-        self._states_seen: List[np.ndarray] = []
-
-    # ------------------------------------------------------------------
-    # Public API
-    # ------------------------------------------------------------------
-
-    def select_action(self, state: np.ndarray) -> int:
-        if random.random() < self.epsilon:
-            return random.randint(0, self.output_dim - 1)
-        s = torch.from_numpy(state).float().to(self.device)
-        self.q_net.eval()
-        with torch.no_grad():
-            q = self.q_net(s)
-        self.q_net.train()
-        return int(q.argmax().item())
-
-    def store(
-        self,
-        state: np.ndarray,
-        action: int,
-        reward: float,
-        next_state: np.ndarray,
-        done: bool,
-    ) -> None:
-        self.memory.append((state, action, reward, next_state, done))
-        self._states_seen.append(state.astype("float32"))
-
-    def train_step(self) -> Optional[float]:
-        if len(self.memory) < self.batch_size:
-            return None
-        batch = random.sample(self.memory, self.batch_size)
-        states = torch.from_numpy(np.stack([b[0] for b in batch])).float().to(self.device)
-        actions = torch.tensor([b[1] for b in batch], device=self.device).unsqueeze(1)
-        rewards = torch.tensor([b[2] for b in batch], dtype=torch.float32, device=self.device)
-        next_states = torch.from_numpy(np.stack([b[3] for b in batch])).float().to(self.device)
-        dones = torch.tensor([b[4] for b in batch], dtype=torch.float32, device=self.device)
-
-        self.q_net.eval()
-        current_q = self.q_net(states).gather(1, actions)
-        with torch.no_grad():
-            next_actions = self.q_net(next_states).argmax(1, keepdim=True)
-            next_q = self.target_net(next_states).gather(1, next_actions)
-            target_q = rewards.unsqueeze(1) + (1 - dones.unsqueeze(1)) * self.gamma * next_q
-        self.q_net.train()
-
-        loss = self.criterion(current_q, target_q)
-        self.optimizer.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(self.q_net.parameters(), 1.0)
-        self.optimizer.step()
-
-        # Soft target update
-        for tp, lp in zip(self.target_net.parameters(), self.q_net.parameters()):
-            tp.data.copy_(self.tau * lp.data + (1.0 - self.tau) * tp.data)
-
-        # Decay epsilon
-        self.epsilon = max(self.epsilon_min, self.epsilon * self.epsilon_decay)
-        return float(loss.item())
-
-    def replay_states(self) -> np.ndarray:
-        """Return all states seen during training as float32 (N, input_dim)."""
-        if not self._states_seen:
-            return np.empty((0, 4), dtype="float32")
-        return np.stack(self._states_seen, axis=0).astype("float32")
+from cartpole_dqn_training import train_cartpole_parent  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -241,13 +105,9 @@ def _train_one_parent(
     print(f"  lr         : {lr}  gamma={gamma}  eps_decay={epsilon_decay}")
     print(f"{'=' * 60}")
 
-    env = gym.make("CartPole-v1")
-    input_dim = int(env.observation_space.shape[0])   # _CARTPOLE_INPUT_DIM = 4
-    output_dim = int(env.action_space.n)               # _CARTPOLE_OUTPUT_DIM = 2
-
-    agent = _CartPoleDQN(
-        input_dim=input_dim,
-        output_dim=output_dim,
+    result = train_cartpole_parent(
+        label=label,
+        episodes=episodes,
         hidden_size=hidden_size,
         lr=lr,
         gamma=gamma,
@@ -258,73 +118,19 @@ def _train_one_parent(
         memory_size=memory_size,
         batch_size=batch_size,
         seed=seed,
+        output_dir=output_dir,
+        log_every=log_every,
         device=device,
+        env_reset_seed=None,
     )
 
-    episode_rewards: List[float] = []
-    recent: Deque[float] = collections.deque(maxlen=100)
-
-    for ep in range(1, episodes + 1):
-        obs, _ = env.reset(seed=None)
-        state = np.array(obs, dtype="float32")
-        total_reward = 0.0
-        done = False
-
-        while not done:
-            action = agent.select_action(state)
-            obs2, reward, terminated, truncated, _ = env.step(action)
-            next_state = np.array(obs2, dtype="float32")
-            done = terminated or truncated
-            agent.store(state, action, float(reward), next_state, done)
-            agent.train_step()
-            state = next_state
-            total_reward += float(reward)
-
-        episode_rewards.append(total_reward)
-        recent.append(total_reward)
-
-        if ep % log_every == 0 or ep == episodes:
-            mean100 = float(np.mean(recent))
-            print(
-                f"  ep {ep:>5}/{episodes}  reward={total_reward:6.1f}"
-                f"  mean100={mean100:6.2f}  ε={agent.epsilon:.4f}"
-            )
-
-    env.close()
-
-    # Save state dict checkpoint
-    os.makedirs(output_dir, exist_ok=True)
-    ckpt_path = os.path.join(output_dir, f"parent_{label}.pt")
-    agent.q_net.eval()
-    torch.save(agent.q_net.state_dict(), ckpt_path)
-
-    # Companion metadata
-    mean_last50 = float(np.mean(episode_rewards[-50:])) if episode_rewards else 0.0
-    meta = {
-        "label": label,
-        "env": "CartPole-v1",
-        "input_dim": input_dim,
-        "output_dim": output_dim,
-        "hidden_size": hidden_size,
-        "episodes_trained": episodes,
-        "seed": seed,
-        "final_epsilon": round(agent.epsilon, 6),
-        "mean_reward_last_50_episodes": round(mean_last50, 4),
-        "episode_rewards": [round(r, 4) for r in episode_rewards],
-    }
-    meta_path = ckpt_path + ".json"
-    with open(meta_path, "w", encoding="utf-8") as fh:
-        json.dump(meta, fh, indent=2)
-
-    print(f"\n  ✓ Checkpoint   : {ckpt_path}")
-    print(f"  ✓ Metadata     : {meta_path}")
-    print(f"  Mean reward (last 50 eps): {mean_last50:.2f}")
-
-    # Save replay states (overwritten each time – caller picks up the last one)
-    states_path = os.path.join(output_dir, "replay_states.npy")
-    replay = agent.replay_states()
-    np.save(states_path, replay)
-    print(f"  ✓ Replay states: {states_path}  shape={replay.shape}")
+    print(f"\n  ✓ Checkpoint   : {result.checkpoint_path}")
+    print(f"  ✓ Metadata     : {result.metadata_path}")
+    print(f"  Mean reward (last 50 eps): {result.mean_reward_last_50:.2f}")
+    print(
+        f"  ✓ Replay states: {result.replay_states_path}  "
+        f"shape={result.replay_states_shape}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/train_cartpole_parents.py
+++ b/scripts/train_cartpole_parents.py
@@ -39,10 +39,10 @@ Outputs
     Companion metadata: input/output dims, hidden size, seed, final epsilon,
     mean reward of the last 50 episodes.
 ``<output-dir>/parent_B.pt``  (and ``.pt.json``) — same for parent B.
-``<output-dir>/replay_states.npy``
-    Concatenated experience states (float32, shape ``(N, 4)``) collected during
-    the *last* training run (parent B, or parent A if only pair A is trained).
-    Useful as a real-distribution state buffer for downstream pipeline stages.
+``<output-dir>/replay_states_A.npy``, ``<output-dir>/replay_states_B.npy``
+    Per-parent experience states (float32, shape ``(N, 4)``), capped by
+    ``--max-replay-states`` (default 200000; use ``-1`` for no cap). Downstream
+    scripts typically prefer parent B's file when both exist.
 
 The script also writes per-episode rewards to stdout so progress can be
 monitored in real time.
@@ -71,7 +71,7 @@ for _p in (_repo_root, _scripts_dir):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
-from cartpole_dqn_training import train_cartpole_parent  # noqa: E402
+from cartpole_dqn_training import parse_torch_device, train_cartpole_parent  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -95,6 +95,7 @@ def _train_one_parent(
     output_dir: str,
     log_every: int,
     device: torch.device,
+    max_replay_states: Optional[int],
 ) -> None:
     """Run a full DQN training loop for one parent and save the checkpoint."""
     print(f"\n{'=' * 60}")
@@ -122,6 +123,7 @@ def _train_one_parent(
         log_every=log_every,
         device=device,
         env_reset_seed=None,
+        max_replay_states=max_replay_states,
     )
 
     print(f"\n  ✓ Checkpoint   : {result.checkpoint_path}")
@@ -181,12 +183,26 @@ def _parse_args() -> argparse.Namespace:
         default=50,
         help="Print progress every N episodes.",
     )
+    p.add_argument(
+        "--device",
+        default="cpu",
+        help="Torch device for training (cpu, cuda, …).",
+    )
+    p.add_argument(
+        "--max-replay-states",
+        type=int,
+        default=200_000,
+        help="Max replay-state rows kept per parent (-1 = unlimited).",
+    )
     return p.parse_args()
 
 
 def main() -> None:
     args = _parse_args()
-    device = torch.device("cpu")
+    device = parse_torch_device(args.device)
+    max_replay_states: Optional[int] = (
+        None if args.max_replay_states < 0 else args.max_replay_states
+    )
 
     common = dict(
         hidden_size=args.hidden_size,
@@ -201,6 +217,7 @@ def main() -> None:
         output_dir=args.output_dir,
         log_every=args.log_every,
         device=device,
+        max_replay_states=max_replay_states,
     )
 
     if args.pair in ("A", "both"):

--- a/scripts/train_cartpole_parents.py
+++ b/scripts/train_cartpole_parents.py
@@ -84,6 +84,10 @@ except ImportError as exc:
 
 from farm.core.decision.base_dqn import BaseQNetwork  # noqa: E402
 
+# CartPole-v1 dimensions used as fallback (inferred at runtime from environment).
+_CARTPOLE_INPUT_DIM = 4
+_CARTPOLE_OUTPUT_DIM = 2
+
 
 # ---------------------------------------------------------------------------
 # DQN trainer (self-contained, no SimulationDatabase dependency)
@@ -238,8 +242,8 @@ def _train_one_parent(
     print(f"{'=' * 60}")
 
     env = gym.make("CartPole-v1")
-    input_dim = int(env.observation_space.shape[0])   # 4
-    output_dim = int(env.action_space.n)               # 2
+    input_dim = int(env.observation_space.shape[0])   # _CARTPOLE_INPUT_DIM = 4
+    output_dim = int(env.action_space.n)               # _CARTPOLE_OUTPUT_DIM = 2
 
     agent = _CartPoleDQN(
         input_dim=input_dim,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds new CLI scripts without modifying existing library code paths; main risk is runtime dependency/environment assumptions (e.g., `gymnasium`, Torch `weights_only` load) when users run them.
> 
> **Overview**
> Adds `scripts/train_cartpole_parents.py` to train CartPole-v1 `BaseQNetwork` parent checkpoints (A/B) via a minimal DQN loop and export metadata plus `replay_states.npy`.
> 
> Adds `scripts/run_cartpole_recombination.py` to orchestrate the full pipeline: optionally train parents, generate a child via `crossover_quantized_state_dict`, fine-tune via `FineTuner`, then validate with `RecombinationEvaluator` and write `recombination_validation.json` with configurable thresholds and a `--report-only` mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 298cb9b251e36e7b4b842bc16c1bad0c7432a5b5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->