### PR TITLE
Enhance hyperparameter evolution tracking and agent rollback logic

### DIFF
--- a/docs/design/hyperparameter_chromosome.md
+++ b/docs/design/hyperparameter_chromosome.md
@@ -257,3 +257,16 @@ They are parallel tracks today; a future unification step can compose both into 
 - log-scale encoding requires strictly positive gene bounds; genes with `min_value ≤ 0` must use `GeneEncodingScale.LINEAR`
 
 These are deliberate for a small, verifiable first increment.
+
+## Evolution experiment outputs
+
+`farm/runners/evolution_experiment.py` persists two machine-readable artifacts when `output_dir` is set:
+
+- `evolution_generation_summaries.json`
+  - per-generation fitness aggregates (`best_fitness`, `mean_fitness`, `min_fitness`)
+  - per-gene statistics (`mean`, `median`, `std`, `min`, `max`)
+  - best candidate chromosome values for that generation
+- `evolution_lineage.json`
+  - one row per evaluated candidate with lineage (`parent_ids`) and fitness metadata
+
+Use `scripts/plot_hyperparameter_evolution.py` to produce a convergence chart from the summaries JSON.

--- a/docs/design/hyperparameter_chromosome.md
+++ b/docs/design/hyperparameter_chromosome.md
@@ -80,13 +80,20 @@ On agent init:
 - `self.hyperparameter_chromosome` is created from `self.config.decision`.
 
 On `AgentCore.reproduce()`:
-1. Build a chromosome from the parent decision config.
+1. Use the parent's stored chromosome (`self.hyperparameter_chromosome`) as the
+   source of inheritable hyperparameters.
+   - If that attribute is missing, derive it from `self.config.decision` and
+     sync it back onto the parent.
 2. Mutate evolvable genes via `mutate_chromosome(...)`.
 3. Deep-copy parent config.
 4. Apply chromosome values to child decision config via `apply_chromosome_to_learning_config(...)`.
 5. Deduct the reproduction resource cost (`offspring_cost`) from the parent agent.
    - If the resource component reports that the deduction failed (insufficient resources), `reproduce()` returns `False` immediately without creating offspring.
-   - If offspring creation subsequently raises an exception after the cost has been deducted, the cost is **refunded** by calling `resource_comp.add(offspring_cost)` before propagating the error, preventing phantom resource loss.
+   - If offspring creation subsequently raises an exception after the cost has
+     been deducted, reproduction attempts a partial-add rollback when needed and
+     then refunds by calling `resource_comp.add(offspring_cost)`.
+   - Refund is only suppressed when rollback fails *and* the offspring still
+     appears present in environment tracking structures (unresolved state).
 6. Create offspring with the child config.
 7. Store the resulting chromosome on the offspring.
 
@@ -96,11 +103,14 @@ This keeps:
 
 ## Mutation behavior
 
-`mutate_chromosome(chromosome, mutation_rate=0.1, mutation_scale=0.2)`:
+`mutate_chromosome(chromosome, mutation_rate=0.1, mutation_scale=0.2, mutation_mode="gaussian")`:
 
 - only mutates genes where `evolvable=True`
-- applies multiplicative perturbation for real-valued genes:
-  - `new_value = old_value * (1 + uniform(-scale, scale))`
+- supports two real-valued mutation operators:
+  - `gaussian` (default):
+    - `new_value = old_value + Normal(0, mutation_scale * (max_value - min_value))`
+  - `multiplicative` (legacy mode):
+    - `new_value = old_value * (1 + uniform(-scale, scale))`
 - clamps to `[min_value, max_value]`
 
 ## Gene encoding and decoding
@@ -230,7 +240,8 @@ The current mutation strategy is simple and intentionally local.
 
 To adapt:
 
-- replace multiplicative mutation with additive/log-space strategy
+- change the default mutation operator (for example, gaussian ↔ multiplicative,
+  or implement log-space mutation for selected genes)
 - add per-gene mutation scales
 - add schedule-based mutation rate by generation
 - support crossover across two parent chromosomes

