### PR TITLE
Implement multi-generation hyperparameter evolution and rollback mechanism

### DIFF
--- a/experiments/evolution_smoke/evolution_generation_summaries.json
+++ b/experiments/evolution_smoke/evolution_generation_summaries.json
@@ -1,0 +1,16 @@
+[
+  {
+    "generation": 0,
+    "best_fitness": 6.0,
+    "mean_fitness": 6.0,
+    "min_fitness": 6.0,
+    "best_candidate_id": "g0_c0"
+  },
+  {
+    "generation": 1,
+    "best_fitness": 6.0,
+    "mean_fitness": 6.0,
+    "min_fitness": 6.0,
+    "best_candidate_id": "g1_elite0"
+  }
+]

--- a/experiments/evolution_smoke/evolution_lineage.json
+++ b/experiments/evolution_smoke/evolution_lineage.json
@@ -1,0 +1,106 @@
+[
+  {
+    "candidate_id": "g0_c0",
+    "generation": 0,
+    "fitness": 6.0,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 6
+    }
+  },
+  {
+    "candidate_id": "g0_c1",
+    "generation": 0,
+    "fitness": 6.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 6
+    }
+  },
+  {
+    "candidate_id": "g0_c2",
+    "generation": 0,
+    "fitness": 6.0,
+    "learning_rate": 0.004224876496908031,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 6
+    }
+  },
+  {
+    "candidate_id": "g0_c3",
+    "generation": 0,
+    "fitness": 6.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 6
+    }
+  },
+  {
+    "candidate_id": "g1_elite0",
+    "generation": 1,
+    "fitness": 6.0,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c0"
+    ],
+    "metadata": {
+      "final_population": 6
+    }
+  },
+  {
+    "candidate_id": "g1_c1",
+    "generation": 1,
+    "fitness": 6.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c1"
+    ],
+    "metadata": {
+      "final_population": 6
+    }
+  },
+  {
+    "candidate_id": "g1_c2",
+    "generation": 1,
+    "fitness": 6.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c3"
+    ],
+    "metadata": {
+      "final_population": 6
+    }
+  },
+  {
+    "candidate_id": "g1_c3",
+    "generation": 1,
+    "fitness": 6.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c3",
+      "g0_c1"
+    ],
+    "metadata": {
+      "final_population": 6
+    }
+  }
+]

--- a/farm/core/agent/config/component_configs.py
+++ b/farm/core/agent/config/component_configs.py
@@ -253,6 +253,7 @@ class AgentComponentConfig:
         """
         # Extract values from simulation config with fallbacks
         agent_behavior = getattr(sim_config, 'agent_behavior', None)
+        learning = getattr(sim_config, "learning", None)
         
         if agent_behavior:
             # Use values from agent_behavior config
@@ -275,6 +276,24 @@ class AgentComponentConfig:
             base_attack_strength = 10.0
             base_defense_strength = 5.0
         
+        decision_kwargs = {}
+        if learning:
+            learning_to_decision_fields = (
+                ("learning_rate", "learning_rate"),
+                ("gamma", "gamma"),
+                ("epsilon_start", "epsilon_start"),
+                ("epsilon_min", "epsilon_min"),
+                ("epsilon_decay", "epsilon_decay"),
+                ("memory_size", "memory_size"),
+                ("batch_size", "batch_size"),
+                ("training_frequency", "rl_train_freq"),
+                ("dqn_hidden_size", "dqn_hidden_size"),
+                ("tau", "tau"),
+            )
+            for learning_field, decision_field in learning_to_decision_fields:
+                if hasattr(learning, learning_field):
+                    decision_kwargs[decision_field] = getattr(learning, learning_field)
+
         return cls(
             resource=ResourceConfig(
                 base_consumption_rate=base_consumption_rate,
@@ -291,4 +310,5 @@ class AgentComponentConfig:
                 offspring_cost=offspring_cost,
                 offspring_initial_resources=offspring_initial_resources,
             ),
+            decision=DecisionConfig(**decision_kwargs),
         )

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -782,13 +782,25 @@ class AgentCore:
     def _rollback_offspring_from_environment(self, agent_id: str) -> bool:
         """Best-effort rollback for a partially inserted offspring.
 
