### PR TITLE
Add crossover and mutation modes for hyperparameter chromosomes

### DIFF
--- a/docs/design/distill_quantize_crossover_finetune.md
+++ b/docs/design/distill_quantize_crossover_finetune.md
@@ -300,7 +300,7 @@ python scripts/run_dual_teacher_cartpole.py \
 > **Security note:** `--allow-unsafe-unpickle` defaults to **disabled**.  Pickle
 > deserialization can execute arbitrary code; only pass this flag when you control
 > the source of the checkpoint files.  The flag is recorded in `pipeline_report.json`
-> under `parameters.allow_unsafe_unpickle` for audit purposes.
+> under `config.allow_unsafe_unpickle` for audit purposes.
 
 **Outputs written to `<output-dir>/`:**
 

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -724,7 +724,18 @@ class AgentCore:
             # Genome ID will be generated in add_agent() using parent info
             self.environment.add_agent(offspring, flush_immediately=True)
         except Exception:
-            if resource_comp and resource_deducted:
+            should_refund = bool(resource_comp and resource_deducted)
+            if should_refund and offspring_id and self._is_agent_present_in_environment(offspring_id):
+                rollback_ok = self._rollback_offspring_from_environment(offspring_id)
+                if not rollback_ok:
+                    should_refund = False
+                    logger.exception(
+                        "agent_reproduction_partial_offspring_rollback_failed",
+                        agent_id=self.agent_id,
+                        generation=self.generation,
+                        offspring_id=offspring_id,
+                    )
+            if should_refund and resource_comp:
                 try:
                     resource_comp.add(offspring_cost)
                 except Exception:
@@ -756,6 +767,77 @@ class AgentCore:
                 offspring_id=offspring_id,
             )
         return True