--- a/docs/experiments/hyperparameter_evolution_convergence.md
+++ b/docs/experiments/hyperparameter_evolution_convergence.md
@@ -1,0 +1,57 @@
+# Hyperparameter Evolution Convergence
+
+This note documents how to capture and interpret learning-rate convergence from the hyperparameter chromosome evolution runner.
+
+## Methodology
+
+- Runner: `scripts/run_evolution_experiment.py`
+- Generational metrics source: `evolution_generation_summaries.json`
+- Lineage source: `evolution_lineage.json`
+- Typical search controls:
+  - parent selection: tournament or roulette
+  - mutation rate: `--mutation-rate` (default `0.25`)
+  - mutation scale: `--mutation-scale` (default `0.2`)
+  - fitness metric: `final_population`, `total_births`, or `final_resources`
+
+Example:
+
+```bash
+source venv/bin/activate
+python scripts/run_evolution_experiment.py \
+  --generations 8 \
+  --population-size 10 \
+  --steps-per-candidate 80 \
+  --selection-method tournament \
+  --mutation-rate 0.25 \
+  --mutation-scale 0.2 \
+  --fitness-metric final_population \
+  --output-dir experiments/evolution_convergence
+```
+
+## Visualization
+
+Use the plotting helper to generate a convergence figure from persisted summaries:
+
+```bash
+source venv/bin/activate
+python scripts/plot_hyperparameter_evolution.py \
+  --summary-json experiments/evolution_convergence/evolution_generation_summaries.json \
+  --output experiments/evolution_convergence/hyperparameter_evolution.png
+```
+
+The chart contains:
+- best fitness per generation
+- per-gene mean and `+-1 std` trend over generations
+
+## Interpreting Results
+
+When reviewing `learning_rate` convergence:
+
+- tightening standard deviation over generations suggests convergence pressure
+- unstable or growing spread suggests mutation pressure dominates selection
+- rising best fitness with shrinking spread usually indicates useful convergence
+
+For issue closure write-ups, include:
+- selected mutation/selection settings
+- one generated convergence figure
+- a short narrative of whether convergence, oscillation, or collapse occurred

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -725,16 +725,28 @@ class AgentCore:
             self.environment.add_agent(offspring, flush_immediately=True)
         except Exception:
             should_refund = bool(resource_comp and resource_deducted)
+            rollback_attempted = False
+            rollback_ok = False
             if should_refund and offspring_id and self._is_agent_present_in_environment(offspring_id):
+                rollback_attempted = True
                 rollback_ok = self._rollback_offspring_from_environment(offspring_id)
                 if not rollback_ok:
-                    should_refund = False
                     logger.exception(
                         "agent_reproduction_partial_offspring_rollback_failed",
                         agent_id=self.agent_id,
                         generation=self.generation,
                         offspring_id=offspring_id,
                     )
+                    # Refund unless we still have strong evidence that offspring
+                    # may remain active (to avoid double-crediting parent resources).
+                    if self._is_agent_present_in_environment(offspring_id):
+                        should_refund = False
+                        logger.exception(
+                            "agent_reproduction_refund_suppressed_unresolved_offspring_state",
+                            agent_id=self.agent_id,
+                            generation=self.generation,
+                            offspring_id=offspring_id,
+                        )
             if should_refund and resource_comp:
                 try:
                     resource_comp.add(offspring_cost)
@@ -745,6 +757,8 @@ class AgentCore:
                         generation=self.generation,
                         offspring_cost=offspring_cost,
                         offspring_id=offspring_id,