-        Removes the offspring from environment tracking structures without
-        triggering lifecycle events (death recording, DB writes, metrics skew)
-        that ``Environment.remove_agent`` would cause for an agent that was
-        never fully born.
+        Prefers an environment-provided compensation hook that can roll back
+        in-memory structures plus persistence/metrics side effects; falls back
+        to local in-memory cleanup for test doubles and legacy environments.
         """
         if not self.environment:
             return True
+
+        rollback_hook = getattr(self.environment, "rollback_partial_agent_add", None)
+        if callable(rollback_hook):
+            try:
+                return bool(rollback_hook(agent_id))
+            except Exception:
+                logger.exception(
+                    "agent_reproduction_partial_offspring_environment_rollback_failed",
+                    agent_id=self.agent_id,
+                    generation=self.generation,
+                    offspring_id=agent_id,
+                )
+                return False
 
         if not self._is_agent_present_in_environment(agent_id):
             return True

--- a/farm/core/environment.py
+++ b/farm/core/environment.py
@@ -1234,6 +1234,86 @@ class Environment(AECEnv):
                     self._logged_population_milestones.add(milestone)
                     break
 
+    def rollback_partial_agent_add(self, agent_id: str) -> bool:
+        """Best-effort rollback for an agent add that failed mid-flight.
+
+        This compensates for failures that happen after internal structures,
+        metrics, or database state may have been updated, but before the add
+        operation is considered successful by the caller.
+        """
+        try:
+            if agent_id in self._agent_objects:
+                del self._agent_objects[agent_id]
+            if agent_id in self.agents:
+                self.agents.remove(agent_id)
+
+            for mapping_name in (
+                "rewards",
+                "_cumulative_rewards",
+                "terminations",
+                "truncations",
+                "infos",
+                "observations",
+                "agent_observations",
+            ):
+                mapping = getattr(self, mapping_name, None)
+                if hasattr(mapping, "pop"):
+                    mapping.pop(agent_id, None)
+        except Exception:
+            logger.exception(
+                "environment_partial_agent_add_cleanup_failed",
+                agent_id=agent_id,
+                step=self.time,
+            )
+            return False
+
+        # Rebuild spatial references so removed agents are not query-visible.
+        try:
+            if hasattr(self, "spatial_index") and self.spatial_index is not None:
+                self.spatial_index.set_references(list(self._agent_objects.values()), self.resources)
+        except Exception:
+            logger.exception(
+                "environment_partial_agent_add_spatial_cleanup_failed",
+                agent_id=agent_id,
+                step=self.time,
+            )
+            return False
+
+        # Undo birth metric increment when it was recorded in this step.
+        try:
+            if (
+                self.time > 0
+                and hasattr(self, "metrics_tracker")
+                and self.metrics_tracker is not None
+                and hasattr(self.metrics_tracker, "step_metrics")
+                and getattr(self.metrics_tracker.step_metrics, "births", 0) > 0
+            ):
+                self.metrics_tracker.step_metrics.births -= 1
+        except Exception:
+            logger.exception(
+                "environment_partial_agent_add_metric_rollback_failed",
+                agent_id=agent_id,
+                step=self.time,
+            )
+
+        # If a DB row for this agent was persisted, mark it dead at this step
+        # so "alive population" queries do not include a phantom agent.
+        try:
+            if hasattr(self, "db") and self.db is not None:
+                self.db.update_agent_death(
+                    agent_id=agent_id,
+                    death_time=self.time,
+                    cause="rollback_partial_add",
+                )
+        except Exception:
+            logger.exception(
+                "environment_partial_agent_add_db_rollback_failed",
+                agent_id=agent_id,
+                step=self.time,
+            )
+
+        return agent_id not in self._agent_objects and agent_id not in self.agents
+
     def cleanup(self) -> None:
         """Clean up environment resources.
 

--- a/farm/runners/__init__.py
+++ b/farm/runners/__init__.py
@@ -1,0 +1,21 @@
+"""Runner exports."""
+
+from farm.runners.evolution_experiment import (
+    EvolutionCandidateEvaluation,
+    EvolutionExperiment,
+    EvolutionExperimentConfig,
+    EvolutionExperimentResult,
+    EvolutionFitnessMetric,
+    EvolutionGenerationSummary,
+    EvolutionSelectionMethod,
+)
+
+__all__ = [
+    "EvolutionCandidateEvaluation",
+    "EvolutionExperiment",
+    "EvolutionExperimentConfig",
+    "EvolutionExperimentResult",
+    "EvolutionFitnessMetric",
+    "EvolutionGenerationSummary",
+    "EvolutionSelectionMethod",
+]

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import random
 import statistics
 from dataclasses import asdict, dataclass
 from enum import Enum
@@ -134,9 +135,13 @@ class EvolutionExperiment:
         self.config = config
         self._initial_chromosome = chromosome_from_learning_config(base_config.learning)
         self._selection_call_count = 0
+        self._run_rng: Optional[random.Random] = None
 
     def run(self, fitness_evaluator: Optional[FitnessEvaluator] = None) -> EvolutionExperimentResult:
         """Run the configured number of generations and return tracked lineage."""
+        # Keep seeded runs reproducible even when the same experiment instance is reused.
+        self._selection_call_count = 0
+        self._run_rng = random.Random(self.config.seed) if self.config.seed is not None else random.Random()
         evaluator = fitness_evaluator or self._default_fitness_evaluator
         population = self._initialize_population()
         generation_summaries: List[EvolutionGenerationSummary] = []
@@ -167,6 +172,7 @@ class EvolutionExperiment:
                     mutation_rate=1.0,
                     mutation_scale=self.config.mutation_scale,
                     mutation_mode=self.config.mutation_mode,