+
+    def _is_agent_present_in_environment(self, agent_id: str) -> bool:
+        """Return whether an agent ID appears in environment tracking structures."""
+        if not self.environment:
+            return False
+
+        agent_objects = getattr(self.environment, "_agent_objects", None)
+        in_objects = bool(isinstance(agent_objects, dict) and agent_id in agent_objects)
+        agent_ids = getattr(self.environment, "agents", None)
+        in_ids = bool(isinstance(agent_ids, list) and agent_id in agent_ids)
+        return in_objects or in_ids
+
+    def _rollback_offspring_from_environment(self, agent_id: str) -> bool:
+        """Best-effort rollback for a partially inserted offspring."""
+        if not self.environment:
+            return True
+
+        if not self._is_agent_present_in_environment(agent_id):
+            return True
+
+        # Prefer environment-level removal when available so dependent state is
+        # cleaned consistently.
+        if (
+            hasattr(self.environment, "_agent_objects")
+            and hasattr(self.environment, "remove_agent")
+            and isinstance(self.environment._agent_objects, dict)
+        ):
+            offspring_obj = self.environment._agent_objects.get(agent_id)
+            if offspring_obj is not None:
+                try:
+                    self.environment.remove_agent(offspring_obj)
+                except Exception:
+                    return False
+                return not self._is_agent_present_in_environment(agent_id)
+
+        # Fallback for partially inserted records where no object is available.
+        if (
+            hasattr(self.environment, "_agent_objects")
+            and isinstance(self.environment._agent_objects, dict)
+        ):
+            self.environment._agent_objects.pop(agent_id, None)
+        if (
+            hasattr(self.environment, "agents")
+            and isinstance(self.environment.agents, list)
+            and agent_id in self.environment.agents
+        ):
+            self.environment.agents.remove(agent_id)
+        for mapping_name in (
+            "rewards",
+            "_cumulative_rewards",
+            "terminations",
+            "truncations",
+            "infos",
+            "observations",
+            "agent_observations",
+        ):
+            mapping = getattr(self.environment, mapping_name, None)
+            if hasattr(mapping, "pop"):
+                mapping.pop(agent_id, None)
+
+        if hasattr(self.environment, "spatial_index"):
+            try:
+                self.environment.spatial_index.mark_positions_dirty()
+            except Exception:
+                logger.exception(
+                    "agent_reproduction_partial_offspring_spatial_cleanup_failed",
+                    agent_id=self.agent_id,
+                    generation=self.generation,
+                    offspring_id=agent_id,
+                )
+        return not self._is_agent_present_in_environment(agent_id)
 
     def take_damage(self, damage: float) -> float:
         """

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -780,56 +780,74 @@ class AgentCore:
         return in_objects or in_ids
 
     def _rollback_offspring_from_environment(self, agent_id: str) -> bool:
-        """Best-effort rollback for a partially inserted offspring."""
+        """Best-effort rollback for a partially inserted offspring.
+
+        Removes the offspring from environment tracking structures without
+        triggering lifecycle events (death recording, DB writes, metrics skew)
+        that ``Environment.remove_agent`` would cause for an agent that was
+        never fully born.
+        """
         if not self.environment:
             return True
 
         if not self._is_agent_present_in_environment(agent_id):
             return True
 
-        # Prefer environment-level removal when available so dependent state is
-        # cleaned consistently.
-        if (
-            hasattr(self.environment, "_agent_objects")
-            and hasattr(self.environment, "remove_agent")
-            and isinstance(self.environment._agent_objects, dict)
-        ):
-            offspring_obj = self.environment._agent_objects.get(agent_id)
-            if offspring_obj is not None:
-                try:
-                    self.environment.remove_agent(offspring_obj)
-                except Exception:
-                    return False
-                return not self._is_agent_present_in_environment(agent_id)
+        # Directly clean up tracking structures, bypassing remove_agent so that
+        # no death events, DB writes, or metrics updates occur for an agent that
+        # was never fully inserted.
+        try:
+            if (
+                hasattr(self.environment, "_agent_objects")
+                and isinstance(self.environment._agent_objects, dict)
+            ):
+                self.environment._agent_objects.pop(agent_id, None)
+            if (
+                hasattr(self.environment, "agents")
+                and isinstance(self.environment.agents, list)
+                and agent_id in self.environment.agents
+            ):
+                self.environment.agents.remove(agent_id)
+            for mapping_name in (
+                "rewards",
+                "_cumulative_rewards",
+                "terminations",
+                "truncations",
+                "infos",
+                "observations",
+                "agent_observations",
+            ):
+                mapping = getattr(self.environment, mapping_name, None)
+                if hasattr(mapping, "pop"):
+                    mapping.pop(agent_id, None)
+        except Exception:
+            logger.exception(
+                "agent_reproduction_partial_offspring_cleanup_failed",
+                agent_id=self.agent_id,
+                generation=self.generation,
+                offspring_id=agent_id,
+            )
+            return False
 
-        # Fallback for partially inserted records where no object is available.
-        if (
-            hasattr(self.environment, "_agent_objects")
-            and isinstance(self.environment._agent_objects, dict)
-        ):
-            self.environment._agent_objects.pop(agent_id, None)
-        if (
-            hasattr(self.environment, "agents")
-            and isinstance(self.environment.agents, list)
-            and agent_id in self.environment.agents
-        ):
-            self.environment.agents.remove(agent_id)
-        for mapping_name in (
-            "rewards",
-            "_cumulative_rewards",
-            "terminations",
-            "truncations",
-            "infos",
-            "observations",
-            "agent_observations",
-        ):
-            mapping = getattr(self.environment, mapping_name, None)
-            if hasattr(mapping, "pop"):
-                mapping.pop(agent_id, None)
-
+        # Refresh the spatial index so the removed offspring is no longer
+        # visible in KD-tree queries.  mark_positions_dirty() alone only flags
+        # the index as stale but does not evict the object reference from
+        # SpatialIndex._agents; set_references() must be called with the
+        # current agent list to fully remove the ghost entry.
         if hasattr(self.environment, "spatial_index"):
             try:
-                self.environment.spatial_index.mark_positions_dirty()
+                spatial_index = self.environment.spatial_index
+                if hasattr(spatial_index, "set_references"):
+                    agents = (
+                        list(self.environment._agent_objects.values())
+                        if hasattr(self.environment, "_agent_objects")
+                        and isinstance(self.environment._agent_objects, dict)
+                        else []
+                    )
+                    resources = getattr(self.environment, "resources", [])
+                    spatial_index.set_references(agents, resources)
+                else:
+                    spatial_index.mark_positions_dirty()
             except Exception:
                 logger.exception(
                     "agent_reproduction_partial_offspring_spatial_cleanup_failed",

--- a/farm/core/hyperparameter_chromosome.py
+++ b/farm/core/hyperparameter_chromosome.py
@@ -36,6 +36,20 @@ class GeneEncodingScale(str, Enum):
     LOG = "log"
 
 
+class CrossoverMode(str, Enum):
+    """Supported crossover operators for chromosome vectors."""
+
+    SINGLE_POINT = "single_point"
+    UNIFORM = "uniform"
+
+
+class MutationMode(str, Enum):
+    """Supported mutation operators for real-valued genes."""
+
+    GAUSSIAN = "gaussian"
+    MULTIPLICATIVE = "multiplicative"
+
+
 @dataclass(frozen=True)
 class GeneEncodingSpec:
     """Encoding settings for converting gene values to stored representations."""
@@ -472,25 +486,115 @@ def mutate_chromosome(
     chromosome: HyperparameterChromosome,
     mutation_rate: float = 0.1,
     mutation_scale: float = 0.2,
+    mutation_mode: Union[MutationMode, str] = MutationMode.GAUSSIAN,
+    rng: Optional[random.Random] = None,
 ) -> HyperparameterChromosome:
-    """Mutate evolvable genes by bounded multiplicative perturbation."""
+    """Mutate evolvable genes using bounded real-valued perturbations.
+
+    Notes:
+        - ``gaussian``: additive Gaussian perturbation where sigma is
+          ``mutation_scale * (max_value - min_value)``.
+        - ``multiplicative``: legacy multiplicative perturbation using a
+          uniform delta in ``[-mutation_scale, mutation_scale]``.
+        - All mutations are clamped to each gene's bounds.
+    """
     if not 0.0 <= mutation_rate <= 1.0:
         raise ValueError("mutation_rate must be between 0 and 1.")
     if mutation_scale < 0.0:
         raise ValueError("mutation_scale must be non-negative.")
 
+    resolved_mode = MutationMode(mutation_mode)
+    resolved_rng = rng or random
     updated_genes: List[HyperparameterGene] = []
     for gene in chromosome.genes:
-        if not gene.evolvable or random.random() >= mutation_rate:
+        if not gene.evolvable or resolved_rng.random() >= mutation_rate:
             updated_genes.append(gene)
             continue
 
-        delta = random.uniform(-mutation_scale, mutation_scale)
-        raw_value = gene.value * (1.0 + delta)
+        if resolved_mode is MutationMode.GAUSSIAN:
+            span = gene.max_value - gene.min_value
+            sigma = span * mutation_scale
+            raw_value = gene.value + resolved_rng.gauss(0.0, sigma)
+        else:
+            delta = resolved_rng.uniform(-mutation_scale, mutation_scale)
+            raw_value = gene.value * (1.0 + delta)
+
         bounded_value = max(gene.min_value, min(gene.max_value, raw_value))
         updated_genes.append(gene.with_value(bounded_value))
 
     return HyperparameterChromosome(genes=tuple(updated_genes))
+
+
+def crossover_chromosomes(
+    parent_a: HyperparameterChromosome,
+    parent_b: HyperparameterChromosome,
+    *,
+    mode: Union[CrossoverMode, str] = CrossoverMode.SINGLE_POINT,
+    include_fixed: bool = False,
+    uniform_parent_b_probability: float = 0.5,
+    rng: Optional[random.Random] = None,
+) -> HyperparameterChromosome:
+    """Create a child chromosome by crossing two parent gene vectors.
+
+    Notes:
+        This operator intentionally lives outside ``Genome`` to keep action-set
+        genome evolution separate from hyperparameter chromosome evolution.
+    """
+    if not 0.0 <= uniform_parent_b_probability <= 1.0:
+        raise ValueError("uniform_parent_b_probability must be between 0 and 1.")
+
+    _validate_compatible_chromosomes(parent_a, parent_b)
+    resolved_mode = CrossoverMode(mode)
+    resolved_rng = rng or random
+
+    selected_indices = [
+        idx
+        for idx, gene in enumerate(parent_a.genes)
+        if include_fixed or gene.evolvable
+    ]
+    if not selected_indices:
+        return HyperparameterChromosome(genes=tuple(parent_a.genes))
+
+    child_genes = list(parent_a.genes)
+    if resolved_mode is CrossoverMode.SINGLE_POINT:
+        if len(selected_indices) == 1:
+            selected_parent = parent_b if resolved_rng.random() < 0.5 else parent_a
+            child_genes[selected_indices[0]] = selected_parent.genes[selected_indices[0]]
+        else:
+            pivot = resolved_rng.randint(1, len(selected_indices) - 1)
+            for selected_position, gene_idx in enumerate(selected_indices):
+                source = parent_a if selected_position < pivot else parent_b
+                child_genes[gene_idx] = source.genes[gene_idx]
+    else:
+        for gene_idx in selected_indices:
+            if resolved_rng.random() < uniform_parent_b_probability:
+                child_genes[gene_idx] = parent_b.genes[gene_idx]
+
+    return HyperparameterChromosome(genes=tuple(child_genes))
+
+
+def _validate_compatible_chromosomes(
+    parent_a: HyperparameterChromosome,
+    parent_b: HyperparameterChromosome,
+) -> None:
+    if len(parent_a.genes) != len(parent_b.genes):
+        raise ValueError("Chromosomes must have the same number of genes for crossover.")
+
+    for index, (gene_a, gene_b) in enumerate(zip(parent_a.genes, parent_b.genes)):
+        if gene_a.name != gene_b.name:
+            raise ValueError(
+                f"Chromosome gene mismatch at index {index}: "
+                f"'{gene_a.name}' != '{gene_b.name}'."
+            )
+        if (
+            gene_a.value_type != gene_b.value_type
+            or gene_a.min_value != gene_b.min_value
+            or gene_a.max_value != gene_b.max_value
+            or gene_a.evolvable != gene_b.evolvable
+        ):
+            raise ValueError(
+                f"Chromosome gene '{gene_a.name}' has incompatible schema across parents."
+            )
 
 
 def apply_chromosome_to_learning_config(
@@ -502,6 +606,11 @@ def apply_chromosome_to_learning_config(
     Supports Pydantic v2 models via ``model_copy(update=...)`` and falls back to
     a deep copy with attributes updated for plain objects, ensuring the original
     is never mutated regardless of config type.
+
+    Integration note:
+        ``Genome.from_agent`` captures action weights and module state only, not this
+        hyperparameter chromosome. Apply chromosome values to decision config before
+        constructing offspring so module initialization sees the evolved settings.
     """
     updates: Dict[str, Any] = {}
     for gene in chromosome.genes:

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -55,7 +55,7 @@ def test_reproduce_mutates_learning_rate_and_passes_child_config():
     offspring.state._state.model_copy.return_value = Mock()
 
     with patch("farm.core.hyperparameter_chromosome.random.random", return_value=0.0), patch(
-        "farm.core.hyperparameter_chromosome.random.uniform", return_value=0.2
+        "farm.core.hyperparameter_chromosome.random.gauss", return_value=0.002
     ), patch("farm.core.agent.factory.AgentFactory") as factory_cls:
         factory = factory_cls.return_value
         factory.create_learning_agent.return_value = offspring

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -189,3 +189,95 @@ def test_validate_decision_config_passes_for_valid_values():
     # Should not raise
     agent._validate_decision_config_for_hyperparameters()
 