+                        rollback_attempted=rollback_attempted,
+                        rollback_ok=rollback_ok,
                     )
             logger.exception(
                 "agent_reproduction_failed",

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -741,11 +741,14 @@ class AgentCore:
                     # may remain active (to avoid double-crediting parent resources).
                     if self._is_agent_present_in_environment(offspring_id):
                         should_refund = False
-                        logger.exception(
+                        logger.warning(
                             "agent_reproduction_refund_suppressed_unresolved_offspring_state",
                             agent_id=self.agent_id,
                             generation=self.generation,
                             offspring_id=offspring_id,
+                            rollback_attempted=True,
+                            rollback_ok=False,
+                            suppression_reason="offspring_still_present_after_rollback_attempt",
                         )
             if should_refund and resource_comp:
                 try:

--- a/farm/core/environment.py
+++ b/farm/core/environment.py
@@ -1296,15 +1296,24 @@ class Environment(AECEnv):
                 step=self.time,
             )
 
-        # If a DB row for this agent was persisted, mark it dead at this step
-        # so "alive population" queries do not include a phantom agent.
+        # If a DB row for this agent was persisted, remove it as compensation.
+        # This avoids polluting death analytics with rollback-only artifacts.
         try:
-            if hasattr(self, "db") and self.db is not None:
-                self.db.update_agent_death(
-                    agent_id=agent_id,
-                    death_time=self.time,
-                    cause="rollback_partial_add",
-                )
+            if (
+                hasattr(self, "db")
+                and self.db is not None
+                and hasattr(self.db, "_execute_in_transaction")
+            ):
+                from farm.database.models import AgentModel
+
+                def _delete_agent_row(session):
+                    row = session.query(AgentModel).filter(AgentModel.agent_id == agent_id).first()
+                    if row is None:
+                        return False
+                    session.delete(row)
+                    return True
+
+                self.db._execute_in_transaction(_delete_agent_row)
         except Exception:
             logger.exception(
                 "environment_partial_agent_add_db_rollback_failed",

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -110,6 +110,8 @@ class EvolutionGenerationSummary:
     mean_fitness: float
     min_fitness: float
     best_candidate_id: str
+    gene_statistics: Dict[str, Dict[str, float]]
+    best_chromosome: Dict[str, float]
 
 
 @dataclass
@@ -299,13 +301,44 @@ class EvolutionExperiment:
     ) -> EvolutionGenerationSummary:
         best = max(generation_evals, key=lambda item: item.fitness)
         fitness_values = [evaluation.fitness for evaluation in generation_evals]
+        gene_statistics = self._build_gene_statistics(generation_evals)
+        best_chromosome = {
+            gene.name: gene.value
+            for gene in best.metadata["chromosome"].genes
+        }
         return EvolutionGenerationSummary(
             generation=generation,
             best_fitness=max(fitness_values),
             mean_fitness=statistics.mean(fitness_values),
             min_fitness=min(fitness_values),
             best_candidate_id=best.candidate_id,
+            gene_statistics=gene_statistics,
+            best_chromosome=best_chromosome,
         )
+
+    def _build_gene_statistics(
+        self,
+        generation_evals: List[EvolutionCandidateEvaluation],
+    ) -> Dict[str, Dict[str, float]]:
+        if not generation_evals:
+            return {}
+
+        gene_values: Dict[str, List[float]] = {}
+        for evaluation in generation_evals:
+            chromosome = evaluation.metadata["chromosome"]
+            for gene in chromosome.genes:
+                gene_values.setdefault(gene.name, []).append(gene.value)
+
+        gene_statistics: Dict[str, Dict[str, float]] = {}
+        for gene_name, values in gene_values.items():
+            gene_statistics[gene_name] = {
+                "mean": statistics.mean(values),
+                "median": statistics.median(values),
+                "std": statistics.pstdev(values) if len(values) > 1 else 0.0,
+                "min": min(values),
+                "max": max(values),
+            }
+        return gene_statistics
 
     def _config_for_chromosome(self, chromosome: HyperparameterChromosome) -> SimulationConfig:
         config_copy = self.base_config.copy()

--- a/scripts/plot_hyperparameter_evolution.py
+++ b/scripts/plot_hyperparameter_evolution.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Plot per-generation hyperparameter evolution metrics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List
+
+import matplotlib.pyplot as plt
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Plot hyperparameter evolution from generation summary JSON.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--summary-json",
+        type=Path,
+        required=True,
+        help="Path to evolution_generation_summaries.json.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("hyperparameter_evolution.png"),
+        help="Destination image path.",
+    )
+    return parser.parse_args()
+
+
+def _load_summaries(path: Path) -> List[Dict]:
+    with open(path, encoding="utf-8") as handle:
+        summaries = json.load(handle)
+    if not summaries:
+        raise ValueError(f"No generation summaries found in {path}")
+    return summaries
+
+
+def main() -> int:
+    args = _parse_args()
+    summaries = _load_summaries(args.summary_json)
+
+    generations = [entry["generation"] for entry in summaries]
+    best_fitness = [entry["best_fitness"] for entry in summaries]
+
+    fig, axes = plt.subplots(2, 1, figsize=(10, 8), sharex=True)
+
+    axes[0].plot(generations, best_fitness, marker="o", label="best_fitness")
+    axes[0].set_ylabel("Fitness")
+    axes[0].set_title("Fitness Convergence")
+    axes[0].grid(alpha=0.3)
+    axes[0].legend()
+
+    gene_names = sorted(summaries[0].get("gene_statistics", {}).keys())
+    if gene_names:
+        for gene_name in gene_names:
+            means = [entry["gene_statistics"][gene_name]["mean"] for entry in summaries]
+            stds = [entry["gene_statistics"][gene_name]["std"] for entry in summaries]
+            lower = [mean - std for mean, std in zip(means, stds)]
+            upper = [mean + std for mean, std in zip(means, stds)]
+            axes[1].plot(generations, means, marker="o", label=f"{gene_name} mean")
+            axes[1].fill_between(generations, lower, upper, alpha=0.2, label=f"{gene_name} ±1 std")
+        axes[1].legend()
+    else:
+        axes[1].text(
+            0.5,
+            0.5,
+            "No gene_statistics found in summary JSON",
+            ha="center",
+            va="center",
+            transform=axes[1].transAxes,
+        )
+
+    axes[1].set_xlabel("Generation")
+    axes[1].set_ylabel("Gene Value")
+    axes[1].set_title("Gene Evolution (mean ± std)")
+    axes[1].grid(alpha=0.3)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(args.output, dpi=150)
+    print(f"Wrote hyperparameter evolution plot to: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -126,6 +126,13 @@ class TestEvolutionExperiment(unittest.TestCase):
             self.assertEqual(len(lineage), 8)
             self.assertEqual(lineage[0]["generation"], 0)
             self.assertEqual(lineage[-1]["generation"], 1)
+            self.assertIn("gene_statistics", summaries[0])
+            self.assertIn("learning_rate", summaries[0]["gene_statistics"])
+            self.assertIn("mean", summaries[0]["gene_statistics"]["learning_rate"])
+            self.assertIn("median", summaries[0]["gene_statistics"]["learning_rate"])
+            self.assertIn("std", summaries[0]["gene_statistics"]["learning_rate"])
+            self.assertIn("best_chromosome", summaries[0])
+            self.assertIn("learning_rate", summaries[0]["best_chromosome"])
 
     def test_repeated_run_on_same_instance_is_deterministic_with_seed(self):
         base_config = SimulationConfig()

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -284,6 +284,51 @@ def test_reproduce_skips_refund_when_partial_offspring_rollback_fails():
     parent.get_component("resource").add.assert_not_called()
 
 
+def test_reproduce_refunds_when_rollback_errors_but_offspring_is_not_present():
+    """Refund should proceed when rollback errors but no offspring remains."""
+    parent = _build_parent_agent_for_reproduction()
+
+    class _RollbackHookRaisesAfterCleanupEnvironment:
+        def __init__(self):
+            self._agent_objects = {}
+            self.agents = []
+
+        def get_next_agent_id(self) -> str:
+            return "child_1"
+
+        def add_agent(self, offspring, flush_immediately: bool = False):
+            self._agent_objects[offspring.agent_id] = offspring
+            self.agents.append(offspring.agent_id)
+            raise RuntimeError("flush failed after insert")
+
+        def rollback_partial_agent_add(self, agent_id: str) -> bool:
+            self._agent_objects.pop(agent_id, None)
+            if agent_id in self.agents:
+                self.agents.remove(agent_id)
+            raise RuntimeError("rollback hook threw after cleanup")
+
+    parent.environment = _RollbackHookRaisesAfterCleanupEnvironment()
+    offspring = SimpleNamespace(
+        agent_id="child_1",
+        state=Mock(),
+        generation=0,
+    )
+    offspring.state._state = Mock()
+    offspring.state._state.model_copy.return_value = Mock()
+
+    with patch("farm.core.hyperparameter_chromosome.random.random", return_value=1.0), patch(
+        "farm.core.agent.factory.AgentFactory"
+    ) as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is False
+    parent.get_component("resource").add.assert_called_once_with(5.0)
+    assert "child_1" not in parent.environment._agent_objects
+    assert "child_1" not in parent.environment.agents
+
+
 def test_reproduce_uses_environment_partial_add_rollback_hook_when_available():
     """Prefer Environment.rollback_partial_agent_add for rollback-aware cleanup."""
     parent = _build_parent_agent_for_reproduction()

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -206,7 +206,7 @@ class TestEnvironment(unittest.TestCase):
         agent_ids = [agent.agent_id for agent in self.env.agent_objects]
         self.assertEqual(len(agent_ids), len(set(agent_ids)))
 
-    def test_rollback_partial_agent_add_rolls_back_state_metrics_and_db_marker(self):
+    def test_rollback_partial_agent_add_rolls_back_state_metrics_and_db_row(self):
         """Rollback hook should clean partial inserts and compensate side effects."""
         agent_id = "rollback_test_agent"
         self.env.time = 5
@@ -231,11 +231,8 @@ class TestEnvironment(unittest.TestCase):
         self.assertNotIn(agent_id, self.env._agent_objects)
         self.assertNotIn(agent_id, self.env.agents)
         self.assertEqual(self.env.metrics_tracker.step_metrics.births, 1)
-        self.env.db.update_agent_death.assert_called_once_with(
-            agent_id=agent_id,
-            death_time=5,
-            cause="rollback_partial_add",
-        )
+        self.env.db._execute_in_transaction.assert_called_once()
+        self.env.db.update_agent_death.assert_not_called()
 
     def test_resource_initialization(self):
         """Test that resources are properly initialized"""


### PR DESCRIPTION
This pull request introduces significant improvements to the hyperparameter evolution experiment infrastructure, focusing on more robust agent reproduction error handling, enhanced experiment output and visualization, and improved mutation operator flexibility. The changes add richer per-generation statistics, a new plotting script for convergence analysis, and more resilient rollback/refund logic during agent reproduction failures.

**Experiment Output and Visualization Enhancements:**

- Added per-generation gene statistics and best chromosome tracking to the evolution experiment outputs (`evolution_generation_summaries.json`), enabling more detailed analysis of convergence and gene behavior. (`farm/runners/evolution_experiment.py`, `docs/design/hyperparameter_chromosome.md`, [[1]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR113-R114) [[2]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR304-R342) [[3]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12R271-R283)
- Introduced a new script, `scripts/plot_hyperparameter_evolution.py`, to generate convergence and gene evolution plots from the JSON summaries, and documented its usage and interpretation in a new experiment note. (`scripts/plot_hyperparameter_evolution.py`, `docs/experiments/hyperparameter_evolution_convergence.md`, [[1]](diffhunk://#diff-513a3113baee2cdb57354ac3df678ab18cbf3d21ca401f11b0d46c63843a144fR1-R90) [[2]](diffhunk://#diff-0a53949f26d90f2b6c468cc3fd8398472b86bed8d532fd96511759c0195bd8b4R1-R57)

**Agent Reproduction Error Handling Improvements:**

- Refined the agent reproduction refund and rollback logic to handle edge cases where rollback fails but the offspring is no longer present, ensuring refunds are only suppressed when the offspring remains in an unresolved state. Enhanced logging for these scenarios. (`farm/core/agent/core.py`, [[1]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L83-R96) [[2]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393R728-R749) [[3]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393R760-R761) [[4]](diffhunk://#diff-4b59fc907ff2fcd4bc8049d2392e0abb07d57e44aba581c1c2a74b7e76b94427R287-R331)
- Updated the environment rollback hook to fully remove agent database rows on rollback, avoiding the creation of misleading death records and ensuring clean analytics. (`farm/core/environment.py`, [[1]](diffhunk://#diff-fa1b6a3f2472c76f3ffc7cbc82edcf330f56046d4a3f98d2f182702d6c195b8aL209-R209) [[2]](diffhunk://#diff-fa1b6a3f2472c76f3ffc7cbc82edcf330f56046d4a3f98d2f182702d6c195b8aL234-R235) [[3]](diffhunk://#diff-81e4f05efb3dec2895bc17955ac6beff6dfbe39f6bf0e30de616e532698de662L1299-R1316)

**Mutation Operator Flexibility:**

- Extended mutation behavior to support both additive (Gaussian) and multiplicative mutation modes, with Gaussian now the default. Updated documentation to clarify mutation options and future extensibility. (`docs/design/hyperparameter_chromosome.md`, [[1]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L99-R112) [[2]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L233-R244)

**Testing Improvements:**

- Expanded and updated tests to cover new refund/rollback logic, per-generation gene statistics, and database row cleanup on rollback. (`tests/runners/test_evolution_experiment.py`, `tests/test_agent_reproduction_hyperparameters.py`, `tests/test_environment.py`, [[1]](diffhunk://#diff-2e3ed6332444b9ae7417ca931cd484bb5c4a3e9dc9e16c74188bddbeb55d1deaR129-R135) [[2]](diffhunk://#diff-4b59fc907ff2fcd4bc8049d2392e0abb07d57e44aba581c1c2a74b7e76b94427R287-R331) [[3]](diffhunk://#diff-fa1b6a3f2472c76f3ffc7cbc82edcf330f56046d4a3f98d2f182702d6c195b8aL209-R209) [[4]](diffhunk://#diff-fa1b6a3f2472c76f3ffc7cbc82edcf330f56046d4a3f98d2f182702d6c195b8aL234-R235)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent reproduction compensation logic and environment DB rollback behavior, which can affect resource accounting and persisted analytics if edge cases are mishandled, but changes are localized and covered by new tests.
> 
> **Overview**
> Adds richer hyperparameter-evolution artifacts by persisting per-generation `gene_statistics` (mean/median/std/min/max) and the generation’s `best_chromosome` into `evolution_generation_summaries.json`, with accompanying docs and a new `scripts/plot_hyperparameter_evolution.py` utility to visualize fitness convergence and gene trends.
> 
> Hardens reproduction failure handling: `AgentCore.reproduce()` now prefers the parent’s stored `hyperparameter_chromosome` (deriving/syncing if missing) and refines refund suppression so resource refunds only stop when rollback fails *and* the offspring still appears in environment tracking; logging now records rollback attempt/outcome. `Environment.rollback_partial_agent_add()` now compensates by deleting any persisted agent DB row (instead of writing a “death” marker) to avoid rollback-only artifacts in analytics, with tests updated/added for these scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7439ab32c4c8c95220de20321bb78afc11033a20. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->