+                    rng=self._run_rng,
                 )
             population.append(
                 EvolutionCandidate(
@@ -228,12 +234,14 @@ class EvolutionExperiment:
                 parent_b.metadata["chromosome"],
                 mode=self.config.crossover_mode,
                 include_fixed=False,
+                rng=self._run_rng,
             )
             child_chromosome = mutate_chromosome(
                 child_chromosome,
                 mutation_rate=self.config.mutation_rate,
                 mutation_scale=self.config.mutation_scale,
                 mutation_mode=self.config.mutation_mode,
+                rng=self._run_rng,
             )
             child_idx = len(next_population)
             next_population.append(

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -334,7 +334,11 @@ class EvolutionExperiment:
             config=candidate_config,
             path=run_dir,
             save_config=False,
-            seed=(self.config.seed + generation + member_index) if self.config.seed is not None else None,
+            seed=(
+                (self.config.seed + generation * self.config.population_size + member_index)
+                if self.config.seed is not None
+                else None
+            ),
         )
         fitness, metadata = self._fitness_from_environment(env)
         metadata["chromosome"] = candidate.chromosome

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -1,0 +1,379 @@
+"""Evolution experiment runner for multi-generation hyperparameter search."""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from farm.config import SimulationConfig
+from farm.core.genome import Genome, RouletteSelectionConfig, TournamentSelectionConfig
+from farm.core.hyperparameter_chromosome import (
+    CrossoverMode,
+    HyperparameterChromosome,
+    MutationMode,
+    apply_chromosome_to_learning_config,
+    chromosome_from_learning_config,
+    crossover_chromosomes,
+    mutate_chromosome,
+)
+from farm.core.simulation import run_simulation
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class EvolutionFitnessMetric(str, Enum):
+    """Supported built-in fitness metrics for evolution experiments."""
+
+    FINAL_POPULATION = "final_population"
+    TOTAL_BIRTHS = "total_births"
+    FINAL_RESOURCES = "final_resources"
+
+
+class EvolutionSelectionMethod(str, Enum):
+    """Parent selection strategy."""
+
+    TOURNAMENT = "tournament"
+    ROULETTE = "roulette"
+
+
+@dataclass(frozen=True)
+class EvolutionExperimentConfig:
+    """Configuration for generation-based hyperparameter evolution."""
+
+    num_generations: int = 3
+    population_size: int = 6
+    num_steps_per_candidate: int = 50
+    mutation_rate: float = 0.25
+    mutation_scale: float = 0.2
+    mutation_mode: MutationMode = MutationMode.GAUSSIAN
+    crossover_mode: CrossoverMode = CrossoverMode.UNIFORM
+    selection_method: EvolutionSelectionMethod = EvolutionSelectionMethod.TOURNAMENT
+    tournament_size: int = 3
+    elitism_count: int = 1
+    fitness_metric: EvolutionFitnessMetric = EvolutionFitnessMetric.FINAL_POPULATION
+    seed: Optional[int] = None
+    output_dir: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.num_generations < 1:
+            raise ValueError("num_generations must be at least 1.")
+        if self.population_size < 2:
+            raise ValueError("population_size must be at least 2.")
+        if self.num_steps_per_candidate < 1:
+            raise ValueError("num_steps_per_candidate must be at least 1.")
+        if not 0.0 <= self.mutation_rate <= 1.0:
+            raise ValueError("mutation_rate must be between 0 and 1.")
+        if self.mutation_scale < 0.0:
+            raise ValueError("mutation_scale must be non-negative.")
+        if self.tournament_size < 1:
+            raise ValueError("tournament_size must be at least 1.")
+        if self.elitism_count < 0:
+            raise ValueError("elitism_count must be non-negative.")
+        if self.elitism_count >= self.population_size:
+            raise ValueError("elitism_count must be smaller than population_size.")
+
+
+@dataclass(frozen=True)
+class EvolutionCandidate:
+    """Single chromosome candidate in the evolving population."""
+
+    candidate_id: str
+    generation: int
+    chromosome: HyperparameterChromosome
+    parent_ids: Tuple[str, str]
+
+
+@dataclass(frozen=True)
+class EvolutionCandidateEvaluation:
+    """Evaluation result for a single candidate in one generation."""
+
+    candidate_id: str
+    generation: int
+    fitness: float
+    learning_rate: float
+    parent_ids: Tuple[str, str]
+    metadata: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class EvolutionGenerationSummary:
+    """Aggregate stats for one evolved generation."""
+
+    generation: int
+    best_fitness: float
+    mean_fitness: float
+    min_fitness: float
+    best_candidate_id: str
+
+
+@dataclass
+class EvolutionExperimentResult:
+    """Container with generation summaries and per-candidate lineage."""
+
+    generation_summaries: List[EvolutionGenerationSummary]
+    evaluations: List[EvolutionCandidateEvaluation]
+    best_candidate: EvolutionCandidateEvaluation
+
+
+FitnessEvaluator = Callable[
+    [EvolutionCandidate, SimulationConfig, int, int],
+    Tuple[float, Dict[str, Any]],
+]
+
+
+class EvolutionExperiment:
+    """Run multi-generation evolution over hyperparameter chromosomes."""
+
+    def __init__(self, base_config: SimulationConfig, config: EvolutionExperimentConfig):
+        self.base_config = base_config
+        self.config = config
+        self._initial_chromosome = chromosome_from_learning_config(base_config.learning)
+        self._selection_call_count = 0
+
+    def run(self, fitness_evaluator: Optional[FitnessEvaluator] = None) -> EvolutionExperimentResult:
+        """Run the configured number of generations and return tracked lineage."""
+        evaluator = fitness_evaluator or self._default_fitness_evaluator
+        population = self._initialize_population()
+        generation_summaries: List[EvolutionGenerationSummary] = []
+        evaluations: List[EvolutionCandidateEvaluation] = []
+
+        for generation in range(self.config.num_generations):
+            generation_evals = self._evaluate_generation(generation, population, evaluator)
+            evaluations.extend(generation_evals)
+            generation_summaries.append(self._build_generation_summary(generation, generation_evals))
+            population = self._next_generation(generation, generation_evals)
+
+        best_candidate = max(evaluations, key=lambda item: item.fitness)
+        result = EvolutionExperimentResult(
+            generation_summaries=generation_summaries,
+            evaluations=evaluations,
+            best_candidate=best_candidate,
+        )
+        self._persist_results(result)
+        return result
+
+    def _initialize_population(self) -> List[EvolutionCandidate]:
+        population: List[EvolutionCandidate] = []
+        for idx in range(self.config.population_size):
+            chromosome = self._initial_chromosome
+            if idx > 0:
+                chromosome = mutate_chromosome(
+                    chromosome,
+                    mutation_rate=1.0,
+                    mutation_scale=self.config.mutation_scale,
+                    mutation_mode=self.config.mutation_mode,
+                )
+            population.append(
+                EvolutionCandidate(
+                    candidate_id=f"g0_c{idx}",
+                    generation=0,
+                    chromosome=chromosome,
+                    parent_ids=("seed", "seed"),
+                )
+            )
+        return population
+
+    def _evaluate_generation(
+        self,
+        generation: int,
+        population: List[EvolutionCandidate],
+        evaluator: FitnessEvaluator,
+    ) -> List[EvolutionCandidateEvaluation]:
+        generation_evals: List[EvolutionCandidateEvaluation] = []
+        for idx, candidate in enumerate(population):
+            candidate_config = self._config_for_chromosome(candidate.chromosome)
+            fitness, metadata = evaluator(candidate, candidate_config, generation, idx)
+            metadata_with_lineage = dict(metadata)
+            metadata_with_lineage["chromosome"] = candidate.chromosome
+            generation_evals.append(
+                EvolutionCandidateEvaluation(
+                    candidate_id=candidate.candidate_id,
+                    generation=generation,
+                    fitness=float(fitness),
+                    learning_rate=candidate.chromosome.get_value("learning_rate"),
+                    parent_ids=candidate.parent_ids,
+                    metadata=metadata_with_lineage,
+                )
+            )
+        return generation_evals
+
+    def _next_generation(
+        self,
+        generation: int,
+        generation_evals: List[EvolutionCandidateEvaluation],
+    ) -> List[EvolutionCandidate]:
+        ranked = sorted(generation_evals, key=lambda item: item.fitness, reverse=True)
+        next_population: List[EvolutionCandidate] = []
+
+        for elite_idx in range(self.config.elitism_count):
+            elite_eval = ranked[elite_idx]
+            next_population.append(
+                EvolutionCandidate(
+                    candidate_id=f"g{generation + 1}_elite{elite_idx}",
+                    generation=generation + 1,
+                    chromosome=elite_eval.metadata["chromosome"],
+                    parent_ids=(elite_eval.candidate_id, elite_eval.candidate_id),
+                )
+            )
+
+        while len(next_population) < self.config.population_size:
+            parent_a, parent_b = self._select_parents(generation_evals)
+            child_chromosome = crossover_chromosomes(
+                parent_a.metadata["chromosome"],
+                parent_b.metadata["chromosome"],
+                mode=self.config.crossover_mode,
+                include_fixed=False,
+            )
+            child_chromosome = mutate_chromosome(
+                child_chromosome,
+                mutation_rate=self.config.mutation_rate,
+                mutation_scale=self.config.mutation_scale,
+                mutation_mode=self.config.mutation_mode,
+            )
+            child_idx = len(next_population)
+            next_population.append(
+                EvolutionCandidate(
+                    candidate_id=f"g{generation + 1}_c{child_idx}",
+                    generation=generation + 1,
+                    chromosome=child_chromosome,
+                    parent_ids=(parent_a.candidate_id, parent_b.candidate_id),
+                )
+            )
+        return next_population
+
+    def _select_parents(
+        self, generation_evals: List[EvolutionCandidateEvaluation]
+    ) -> Tuple[EvolutionCandidateEvaluation, EvolutionCandidateEvaluation]:
+        population = generation_evals
+        fitnesses = [evaluation.fitness for evaluation in generation_evals]
+        if self.config.selection_method is EvolutionSelectionMethod.ROULETTE:
+            seed = (
+                self.config.seed + self._selection_call_count
+                if self.config.seed is not None
+                else None
+            )
+            parent_indices = Genome.roulette_selection(
+                population,
+                fitnesses,
+                RouletteSelectionConfig(
+                    num_selected=2,
+                    seed=seed,
+                    return_indices=True,
+                    shift_negative_fitness=True,
+                ),
+            )
+        else:
+            seed = (
+                self.config.seed + self._selection_call_count
+                if self.config.seed is not None
+                else None
+            )
+            parent_indices = Genome.tournament_selection(
+                population,
+                fitnesses,
+                TournamentSelectionConfig(
+                    num_selected=2,
+                    tournament_size=self.config.tournament_size,
+                    seed=seed,
+                    return_indices=True,
+                ),
+            )
+        self._selection_call_count += 1
+        return population[parent_indices[0]], population[parent_indices[1]]
+
+    def _build_generation_summary(
+        self, generation: int, generation_evals: List[EvolutionCandidateEvaluation]
+    ) -> EvolutionGenerationSummary:
+        best = max(generation_evals, key=lambda item: item.fitness)
+        fitness_values = [evaluation.fitness for evaluation in generation_evals]
+        return EvolutionGenerationSummary(
+            generation=generation,
+            best_fitness=max(fitness_values),
+            mean_fitness=statistics.mean(fitness_values),
+            min_fitness=min(fitness_values),
+            best_candidate_id=best.candidate_id,
+        )
+
+    def _config_for_chromosome(self, chromosome: HyperparameterChromosome) -> SimulationConfig:
+        config_copy = self.base_config.copy()
+        config_copy.learning = apply_chromosome_to_learning_config(
+            config_copy.learning,
+            chromosome,
+        )
+        return config_copy
+
+    def _default_fitness_evaluator(
+        self,
+        candidate: EvolutionCandidate,
+        candidate_config: SimulationConfig,
+        generation: int,
+        member_index: int,
+    ) -> Tuple[float, Dict[str, Any]]:
+        run_dir = self.config.output_dir
+        if run_dir:
+            run_dir = os.path.join(
+                run_dir,
+                f"generation_{generation}",
+                candidate.candidate_id,
+            )
+        env = run_simulation(
+            num_steps=self.config.num_steps_per_candidate,
+            config=candidate_config,
+            path=run_dir,
+            save_config=False,
+            seed=(self.config.seed + generation + member_index) if self.config.seed is not None else None,
+        )
+        fitness, metadata = self._fitness_from_environment(env)
+        metadata["chromosome"] = candidate.chromosome
+        return fitness, metadata
+
+    def _fitness_from_environment(self, environment: Any) -> Tuple[float, Dict[str, Any]]:
+        if self.config.fitness_metric is EvolutionFitnessMetric.TOTAL_BIRTHS:
+            births = (
+                getattr(environment.metrics_tracker.cumulative_metrics, "total_births", 0)
+                if getattr(environment, "metrics_tracker", None)
+                and getattr(environment.metrics_tracker, "cumulative_metrics", None)
+                else 0
+            )
+            return float(births), {"total_births": births}
+        if self.config.fitness_metric is EvolutionFitnessMetric.FINAL_RESOURCES:
+            return float(environment.cached_total_resources), {
+                "final_resources": environment.cached_total_resources,
+            }
+        return float(len(environment.agents)), {"final_population": len(environment.agents)}
+
+    def _persist_results(self, result: EvolutionExperimentResult) -> None:
+        if not self.config.output_dir:
+            return
+        os.makedirs(self.config.output_dir, exist_ok=True)
+        summaries_path = os.path.join(self.config.output_dir, "evolution_generation_summaries.json")
+        lineage_path = os.path.join(self.config.output_dir, "evolution_lineage.json")
+
+        with open(summaries_path, "w", encoding="utf-8") as summaries_file:
+            json.dump([asdict(summary) for summary in result.generation_summaries], summaries_file, indent=2)
+
+        serialized_evaluations: List[Dict[str, Any]] = []
+        for evaluation in result.evaluations:
+            payload = asdict(evaluation)
+            payload["metadata"] = {
+                key: value
+                for key, value in evaluation.metadata.items()
+                if key != "chromosome"
+            }
+            serialized_evaluations.append(payload)
+
+        with open(lineage_path, "w", encoding="utf-8") as lineage_file:
+            json.dump(serialized_evaluations, lineage_file, indent=2)
+
+        logger.info(
+            "evolution_experiment_persisted",
+            output_dir=self.config.output_dir,
+            summaries_path=summaries_path,
+            lineage_path=lineage_path,
+            num_generations=self.config.num_generations,
+        )

--- a/scripts/run_evolution_experiment.py
+++ b/scripts/run_evolution_experiment.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""CLI entrypoint for multi-generation hyperparameter evolution experiments."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+from farm.config import SimulationConfig
+from farm.runners import (
+    EvolutionExperiment,
+    EvolutionExperimentConfig,
+    EvolutionFitnessMetric,
+    EvolutionSelectionMethod,
+)
+from farm.utils.logging import configure_logging, get_logger
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run multi-generation hyperparameter evolution experiments.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--environment",
+        type=str,
+        default="development",
+        choices=["development", "production", "testing"],
+        help="Centralized config environment.",
+    )
+    parser.add_argument(
+        "--profile",
+        type=str,
+        default=None,
+        choices=["benchmark", "simulation", "research"],
+        help="Optional centralized config profile.",
+    )
+    parser.add_argument("--generations", type=int, default=2, help="Number of generations to run.")
+    parser.add_argument("--population-size", type=int, default=4, help="Candidates per generation.")
+    parser.add_argument(
+        "--steps-per-candidate",
+        type=int,
+        default=20,
+        help="Simulation steps used to evaluate each candidate.",
+    )
+    parser.add_argument(
+        "--fitness-metric",
+        type=str,
+        default=EvolutionFitnessMetric.FINAL_POPULATION.value,
+        choices=[metric.value for metric in EvolutionFitnessMetric],
+        help="Built-in fitness metric used for parent selection.",
+    )
+    parser.add_argument(
+        "--selection-method",
+        type=str,
+        default=EvolutionSelectionMethod.TOURNAMENT.value,
+        choices=[method.value for method in EvolutionSelectionMethod],
+        help="Parent selection strategy.",
+    )
+    parser.add_argument("--mutation-rate", type=float, default=0.25, help="Mutation probability per gene.")
+    parser.add_argument(
+        "--mutation-scale",
+        type=float,
+        default=0.2,
+        help="Mutation magnitude for mutated genes.",
+    )
+    parser.add_argument(
+        "--tournament-size",
+        type=int,
+        default=3,
+        help="Tournament bracket size when tournament selection is used.",
+    )
+    parser.add_argument("--elitism-count", type=int, default=1, help="Top candidates copied to next generation.")
+    parser.add_argument("--seed", type=int, default=42, help="Global deterministic seed.")
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="experiments/evolution",
+        help="Directory where lineage and summaries are persisted.",
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Structured logging level.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    configure_logging(environment=args.environment, log_dir="logs", log_level=args.log_level, disable_console=False)
+    logger = get_logger(__name__)
+
+    logger.info(
+        "evolution_experiment_cli_start",
+        environment=args.environment,
+        profile=args.profile,
+        generations=args.generations,
+        population_size=args.population_size,
+        steps_per_candidate=args.steps_per_candidate,
+        fitness_metric=args.fitness_metric,
+        selection_method=args.selection_method,
+        output_dir=args.output_dir,
+    )
+
+    try:
+        base_config = SimulationConfig.from_centralized_config(
+            environment=args.environment,
+            profile=args.profile,
+        )
+
+        experiment_config = EvolutionExperimentConfig(
+            num_generations=args.generations,
+            population_size=args.population_size,
+            num_steps_per_candidate=args.steps_per_candidate,
+            mutation_rate=args.mutation_rate,
+            mutation_scale=args.mutation_scale,
+            selection_method=EvolutionSelectionMethod(args.selection_method),
+            tournament_size=args.tournament_size,
+            elitism_count=args.elitism_count,
+            fitness_metric=EvolutionFitnessMetric(args.fitness_metric),
+            seed=args.seed,
+            output_dir=args.output_dir,
+        )
+
+        start = time.time()
+        result = EvolutionExperiment(base_config, experiment_config).run()
+        elapsed = time.time() - start
+
+        summary = {
+            "elapsed_seconds": round(elapsed, 3),
+            "num_generations": len(result.generation_summaries),
+            "num_evaluations": len(result.evaluations),
+            "best_candidate_id": result.best_candidate.candidate_id,
+            "best_fitness": result.best_candidate.fitness,
+            "best_learning_rate": result.best_candidate.learning_rate,
+            "best_parent_ids": list(result.best_candidate.parent_ids),
+            "output_dir": args.output_dir,
+        }
+        print(json.dumps(summary, indent=2))
+        return 0
+    except Exception as exc:  # pragma: no cover - CLI safety guard
+        logger.error(
+            "evolution_experiment_cli_failed",
+            error_type=type(exc).__name__,
+            error_message=str(exc),
+            exc_info=True,
+        )
+        print(f"Evolution experiment failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/config/test_config_classes.py
+++ b/tests/config/test_config_classes.py
@@ -8,7 +8,9 @@ This module tests the core configuration dataclasses including:
 """
 
 import unittest
+from types import SimpleNamespace
 from farm.config import VisualizationConfig, RedisMemoryConfig
+from farm.core.agent.config.component_configs import AgentComponentConfig
 
 
 class TestVisualizationConfig(unittest.TestCase):
@@ -217,6 +219,55 @@ class TestRedisMemoryConfig(unittest.TestCase):
         config_dict = config.to_dict()
 
         self.assertIsNone(config_dict["password"])
+
+
+class TestAgentComponentConfig(unittest.TestCase):
+    """Tests for simulation->agent component config projection."""
+
+    def test_from_simulation_config_projects_learning_to_decision(self):
+        simulation_config = type(
+            "ConfigStub",
+            (),
+            {
+                "agent_behavior": type(
+                    "AgentBehavior",
+                    (),
+                    {
+                        "base_consumption_rate": 0.2,
+                        "starvation_threshold": 8,
+                        "offspring_cost": 4.0,
+                        "offspring_initial_resources": 6.0,
+                        "starting_health": 90.0,
+                        "base_attack_strength": 3.0,
+                        "base_defense_strength": 2.0,
+                    },
+                )(),
+                "learning": SimpleNamespace(
+                    learning_rate=0.02,
+                    gamma=0.9,
+                    epsilon_start=0.8,
+                    epsilon_min=0.05,
+                    epsilon_decay=0.98,
+                    memory_size=1234,
+                    batch_size=16,
+                    training_frequency=3,
+                    dqn_hidden_size=32,
+                    tau=0.02,
+                ),
+            },
+        )()
+
+        component_config = AgentComponentConfig.from_simulation_config(simulation_config)
+        self.assertEqual(component_config.decision.learning_rate, 0.02)
+        self.assertEqual(component_config.decision.gamma, 0.9)
+        self.assertEqual(component_config.decision.epsilon_start, 0.8)
+        self.assertEqual(component_config.decision.epsilon_min, 0.05)
+        self.assertEqual(component_config.decision.epsilon_decay, 0.98)
+        self.assertEqual(component_config.decision.memory_size, 1234)
+        self.assertEqual(component_config.decision.batch_size, 16)
+        self.assertEqual(component_config.decision.rl_train_freq, 3)
+        self.assertEqual(component_config.decision.dqn_hidden_size, 32)
+        self.assertEqual(component_config.decision.tau, 0.02)
 
 
 if __name__ == '__main__':

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -1,0 +1,132 @@
+"""Tests for multi-generation hyperparameter evolution runner."""
+
+import json
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from farm.config import SimulationConfig
+from farm.runners.evolution_experiment import (
+    EvolutionExperiment,
+    EvolutionExperimentConfig,
+    EvolutionFitnessMetric,
+)
+
+
+class TestEvolutionExperimentConfig(unittest.TestCase):
+    def test_rejects_invalid_population_size(self):
+        with self.assertRaises(ValueError):
+            EvolutionExperimentConfig(population_size=1)
+
+    def test_rejects_invalid_generation_count(self):
+        with self.assertRaises(ValueError):
+            EvolutionExperimentConfig(num_generations=0)
+
+
+class TestEvolutionExperiment(unittest.TestCase):
+    def test_runs_two_generations_with_population_four(self):
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=2,
+            population_size=4,
+            num_steps_per_candidate=1,
+            seed=7,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        evaluation_calls = []
+
+        def evaluator(candidate, candidate_config, generation, member_index):
+            evaluation_calls.append((candidate.candidate_id, generation, member_index))
+            fitness = candidate.chromosome.get_value("learning_rate") * 1000.0
+            return fitness, {"member_index": member_index}
+
+        result = experiment.run(fitness_evaluator=evaluator)
+
+        self.assertEqual(len(result.generation_summaries), 2)
+        self.assertEqual(len(result.evaluations), 8)
+        self.assertEqual(len(evaluation_calls), 8)
+        self.assertTrue(result.best_candidate.learning_rate > 0.0)
+        self.assertEqual(result.evaluations[0].generation, 0)
+        self.assertEqual(result.evaluations[-1].generation, 1)
+        self.assertEqual(result.evaluations[4].parent_ids[0][:2], "g0")
+
+    def test_custom_fitness_receives_learning_rate_applied_config(self):
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=2,
+            population_size=4,
+            num_steps_per_candidate=1,
+            seed=11,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        seen_learning_rates = []
+
+        def evaluator(candidate, candidate_config, generation, member_index):
+            seen_learning_rates.append(candidate_config.learning.learning_rate)
+            fitness = candidate_config.learning.learning_rate
+            return fitness, {"generation": generation, "member": member_index}
+
+        result = experiment.run(fitness_evaluator=evaluator)
+        self.assertEqual(len(seen_learning_rates), 8)
+        self.assertTrue(any(rate != base_config.learning.learning_rate for rate in seen_learning_rates[1:]))
+        self.assertGreater(result.best_candidate.fitness, 0.0)
+
+    @patch("farm.runners.evolution_experiment.run_simulation")
+    def test_default_fitness_metric_uses_environment_summary(self, run_simulation_mock):
+        base_config = SimulationConfig()
+        run_simulation_mock.return_value = SimpleNamespace(
+            agents=["a", "b", "c"],
+            cached_total_resources=42.0,
+            metrics_tracker=SimpleNamespace(
+                cumulative_metrics=SimpleNamespace(total_births=5),
+            ),
+        )
+        config = EvolutionExperimentConfig(
+            num_generations=2,
+            population_size=4,
+            num_steps_per_candidate=1,
+            fitness_metric=EvolutionFitnessMetric.FINAL_POPULATION,
+        )
+        result = EvolutionExperiment(base_config, config).run()
+        self.assertEqual(len(result.evaluations), 8)
+        self.assertEqual(result.best_candidate.fitness, 3.0)
+        self.assertEqual(run_simulation_mock.call_count, 8)
+
+    def test_persists_generation_and_lineage_json(self):
+        base_config = SimulationConfig()
+        with tempfile.TemporaryDirectory() as output_dir:
+            config = EvolutionExperimentConfig(
+                num_generations=2,
+                population_size=4,
+                num_steps_per_candidate=1,
+                output_dir=output_dir,
+            )
+            experiment = EvolutionExperiment(base_config, config)
+            experiment.run(
+                fitness_evaluator=lambda candidate, cfg, generation, member: (
+                    float(member + generation),
+                    {"member": member},
+                )
+            )
+
+            with open(
+                f"{output_dir}/evolution_generation_summaries.json",
+                encoding="utf-8",
+            ) as summaries_file:
+                summaries = json.load(summaries_file)
+
+            with open(
+                f"{output_dir}/evolution_lineage.json",
+                encoding="utf-8",
+            ) as lineage_file:
+                lineage = json.load(lineage_file)
+
+            self.assertEqual(len(summaries), 2)
+            self.assertEqual(len(lineage), 8)
+            self.assertEqual(lineage[0]["generation"], 0)
+            self.assertEqual(lineage[-1]["generation"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -127,6 +127,28 @@ class TestEvolutionExperiment(unittest.TestCase):
             self.assertEqual(lineage[0]["generation"], 0)
             self.assertEqual(lineage[-1]["generation"], 1)
 
+    def test_repeated_run_on_same_instance_is_deterministic_with_seed(self):
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=2,
+            population_size=4,
+            num_steps_per_candidate=1,
+            seed=17,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+
+        def evaluator(candidate, candidate_config, generation, member_index):
+            fitness = candidate_config.learning.learning_rate * 1000.0
+            return fitness, {"generation": generation, "member": member_index}
+
+        result_a = experiment.run(fitness_evaluator=evaluator)
+        result_b = experiment.run(fitness_evaluator=evaluator)
+
+        lineage_a = [(ev.candidate_id, ev.parent_ids, ev.fitness) for ev in result_a.evaluations]
+        lineage_b = [(ev.candidate_id, ev.parent_ids, ev.fitness) for ev in result_b.evaluations]
+        self.assertEqual(lineage_a, lineage_b)
+        self.assertEqual(result_a.best_candidate.candidate_id, result_b.best_candidate.candidate_id)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -283,3 +283,49 @@ def test_reproduce_skips_refund_when_partial_offspring_rollback_fails():
     assert success is False
     parent.get_component("resource").add.assert_not_called()
 
+
+def test_reproduce_uses_environment_partial_add_rollback_hook_when_available():
+    """Prefer Environment.rollback_partial_agent_add for rollback-aware cleanup."""
+    parent = _build_parent_agent_for_reproduction()
+
+    class _HookedRollbackEnvironment:
+        def __init__(self):
+            self.rollback_calls = []
+            self._agent_objects = {}
+            self.agents = []
+
+        def get_next_agent_id(self) -> str:
+            return "child_1"
+
+        def add_agent(self, offspring, flush_immediately: bool = False):
+            self._agent_objects[offspring.agent_id] = offspring
+            self.agents.append(offspring.agent_id)
+            raise RuntimeError("flush failed after insert")
+
+        def rollback_partial_agent_add(self, agent_id: str) -> bool:
+            self.rollback_calls.append(agent_id)
+            self._agent_objects.pop(agent_id, None)
+            if agent_id in self.agents:
+                self.agents.remove(agent_id)
+            return True
+
+    parent.environment = _HookedRollbackEnvironment()
+    offspring = SimpleNamespace(
+        agent_id="child_1",
+        state=Mock(),
+        generation=0,
+    )
+    offspring.state._state = Mock()
+    offspring.state._state.model_copy.return_value = Mock()
+
+    with patch("farm.core.hyperparameter_chromosome.random.random", return_value=1.0), patch(
+        "farm.core.agent.factory.AgentFactory"
+    ) as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is False
+    assert parent.environment.rollback_calls == ["child_1"]
+    parent.get_component("resource").add.assert_called_once_with(5.0)
+

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -206,6 +206,37 @@ class TestEnvironment(unittest.TestCase):
         agent_ids = [agent.agent_id for agent in self.env.agent_objects]
         self.assertEqual(len(agent_ids), len(set(agent_ids)))
 
+    def test_rollback_partial_agent_add_rolls_back_state_metrics_and_db_marker(self):
+        """Rollback hook should clean partial inserts and compensate side effects."""
+        agent_id = "rollback_test_agent"
+        self.env.time = 5
+        self.env.metrics_tracker.step_metrics.births = 2
+        self.env.db = Mock()
+
+        ghost_agent = Mock()
+        ghost_agent.agent_id = agent_id
+        self.env._agent_objects[agent_id] = ghost_agent
+        self.env.agents.append(agent_id)
+        self.env.rewards[agent_id] = 0
+        self.env._cumulative_rewards[agent_id] = 0
+        self.env.terminations[agent_id] = False
+        self.env.truncations[agent_id] = False
+        self.env.infos[agent_id] = {}
+        self.env.observations[agent_id] = np.zeros(self.env._observation_space.shape, dtype=np.float32)
+        self.env.agent_observations[agent_id] = Mock()
+
+        rolled_back = self.env.rollback_partial_agent_add(agent_id)
+
+        self.assertTrue(rolled_back)
+        self.assertNotIn(agent_id, self.env._agent_objects)
+        self.assertNotIn(agent_id, self.env.agents)
+        self.assertEqual(self.env.metrics_tracker.step_metrics.births, 1)
+        self.env.db.update_agent_death.assert_called_once_with(
+            agent_id=agent_id,
+            death_time=5,
+            cause="rollback_partial_add",
+        )
+
     def test_resource_initialization(self):
         """Test that resources are properly initialized"""
         # Resource count should match the amount specified in resource_distribution


### PR DESCRIPTION
This pull request introduces several enhancements and new features related to agent configuration, environment robustness, and experiment tracking for evolutionary experiments. The main changes include adding a robust rollback mechanism for partially-added agents, improving the mapping of learning configuration parameters, and exporting evolution experiment types for easier use. Additionally, new experiment summary and lineage JSON files are included for tracking evolutionary runs.

**Agent and Environment Robustness Improvements:**

* Added a comprehensive `rollback_partial_agent_add` method to the `Environment` class, ensuring that failed agent additions are properly rolled back from in-memory structures, metrics, and persistent storage. This helps prevent inconsistencies and phantom agents in the environment.
* Updated the agent core's offspring rollback logic to prefer using the environment's rollback hook, providing more reliable cleanup and error logging when an agent fails to be fully added.

**Agent Configuration Enhancements:**

* Improved the `from_simulation_config` method in `AgentComponentConfig` to map learning-related fields from the simulation config's `learning` section into the agent's decision configuration, supporting a wider range of RL parameters. [[1]](diffhunk://#diff-e6b88b518e7ae957bc0757795c99fa2143b200d0065d5c2ac42290449f63c8e4R256) [[2]](diffhunk://#diff-e6b88b518e7ae957bc0757795c99fa2143b200d0065d5c2ac42290449f63c8e4R279-R296) [[3]](diffhunk://#diff-e6b88b518e7ae957bc0757795c99fa2143b200d0065d5c2ac42290449f63c8e4R313)

**Experiment Tracking and Exports:**

* Added new JSON files (`evolution_generation_summaries.json` and `evolution_lineage.json`) to track generation-level summaries and candidate lineages in evolutionary experiments. [[1]](diffhunk://#diff-128da51dce5768361624d16135525df8dc77db43b6b361ae52c4a21002fd618cR1-R16) [[2]](diffhunk://#diff-4cbe2a0ba31b2ad4695806a1ae7a7aa56b1f97813ef6fc8cbce1c7aebf72dcdfR1-R106)
* Exported evolution experiment types and classes from `farm.runners` for easier import and use in other modules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent lifecycle rollback, metrics, and DB updates during reproduction/add-agent failures, which could affect population accounting and persistence if incorrect. The evolution runner/CLI are additive but may increase runtime and filesystem output surface.
> 
> **Overview**
> Adds a multi-generation hyperparameter evolution runner (`EvolutionExperiment`) with tournament/roulette parent selection, elitism, mutation/crossover, built-in fitness metrics, and optional persistence of per-generation summaries + candidate lineage JSON.
> 
> Improves simulation robustness by introducing `Environment.rollback_partial_agent_add` and updating agent reproduction rollback to prefer this hook, cleaning up in-memory state, spatial index visibility, step birth metrics, and marking any persisted “phantom” agents dead in the DB.
> 
> Extends `AgentComponentConfig.from_simulation_config` to project `sim_config.learning` fields into `DecisionConfig`, adds a CLI script (`run_evolution_experiment.py`) and runner exports, and includes a small smoke output under `experiments/evolution_smoke/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae2b02d54c91e6af9f53c7f9f5b283a546f33819. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->