+
+def test_reproduce_rolls_back_partially_added_offspring_before_refund():
+    """If add_agent partially inserts offspring and then fails, rollback then refund."""
+    parent = _build_parent_agent_for_reproduction()
+
+    class _PartiallyFailingEnvironment:
+        def __init__(self):
+            self._agent_objects = {}
+            self.agents = []
+            self.rewards = {}
+            self._cumulative_rewards = {}
+            self.terminations = {}
+            self.truncations = {}
+            self.infos = {}
+            self.observations = {}
+            self.agent_observations = {}
+            self.spatial_index = Mock()
+
+        def get_next_agent_id(self) -> str:
+            return "child_1"
+
+        def add_agent(self, offspring, flush_immediately: bool = False):
+            self._agent_objects[offspring.agent_id] = offspring
+            self.agents.append(offspring.agent_id)
+            raise RuntimeError("flush failed after insert")
+
+        def remove_agent(self, offspring) -> None:
+            self._agent_objects.pop(offspring.agent_id, None)
+            if offspring.agent_id in self.agents:
+                self.agents.remove(offspring.agent_id)
+
+    parent.environment = _PartiallyFailingEnvironment()
+    offspring = SimpleNamespace(
+        agent_id="child_1",
+        state=Mock(),
+        generation=0,
+    )
+    offspring.state._state = Mock()
+    offspring.state._state.model_copy.return_value = Mock()
+
+    with patch("farm.core.hyperparameter_chromosome.random.random", return_value=1.0), patch(
+        "farm.core.agent.factory.AgentFactory"
+    ) as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is False
+    parent.get_component("resource").add.assert_called_once_with(5.0)
+    assert "child_1" not in parent.environment._agent_objects
+    assert "child_1" not in parent.environment.agents
+
+
+def test_reproduce_skips_refund_when_partial_offspring_rollback_fails():
+    """Avoid refund if offspring may still exist and rollback cannot complete."""
+    parent = _build_parent_agent_for_reproduction()
+
+    class _RollbackFailingEnvironment:
+        def __init__(self):
+            self._agent_objects = {}
+            self.agents = []
+
+        def get_next_agent_id(self) -> str:
+            return "child_1"
+
+        def add_agent(self, offspring, flush_immediately: bool = False):
+            self._agent_objects[offspring.agent_id] = offspring
+            self.agents.append(offspring.agent_id)
+            raise RuntimeError("flush failed after insert")
+
+        def remove_agent(self, offspring) -> None:
+            raise RuntimeError("rollback failed")
+
+    parent.environment = _RollbackFailingEnvironment()
+    offspring = SimpleNamespace(
+        agent_id="child_1",
+        state=Mock(),
+        generation=0,
+    )
+    offspring.state._state = Mock()
+    offspring.state._state.model_copy.return_value = Mock()
+
+    with patch("farm.core.hyperparameter_chromosome.random.random", return_value=1.0), patch(
+        "farm.core.agent.factory.AgentFactory"
+    ) as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is False
+    parent.get_component("resource").add.assert_not_called()
+

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -215,11 +215,6 @@ def test_reproduce_rolls_back_partially_added_offspring_before_refund():
             self.agents.append(offspring.agent_id)
             raise RuntimeError("flush failed after insert")
 
