### PR TITLE
Implement selection methods and enhance validation for hyperparameters

### DIFF
--- a/docs/design/hyperparameter_chromosome.md
+++ b/docs/design/hyperparameter_chromosome.md
@@ -50,7 +50,7 @@ The chromosome model is intentionally narrow and strict:
 
 The default registry is defined in `DEFAULT_HYPERPARAMETER_GENES`:
 
-- `learning_rate` (evolvable) — range `[1e-5, 1e-1]`, encoded with **log-scale 8-bit quantization** by default so that equal bucket steps map to multiplicative LR changes
+- `learning_rate` (evolvable) — range `[1e-6, 1.0]`, encoded with **log-scale 8-bit quantization** by default so that equal bucket steps map to multiplicative LR changes
 - `epsilon_decay` (fixed placeholder)
 - `memory_size` (fixed placeholder)
 
@@ -126,7 +126,7 @@ spec_log_8bit = GeneEncodingSpec(scale=GeneEncodingScale.LOG, bit_width=8)
 ### Gene-level encode/decode
 
 ```python
-gene = HyperparameterGene("learning_rate", ..., min_value=1e-5, max_value=1e-1, value=1e-3)
+gene = HyperparameterGene("learning_rate", ..., min_value=1e-6, max_value=1.0, value=1e-3)
 
 # Encode using the default policy for this gene name (log + 8-bit)
 bucket = gene.encode()          # e.g., 102 (integer 0..255)

--- a/farm/config/config.py
+++ b/farm/config/config.py
@@ -215,7 +215,7 @@ class EnvironmentalFactorsConfig:
     tolerance_width: float = 0.3
 
     def __post_init__(self) -> None:
-        """Clamp normalized factors to [0, 1] and validate tolerance settings."""
+        """Validate normalized factors and tolerance settings."""
         normalized_fields = (
             "temperature",
             "moisture",
@@ -228,7 +228,10 @@ class EnvironmentalFactorsConfig:
         )
         for field_name in normalized_fields:
             value = getattr(self, field_name)
-            setattr(self, field_name, max(0.0, min(1.0, value)))
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(
+                    f"{field_name} must be within [0.0, 1.0], got {value!r}."
+                )
 
         if self.tolerance_width <= 0:
             raise ValueError("tolerance_width must be greater than 0")

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -658,7 +658,7 @@ class AgentCore:
         resource_comp = self.get_component("resource")
         offspring_cost = repro_comp.config.offspring_cost
         resource_deducted = False
-        offspring_added = False
+        offspring_id: Optional[str] = None
 
         try:
             # Deduct reproduction cost
@@ -723,15 +723,8 @@ class AgentCore:
             # Add offspring to environment with immediate flush to ensure it's in database
             # Genome ID will be generated in add_agent() using parent info
             self.environment.add_agent(offspring, flush_immediately=True)
-            offspring_added = True
-
-            # Update reproduction component tracking
-            repro_comp.offspring_created += 1
-
-            return True
-
         except Exception:
-            if resource_comp and resource_deducted and not offspring_added:
+            if resource_comp and resource_deducted:
                 try:
                     resource_comp.add(offspring_cost)
                 except Exception:
@@ -740,14 +733,29 @@ class AgentCore:
                         agent_id=self.agent_id,
                         generation=self.generation,
                         offspring_cost=offspring_cost,
+                        offspring_id=offspring_id,
                     )
             logger.exception(
                 "agent_reproduction_failed",
                 agent_id=self.agent_id,
                 generation=self.generation,
                 initial_resources=initial_resources,
+                offspring_id=offspring_id,
             )
             return False
+
+        # Offspring insertion succeeded: reproduction is successful. Any bookkeeping
+        # errors below should not convert the operation into a failed reproduction.
+        try:
+            repro_comp.offspring_created += 1
+        except Exception:
+            logger.exception(
+                "agent_reproduction_post_add_bookkeeping_failed",
+                agent_id=self.agent_id,
+                generation=self.generation,
+                offspring_id=offspring_id,
+            )
+        return True
 
     def take_damage(self, damage: float) -> float:
         """

--- a/farm/core/genome.py
+++ b/farm/core/genome.py
@@ -1,6 +1,7 @@
 import json
 import random
-from typing import TYPE_CHECKING, Optional, Union
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, TypeVar, Union
 
 from farm.core.action import (
     Action,
@@ -16,6 +17,38 @@ from farm.core.action import (
 if TYPE_CHECKING:
     from farm.core.agent import AgentCore
     from farm.core.environment import Environment
+
+TChromosome = TypeVar("TChromosome")
+
+
+@dataclass(frozen=True)
+class TournamentSelectionConfig:
+    """Configuration for tournament-based parent selection."""
+
+    num_selected: int = 2
+    tournament_size: int = 3
+    seed: Optional[int] = None
+    return_indices: bool = False
+
+    def __post_init__(self) -> None:
+        if self.num_selected <= 0:
+            raise ValueError("num_selected must be positive.")
+        if self.tournament_size <= 0:
+            raise ValueError("tournament_size must be positive.")
+
+
+@dataclass(frozen=True)
+class RouletteSelectionConfig:
+    """Configuration for roulette-wheel parent selection."""
+
+    num_selected: int = 2
+    seed: Optional[int] = None
+    return_indices: bool = False
+    shift_negative_fitness: bool = False
+
+    def __post_init__(self) -> None:
+        if self.num_selected <= 0:
+            raise ValueError("num_selected must be positive.")
 
 
 # Action registry for secure function resolution
@@ -310,3 +343,110 @@ class Genome:
             json_str is not None
         ), "Genome.save() should return a string when no path is provided"
         return Genome.load(json_str)
+
+    @staticmethod
+    def tournament_selection(
+        population: Sequence[TChromosome],
+        fitnesses: Sequence[float],
+        config: Optional[TournamentSelectionConfig] = None,
+    ) -> Union[List[int], List[TChromosome]]:
+        """Select individuals via tournament selection.
+
+        Args:
+            population: Sequence of chromosome-like representations.
+            fitnesses: Non-empty sequence of fitness values aligned with ``population``.
+            config: Selection options. If ``None``, defaults are used.
+
+        Returns:
+            A list of selected indices when ``return_indices=True``;
+            otherwise a list of selected population items.
+
+        Notes:
+            - Selection is with replacement across tournaments.
+            - With a single individual, that individual is selected each time.
+            - Tournament size is capped to population size.
+        """
+        resolved_config = config or TournamentSelectionConfig()
+        Genome._validate_population_and_fitnesses(population, fitnesses)
+
+        rng = random.Random(resolved_config.seed)
+        candidate_count = len(population)
+        tournament_size = min(resolved_config.tournament_size, candidate_count)
+        selected_indices: List[int] = []
+
+        for _ in range(resolved_config.num_selected):
+            competitors = rng.sample(range(candidate_count), k=tournament_size)
+            best_idx = max(competitors, key=lambda idx: fitnesses[idx])
+            selected_indices.append(best_idx)
+
+        if resolved_config.return_indices:
+            return selected_indices
+        return [population[idx] for idx in selected_indices]
+
+    @staticmethod
+    def roulette_selection(
+        population: Sequence[TChromosome],
+        fitnesses: Sequence[float],
+        config: Optional[RouletteSelectionConfig] = None,
+    ) -> Union[List[int], List[TChromosome]]:
+        """Select individuals using roulette-wheel (fitness-proportionate) sampling.
+
+        Args:
+            population: Sequence of chromosome-like representations.
+            fitnesses: Fitness values aligned with ``population``.
+            config: Selection options. If ``None``, defaults are used.
+
+        Returns:
+            A list of selected indices when ``return_indices=True``;
+            otherwise a list of selected population items.
+
+        Notes:
+            - Roulette selection assumes non-negative fitness values.
+            - When ``shift_negative_fitness=True``, fitnesses are shifted by
+              ``-min_fitness`` so the smallest value becomes ``0``.
+            - If all resulting fitnesses are ``0`` (uniform/degenerate case),
+              selection falls back to uniform random choice.
+            - With a single individual, that individual is selected each time.
+        """
+        resolved_config = config or RouletteSelectionConfig()
+        Genome._validate_population_and_fitnesses(population, fitnesses)
+
+        adjusted_fitnesses = [float(fitness) for fitness in fitnesses]
+        min_fitness = min(adjusted_fitnesses)
+        if min_fitness < 0.0:
+            if not resolved_config.shift_negative_fitness:
+                raise ValueError(
+                    "roulette_selection requires non-negative fitnesses unless "
+                    "shift_negative_fitness=True."
+                )
+            shift = -min_fitness
+            adjusted_fitnesses = [fitness + shift for fitness in adjusted_fitnesses]
+
+        total_fitness = sum(adjusted_fitnesses)
+        candidate_indices = list(range(len(population)))
+        rng = random.Random(resolved_config.seed)
+
+        if total_fitness == 0.0:
+            selected_indices = [
+                rng.choice(candidate_indices) for _ in range(resolved_config.num_selected)
+            ]
+        else:
+            selected_indices = rng.choices(
+                candidate_indices,
+                weights=adjusted_fitnesses,
+                k=resolved_config.num_selected,
+            )
+
+        if resolved_config.return_indices:
+            return selected_indices
+        return [population[idx] for idx in selected_indices]
+
+    @staticmethod
+    def _validate_population_and_fitnesses(
+        population: Sequence[Any],
+        fitnesses: Sequence[float],
+    ) -> None:
+        if not population:
+            raise ValueError("population must not be empty.")
+        if len(population) != len(fitnesses):
+            raise ValueError("population and fitnesses must have the same length.")

--- a/tests/config/test_environmental_factors_config.py
+++ b/tests/config/test_environmental_factors_config.py
@@ -1,0 +1,53 @@
+"""Tests for EnvironmentalFactorsConfig validation behavior."""
+
+import pytest
+
+from farm.config.config import EnvironmentalFactorsConfig
+
+
+def test_environmental_factors_accepts_in_range_values():
+    cfg = EnvironmentalFactorsConfig(
+        temperature=0.2,
+        moisture=0.4,
+        light=0.6,
+        soil_quality=0.8,
+        optimal_temperature=0.3,
+        optimal_moisture=0.5,
+        optimal_light=0.7,
+        optimal_soil=0.9,
+        tolerance_width=0.1,
+    )
+    assert cfg.temperature == pytest.approx(0.2)
+    assert cfg.optimal_soil == pytest.approx(0.9)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "bad_value"),
+    [
+        ("temperature", -0.1),
+        ("temperature", 1.1),
+        ("moisture", -0.1),
+        ("moisture", 1.1),
+        ("light", -0.1),
+        ("light", 1.1),
+        ("soil_quality", -0.1),
+        ("soil_quality", 1.1),
+        ("optimal_temperature", -0.1),
+        ("optimal_temperature", 1.1),
+        ("optimal_moisture", -0.1),
+        ("optimal_moisture", 1.1),
+        ("optimal_light", -0.1),
+        ("optimal_light", 1.1),
+        ("optimal_soil", -0.1),
+        ("optimal_soil", 1.1),
+    ],
+)
+def test_environmental_factors_rejects_out_of_range_values(field_name, bad_value):
+    kwargs = {field_name: bad_value}
+    with pytest.raises(ValueError, match=field_name):
+        EnvironmentalFactorsConfig(**kwargs)
+
+
+def test_environmental_factors_rejects_non_positive_tolerance_width():
+    with pytest.raises(ValueError, match="tolerance_width"):
+        EnvironmentalFactorsConfig(tolerance_width=0.0)

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -1,6 +1,7 @@
 """Tests for hyperparameter chromosome wiring in AgentCore reproduction."""
 
 import pytest
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from farm.core.agent.config.component_configs import AgentComponentConfig
@@ -88,6 +89,45 @@ def test_reproduce_logs_exception_and_returns_false():
     assert success is False
     parent.get_component("resource").remove.assert_called_once_with(5.0)
     parent.get_component("resource").add.assert_called_once_with(5.0)
+    log_exception.assert_called_once()
+
+
+def test_reproduce_returns_true_when_post_add_bookkeeping_fails():
+    """Once offspring insertion succeeds, bookkeeping errors should not flip success to failure."""
+    parent = _build_parent_agent_for_reproduction()
+    offspring = Mock()
+    offspring.state = Mock()
+    offspring.state._state = Mock()
+    offspring.state._state.model_copy.return_value = Mock()
+
+    class _ReproductionComponentWithFailingCounter:
+        def __init__(self):
+            self.config = SimpleNamespace(offspring_cost=5.0, offspring_initial_resources=7.0)
+
+        def can_reproduce(self) -> bool:
+            return True
+
+        @property
+        def offspring_created(self) -> int:
+            return 0
+
+        @offspring_created.setter
+        def offspring_created(self, _value: int) -> None:
+            raise RuntimeError("counter write failed")
+
+    parent._components["reproduction"] = _ReproductionComponentWithFailingCounter()
+
+    with patch("farm.core.hyperparameter_chromosome.random.random", return_value=1.0), patch(
+        "farm.core.agent.factory.AgentFactory"
+    ) as factory_cls, patch("farm.core.agent.core.logger.exception") as log_exception:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+
+        success = AgentCore.reproduce(parent)
+
+    assert success is True
+    parent.environment.add_agent.assert_called_once_with(offspring, flush_immediately=True)
+    parent.get_component("resource").add.assert_not_called()
     log_exception.assert_called_once()
 
 

--- a/tests/test_genome.py
+++ b/tests/test_genome.py
@@ -5,7 +5,12 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock
 
-from farm.core.genome import Genome, ACTION_FUNCTIONS
+from farm.core.genome import (
+    ACTION_FUNCTIONS,
+    Genome,
+    RouletteSelectionConfig,
+    TournamentSelectionConfig,
+)
 
 
 def _make_mock_genome():
@@ -305,3 +310,87 @@ class TestGenomeToAgent(unittest.TestCase):
             genome["current_health"], combat_comp.config.starting_health
         )
         mock_agent.state.update_health.assert_called_once_with(expected_health)
+
+
+class TestGenomeSelectionOperators(unittest.TestCase):
+    def setUp(self):
+        self.population = ["a", "b", "c", "d"]
+        self.fitnesses = [1.0, 3.0, 2.0, 4.0]
+
+    def test_tournament_returns_indices_when_requested(self):
+        config = TournamentSelectionConfig(
+            num_selected=5,
+            tournament_size=2,
+            seed=7,
+            return_indices=True,
+        )
+        selected = Genome.tournament_selection(self.population, self.fitnesses, config)
+        self.assertEqual(len(selected), 5)
+        self.assertTrue(all(isinstance(idx, int) for idx in selected))
+        self.assertTrue(all(0 <= idx < len(self.population) for idx in selected))
+
+    def test_tournament_is_deterministic_with_seed(self):
+        config = TournamentSelectionConfig(
+            num_selected=6,
+            tournament_size=3,
+            seed=123,
+            return_indices=True,
+        )
+        selected_a = Genome.tournament_selection(self.population, self.fitnesses, config)
+        selected_b = Genome.tournament_selection(self.population, self.fitnesses, config)
+        self.assertEqual(selected_a, selected_b)
+
+    def test_tournament_single_individual(self):
+        config = TournamentSelectionConfig(
+            num_selected=4,
+            tournament_size=3,
+            return_indices=True,
+        )
+        selected = Genome.tournament_selection(["only"], [9.0], config)
+        self.assertEqual(selected, [0, 0, 0, 0])
+
+    def test_roulette_returns_population_items(self):
+        config = RouletteSelectionConfig(
+            num_selected=4,
+            seed=11,
+            return_indices=False,
+        )
+        selected = Genome.roulette_selection(self.population, self.fitnesses, config)
+        self.assertEqual(len(selected), 4)
+        self.assertTrue(all(item in self.population for item in selected))
+
+    def test_roulette_is_deterministic_with_seed(self):
+        config = RouletteSelectionConfig(
+            num_selected=8,
+            seed=99,
+            return_indices=True,
+        )
+        selected_a = Genome.roulette_selection(self.population, self.fitnesses, config)
+        selected_b = Genome.roulette_selection(self.population, self.fitnesses, config)
+        self.assertEqual(selected_a, selected_b)
+
+    def test_roulette_rejects_negative_fitness_without_shift(self):
+        config = RouletteSelectionConfig(num_selected=2, seed=1)
+        with self.assertRaises(ValueError):
+            Genome.roulette_selection(["x", "y"], [-1.0, 3.0], config)
+
+    def test_roulette_supports_negative_fitness_with_shift(self):
+        config = RouletteSelectionConfig(
+            num_selected=5,
+            seed=1,
+            shift_negative_fitness=True,
+            return_indices=True,
+        )
+        selected = Genome.roulette_selection(["x", "y"], [-1.0, 3.0], config)
+        self.assertEqual(len(selected), 5)
+        self.assertTrue(all(idx in [0, 1] for idx in selected))
+
+    def test_roulette_uniform_fallback_for_zero_total_fitness(self):
+        config = RouletteSelectionConfig(
+            num_selected=5,
+            seed=5,
+            return_indices=True,
+        )
+        selected = Genome.roulette_selection(["x", "y", "z"], [0.0, 0.0, 0.0], config)
+        self.assertEqual(len(selected), 5)
+        self.assertTrue(all(0 <= idx < 3 for idx in selected))


### PR DESCRIPTION
This pull request introduces several improvements and new features, focusing on genetic algorithm selection operators, stricter validation for environmental configuration, and enhanced robustness in agent reproduction. It also expands test coverage for these areas. The most important changes are summarized below:

**Genetic Algorithm Selection Operators:**

* Added `TournamentSelectionConfig` and `RouletteSelectionConfig` dataclasses in `farm/core/genome.py` to configure tournament and roulette-wheel parent selection strategies. Implemented `Genome.tournament_selection` and `Genome.roulette_selection` static methods, including validation and support for deterministic selection via seeds, negative fitness handling, and fallback behaviors. [[1]](diffhunk://#diff-e666683a1d13dd935728e76e8bea0a073dec395c061e816efb723fc0fe43fbaaR21-R52) [[2]](diffhunk://#diff-e666683a1d13dd935728e76e8bea0a073dec395c061e816efb723fc0fe43fbaaR346-R452)
* Added comprehensive unit tests for the new selection operators in `tests/test_genome.py`, covering determinism, edge cases, and error handling.

**Environmental Factors Validation:**

* Changed `EnvironmentalFactorsConfig` in `farm/config/config.py` to strictly validate that all normalized fields are within `[0.0, 1.0]` and that `tolerance_width` is positive, raising `ValueError` when invalid. [[1]](diffhunk://#diff-4b2fc3c00fa9df153de28d46f1d13e4a6d9eede8ef44d3b56f6aea46238defc4L218-R218) [[2]](diffhunk://#diff-4b2fc3c00fa9df153de28d46f1d13e4a6d9eede8ef44d3b56f6aea46238defc4L231-R234)
* Added a new test module `tests/config/test_environmental_factors_config.py` to verify correct validation and error handling for `EnvironmentalFactorsConfig`.

**Agent Reproduction Robustness:**

* Refactored `AgentCore.reproduce` in `farm/core/agent/core.py` to ensure that once offspring insertion succeeds, any subsequent bookkeeping errors (such as updating counters) do not cause the overall operation to fail. Logging is improved, and the return value reflects success as long as the critical operation completes. [[1]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393L661-R661) [[2]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393L726-R727) [[3]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393R736-R759)
* Added a test in `tests/test_agent_reproduction_hyperparameters.py` to confirm that post-insertion bookkeeping failures do not cause reproduction to return failure.

**Documentation and Parameter Range Updates:**

* Updated the documentation in `docs/design/hyperparameter_chromosome.md` to expand the default `learning_rate` gene's range from `[1e-5, 1e-1]` to `[1e-6, 1.0]` and reflect this in code examples. [[1]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L53-R53) [[2]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L129-R129)

These changes collectively improve the flexibility, correctness, and reliability of the genetic algorithm framework and its configuration validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches reproduction flow and configuration validation semantics (clamp→error), which can change runtime behavior and failure modes. New selection utilities are additive and well-tested but may impact downstream callers if adopted.
> 
> **Overview**
> Adds GA parent-selection utilities to `Genome` via configurable `tournament_selection` and `roulette_selection` (seedable, input-validated, negative/zero-fitness handling) and expands unit coverage for these operators.
> 
> Tightens `EnvironmentalFactorsConfig` by switching from clamping to *strict* `[0,1]` validation (raising `ValueError`), and makes `AgentCore.reproduce()` more robust by treating offspring insertion as the success boundary (refunding resources only on true failures; logging but not failing on post-add bookkeeping errors).
> 
> Updates hyperparameter chromosome docs to widen the default `learning_rate` range to `[1e-6, 1.0]` and aligns examples accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89ea9ffe9413a5fb84eb33ac3cb38187cfc3b936. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->