### PR TITLE
Enhance gene encoding and resource generation error handling

### DIFF
--- a/docs/config/configuration_guide.md
+++ b/docs/config/configuration_guide.md
@@ -56,6 +56,15 @@ resource_regen_amount: 2            # Resources added per regeneration
 max_resource_amount: 30             # Maximum resources per cell
 ```
 
+> **Validation rules for `ResourceGenerationConfig`** (`farm/core/resource_patterns.py`):
+> - `regen_rate` must be in `[0.0, 1.0]`
+> - `regen_amount` must be `≥ 0`
+> - `max_amount` must be `≥ 0`
+> - `min_amount` must be `≥ 0`
+> - `min_amount` must not exceed `max_amount`
+>
+> These constraints are enforced at construction time; invalid values raise `ValueError`.
+
 ### Agent Population and Basic Properties
 
 ```yaml

--- a/docs/design/crossover_strategies.md
+++ b/docs/design/crossover_strategies.md
@@ -72,7 +72,7 @@ child_sd = crossover_quantized_state_dict(
 
 **PTQ checkpoints (dynamic only)**: If `<path>.json` looks like **dynamic** PTQ metadata from `PostTrainingQuantizer.save_checkpoint` (`quantization.mode == "dynamic"`, `dtype == "qint8"`), the `.pt` is loaded with `load_quantized_checkpoint` and **dequantized** into a plain float state dict (packed dynamic-quant layers are not fed directly into crossover). That load uses full-model unpickling (`weights_only=False`); you must pass **`allow_unsafe_unpickle=True` for trusted checkpoints only**—otherwise resolution raises with guidance to opt in. Static PTQ sidecars are not treated as auto-loadable on this path.
 
-**Optional kwargs**: `auto_load_ptq_checkpoints` (default `True`), `architecture=ChildArchitectureSpec(...)`, `network_class=StudentQNetwork` when parents are dicts/paths. **`allow_unsafe_unpickle`**: required for the dynamic PTQ sidecar path above; also use `True` for trusted non-PTQ full-model pickles when `weights_only=True` fails.
+**Optional kwargs**: `auto_load_ptq_checkpoints` (default `True`), `architecture=ChildArchitectureSpec(...)`, `network_class=StudentQNetwork` when parents are dicts/paths. **`allow_unsafe_unpickle`** (default `False`): must be explicitly set to `True` for the dynamic PTQ sidecar path above. Also set `True` for trusted non-PTQ full-model pickles when `weights_only=True` fails. **Never pass `True` for untrusted checkpoints.**
 
 ```python
 from farm.core.decision.training.crossover import (

--- a/docs/design/distill_quantize_crossover_finetune.md
+++ b/docs/design/distill_quantize_crossover_finetune.md
@@ -287,7 +287,20 @@ python scripts/run_dual_teacher_cartpole.py \
     --finetune-epochs 15 --finetune-lr 5e-4 \
     --finetune-teacher-weight-a 0.5 \
     --output-dir checkpoints/issue8_run
+
+# When the pipeline must load dynamic-PTQ checkpoints that require full unpickling
+# (only use this with checkpoints you trust):
+python scripts/run_dual_teacher_cartpole.py \
+    --parent-a-ckpt checkpoints/cartpole/parent_A_int8.pt \
+    --parent-b-ckpt checkpoints/cartpole/parent_B_int8.pt \
+    --allow-unsafe-unpickle \
+    --output-dir checkpoints/issue8_run
 ```
+
+> **Security note:** `--allow-unsafe-unpickle` defaults to **disabled**.  Pickle
+> deserialization can execute arbitrary code; only pass this flag when you control
+> the source of the checkpoint files.  The flag is recorded in `pipeline_report.json`
+> under `parameters.allow_unsafe_unpickle` for audit purposes.
 
 **Outputs written to `<output-dir>/`:**
 

--- a/docs/design/hyperparameter_chromosome.md
+++ b/docs/design/hyperparameter_chromosome.md
@@ -19,12 +19,24 @@ The chromosome model is intentionally narrow and strict:
 
 - `GeneValueType`
   - currently supports `real` (with extension points for discrete/binary later)
+- `GeneEncodingScale` *(new)*
+  - `LINEAR` — uniform spacing across the gene's numeric range
+  - `LOG` — log₁₀ spacing; equal bucket steps correspond to multiplicative changes (requires strictly positive bounds and value)
+- `GeneEncodingSpec` *(new)*
+  - frozen dataclass: `scale` (`GeneEncodingScale`) + optional `bit_width`
+  - when `bit_width` is set, the normalized float is quantized to an integer in `[0, 2^bit_width − 1]`
+  - `bit_width` must be positive (validated at construction)
 - `HyperparameterGene`
   - name, type, value, min/max bounds, default, and `evolvable` flag
   - validates:
     - non-empty name
     - valid min/max range
     - in-range numeric value and default
+  - **new methods** (real-valued genes only):
+    - `normalize(value, *, scale)` → `float` in `[0, 1]`
+    - `denormalize(normalized_value, *, scale)` → `float` in gene range
+    - `encode(value, *, encoding)` → `float` or `int` (uses `default_encoding_spec_for_gene` if omitted)
+    - `decode(encoded_value, *, encoding)` → `float`
 - `HyperparameterChromosome`
   - ordered tuple of `HyperparameterGene`
   - enforces unique gene names
@@ -38,9 +50,19 @@ The chromosome model is intentionally narrow and strict:
 
 The default registry is defined in `DEFAULT_HYPERPARAMETER_GENES`:
 
-- `learning_rate` (evolvable)
+- `learning_rate` (evolvable) — range `[1e-5, 1e-1]`, encoded with **log-scale 8-bit quantization** by default so that equal bucket steps map to multiplicative LR changes
 - `epsilon_decay` (fixed placeholder)
 - `memory_size` (fixed placeholder)
+
+Default encoding policies per gene name are stored in `DEFAULT_GENE_ENCODINGS`:
+
+```python
+DEFAULT_GENE_ENCODINGS = {
+    "learning_rate": GeneEncodingSpec(scale=GeneEncodingScale.LOG, bit_width=8),
+}
+```
+
+Genes not listed in `DEFAULT_GENE_ENCODINGS` fall back to `GeneEncodingSpec()` (linear scale, no quantization).
 
 Helpers:
 
@@ -48,6 +70,7 @@ Helpers:
 - `hyperparameter_evolution_registry()`
 - `chromosome_from_values()`
 - `chromosome_from_learning_config()`
+- `default_encoding_spec_for_gene(gene_name)` — look up the default `GeneEncodingSpec` for a gene name
 
 ## Runtime wiring in reproduction
 
@@ -61,8 +84,11 @@ On `AgentCore.reproduce()`:
 2. Mutate evolvable genes via `mutate_chromosome(...)`.
 3. Deep-copy parent config.
 4. Apply chromosome values to child decision config via `apply_chromosome_to_learning_config(...)`.
-5. Create offspring with the child config.
-6. Store the resulting chromosome on the offspring.
+5. Deduct the reproduction resource cost (`offspring_cost`) from the parent agent.
+   - If the resource component reports that the deduction failed (insufficient resources), `reproduce()` returns `False` immediately without creating offspring.
+   - If offspring creation subsequently raises an exception after the cost has been deducted, the cost is **refunded** by calling `resource_comp.add(offspring_cost)` before propagating the error, preventing phantom resource loss.
+6. Create offspring with the child config.
+7. Store the resulting chromosome on the offspring.
 
 This keeps:
 - existing action/module-state genome behavior intact
@@ -76,6 +102,71 @@ This keeps:
 - applies multiplicative perturbation for real-valued genes:
   - `new_value = old_value * (1 + uniform(-scale, scale))`
 - clamps to `[min_value, max_value]`
+
+## Gene encoding and decoding
+
+Encoding converts a gene's float value into a compact representation for storage, transmission, or evolutionary search.  Decoding is the inverse operation.
+
+### Encoding specs
+
+```python
+from farm.core.hyperparameter_chromosome import GeneEncodingScale, GeneEncodingSpec
+
+# Linear scale, no quantization (floating-point normalized to [0, 1])
+spec_linear = GeneEncodingSpec()
+
+# Log scale, 8-bit quantized integer in [0, 255]
+spec_log_8bit = GeneEncodingSpec(scale=GeneEncodingScale.LOG, bit_width=8)
+```
+
+- **`scale=LINEAR`** — `(value - min) / (max - min)`
+- **`scale=LOG`** — `(log10(value) - log10(min)) / (log10(max) - log10(min))`.  Bounds and value must be strictly positive.
+- **`bit_width`** — when set, the normalized float is rounded to `round(normalized * (2**bit_width - 1))`, yielding an integer bucket.
+
+### Gene-level encode/decode
+
+```python
+gene = HyperparameterGene("learning_rate", ..., min_value=1e-5, max_value=1e-1, value=1e-3)
+
+# Encode using the default policy for this gene name (log + 8-bit)
+bucket = gene.encode()          # e.g., 102 (integer 0..255)
+lr     = gene.decode(bucket)    # ~1e-3
+
+# Override with an explicit spec
+spec   = GeneEncodingSpec(scale=GeneEncodingScale.LINEAR)
+norm   = gene.encode(encoding=spec)   # float in [0, 1]
+lr     = gene.decode(norm, encoding=spec)
+```
+
+### Chromosome-level helpers
+
+Four module-level functions work on full chromosomes:
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `encode_chromosome(chromosome, *, include_fixed, encoding_specs)` | `Dict[str, int \| float]` | Encode evolvable genes by name |
+| `decode_chromosome(encoded_values, *, template, encoding_specs)` | `HyperparameterChromosome` | Decode named values back to a chromosome |
+| `encode_chromosome_vector(chromosome, *, include_fixed, encoding_specs)` | `Tuple[int \| float, …]` | Encode as an ordered vector |
+| `decode_chromosome_vector(encoded_values, *, template, include_fixed, encoding_specs)` | `HyperparameterChromosome` | Decode an ordered vector using template gene order |
+
+`encoding_specs` is an optional `Mapping[str, GeneEncodingSpec]` that overrides per-gene defaults.  If omitted, `DEFAULT_GENE_ENCODINGS` is used.
+
+```python
+from farm.core.hyperparameter_chromosome import (
+    encode_chromosome, decode_chromosome,
+    encode_chromosome_vector, decode_chromosome_vector,
+)
+
+chrom = default_hyperparameter_chromosome()
+
+# Round-trip via dict
+encoded = encode_chromosome(chrom)          # {"learning_rate": 102}
+restored = decode_chromosome(encoded, template=chrom)
+
+# Round-trip via vector (preserves gene order)
+vec = encode_chromosome_vector(chrom)       # (102,)
+restored_vec = decode_chromosome_vector(vec, template=chrom)
+```
 
 ## How to add a new gene
 
@@ -100,7 +191,17 @@ Guidelines:
 - choose conservative bounds first, then broaden based on empirical results
 - mark as fixed (`evolvable=False`) until ready for live evolution
 
-### 2) Ensure config compatibility
+### 2) Register an encoding policy (optional)
+
+If the default linear/no-quantization encoding is not appropriate, add an entry to `DEFAULT_GENE_ENCODINGS`:
+
+```python
+DEFAULT_GENE_ENCODINGS["gamma"] = GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8)
+```
+
+Use log-scale for parameters that span multiple orders of magnitude (e.g., learning rates, weight-decay coefficients).  Omit the entry to fall back to continuous linear encoding.
+
+### 3) Ensure config compatibility
 
 `apply_chromosome_to_learning_config(...)` applies values only for fields that exist on the target config object.
 
@@ -111,13 +212,14 @@ For non-decision hyperparameters:
 - either add a corresponding field on decision config
 - or extend application logic for another config target
 
-### 3) Add tests
+### 4) Add tests
 
 At minimum add tests in `tests/test_hyperparameter_chromosome.py` for:
 - bound validation
 - serialization round-trip
 - mutation behavior
 - config projection
+- encode/decode round-trip (including edge values and quantization boundaries)
 
 If runtime flow changes, add or update integration tests similar to:
 - `tests/test_agent_reproduction_hyperparameters.py`
@@ -152,5 +254,6 @@ They are parallel tracks today; a future unification step can compose both into 
 - only real-valued genes are implemented
 - runtime integration currently mutates during `AgentCore.reproduce()` only
 - mutation rate is currently a constant in `AgentCore` (`DEFAULT_HYPERPARAMETER_MUTATION_RATE`)
+- log-scale encoding requires strictly positive gene bounds; genes with `min_value ≤ 0` must use `GeneEncodingScale.LINEAR`
 
 These are deliberate for a small, verifiable first increment.

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -655,11 +655,17 @@ class AgentCore:
         # Store initial resources for logging
         initial_resources = self.resource_level
 
+        resource_comp = self.get_component("resource")
+        offspring_cost = repro_comp.config.offspring_cost
+        resource_deducted = False
+        offspring_added = False
+
         try:
             # Deduct reproduction cost
-            resource_comp = self.get_component("resource")
             if resource_comp:
-                resource_comp.remove(repro_comp.config.offspring_cost)
+                if not resource_comp.remove(offspring_cost):
+                    return False
+                resource_deducted = True
 
             # Get offspring initial resources from reproduction component config
             # This uses offspring_initial_resources (not initial_resource_level which is for initial population)
@@ -717,6 +723,7 @@ class AgentCore:
             # Add offspring to environment with immediate flush to ensure it's in database
             # Genome ID will be generated in add_agent() using parent info
             self.environment.add_agent(offspring, flush_immediately=True)
+            offspring_added = True
 
             # Update reproduction component tracking
             repro_comp.offspring_created += 1
@@ -724,6 +731,16 @@ class AgentCore:
             return True
 
         except Exception:
+            if resource_comp and resource_deducted and not offspring_added:
+                try:
+                    resource_comp.add(offspring_cost)
+                except Exception:
+                    logger.exception(
+                        "agent_reproduction_resource_refund_failed",
+                        agent_id=self.agent_id,
+                        generation=self.generation,
+                        offspring_cost=offspring_cost,
+                    )
             logger.exception(
                 "agent_reproduction_failed",
                 agent_id=self.agent_id,

--- a/farm/core/hyperparameter_chromosome.py
+++ b/farm/core/hyperparameter_chromosome.py
@@ -11,10 +11,11 @@ without changing the existing genome serialization abstraction.
 from __future__ import annotations
 
 import copy
+import math
 import random
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 
 class GeneValueType(str, Enum):
@@ -26,6 +27,25 @@ class GeneValueType(str, Enum):
     """
 
     REAL = "real"
+
+
+class GeneEncodingScale(str, Enum):
+    """Supported scale transforms for real-valued genes."""
+
+    LINEAR = "linear"
+    LOG = "log"
+
+
+@dataclass(frozen=True)
+class GeneEncodingSpec:
+    """Encoding settings for converting gene values to stored representations."""
+
+    scale: GeneEncodingScale = GeneEncodingScale.LINEAR
+    bit_width: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.bit_width is not None and self.bit_width <= 0:
+            raise ValueError("bit_width must be positive when provided.")
 
 
 @dataclass(frozen=True)
@@ -81,6 +101,69 @@ class HyperparameterGene:
             default=self.default,
             evolvable=self.evolvable,
         )
+
+    def normalize(
+        self,
+        value: Optional[float] = None,
+        *,
+        scale: GeneEncodingScale = GeneEncodingScale.LINEAR,
+    ) -> float:
+        """Normalize a real value to [0, 1] using the requested scale."""
+        raw_value = self.value if value is None else float(value)
+        self._validate_value(raw_value, field_name="value")
+        return _normalize_real_value(raw_value, self.min_value, self.max_value, scale)
+
+    def denormalize(
+        self,
+        normalized_value: float,
+        *,
+        scale: GeneEncodingScale = GeneEncodingScale.LINEAR,
+    ) -> float:
+        """Decode a normalized [0, 1] scalar into the gene's value range."""
+        if not 0.0 <= normalized_value <= 1.0:
+            raise ValueError("normalized_value must be within [0, 1].")
+        return _denormalize_real_value(normalized_value, self.min_value, self.max_value, scale)
+
+    def encode(
+        self,
+        value: Optional[float] = None,
+        *,
+        encoding: Optional[GeneEncodingSpec] = None,
+    ) -> Union[float, int]:
+        """Encode a gene value as normalized float or quantized integer."""
+        resolved_encoding = encoding or default_encoding_spec_for_gene(self.name)
+        normalized = self.normalize(value=value, scale=resolved_encoding.scale)
+        if resolved_encoding.bit_width is None:
+            return normalized
+
+        max_bucket = _quantization_max_bucket(resolved_encoding.bit_width)
+        return int(round(normalized * max_bucket))
+
+    def decode(
+        self,
+        encoded_value: Union[float, int],
+        *,
+        encoding: Optional[GeneEncodingSpec] = None,
+    ) -> float:
+        """Decode a normalized float or quantized integer into real value."""
+        resolved_encoding = encoding or default_encoding_spec_for_gene(self.name)
+        normalized_value: float
+        if resolved_encoding.bit_width is None:
+            normalized_value = float(encoded_value)
+        else:
+            if not isinstance(encoded_value, (int, float)):
+                raise TypeError("Quantized encoded value must be numeric.")
+            if isinstance(encoded_value, float) and not encoded_value.is_integer():
+                raise ValueError("Quantized encoded value must be an integer bucket.")
+            bucket = int(encoded_value)
+            max_bucket = _quantization_max_bucket(resolved_encoding.bit_width)
+            if bucket < 0 or bucket > max_bucket:
+                raise ValueError(
+                    f"Quantized encoded value must be within [0, {max_bucket}], got {bucket}."
+                )
+            normalized_value = bucket / max_bucket
+
+        return self.denormalize(normalized_value, scale=resolved_encoding.scale)
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize gene data to a plain dictionary."""
@@ -168,6 +251,14 @@ class HyperparameterChromosome:
         return cls(genes=genes)
 
 
+# Default encoding policy by gene name.
+# learning_rate uses log-space 8-bit quantization so equal bucket changes map to
+# multiplicative LR changes, which is typically more meaningful than linear shifts.
+DEFAULT_GENE_ENCODINGS: Dict[str, GeneEncodingSpec] = {
+    "learning_rate": GeneEncodingSpec(scale=GeneEncodingScale.LOG, bit_width=8),
+}
+
+
 # Default hyperparameter loci.
 # learning_rate is enabled for evolution now; others are placeholders that
 # document the extension path while remaining fixed in global config.
@@ -205,6 +296,151 @@ DEFAULT_HYPERPARAMETER_GENES: Tuple[HyperparameterGene, ...] = (
 def default_hyperparameter_chromosome() -> HyperparameterChromosome:
     """Return default chromosome with baseline hyperparameter loci."""
     return HyperparameterChromosome(genes=DEFAULT_HYPERPARAMETER_GENES)
+
+
+def default_encoding_spec_for_gene(gene_name: str) -> GeneEncodingSpec:
+    """Return default encoding settings for a gene name."""
+    return DEFAULT_GENE_ENCODINGS.get(gene_name, GeneEncodingSpec())
+
+
+def _quantization_max_bucket(bit_width: int) -> int:
+    return (1 << bit_width) - 1
+
+
+def _normalize_real_value(
+    value: float,
+    min_value: float,
+    max_value: float,
+    scale: GeneEncodingScale,
+) -> float:
+    if min_value == max_value:
+        return 0.0
+
+    if scale is GeneEncodingScale.LINEAR:
+        return (value - min_value) / (max_value - min_value)
+
+    if min_value <= 0.0 or max_value <= 0.0 or value <= 0.0:
+        raise ValueError("Log scale encoding requires strictly positive bounds and value.")
+
+    min_log = math.log10(min_value)
+    max_log = math.log10(max_value)
+    value_log = math.log10(value)
+    return (value_log - min_log) / (max_log - min_log)
+
+
+def _denormalize_real_value(
+    normalized_value: float,
+    min_value: float,
+    max_value: float,
+    scale: GeneEncodingScale,
+) -> float:
+    if min_value == max_value:
+        return min_value
+
+    if scale is GeneEncodingScale.LINEAR:
+        return min_value + normalized_value * (max_value - min_value)
+
+    if min_value <= 0.0 or max_value <= 0.0:
+        raise ValueError("Log scale decoding requires strictly positive bounds.")
+
+    min_log = math.log10(min_value)
+    max_log = math.log10(max_value)
+    decoded_log = min_log + normalized_value * (max_log - min_log)
+    return math.pow(10.0, decoded_log)
+
+
+def _resolve_encoding_spec(
+    gene_name: str,
+    encoding_specs: Optional[Mapping[str, GeneEncodingSpec]],
+) -> GeneEncodingSpec:
+    if encoding_specs and gene_name in encoding_specs:
+        return encoding_specs[gene_name]
+    return default_encoding_spec_for_gene(gene_name)
+
+
+def _selected_genes(
+    chromosome: HyperparameterChromosome,
+    include_fixed: bool,
+) -> Tuple[HyperparameterGene, ...]:
+    if include_fixed:
+        return chromosome.genes
+    return tuple(gene for gene in chromosome.genes if gene.evolvable)
+
+
+def encode_chromosome(
+    chromosome: HyperparameterChromosome,
+    *,
+    include_fixed: bool = False,
+    encoding_specs: Optional[Mapping[str, GeneEncodingSpec]] = None,
+) -> Dict[str, Union[int, float]]:
+    """Encode genes by name to normalized floats or quantized integers."""
+    return {
+        gene.name: gene.encode(encoding=_resolve_encoding_spec(gene.name, encoding_specs))
+        for gene in _selected_genes(chromosome, include_fixed=include_fixed)
+    }
+
+
+def decode_chromosome(
+    encoded_values: Mapping[str, Union[int, float]],
+    *,
+    template: Optional[HyperparameterChromosome] = None,
+    encoding_specs: Optional[Mapping[str, GeneEncodingSpec]] = None,
+) -> HyperparameterChromosome:
+    """Decode named encoded values into a chromosome instance."""
+    chromosome_template = template or default_hyperparameter_chromosome()
+    genes_by_name = {gene.name: gene for gene in chromosome_template.genes}
+
+    unknown_names = set(encoded_values) - set(genes_by_name)
+    if unknown_names:
+        unknown = ", ".join(sorted(unknown_names))
+        raise KeyError(f"Unknown encoded gene value(s): {unknown}")
+
+    overrides: Dict[str, float] = {}
+    for gene_name, encoded_value in encoded_values.items():
+        gene = genes_by_name[gene_name]
+        overrides[gene_name] = gene.decode(
+            encoded_value,
+            encoding=_resolve_encoding_spec(gene_name, encoding_specs),
+        )
+    return chromosome_template.with_overrides(overrides)
+
+
+def encode_chromosome_vector(
+    chromosome: HyperparameterChromosome,
+    *,
+    include_fixed: bool = False,
+    encoding_specs: Optional[Mapping[str, GeneEncodingSpec]] = None,
+) -> Tuple[Union[int, float], ...]:
+    """Encode selected genes as an ordered vector."""
+    return tuple(
+        gene.encode(encoding=_resolve_encoding_spec(gene.name, encoding_specs))
+        for gene in _selected_genes(chromosome, include_fixed=include_fixed)
+    )
+
+
+def decode_chromosome_vector(
+    encoded_values: Sequence[Union[int, float]],
+    *,
+    template: Optional[HyperparameterChromosome] = None,
+    include_fixed: bool = False,
+    encoding_specs: Optional[Mapping[str, GeneEncodingSpec]] = None,
+) -> HyperparameterChromosome:
+    """Decode an ordered vector into a chromosome using template gene order."""
+    chromosome_template = template or default_hyperparameter_chromosome()
+    genes = _selected_genes(chromosome_template, include_fixed=include_fixed)
+    if len(encoded_values) != len(genes):
+        raise ValueError(
+            f"encoded_values length {len(encoded_values)} does not match expected {len(genes)}."
+        )
+
+    overrides = {
+        gene.name: gene.decode(
+            encoded_value,
+            encoding=_resolve_encoding_spec(gene.name, encoding_specs),
+        )
+        for gene, encoded_value in zip(genes, encoded_values)
+    }
+    return chromosome_template.with_overrides(overrides)
 
 
 def hyperparameter_evolution_registry() -> Dict[str, bool]:

--- a/farm/core/resource_patterns.py
+++ b/farm/core/resource_patterns.py
@@ -35,10 +35,8 @@ from __future__ import annotations
 import math
 import random
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional
-
-import numpy as np
 
 if TYPE_CHECKING:
     from farm.core.resources import Resource
@@ -69,6 +67,18 @@ class ResourceGenerationConfig:
     regen_amount: int = 1
     max_amount: int = 10
     min_amount: int = 0
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.regen_rate <= 1.0:
+            raise ValueError("regen_rate must be within [0, 1].")
+        if self.regen_amount < 0:
+            raise ValueError("regen_amount must be >= 0.")
+        if self.max_amount < 0:
+            raise ValueError("max_amount must be >= 0.")
+        if self.min_amount < 0:
+            raise ValueError("min_amount must be >= 0.")
+        if self.min_amount > self.max_amount:
+            raise ValueError("min_amount cannot be greater than max_amount.")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/run_dual_teacher_cartpole.py
+++ b/scripts/run_dual_teacher_cartpole.py
@@ -431,13 +431,14 @@ def _crossover(
     alpha: float,
     seed: Optional[int],
     output_dir: str,
+    allow_unsafe_unpickle: bool = False,
 ) -> Tuple[str, StudentQNetwork]:
     """Crossover two quantized students and save the float32 child snapshot."""
     print(f"\n[Stage 4] Crossover  (mode={mode!r}, alpha={alpha})")
 
-    # Use initialize_child_from_crossover which handles PTQ sidecar JSON
-    # and dequantizes packed weights automatically.  The PTQ checkpoints are
-    # trusted artefacts written by this pipeline, so unsafe unpickling is safe.
+    # Use initialize_child_from_crossover which handles PTQ sidecar JSON and
+    # dequantizes packed weights automatically. Unsafe checkpoint unpickling is
+    # disabled by default and must be explicitly enabled via CLI.
     arch = ChildArchitectureSpec(
         input_dim=_INPUT_DIM,
         output_dim=_OUTPUT_DIM,
@@ -449,7 +450,7 @@ def _crossover(
         student_b_int8_ckpt,
         strategy=mode,
         rng=seed,
-        allow_unsafe_unpickle=True,
+        allow_unsafe_unpickle=allow_unsafe_unpickle,
         architecture=arch,
         network_class=StudentQNetwork,
         alpha=alpha,
@@ -865,6 +866,7 @@ def _write_pipeline_report(
             "finetune_lr": args.finetune_lr,
             "finetune_temperature": args.finetune_temperature,
             "finetune_teacher_weight_a": args.finetune_teacher_weight_a,
+            "allow_unsafe_unpickle": args.allow_unsafe_unpickle,
         },
         "artifacts": artifact_paths,
         "stages": stage_metrics,
@@ -929,6 +931,11 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("--crossover-mode", choices=list(CROSSOVER_MODES), default="weighted")
     p.add_argument("--crossover-alpha", type=float, default=0.5)
     p.add_argument("--crossover-seed", type=int, default=None)
+    p.add_argument(
+        "--allow-unsafe-unpickle",
+        action="store_true",
+        help="Allow unsafe checkpoint unpickling for trusted artifacts only.",
+    )
 
     # Dual-teacher fine-tuning
     p.add_argument("--finetune-epochs", type=int, default=10)
@@ -1082,6 +1089,7 @@ def main() -> None:  # noqa: C901  (intentionally linear pipeline)
         args.crossover_alpha,
         args.crossover_seed,
         out,
+        allow_unsafe_unpickle=args.allow_unsafe_unpickle,
     )
     artifacts["child_crossover"] = child_crossover_ckpt
 

--- a/tests/decision/test_run_dual_teacher_cartpole_script.py
+++ b/tests/decision/test_run_dual_teacher_cartpole_script.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import numpy as np
 import pytest
+import torch.nn as nn
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 _SCRIPT_PATH = os.path.join(_REPO_ROOT, "scripts", "run_dual_teacher_cartpole.py")
@@ -164,3 +165,56 @@ def test_validate_cli_ranges_rejects_invalid_val_fraction(
                 finetune_val_fraction=val_fraction,
             )
         )
+
+
+@pytest.mark.ml
+def test_parse_args_defaults_unsafe_unpickle_disabled(
+    dual_teacher: Any, monkeypatch: Any
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["run_dual_teacher_cartpole.py"])
+    args = dual_teacher._parse_args()
+    assert args.allow_unsafe_unpickle is False
+
+
+@pytest.mark.ml
+def test_parse_args_enables_unsafe_unpickle_flag(
+    dual_teacher: Any, monkeypatch: Any
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["run_dual_teacher_cartpole.py", "--allow-unsafe-unpickle"],
+    )
+    args = dual_teacher._parse_args()
+    assert args.allow_unsafe_unpickle is True
+
+
+@pytest.mark.ml
+def test_crossover_forwards_unsafe_unpickle_flag(
+    dual_teacher: Any, monkeypatch: Any, tmp_path: Any
+) -> None:
+    calls: dict[str, Any] = {}
+
+    def _fake_initialize_child_from_crossover(*_args: Any, **kwargs: Any) -> Any:
+        calls["allow_unsafe_unpickle"] = kwargs["allow_unsafe_unpickle"]
+        return nn.Linear(1, 1)
+
+    monkeypatch.setattr(
+        dual_teacher,
+        "initialize_child_from_crossover",
+        _fake_initialize_child_from_crossover,
+    )
+
+    ckpt, _child = dual_teacher._crossover(
+        student_a_int8_ckpt="a.pt",
+        student_b_int8_ckpt="b.pt",
+        hidden_size=64,
+        mode="weighted",
+        alpha=0.5,
+        seed=0,
+        output_dir=str(tmp_path),
+        allow_unsafe_unpickle=True,
+    )
+
+    assert calls["allow_unsafe_unpickle"] is True
+    assert os.path.isfile(ckpt)

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -86,6 +86,8 @@ def test_reproduce_logs_exception_and_returns_false():
         success = AgentCore.reproduce(parent)
 
     assert success is False
+    parent.get_component("resource").remove.assert_called_once_with(5.0)
+    parent.get_component("resource").add.assert_called_once_with(5.0)
     log_exception.assert_called_once()
 
 

--- a/tests/test_hyperparameter_chromosome.py
+++ b/tests/test_hyperparameter_chromosome.py
@@ -5,6 +5,10 @@ from unittest.mock import patch
 
 from farm.core.hyperparameter_chromosome import (
     apply_chromosome_to_learning_config,
+    decode_chromosome,
+    decode_chromosome_vector,
+    encode_chromosome,
+    encode_chromosome_vector,
     GeneValueType,
     HyperparameterChromosome,
     HyperparameterGene,
@@ -129,6 +133,67 @@ class TestHyperparameterChromosome(unittest.TestCase):
         self.assertIsNot(updated, stub)
         self.assertEqual(updated.learning_rate, 0.05)
         self.assertEqual(stub.learning_rate, 0.02)
+
+
+class TestHyperparameterEncoding(unittest.TestCase):
+    def test_learning_rate_quantized_encoding_uses_8bit_bounds(self):
+        chromosome = default_hyperparameter_chromosome()
+        learning_rate_gene = chromosome.get_gene("learning_rate")
+        assert learning_rate_gene is not None
+
+        self.assertEqual(learning_rate_gene.encode(learning_rate_gene.min_value), 0)
+        self.assertEqual(learning_rate_gene.encode(learning_rate_gene.max_value), 255)
+
+    def test_learning_rate_encoding_is_monotonic(self):
+        chromosome = default_hyperparameter_chromosome()
+        learning_rate_gene = chromosome.get_gene("learning_rate")
+        assert learning_rate_gene is not None
+
+        values = [1e-6, 1e-4, 1e-2, 0.1, 1.0]
+        encoded = [learning_rate_gene.encode(value) for value in values]
+        self.assertEqual(encoded, sorted(encoded))
+
+    def test_learning_rate_encode_decode_round_trip_with_quantization_tolerance(self):
+        chromosome = default_hyperparameter_chromosome()
+        learning_rate_gene = chromosome.get_gene("learning_rate")
+        assert learning_rate_gene is not None
+
+        original = 0.0123
+        encoded = learning_rate_gene.encode(original)
+        decoded = learning_rate_gene.decode(encoded)
+        self.assertAlmostEqual(decoded, original, delta=original * 0.06)
+
+    def test_chromosome_dict_encode_decode_round_trip(self):
+        chromosome = chromosome_from_values({"learning_rate": 0.02})
+        encoded = encode_chromosome(chromosome)
+        decoded = decode_chromosome(encoded, template=chromosome)
+        self.assertAlmostEqual(
+            decoded.get_value("learning_rate"),
+            chromosome.get_value("learning_rate"),
+            delta=chromosome.get_value("learning_rate") * 0.06,
+        )
+
+    def test_chromosome_vector_encode_decode_round_trip(self):
+        chromosome = chromosome_from_values({"learning_rate": 0.02})
+        encoded = encode_chromosome_vector(chromosome)
+        decoded = decode_chromosome_vector(encoded, template=chromosome)
+        self.assertAlmostEqual(
+            decoded.get_value("learning_rate"),
+            chromosome.get_value("learning_rate"),
+            delta=chromosome.get_value("learning_rate") * 0.06,
+        )
+
+    def test_decode_rejects_out_of_range_quantized_value(self):
+        chromosome = default_hyperparameter_chromosome()
+        learning_rate_gene = chromosome.get_gene("learning_rate")
+        assert learning_rate_gene is not None
+
+        with self.assertRaises(ValueError):
+            learning_rate_gene.decode(256)
+
+    def test_decode_chromosome_rejects_unknown_gene_name(self):
+        with self.assertRaises(KeyError):
+            decode_chromosome({"unknown_gene": 12})
 
 
 if __name__ == "__main__":

--- a/tests/test_resource_patterns.py
+++ b/tests/test_resource_patterns.py
@@ -87,6 +87,24 @@ class TestResourceGenerationConfig:
         assert cfg.regen_amount == 3
         assert cfg.max_amount == 20
 
+    @pytest.mark.parametrize("regen_rate", [-0.1, 1.1])
+    def test_rejects_invalid_regen_rate(self, regen_rate):
+        with pytest.raises(ValueError, match="regen_rate"):
+            ResourceGenerationConfig(regen_rate=regen_rate)
+
+    @pytest.mark.parametrize(
+        ("field_name", "value"),
+        [("regen_amount", -1), ("max_amount", -1), ("min_amount", -1)],
+    )
+    def test_rejects_negative_amount_fields(self, field_name, value):
+        kwargs = {field_name: value}
+        with pytest.raises(ValueError):
+            ResourceGenerationConfig(**kwargs)
+
+    def test_rejects_min_amount_greater_than_max_amount(self):
+        with pytest.raises(ValueError, match="min_amount"):
+            ResourceGenerationConfig(min_amount=11, max_amount=10)
+
 
 # ---------------------------------------------------------------------------
 # BasicRegenerator


### PR DESCRIPTION
This pull request introduces several improvements and new features across the codebase, focusing on robust gene encoding/decoding for hyperparameters, enhanced safety and configurability for checkpoint loading, and improved validation and error handling in resource management and agent reproduction. The most significant changes are outlined below.

**Hyperparameter Chromosome Encoding/Decoding Enhancements:**

* Added support for encoding and decoding hyperparameter genes with configurable scaling (linear/log) and quantization, including helper classes `GeneEncodingScale` and `GeneEncodingSpec`, and utility functions for encoding/decoding both by name and as vectors. Default quantized log-scale encoding is now used for learning rate. [[1]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R32-R50) [[2]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R105-R167) [[3]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R254-R261)

**Resource and Agent Reproduction Robustness:**

* Improved the `AgentCore.reproduce` method to ensure resource costs are refunded if offspring creation fails after deduction, with clear tracking and exception logging. [[1]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393R658-R668) [[2]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393R726-R743)
* Added stricter validation in `ResourceGenerationConfig` to enforce non-negative and consistent resource parameters.

**Checkpoint Loading Safety and CLI Integration:**

* Made checkpoint unpickling safety configurable via the new `--allow-unsafe-unpickle` CLI flag in `run_dual_teacher_cartpole.py`, defaulting to disabled for security, and ensured the flag is propagated through the pipeline and reported in outputs. [[1]](diffhunk://#diff-69b779bfe8a2ad30d6a299beb70d2fa2435de597aaba86299515287eed500a51R434-R441) [[2]](diffhunk://#diff-69b779bfe8a2ad30d6a299beb70d2fa2435de597aaba86299515287eed500a51L452-R453) [[3]](diffhunk://#diff-69b779bfe8a2ad30d6a299beb70d2fa2435de597aaba86299515287eed500a51R869) [[4]](diffhunk://#diff-69b779bfe8a2ad30d6a299beb70d2fa2435de597aaba86299515287eed500a51R934-R938) [[5]](diffhunk://#diff-69b779bfe8a2ad30d6a299beb70d2fa2435de597aaba86299515287eed500a51R1092)

**Testing Improvements:**

* Added tests to verify the default and enabled behavior of the unsafe unpickle flag, and to ensure the crossover process correctly forwards this flag.
* Extended the agent reproduction test to check that resource deduction and refund methods are called as expected during error handling.

**Minor Cleanups:**

* Removed unused imports (`numpy`) and improved typing in resource pattern code.
* Added imports for new test dependencies.
* Updated test imports to cover new encode/decode utilities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core evolution/learning configuration paths (chromosome encoding semantics and reproduction resource accounting) and alters checkpoint-loading behavior; mistakes could skew training/evolution outcomes or break pipelines, though changes are guarded by validations and tests.
> 
> **Overview**
> Adds a first-class hyperparameter *encoding/decoding* layer in `hyperparameter_chromosome.py`, including linear/log scaling and optional bit-width quantization, plus helpers to encode/decode chromosomes by name or vector; `learning_rate` now defaults to **log-scale 8-bit quantization**.
> 
> Hardens simulation robustness by refunding reproduction resources in `AgentCore.reproduce()` when offspring creation fails after costs are deducted, and by validating `ResourceGenerationConfig` bounds at construction time.
> 
> Improves checkpoint-loading safety in `run_dual_teacher_cartpole.py` by making unsafe unpickling **opt-in** via `--allow-unsafe-unpickle` (propagated through crossover and included in the pipeline report), with new tests covering these behaviors and the new encoding/validation logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f65db9abcd89e9140fc2d025720692d95d4af518. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->