### PR TITLE
Enhance mutation controls and validation for HyperparameterGene

### DIFF
--- a/docs/design/hyperparameter_chromosome.md
+++ b/docs/design/hyperparameter_chromosome.md
@@ -28,10 +28,15 @@ The chromosome model is intentionally narrow and strict:
   - `bit_width` must be positive (validated at construction)
 - `HyperparameterGene`
   - name, type, value, min/max bounds, default, and `evolvable` flag
+  - per-gene mutation controls:
+    - `mutation_scale` (default `0.2`)
+    - `mutation_probability` (default `0.1`)
+    - `mutation_strategy` (`MutationMode`, default `GAUSSIAN`)
   - validates:
     - non-empty name
     - valid min/max range
     - in-range numeric value and default
+    - valid mutation controls (non-negative scale, probability in `[0, 1]`)
   - **new methods** (real-valued genes only):
     - `normalize(value, *, scale)` → `float` in `[0, 1]`
     - `denormalize(normalized_value, *, scale)` → `float` in gene range
@@ -68,6 +73,7 @@ Helpers:
 
 - `default_hyperparameter_chromosome()`
 - `hyperparameter_evolution_registry()`
+- `default_hyperparameter_registry()` *(alias for the default evolution registry)*
 - `chromosome_from_values()`
 - `chromosome_from_learning_config()`
 - `default_encoding_spec_for_gene(gene_name)` — look up the default `GeneEncodingSpec` for a gene name
@@ -103,9 +109,14 @@ This keeps:
 
 ## Mutation behavior
 
-`mutate_chromosome(chromosome, mutation_rate=0.1, mutation_scale=0.2, mutation_mode="gaussian")`:
+`mutate_chromosome(chromosome, mutation_rate=None, mutation_scale=None, mutation_mode=None)`:
 
 - only mutates genes where `evolvable=True`
+- resolves mutation settings per gene by default:
+  - probability from `gene.mutation_probability`
+  - scale from `gene.mutation_scale`
+  - strategy from `gene.mutation_strategy`
+- optional global arguments override per-gene values when provided
 - supports two real-valued mutation operators:
   - `gaussian` (default):
     - `new_value = old_value + Normal(0, mutation_scale * (max_value - min_value))`
@@ -248,7 +259,7 @@ To adapt:
 
 Recommended approach:
 - keep `HyperparameterGene` and `HyperparameterChromosome` validation unchanged
-- implement strategy changes behind `mutate_chromosome(...)` or a new strategy function
+- prefer per-gene mutation controls first; add new strategy functions only when needed
 - keep tests deterministic by patching randomness in unit tests
 
 ## Relationship to `Genome`