-        def remove_agent(self, offspring) -> None:
-            self._agent_objects.pop(offspring.agent_id, None)
-            if offspring.agent_id in self.agents:
-                self.agents.remove(offspring.agent_id)
-
     parent.environment = _PartiallyFailingEnvironment()
     offspring = SimpleNamespace(
         agent_id="child_1",
@@ -240,15 +235,25 @@ def test_reproduce_rolls_back_partially_added_offspring_before_refund():
     parent.get_component("resource").add.assert_called_once_with(5.0)
     assert "child_1" not in parent.environment._agent_objects
     assert "child_1" not in parent.environment.agents
+    # Verify spatial index was fully refreshed (not just marked dirty) so the
+    # removed offspring is evicted from KD-tree queries.
+    parent.environment.spatial_index.set_references.assert_called_once_with([], [])
 
 
 def test_reproduce_skips_refund_when_partial_offspring_rollback_fails():
     """Avoid refund if offspring may still exist and rollback cannot complete."""
     parent = _build_parent_agent_for_reproduction()
 
+    class _CleanupFailingDict(dict):
+        """dict subclass whose pop() always raises to simulate a cleanup failure."""
+
+        def pop(self, key, *args):
+            raise RuntimeError("rollback failed")
+
     class _RollbackFailingEnvironment:
         def __init__(self):
-            self._agent_objects = {}
+            # Use the failing dict so direct cleanup (pop) raises during rollback.
+            self._agent_objects = _CleanupFailingDict()
             self.agents = []
 
         def get_next_agent_id(self) -> str:
@@ -258,9 +263,6 @@ def test_reproduce_skips_refund_when_partial_offspring_rollback_fails():
             self._agent_objects[offspring.agent_id] = offspring
             self.agents.append(offspring.agent_id)
             raise RuntimeError("flush failed after insert")
-
-        def remove_agent(self, offspring) -> None:
-            raise RuntimeError("rollback failed")
 
     parent.environment = _RollbackFailingEnvironment()
     offspring = SimpleNamespace(

--- a/tests/test_hyperparameter_chromosome.py
+++ b/tests/test_hyperparameter_chromosome.py
@@ -1,10 +1,14 @@
 """Tests for typed hyperparameter chromosome schema."""
 
 import unittest
+import random
 from unittest.mock import patch
 
 from farm.core.hyperparameter_chromosome import (
+    CrossoverMode,
+    MutationMode,
     apply_chromosome_to_learning_config,
+    crossover_chromosomes,
     decode_chromosome,
     decode_chromosome_vector,
     encode_chromosome,
@@ -106,11 +110,28 @@ class TestHyperparameterChromosome(unittest.TestCase):
 
     def test_mutation_only_changes_evolvable_genes(self):
         chromosome = default_hyperparameter_chromosome()
-        with patch("farm.core.hyperparameter_chromosome.random.uniform", return_value=0.1):
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=0.05):
             mutated = mutate_chromosome(chromosome, mutation_rate=1.0, mutation_scale=0.1)
         self.assertNotEqual(mutated.get_value("learning_rate"), chromosome.get_value("learning_rate"))
         self.assertEqual(mutated.get_value("epsilon_decay"), chromosome.get_value("epsilon_decay"))
         self.assertEqual(mutated.get_value("memory_size"), chromosome.get_value("memory_size"))
+
+    def test_gaussian_mutation_clamps_to_gene_bounds(self):
+        chromosome = chromosome_from_values({"learning_rate": 0.999})
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=5.0):
+            mutated = mutate_chromosome(chromosome, mutation_rate=1.0, mutation_scale=1.0)
+        self.assertEqual(mutated.get_value("learning_rate"), 1.0)
+
+    def test_mutation_supports_legacy_multiplicative_mode(self):
+        chromosome = chromosome_from_values({"learning_rate": 0.01})
+        with patch("farm.core.hyperparameter_chromosome.random.uniform", return_value=0.2):
+            mutated = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=0.2,
+                mutation_mode=MutationMode.MULTIPLICATIVE,
+            )
+        self.assertAlmostEqual(mutated.get_value("learning_rate"), 0.012)
 
     def test_apply_chromosome_to_learning_config(self):
         decision = DecisionConfig(learning_rate=0.02, epsilon_decay=0.98, memory_size=5000)
@@ -194,6 +215,73 @@ class TestHyperparameterEncoding(unittest.TestCase):
     def test_decode_chromosome_rejects_unknown_gene_name(self):
         with self.assertRaises(KeyError):
             decode_chromosome({"unknown_gene": 12})
+
+
+class TestHyperparameterCrossover(unittest.TestCase):
+    def test_single_point_crossover_combines_parent_vectors(self):
+        parent_a = chromosome_from_values({"learning_rate": 0.01, "epsilon_decay": 0.8})
+        parent_b = chromosome_from_values({"learning_rate": 0.5, "epsilon_decay": 0.9})
+
+        child = crossover_chromosomes(
+            parent_a,
+            parent_b,
+            mode=CrossoverMode.SINGLE_POINT,
+            include_fixed=True,
+            rng=random.Random(7),
+        )
+
+        # With include_fixed=True and deterministic RNG, suffix should come from parent_b.
+        self.assertIn(child.get_value("learning_rate"), (0.01, 0.5))
+        self.assertIn(child.get_value("epsilon_decay"), (0.8, 0.9))
+        self.assertIn(child.get_value("memory_size"), (10000.0,))
+
+    def test_uniform_crossover_uses_probability_for_parent_b(self):
+        parent_a = chromosome_from_values({"learning_rate": 0.01})
+        parent_b = chromosome_from_values({"learning_rate": 0.5})
+
+        child = crossover_chromosomes(
+            parent_a,
+            parent_b,
+            mode=CrossoverMode.UNIFORM,
+            uniform_parent_b_probability=1.0,
+        )
+        self.assertEqual(child.get_value("learning_rate"), 0.5)
+
+    def test_uniform_crossover_keeps_values_in_gene_ranges(self):
+        parent_a = chromosome_from_values({"learning_rate": 1e-6})
+        parent_b = chromosome_from_values({"learning_rate": 1.0})
+
+        child = crossover_chromosomes(
+            parent_a,
+            parent_b,
+            mode=CrossoverMode.UNIFORM,
+            uniform_parent_b_probability=0.5,
+            rng=random.Random(3),
+        )
+        learning_rate = child.get_value("learning_rate")
+        self.assertGreaterEqual(learning_rate, 1e-6)
+        self.assertLessEqual(learning_rate, 1.0)
+
+    def test_crossover_then_mutation_keeps_offspring_in_range(self):
+        parent_a = chromosome_from_values({"learning_rate": 1e-6})
+        parent_b = chromosome_from_values({"learning_rate": 1.0})
+        child = crossover_chromosomes(
+            parent_a,
+            parent_b,
+            mode=CrossoverMode.UNIFORM,
+            uniform_parent_b_probability=0.5,
+            rng=random.Random(11),
+        )
+        mutated = mutate_chromosome(
+            child,
+            mutation_rate=1.0,
+            mutation_scale=1.0,
+            mutation_mode=MutationMode.GAUSSIAN,
+            rng=random.Random(19),
+        )
+        learning_rate = mutated.get_value("learning_rate")
+        self.assertGreaterEqual(learning_rate, 1e-6)
+        self.assertLessEqual(learning_rate, 1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces significant improvements to the hyperparameter chromosome evolution system, focusing on enhancing the flexibility, robustness, and test coverage of genetic operations such as mutation and crossover. The changes include new operator modes, improved error handling during agent reproduction, and expanded tests to ensure correctness and reliability.

**Genetic Operator Enhancements:**

* Added `CrossoverMode` and `MutationMode` enums to support multiple crossover (single-point, uniform) and mutation (Gaussian, multiplicative) strategies for hyperparameter chromosomes, making the genetic algorithm more flexible and extensible.
* Refactored `mutate_chromosome` to support both Gaussian and legacy multiplicative mutation modes, with explicit clamping to gene bounds and support for deterministic random number generators.
* Introduced `crossover_chromosomes` function, allowing creation of child chromosomes from two parents using configurable crossover modes, with schema validation for compatibility.
* Updated tests and added new test cases to verify mutation and crossover behaviors, including edge cases for gene bounds and operator correctness. [[1]](diffhunk://#diff-9c7680134b11855929fe6dd4a3d862d1b80e80be48036a6186b545079899f572L109-R135) [[2]](diffhunk://#diff-9c7680134b11855929fe6dd4a3d862d1b80e80be48036a6186b545079899f572R220-R286)

**Agent Reproduction Robustness:**

* Improved error handling in `AgentCore.reproduce` to ensure that if offspring insertion fails partway, the system attempts to roll back any partial additions before refunding resources, and skips refunds if rollback is unsuccessful.
* Added helper methods `_is_agent_present_in_environment` and `_rollback_offspring_from_environment` for robust and consistent cleanup of partially inserted offspring agents in the environment.
* Added comprehensive tests to verify correct rollback and refund logic during partial agent insertion failures.

**Documentation and Integration Notes:**

* Updated documentation to clarify the integration of hyperparameter chromosomes with agent initialization and to correct the location where the `allow_unsafe_unpickle` flag is recorded. [[1]](diffhunk://#diff-c4863d13eaaefe9c3b9c1c0349120d647bb4c086a3123f6b30b63f7762f42410L303-R303) [[2]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R609-R613)

These changes collectively make the evolutionary hyperparameter system more modular, reliable, and easier to extend or maintain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core evolution/reproduction paths and changes mutation semantics (defaulting to Gaussian), which can affect agent behavior and resource accounting if edge cases slip through.
> 
> **Overview**
> Adds configurable genetic operators for hyperparameter evolution by introducing `CrossoverMode`/`MutationMode`, updating `mutate_chromosome` to support Gaussian (default) vs legacy multiplicative mutation, optional deterministic RNG injection, and adding `crossover_chromosomes` with schema compatibility validation.
> 
> Hardens `AgentCore.reproduce` failure handling by detecting partially-added offspring, attempting best-effort rollback/cleanup before refunding resources (and skipping refunds if rollback fails), with new unit tests covering rollback/refund behavior; docs also correct the audit path for `allow_unsafe_unpickle` to `config.allow_unsafe_unpickle`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 440b8bda61db7bbd5637e6808e0bd9c4f8a512a8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->