--- a/farm/core/hyperparameter_chromosome.py
+++ b/farm/core/hyperparameter_chromosome.py
@@ -532,7 +532,7 @@ def mutate_chromosome(
     for gene in chromosome.genes:
         resolved_probability = mutation_rate if mutation_rate is not None else gene.mutation_probability
         resolved_scale = mutation_scale if mutation_scale is not None else gene.mutation_scale
-        resolved_mode = resolved_mode_override or gene.mutation_strategy
+        resolved_mode = resolved_mode_override if resolved_mode_override is not None else gene.mutation_strategy
         if not gene.evolvable or resolved_rng.random() >= resolved_probability:
             updated_genes.append(gene)
             continue

--- a/farm/core/hyperparameter_chromosome.py
+++ b/farm/core/hyperparameter_chromosome.py
@@ -18,7 +18,7 @@ from enum import Enum
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 
-class GeneValueType(str, Enum):
+class GeneValueType(Enum):
     """Supported gene value kinds.
 
     Notes:
@@ -73,12 +73,16 @@ class HyperparameterGene:
     max_value: float
     default: float
     evolvable: bool = True
+    mutation_scale: float = 0.2
+    mutation_probability: float = 0.1
+    mutation_strategy: MutationMode = MutationMode.GAUSSIAN
 
     def __post_init__(self) -> None:
         self._validate_name()
         self._validate_real_bounds()
         self._validate_value(self.default, field_name="default")
         self._validate_value(self.value, field_name="value")
+        self._validate_mutation_controls()
 
     def _validate_name(self) -> None:
         if not self.name or not self.name.strip():
@@ -104,6 +108,12 @@ class HyperparameterGene:
                 f"[{self.min_value}, {self.max_value}]."
             )
 
+    def _validate_mutation_controls(self) -> None:
+        if self.mutation_scale < 0.0:
+            raise ValueError("mutation_scale must be non-negative.")
+        if not 0.0 <= self.mutation_probability <= 1.0:
+            raise ValueError("mutation_probability must be between 0 and 1.")
+
     def with_value(self, value: float) -> "HyperparameterGene":
         """Return a copy of this gene with a validated replacement value."""
         return HyperparameterGene(
@@ -114,6 +124,9 @@ class HyperparameterGene:
             max_value=self.max_value,
             default=self.default,
             evolvable=self.evolvable,
+            mutation_scale=self.mutation_scale,
+            mutation_probability=self.mutation_probability,
+            mutation_strategy=self.mutation_strategy,
         )
 
     def normalize(
@@ -189,6 +202,9 @@ class HyperparameterGene:
             "max_value": self.max_value,
             "default": self.default,
             "evolvable": self.evolvable,
+            "mutation_scale": self.mutation_scale,
+            "mutation_probability": self.mutation_probability,
+            "mutation_strategy": self.mutation_strategy.value,
         }
 
     @classmethod
@@ -202,6 +218,9 @@ class HyperparameterGene:
             max_value=float(data["max_value"]),
             default=float(data["default"]),
             evolvable=bool(data.get("evolvable", True)),
+            mutation_scale=float(data.get("mutation_scale", 0.2)),
+            mutation_probability=float(data.get("mutation_probability", 0.1)),
+            mutation_strategy=MutationMode(data.get("mutation_strategy", MutationMode.GAUSSIAN.value)),
         )
 
 
@@ -463,6 +482,11 @@ def hyperparameter_evolution_registry() -> Dict[str, bool]:
     return {gene.name: gene.evolvable for gene in chromosome.genes}
 
 
+def default_hyperparameter_registry() -> Dict[str, bool]:
+    """Alias for ``hyperparameter_evolution_registry`` with shorter name."""
+    return hyperparameter_evolution_registry()
+
+
 def chromosome_from_values(
     values: Optional[Dict[str, float]] = None,
 ) -> HyperparameterChromosome:
@@ -484,9 +508,9 @@ def chromosome_from_learning_config(learning_config: Any) -> HyperparameterChrom
 
 def mutate_chromosome(
     chromosome: HyperparameterChromosome,
-    mutation_rate: float = 0.1,
-    mutation_scale: float = 0.2,
-    mutation_mode: Union[MutationMode, str] = MutationMode.GAUSSIAN,
+    mutation_rate: Optional[float] = None,
+    mutation_scale: Optional[float] = None,
+    mutation_mode: Optional[Union[MutationMode, str]] = None,
     rng: Optional[random.Random] = None,
 ) -> HyperparameterChromosome:
     """Mutate evolvable genes using bounded real-valued perturbations.
@@ -498,25 +522,27 @@ def mutate_chromosome(
           uniform delta in ``[-mutation_scale, mutation_scale]``.
         - All mutations are clamped to each gene's bounds.
     """
-    if not 0.0 <= mutation_rate <= 1.0:
+    if mutation_rate is not None and not 0.0 <= mutation_rate <= 1.0:
         raise ValueError("mutation_rate must be between 0 and 1.")
-    if mutation_scale < 0.0:
+    if mutation_scale is not None and mutation_scale < 0.0:
         raise ValueError("mutation_scale must be non-negative.")
-
-    resolved_mode = MutationMode(mutation_mode)
+    resolved_mode_override = MutationMode(mutation_mode) if mutation_mode is not None else None
     resolved_rng = rng or random
     updated_genes: List[HyperparameterGene] = []
     for gene in chromosome.genes:
-        if not gene.evolvable or resolved_rng.random() >= mutation_rate:
+        resolved_probability = mutation_rate if mutation_rate is not None else gene.mutation_probability
+        resolved_scale = mutation_scale if mutation_scale is not None else gene.mutation_scale
+        resolved_mode = resolved_mode_override or gene.mutation_strategy
+        if not gene.evolvable or resolved_rng.random() >= resolved_probability:
             updated_genes.append(gene)
             continue
 
         if resolved_mode is MutationMode.GAUSSIAN:
             span = gene.max_value - gene.min_value
-            sigma = span * mutation_scale
+            sigma = span * resolved_scale
             raw_value = gene.value + resolved_rng.gauss(0.0, sigma)
         else:
-            delta = resolved_rng.uniform(-mutation_scale, mutation_scale)
+            delta = resolved_rng.uniform(-resolved_scale, resolved_scale)
             raw_value = gene.value * (1.0 + delta)
 
         bounded_value = max(gene.min_value, min(gene.max_value, raw_value))

--- a/tests/test_hyperparameter_chromosome.py
+++ b/tests/test_hyperparameter_chromosome.py
@@ -1,6 +1,7 @@
 """Tests for typed hyperparameter chromosome schema."""
 
 import unittest
+import json
 import random
 from unittest.mock import patch
 
@@ -18,6 +19,7 @@ from farm.core.hyperparameter_chromosome import (
     HyperparameterGene,
     chromosome_from_learning_config,
     chromosome_from_values,
+    default_hyperparameter_registry,
     default_hyperparameter_chromosome,
     hyperparameter_evolution_registry,
     mutate_chromosome,
@@ -72,6 +74,9 @@ class TestHyperparameterChromosome(unittest.TestCase):
         self.assertFalse(registry["epsilon_decay"])
         self.assertFalse(registry["memory_size"])
 
+    def test_short_registry_alias_matches_evolution_registry(self):
+        self.assertEqual(default_hyperparameter_registry(), hyperparameter_evolution_registry())
+
     def test_rejects_unknown_override_name(self):
         chromosome = default_hyperparameter_chromosome()
         with self.assertRaises(KeyError):
@@ -93,6 +98,22 @@ class TestHyperparameterChromosome(unittest.TestCase):
         )
         self.assertEqual(restored.get_value("learning_rate"), 0.05)
         self.assertEqual(restored.get_value("epsilon_decay"), 0.97)
+
+    def test_serialization_preserves_gene_order(self):
+        chromosome = chromosome_from_values({"learning_rate": 0.03, "epsilon_decay": 0.92})
+        payload = chromosome.to_dict()
+        restored = HyperparameterChromosome.from_dict(payload)
+        self.assertEqual(
+            [gene.name for gene in chromosome.genes],
+            [gene.name for gene in restored.genes],
+        )
+
+    def test_serialization_round_trip_through_json_keeps_float_precision(self):
+        original = chromosome_from_values({"learning_rate": 0.123456789012345, "epsilon_decay": 0.987654321012345})
+        as_json = json.dumps(original.to_dict(), sort_keys=True)
+        restored = HyperparameterChromosome.from_dict(json.loads(as_json))
+        self.assertAlmostEqual(restored.get_value("learning_rate"), 0.123456789012345, places=15)
+        self.assertAlmostEqual(restored.get_value("epsilon_decay"), 0.987654321012345, places=15)
 
     def test_builds_from_learning_config_like_object(self):
         chromosome = chromosome_from_learning_config(_LearningConfigStub())
@@ -132,6 +153,65 @@ class TestHyperparameterChromosome(unittest.TestCase):
                 mutation_mode=MutationMode.MULTIPLICATIVE,
             )
         self.assertAlmostEqual(mutated.get_value("learning_rate"), 0.012)
+
+    def test_mutation_uses_per_gene_controls_when_globals_not_provided(self):
+        chromosome = HyperparameterChromosome(
+            genes=(
+                HyperparameterGene(
+                    name="learning_rate",
+                    value_type=GeneValueType.REAL,
+                    value=0.01,
+                    min_value=1e-6,
+                    max_value=1.0,
+                    default=0.001,
+                    evolvable=True,
+                    mutation_scale=0.5,
+                    mutation_probability=1.0,
+                    mutation_strategy=MutationMode.MULTIPLICATIVE,
+                ),
+            )
+        )
+        with patch("farm.core.hyperparameter_chromosome.random.uniform", return_value=0.5):
+            mutated = mutate_chromosome(chromosome)
+        self.assertAlmostEqual(mutated.get_value("learning_rate"), 0.015)
+
+    def test_mutation_globals_override_per_gene_controls(self):
+        chromosome = HyperparameterChromosome(
+            genes=(
+                HyperparameterGene(
+                    name="learning_rate",
+                    value_type=GeneValueType.REAL,
+                    value=0.01,
+                    min_value=1e-6,
+                    max_value=1.0,
+                    default=0.001,
+                    evolvable=True,
+                    mutation_scale=0.0,
+                    mutation_probability=0.0,
+                    mutation_strategy=MutationMode.MULTIPLICATIVE,
+                ),
+            )
+        )
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=0.001):
+            mutated = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=0.1,
+                mutation_mode=MutationMode.GAUSSIAN,
+            )
+        self.assertAlmostEqual(mutated.get_value("learning_rate"), 0.011)
+
+    def test_fixed_genes_remain_unchanged_even_with_full_global_mutation(self):
+        chromosome = default_hyperparameter_chromosome()
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=1000.0):
+            mutated = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=1.0,
+                mutation_mode=MutationMode.GAUSSIAN,
+            )
+        self.assertEqual(mutated.get_value("epsilon_decay"), chromosome.get_value("epsilon_decay"))
+        self.assertEqual(mutated.get_value("memory_size"), chromosome.get_value("memory_size"))
 
     def test_apply_chromosome_to_learning_config(self):
         decision = DecisionConfig(learning_rate=0.02, epsilon_decay=0.98, memory_size=5000)


### PR DESCRIPTION
This pull request introduces per-gene mutation controls to the hyperparameter chromosome system, allowing each gene to specify its own mutation probability, scale, and strategy. The mutation function is updated to use these per-gene settings by default, with optional global overrides. The changes also include validation logic, serialization support, new helpers, and expanded tests to ensure correct behavior and backwards compatibility.

**Per-gene mutation controls and logic:**

* Added `mutation_scale`, `mutation_probability`, and `mutation_strategy` attributes to `HyperparameterGene`, with validation to ensure correct ranges. The mutation function (`mutate_chromosome`) now uses these per-gene settings unless global overrides are provided. [[1]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R76-R85) [[2]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R111-R116) [[3]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8L487-R513) [[4]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8L501-R545) [[5]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12R31-R39) [[6]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L106-R119) [[7]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L251-R262)
* Updated `mutate_chromosome` to resolve mutation parameters per gene, falling back to global arguments only when provided. [[1]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8L487-R513) [[2]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8L501-R545) [[3]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L106-R119) [[4]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L251-R262)

**Serialization, deserialization, and helpers:**

* Extended `HyperparameterGene`'s `to_dict`/`from_dict` methods to include per-gene mutation controls, ensuring full serialization and deserialization support. [[1]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R205-R207) [[2]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R221-R223)
* Added `default_hyperparameter_registry()` as an alias for `hyperparameter_evolution_registry()` for convenience. [[1]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R485-R489) [[2]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12R76)

**Testing improvements:**

* Added tests for per-gene mutation controls, global override precedence, serialization round-trip (including float precision and gene order), and the new registry alias. [[1]](diffhunk://#diff-9c7680134b11855929fe6dd4a3d862d1b80e80be48036a6186b545079899f572R77-R79) [[2]](diffhunk://#diff-9c7680134b11855929fe6dd4a3d862d1b80e80be48036a6186b545079899f572R102-R117) [[3]](diffhunk://#diff-9c7680134b11855929fe6dd4a3d862d1b80e80be48036a6186b545079899f572R157-R215) [[4]](diffhunk://#diff-9c7680134b11855929fe6dd4a3d862d1b80e80be48036a6186b545079899f572R22)

**Documentation updates:**

* Updated the design doc to describe per-gene mutation controls, validation, and the new mutation behavior, as well as the new helper alias. [[1]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12R31-R39) [[2]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12R76) [[3]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L106-R119) [[4]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L251-R262)

**Minor code fixes:**

* Changed `GeneValueType` from a subclass of `str, Enum` to just `Enum` for clarity.

These changes make mutation strategies more flexible and customizable at the gene level, while preserving backwards compatibility and improving test coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default mutation behavior and serialized gene schema, which can alter evolution dynamics and compatibility with persisted chromosome payloads if consumers assume old defaults.
> 
> **Overview**
> Adds per-gene mutation configuration to `HyperparameterGene` (`mutation_probability`, `mutation_scale`, `mutation_strategy`) with validation and serialization support.
> 
> Updates `mutate_chromosome` to default to each gene’s mutation settings, while allowing optional global overrides for rate/scale/mode, and adds `default_hyperparameter_registry()` as a short alias for `hyperparameter_evolution_registry()`.
> 
> Expands tests and docs to cover the new mutation behavior (per-gene vs global precedence), fixed-gene invariants, and serialization round-trips (order and JSON float precision).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aed51f344f90160e5bf9fc79d1bddaa0debb84f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->