### PR TITLE
Add reflective mutation and soft boundary penalties to hyperparameter evolution

### DIFF
--- a/docs/design/hyperparameter_chromosome.md
+++ b/docs/design/hyperparameter_chromosome.md
@@ -109,7 +109,7 @@ This keeps:
 
 ## Mutation behavior
 
-`mutate_chromosome(chromosome, mutation_rate=None, mutation_scale=None, mutation_mode=None)`:
+`mutate_chromosome(chromosome, mutation_rate=None, mutation_scale=None, mutation_mode=None, boundary_mode="clamp")`:
 
 - only mutates genes where `evolvable=True`
 - resolves mutation settings per gene by default:
@@ -122,7 +122,81 @@ This keeps:
     - `new_value = old_value + Normal(0, mutation_scale * (max_value - min_value))`
   - `multiplicative` (legacy mode):
     - `new_value = old_value * (1 + uniform(-scale, scale))`
-- clamps to `[min_value, max_value]`
+- boundary handling is controlled by `boundary_mode` (see below)
+
+## Boundary handling
+
+When a mutation produces a raw value outside `[min_value, max_value]`, the
+`boundary_mode` argument to `mutate_chromosome` determines what happens.
+
+### `BoundaryMode.CLAMP` (default)
+
+The raw value is hard-clamped:
+
+```python
+bounded = max(min_value, min(max_value, raw_value))
+```
+
+Simple and safe, but can cause **boundary collapse**: repeated mutations push a
+gene to a wall and it becomes "absorbed" there, eliminating diversity.
+
+### `BoundaryMode.REFLECT`
+
+The raw value is folded back from the boundary like a billiard ball:
+
+- overshoot by *d* above `max_value` → result is `max_value − d` (bounced back)
+- works symmetrically for `min_value`
+- multiple reflections handled correctly via modular arithmetic
+
+This avoids absorbing edge states while still keeping the gene inside
+`[min_value, max_value]`.
+
+```python
+mutated = mutate_chromosome(chromosome, mutation_rate=0.1, boundary_mode="reflect")
+```
+
+**Recommended default**: `CLAMP` for stability in early experiments;
+`REFLECT` when you observe boundary collapse (genes sticking at min/max).
+
+### Soft boundary penalties
+
+`compute_boundary_penalty(chromosome, config)` returns a non-negative float
+that should be **subtracted** from the raw fitness score.
+
+```python
+from farm.core.hyperparameter_chromosome import BoundaryPenaltyConfig, compute_boundary_penalty
+
+cfg = BoundaryPenaltyConfig(
+    enabled=True,
+    penalty_strength=0.01,       # max penalty per gene
+    near_boundary_threshold=0.05, # 5% of range on each side
+)
+adjusted_fitness = raw_fitness - compute_boundary_penalty(chromosome, cfg)
+```
+
+Penalty ramps linearly:
+
+| Gene position (normalized) | Penalty fraction |
+|---|---|
+| exactly on boundary (0.0 or 1.0) | 1.0 × `penalty_strength` |
+| `near_boundary_threshold` inside boundary | 0.0 |
+
+The total penalty is summed over all `evolvable=True` genes.  Fixed genes never
+contribute.  The function returns `0.0` immediately when `enabled=False`
+(default) so callers can include the call unconditionally.
+
+**`BoundaryPenaltyConfig` parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | `bool` | `False` | Whether to compute a penalty at all |
+| `penalty_strength` | `float` | `0.01` | Maximum per-gene penalty |
+| `near_boundary_threshold` | `float` | `0.05` | Fraction of gene range to consider "near boundary" |
+
+**Recommended defaults**: start with `penalty_strength=0.01` and
+`near_boundary_threshold=0.05`.  Increase `penalty_strength` if boundary
+collapse persists; widen `near_boundary_threshold` to push genes further from
+the walls.
 
 ## Gene encoding and decoding
 
@@ -256,6 +330,8 @@ To adapt:
 - add per-gene mutation scales
 - add schedule-based mutation rate by generation
 - support crossover across two parent chromosomes
+- switch `boundary_mode` to `"reflect"` to avoid boundary collapse
+- enable `BoundaryPenaltyConfig` to add a soft fitness signal near walls
 
 Recommended approach:
 - keep `HyperparameterGene` and `HyperparameterChromosome` validation unchanged

--- a/docs/experiments/hyperparameter_evolution_convergence.md
+++ b/docs/experiments/hyperparameter_evolution_convergence.md
@@ -11,6 +11,11 @@ This note documents how to capture and interpret learning-rate convergence from 
   - parent selection: tournament or roulette
   - mutation rate: `--mutation-rate` (default `0.25`)
   - mutation scale: `--mutation-scale` (default `0.2`)
+  - boundary mode: `--boundary-mode` (`clamp` or `reflect`, default `clamp`)
+  - optional soft boundary penalty:
+    - `--boundary-penalty-enabled`
+    - `--boundary-penalty-strength` (default `0.01`)
+    - `--boundary-penalty-threshold` (default `0.05`)
   - fitness metric: `final_population`, `total_births`, or `final_resources`
 
 Example:
@@ -24,6 +29,7 @@ python scripts/run_evolution_experiment.py \
   --selection-method tournament \
   --mutation-rate 0.25 \
   --mutation-scale 0.2 \
+  --boundary-mode clamp \
   --fitness-metric final_population \
   --output-dir experiments/evolution_convergence
 ```
@@ -138,3 +144,127 @@ For issue closure write-ups, include:
 - selected mutation/selection settings
 - one generated convergence figure
 - a short narrative of whether convergence, oscillation, or collapse occurred
+
+## Boundary-Handling Comparison Plan
+
+To specifically evaluate boundary-collapse risk, keep all settings identical and
+toggle only boundary handling. Suggested A/B matrix:
+
+1. clamp baseline
+2. reflect mutation
+3. clamp + soft boundary penalty
+
+Use a shared seed and identical generation/population settings:
+
+```bash
+source venv/bin/activate
+
+# A) Clamp baseline
+python scripts/run_evolution_experiment.py \
+  --generations 6 --population-size 8 --steps-per-candidate 40 \
+  --selection-method tournament --mutation-rate 0.20 --mutation-scale 0.2 \
+  --boundary-mode clamp \
+  --fitness-metric final_population --seed 42 \
+  --output-dir experiments/evolution_convergence/run_clamp_baseline_g6
+
+# B) Reflective mutation
+python scripts/run_evolution_experiment.py \
+  --generations 6 --population-size 8 --steps-per-candidate 40 \
+  --selection-method tournament --mutation-rate 0.20 --mutation-scale 0.2 \
+  --boundary-mode reflect \
+  --fitness-metric final_population --seed 42 \
+  --output-dir experiments/evolution_convergence/run_reflect_g6
+
+# C) Clamp + soft boundary penalty
+python scripts/run_evolution_experiment.py \
+  --generations 6 --population-size 8 --steps-per-candidate 40 \
+  --selection-method tournament --mutation-rate 0.20 --mutation-scale 0.2 \
+  --boundary-mode clamp \
+  --boundary-penalty-enabled \
+  --boundary-penalty-strength 0.01 \
+  --boundary-penalty-threshold 0.05 \
+  --fitness-metric final_population --seed 42 \
+  --output-dir experiments/evolution_convergence/run_clamp_penalty_g6
+```
+
+Compare each run's `evolution_generation_summaries.json` and lineage outputs for:
+
+- best-candidate learning-rate trajectory (especially boundary hits)
+- learning-rate min/max and standard deviation trends
+- fitness gains relative to boundary occupancy
+
+## Boundary-Handling Comparison Results (Completed)
+
+Executed on 2026-04-18 with the exact commands above and shared seed (`42`).
+Outputs were written to:
+
+- `experiments/evolution_convergence/run_clamp_baseline_g6`
+- `experiments/evolution_convergence/run_reflect_g6`
+- `experiments/evolution_convergence/run_clamp_penalty_g6`
+
+Observed outcomes from persisted summaries + lineage:
+
+- Clamp baseline (`run_clamp_baseline_g6`)
+  - best fitness: `72.0 -> 69.0`
+  - best-candidate learning rate: `0.001 -> 1e-06`
+  - learning-rate std: `0.0612 -> 0.1372`
+  - exact min-boundary occupancy by generation: `[2, 3, 3, 5, 8, 7]` (out of 8 candidates)
+- Reflect (`run_reflect_g6`)
+  - best fitness: `74.0 -> 75.0`
+  - best-candidate learning rate: `0.3771 -> 0.3771`
+  - learning-rate std: `0.1143 -> 0.1638`
+  - exact min-boundary occupancy by generation: `[0, 0, 0, 0, 0, 0]`
+- Clamp + penalty (`run_clamp_penalty_g6`)
+  - adjusted best fitness: `75.99 -> 73.99`
+  - raw best fitness (metadata): `76.0` (max over lineage)
+  - best-candidate learning rate: `1e-06 -> 1e-06`
+  - exact min-boundary occupancy by generation: `[2, 4, 5, 6, 8, 7]`
+  - mean boundary penalty across candidates: `0.00764` (max `0.01`)
+
+Interpretation:
+
+- Reflective mutation clearly reduced boundary-collapse risk in this comparison:
+  no candidates landed exactly at the lower bound, while clamp variants showed
+  repeated and increasing lower-bound occupancy.
+- Reflect also preserved/improved optimization signal (best fitness reached
+  `75.0`) without relying on boundary-hugging winners.
+- The small soft-penalty setting (`0.01`, threshold `0.05`) was not strong
+  enough to dislodge clamp dynamics in this setup; it reduced adjusted fitness
+  but did not prevent lower-bound collapse. Increasing penalty strength and/or
+  threshold is the next tuning step if clamp must be retained.
+
+## Penalty Strength Sensitivity (Completed)
+
+A follow-up sweep kept clamp mode fixed and varied only
+`boundary_penalty_strength` (`threshold=0.05`, same seed/settings):
+
+- `experiments/evolution_convergence/run_clamp_penalty002_g6`
+- `experiments/evolution_convergence/run_clamp_penalty005_g6`
+- `experiments/evolution_convergence/run_clamp_penalty010_g6`
+
+Observed outcomes:
+
+- `strength=0.02` (`run_clamp_penalty002_g6`)
+  - adjusted best fitness: `70.0 -> 79.0`
+  - best-candidate learning rate: `0.1594 -> 0.1594`
+  - min-boundary hits by generation: `[2, 3, 2, 2, 1, 0]`
+  - mean penalty: `0.00530` (max `0.02`)
+- `strength=0.05` (`run_clamp_penalty005_g6`)
+  - adjusted best fitness: `68.951 -> 67.95`
+  - best-candidate learning rate: `0.001 -> 1e-06`
+  - min-boundary hits by generation: `[2, 3, 0, 1, 7, 7]`
+  - mean penalty: `0.03262` (max `0.05`)
+- `strength=0.10` (`run_clamp_penalty010_g6`)
+  - adjusted best fitness: `74.902 -> 73.0`
+  - best-candidate learning rate: `0.001 -> 0.1594`
+  - min-boundary hits by generation: `[2, 3, 2, 4, 2, 2]`
+  - mean penalty: `0.04303` (max `0.10`)
+
+Sensitivity takeaway:
+
+- Penalty impact is non-monotonic in this stochastic setting.
+- `0.02` and `0.10` reduced lower-bound collapse relative to prior clamp runs,
+  while `0.05` still collapsed late.
+- A higher penalty (`0.10`) prevented the final winner from collapsing to
+  `1e-06`, but reflective mutation remains the most consistent anti-collapse
+  strategy in this set of experiments.

--- a/experiments/evolution_convergence/run_clamp_baseline_g6/evolution_generation_summaries.json
+++ b/experiments/evolution_convergence/run_clamp_baseline_g6/evolution_generation_summaries.json
@@ -1,0 +1,212 @@
+[
+  {
+    "generation": 0,
+    "best_fitness": 72.0,
+    "mean_fitness": 65.25,
+    "min_fitness": 55.0,
+    "best_candidate_id": "g0_c0",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.055658525648276516,
+        "median": 0.02662644272048611,
+        "std": 0.06118633982230562,
+        "min": 1e-06,
+        "max": 0.15942878976101
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.001,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 1,
+    "best_fitness": 75.0,
+    "mean_fitness": 62.25,
+    "min_fitness": 54.0,
+    "best_candidate_id": "g1_c3",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.05793119334296529,
+        "median": 0.001,
+        "std": 0.10558411559595705,
+        "min": 1e-06,
+        "max": 0.3010177569827123
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.15942878976101,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 2,
+    "best_fitness": 72.0,
+    "mean_fitness": 63.375,
+    "min_fitness": 55.0,
+    "best_candidate_id": "g2_c7",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.09964336860063125,
+        "median": 0.15942878976101,
+        "std": 0.07718264683338114,
+        "min": 1e-06,
+        "max": 0.15942878976101
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 3,
+    "best_fitness": 73.0,
+    "mean_fitness": 65.0,
+    "min_fitness": 60.0,
+    "best_candidate_id": "g3_c4",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.032643645893763215,
+        "median": 1e-06,
+        "std": 0.05635908447804713,
+        "min": 1e-06,
+        "max": 0.15942878976101
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 4,
+    "best_fitness": 70.0,
+    "mean_fitness": 63.75,
+    "min_fitness": 59.0,
+    "best_candidate_id": "g4_c2",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 1e-06,
+        "median": 1e-06,
+        "std": 0.0,
+        "min": 1e-06,
+        "max": 1e-06
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 5,
+    "best_fitness": 69.0,
+    "mean_fitness": 65.5,
+    "min_fitness": 56.0,
+    "best_candidate_id": "g5_elite0",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.051863200200380606,
+        "median": 1e-06,
+        "std": 0.13721448417485127,
+        "min": 1e-06,
+        "max": 0.41489860160304487
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  }
+]

--- a/experiments/evolution_convergence/run_clamp_baseline_g6/evolution_lineage.json
+++ b/experiments/evolution_convergence/run_clamp_baseline_g6/evolution_lineage.json
@@ -1,0 +1,722 @@
+[
+  {
+    "candidate_id": "g0_c0",
+    "generation": 0,
+    "fitness": 72.0,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 72,
+      "raw_fitness": 72.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c1",
+    "generation": 0,
+    "fitness": 69.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c2",
+    "generation": 0,
+    "fitness": 70.0,
+    "learning_rate": 0.02610363003699699,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c3",
+    "generation": 0,
+    "fitness": 55.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 55,
+      "raw_fitness": 55.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c4",
+    "generation": 0,
+    "fitness": 69.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c5",
+    "generation": 0,
+    "fitness": 61.0,
+    "learning_rate": 0.13903446179832052,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c6",
+    "generation": 0,
+    "fitness": 66.0,
+    "learning_rate": 0.02714925540397523,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c7",
+    "generation": 0,
+    "fitness": 60.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_elite0",
+    "generation": 1,
+    "fitness": 62.0,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c0"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c1",
+    "generation": 1,
+    "fitness": 59.0,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c2",
+    "generation": 1,
+    "fitness": 54.0,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c2"
+    ],
+    "metadata": {
+      "final_population": 54,
+      "raw_fitness": 54.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c3",
+    "generation": 1,
+    "fitness": 75.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c1"
+    ],
+    "metadata": {
+      "final_population": 75,
+      "raw_fitness": 75.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c4",
+    "generation": 1,
+    "fitness": 65.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c0"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c5",
+    "generation": 1,
+    "fitness": 63.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c6",
+    "generation": 1,
+    "fitness": 55.0,
+    "learning_rate": 0.3010177569827123,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c2"
+    ],
+    "metadata": {
+      "final_population": 55,
+      "raw_fitness": 55.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c7",
+    "generation": 1,
+    "fitness": 65.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c1",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_elite0",
+    "generation": 2,
+    "fitness": 64.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c3"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c1",
+    "generation": 2,
+    "fitness": 63.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c2",
+    "generation": 2,
+    "fitness": 62.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c7",
+      "g1_c7"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c3",
+    "generation": 2,
+    "fitness": 63.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c1"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c4",
+    "generation": 2,
+    "fitness": 67.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c4",
+      "g1_c7"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c5",
+    "generation": 2,
+    "fitness": 61.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c7"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c6",
+    "generation": 2,
+    "fitness": 55.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c3"
+    ],
+    "metadata": {
+      "final_population": 55,
+      "raw_fitness": 55.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c7",
+    "generation": 2,
+    "fitness": 72.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c7",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 72,
+      "raw_fitness": 72.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_elite0",
+    "generation": 3,
+    "fitness": 65.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c7",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c1",
+    "generation": 3,
+    "fitness": 64.0,
+    "learning_rate": 0.00996096416088228,
+    "parent_ids": [
+      "g2_elite0",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c2",
+    "generation": 3,
+    "fitness": 64.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c4",
+      "g2_c4"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c3",
+    "generation": 3,
+    "fitness": 63.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g2_c3",
+      "g2_elite0"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c4",
+    "generation": 3,
+    "fitness": 73.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_elite0",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 73,
+      "raw_fitness": 73.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c5",
+    "generation": 3,
+    "fitness": 67.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c7",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c6",
+    "generation": 3,
+    "fitness": 60.0,
+    "learning_rate": 0.09175441322821346,
+    "parent_ids": [
+      "g2_c7",
+      "g2_c3"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c7",
+    "generation": 3,
+    "fitness": 64.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_elite0",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_elite0",
+    "generation": 4,
+    "fitness": 60.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c4",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c1",
+    "generation": 4,
+    "fitness": 62.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c2",
+    "generation": 4,
+    "fitness": 70.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c5",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c3",
+    "generation": 4,
+    "fitness": 65.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c2",
+      "g3_c7"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c4",
+    "generation": 4,
+    "fitness": 63.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c1",
+      "g3_c7"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c5",
+    "generation": 4,
+    "fitness": 66.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_elite0",
+      "g3_c7"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c6",
+    "generation": 4,
+    "fitness": 65.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c5",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c7",
+    "generation": 4,
+    "fitness": 59.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_elite0",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_elite0",
+    "generation": 5,
+    "fitness": 69.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c2",
+      "g4_c2"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c1",
+    "generation": 5,
+    "fitness": 65.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c2",
+      "g4_c3"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c2",
+    "generation": 5,
+    "fitness": 69.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c5",
+      "g4_c2"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c3",
+    "generation": 5,
+    "fitness": 56.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c6",
+      "g4_c2"
+    ],
+    "metadata": {
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c4",
+    "generation": 5,
+    "fitness": 68.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c4",
+      "g4_c4"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c5",
+    "generation": 5,
+    "fitness": 62.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c2",
+      "g4_c6"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c6",
+    "generation": 5,
+    "fitness": 69.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c3",
+      "g4_c5"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c7",
+    "generation": 5,
+    "fitness": 66.0,
+    "learning_rate": 0.41489860160304487,
+    "parent_ids": [
+      "g4_c5",
+      "g4_c2"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
+    }
+  }
+]

--- a/experiments/evolution_convergence/run_clamp_penalty002_g6/evolution_generation_summaries.json
+++ b/experiments/evolution_convergence/run_clamp_penalty002_g6/evolution_generation_summaries.json
@@ -1,0 +1,212 @@
+[
+  {
+    "generation": 0,
+    "best_fitness": 70.0,
+    "mean_fitness": 63.61521249698455,
+    "min_fitness": 54.98,
+    "best_candidate_id": "g0_c1",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.055658525648276516,
+        "median": 0.02662644272048611,
+        "std": 0.06118633982230562,
+        "min": 1e-06,
+        "max": 0.15942878976101
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.15942878976101,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 1,
+    "best_fitness": 75.0,
+    "mean_fitness": 65.2425,
+    "min_fitness": 57.0,
+    "best_candidate_id": "g1_c3",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.11152986975338322,
+        "median": 0.14923162577966526,
+        "std": 0.09463761859750551,
+        "min": 1e-06,
+        "max": 0.2749151269457153
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.15942878976101,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 2,
+    "best_fitness": 69.0,
+    "mean_fitness": 63.870000000000005,
+    "min_fitness": 56.0,
+    "best_candidate_id": "g2_elite0",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.13400763446884564,
+        "median": 0.15942878976101,
+        "std": 0.08587902340021279,
+        "min": 1e-06,
+        "max": 0.2749151269457153
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.15942878976101,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 3,
+    "best_fitness": 70.0,
+    "mean_fitness": 62.742997998706045,
+    "min_fitness": 58.0,
+    "best_candidate_id": "g3_c2",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.09242906705414196,
+        "median": 0.12559160149461174,
+        "std": 0.07232149549279666,
+        "min": 1e-06,
+        "max": 0.15942878976101
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.15942878976101,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 4,
+    "best_fitness": 74.0,
+    "mean_fitness": 65.6225,
+    "min_fitness": 61.0,
+    "best_candidate_id": "g4_c5",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.13950031604088375,
+        "median": 0.15942878976101,
+        "std": 0.05272578547254026,
+        "min": 1e-06,
+        "max": 0.15942878976101
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.15942878976101,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 5,
+    "best_fitness": 79.0,
+    "mean_fitness": 70.0,
+    "min_fitness": 60.0,
+    "best_candidate_id": "g5_c3",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.2112909899613906,
+        "median": 0.15942878976101,
+        "std": 0.13721448417485127,
+        "min": 0.15942878976101,
+        "max": 0.5743263913640548
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.15942878976101,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  }
+]

--- a/experiments/evolution_convergence/run_clamp_penalty002_g6/evolution_lineage.json
+++ b/experiments/evolution_convergence/run_clamp_penalty002_g6/evolution_lineage.json
@@ -1,0 +1,722 @@
+[
+  {
+    "candidate_id": "g0_c0",
+    "generation": 0,
+    "fitness": 63.9803996003996,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.019600399600399603
+    }
+  },
+  {
+    "candidate_id": "g0_c1",
+    "generation": 0,
+    "fitness": 70.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c2",
+    "generation": 0,
+    "fitness": 62.99044106245586,
+    "learning_rate": 0.02610363003699699,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.009558937544138748
+    }
+  },
+  {
+    "candidate_id": "g0_c3",
+    "generation": 0,
+    "fitness": 54.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 55,
+      "raw_fitness": 55.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g0_c4",
+    "generation": 0,
+    "fitness": 69.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g0_c5",
+    "generation": 0,
+    "fitness": 64.0,
+    "learning_rate": 0.13903446179832052,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c6",
+    "generation": 0,
+    "fitness": 60.990859313020906,
+    "learning_rate": 0.02714925540397523,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.009140686979096889
+    }
+  },
+  {
+    "candidate_id": "g0_c7",
+    "generation": 0,
+    "fitness": 62.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_elite0",
+    "generation": 1,
+    "fitness": 63.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g0_c1",
+      "g0_c1"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c1",
+    "generation": 1,
+    "fitness": 57.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g0_c1",
+      "g0_c1"
+    ],
+    "metadata": {
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c2",
+    "generation": 1,
+    "fitness": 58.0,
+    "learning_rate": 0.13903446179832052,
+    "parent_ids": [
+      "g0_c5",
+      "g0_c2"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c3",
+    "generation": 1,
+    "fitness": 75.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c1"
+    ],
+    "metadata": {
+      "final_population": 75,
+      "raw_fitness": 75.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c4",
+    "generation": 1,
+    "fitness": 71.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 72,
+      "raw_fitness": 72.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g1_c5",
+    "generation": 1,
+    "fitness": 60.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c1",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g1_c6",
+    "generation": 1,
+    "fitness": 69.0,
+    "learning_rate": 0.2749151269457153,
+    "parent_ids": [
+      "g0_c5",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c7",
+    "generation": 1,
+    "fitness": 66.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c1",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g2_elite0",
+    "generation": 2,
+    "fitness": 69.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c3"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c1",
+    "generation": 2,
+    "fitness": 63.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c2",
+    "generation": 2,
+    "fitness": 63.0,
+    "learning_rate": 0.2749151269457153,
+    "parent_ids": [
+      "g1_c6",
+      "g1_c7"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c3",
+    "generation": 2,
+    "fitness": 56.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c6"
+    ],
+    "metadata": {
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c4",
+    "generation": 2,
+    "fitness": 65.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c4",
+      "g1_c6"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g2_c5",
+    "generation": 2,
+    "fitness": 63.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c6",
+    "generation": 2,
+    "fitness": 62.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c3"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c7",
+    "generation": 2,
+    "fitness": 68.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c6",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g3_elite0",
+    "generation": 3,
+    "fitness": 63.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g2_elite0",
+      "g2_elite0"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c1",
+    "generation": 3,
+    "fitness": 61.983983989648344,
+    "learning_rate": 0.00996096416088228,
+    "parent_ids": [
+      "g2_elite0",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.01601601035165744
+    }
+  },
+  {
+    "candidate_id": "g3_c2",
+    "generation": 3,
+    "fitness": 70.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g2_elite0",
+      "g2_elite0"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c3",
+    "generation": 3,
+    "fitness": 62.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g2_c1",
+      "g2_elite0"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c4",
+    "generation": 3,
+    "fitness": 64.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g2_elite0",
+      "g2_elite0"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c5",
+    "generation": 3,
+    "fitness": 60.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c7",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g3_c6",
+    "generation": 3,
+    "fitness": 58.0,
+    "learning_rate": 0.09175441322821346,
+    "parent_ids": [
+      "g2_c7",
+      "g2_c2"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c7",
+    "generation": 3,
+    "fitness": 61.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_elite0",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g4_elite0",
+    "generation": 4,
+    "fitness": 64.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_c2",
+      "g3_c2"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c1",
+    "generation": 4,
+    "fitness": 65.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_c2",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c2",
+    "generation": 4,
+    "fitness": 63.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_elite0",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c3",
+    "generation": 4,
+    "fitness": 61.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_c2",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c4",
+    "generation": 4,
+    "fitness": 67.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_c2",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c5",
+    "generation": 4,
+    "fitness": 74.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_elite0",
+      "g3_c2"
+    ],
+    "metadata": {
+      "final_population": 74,
+      "raw_fitness": 74.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c6",
+    "generation": 4,
+    "fitness": 63.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g4_c7",
+    "generation": 4,
+    "fitness": 67.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_elite0",
+      "g3_c2"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_elite0",
+    "generation": 5,
+    "fitness": 68.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g4_c5",
+      "g4_c5"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c1",
+    "generation": 5,
+    "fitness": 70.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g4_c5",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c2",
+    "generation": 5,
+    "fitness": 66.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g4_c5",
+      "g4_c1"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c3",
+    "generation": 5,
+    "fitness": 79.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g4_c4",
+      "g4_c5"
+    ],
+    "metadata": {
+      "final_population": 79,
+      "raw_fitness": 79.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c4",
+    "generation": 5,
+    "fitness": 67.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g4_c4",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c5",
+    "generation": 5,
+    "fitness": 60.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g4_c1",
+      "g4_c4"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c6",
+    "generation": 5,
+    "fitness": 75.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g4_c7",
+      "g4_c5"
+    ],
+    "metadata": {
+      "final_population": 75,
+      "raw_fitness": 75.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c7",
+    "generation": 5,
+    "fitness": 75.0,
+    "learning_rate": 0.5743263913640548,
+    "parent_ids": [
+      "g4_c5",
+      "g4_elite0"
+    ],
+    "metadata": {
+      "final_population": 75,
+      "raw_fitness": 75.0,
+      "boundary_penalty": 0.0
+    }
+  }
+]

--- a/experiments/evolution_convergence/run_clamp_penalty005_g6/evolution_generation_summaries.json
+++ b/experiments/evolution_convergence/run_clamp_penalty005_g6/evolution_generation_summaries.json
@@ -1,0 +1,212 @@
+[
+  {
+    "generation": 0,
+    "best_fitness": 68.950999000999,
+    "mean_fitness": 63.850531242461365,
+    "min_fitness": 60.95,
+    "best_candidate_id": "g0_c0",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.055658525648276516,
+        "median": 0.02662644272048611,
+        "std": 0.06118633982230562,
+        "min": 1e-06,
+        "max": 0.15942878976101
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.001,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 1,
+    "best_fitness": 67.0,
+    "mean_fitness": 62.587874625374624,
+    "min_fitness": 56.95,
+    "best_candidate_id": "g1_c3",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.04630852439145308,
+        "median": 0.001,
+        "std": 0.09150888392478951,
+        "min": 1e-06,
+        "max": 0.2749151269457153
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.09255006818590938,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 2,
+    "best_fitness": 73.0,
+    "mean_fitness": 66.23774975024975,
+    "min_fitness": 56.0,
+    "best_candidate_id": "g2_c5",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.09245818348440778,
+        "median": 0.09255006818590938,
+        "std": 0.07907257511597322,
+        "min": 0.001,
+        "max": 0.2749151269457153
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.09255006818590938,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 3,
+    "best_fitness": 70.95,
+    "mean_fitness": 64.59549449726461,
+    "min_fitness": 59.0,
+    "best_candidate_id": "g3_c7",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.03647681422011431,
+        "median": 0.005979982080441142,
+        "std": 0.04360745767373774,
+        "min": 1e-06,
+        "max": 0.09275341322821345
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 4,
+    "best_fitness": 67.95,
+    "mean_fitness": 64.20136987188998,
+    "min_fitness": 57.95,
+    "best_candidate_id": "g4_c5",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.0013708705201102853,
+        "median": 1e-06,
+        "std": 0.00362433672457052,
+        "min": 1e-06,
+        "max": 0.010959964160882282
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 5,
+    "best_fitness": 67.95,
+    "mean_fitness": 63.456250000000004,
+    "min_fitness": 59.95,
+    "best_candidate_id": "g5_c4",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.051863200200380606,
+        "median": 1e-06,
+        "std": 0.13721448417485127,
+        "min": 1e-06,
+        "max": 0.41489860160304487
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  }
+]

--- a/experiments/evolution_convergence/run_clamp_penalty005_g6/evolution_lineage.json
+++ b/experiments/evolution_convergence/run_clamp_penalty005_g6/evolution_lineage.json
@@ -1,0 +1,722 @@
+[
+  {
+    "candidate_id": "g0_c0",
+    "generation": 0,
+    "fitness": 68.950999000999,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.049000999000999
+    }
+  },
+  {
+    "candidate_id": "g0_c1",
+    "generation": 0,
+    "fitness": 62.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c2",
+    "generation": 0,
+    "fitness": 63.97610265613965,
+    "learning_rate": 0.02610363003699699,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.02389734386034687
+    }
+  },
+  {
+    "candidate_id": "g0_c3",
+    "generation": 0,
+    "fitness": 60.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g0_c4",
+    "generation": 0,
+    "fitness": 66.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g0_c5",
+    "generation": 0,
+    "fitness": 62.0,
+    "learning_rate": 0.13903446179832052,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c6",
+    "generation": 0,
+    "fitness": 61.97714828255226,
+    "learning_rate": 0.02714925540397523,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.022851717447742222
+    }
+  },
+  {
+    "candidate_id": "g0_c7",
+    "generation": 0,
+    "fitness": 64.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_elite0",
+    "generation": 1,
+    "fitness": 66.950999000999,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c0"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.049000999000999
+    }
+  },
+  {
+    "candidate_id": "g1_c1",
+    "generation": 1,
+    "fitness": 62.950999000999,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.049000999000999
+    }
+  },
+  {
+    "candidate_id": "g1_c2",
+    "generation": 1,
+    "fitness": 59.950999000999,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c7"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.049000999000999
+    }
+  },
+  {
+    "candidate_id": "g1_c3",
+    "generation": 1,
+    "fitness": 67.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c7"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c4",
+    "generation": 1,
+    "fitness": 63.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c0"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g1_c5",
+    "generation": 1,
+    "fitness": 56.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g1_c6",
+    "generation": 1,
+    "fitness": 65.0,
+    "learning_rate": 0.2749151269457153,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c7",
+    "generation": 1,
+    "fitness": 57.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g2_elite0",
+    "generation": 2,
+    "fitness": 66.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c3"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c1",
+    "generation": 2,
+    "fitness": 69.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c2",
+    "generation": 2,
+    "fitness": 60.0,
+    "learning_rate": 0.2749151269457153,
+    "parent_ids": [
+      "g1_c6",
+      "g1_c1"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c3",
+    "generation": 2,
+    "fitness": 63.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c6"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c4",
+    "generation": 2,
+    "fitness": 72.950999000999,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g1_elite0",
+      "g1_c6"
+    ],
+    "metadata": {
+      "final_population": 73,
+      "raw_fitness": 73.0,
+      "boundary_penalty": 0.049000999000999
+    }
+  },
+  {
+    "candidate_id": "g2_c5",
+    "generation": 2,
+    "fitness": 73.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 73,
+      "raw_fitness": 73.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c6",
+    "generation": 2,
+    "fitness": 56.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c3"
+    ],
+    "metadata": {
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c7",
+    "generation": 2,
+    "fitness": 69.950999000999,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g1_c6",
+      "g1_elite0"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.049000999000999
+    }
+  },
+  {
+    "candidate_id": "g3_elite0",
+    "generation": 3,
+    "fitness": 60.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "g2_c5",
+      "g2_c5"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c1",
+    "generation": 3,
+    "fitness": 63.96095897511986,
+    "learning_rate": 0.010959964160882282,
+    "parent_ids": [
+      "g2_c5",
+      "g2_c4"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.039041024880142605
+    }
+  },
+  {
+    "candidate_id": "g3_c2",
+    "generation": 3,
+    "fitness": 62.950999000999,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g2_c4",
+      "g2_c4"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.049000999000999
+    }
+  },
+  {
+    "candidate_id": "g3_c3",
+    "generation": 3,
+    "fitness": 59.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "g2_c5",
+      "g2_c1"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c4",
+    "generation": 3,
+    "fitness": 63.950999000999,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g2_c5",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.049000999000999
+    }
+  },
+  {
+    "candidate_id": "g3_c5",
+    "generation": 3,
+    "fitness": 69.950999000999,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g2_c4",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.049000999000999
+    }
+  },
+  {
+    "candidate_id": "g3_c6",
+    "generation": 3,
+    "fitness": 66.0,
+    "learning_rate": 0.09275341322821345,
+    "parent_ids": [
+      "g2_c4",
+      "g2_c3"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c7",
+    "generation": 3,
+    "fitness": 70.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c1",
+      "g2_c5"
+    ],
+    "metadata": {
+      "final_population": 71,
+      "raw_fitness": 71.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g4_elite0",
+    "generation": 4,
+    "fitness": 57.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c7"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g4_c1",
+    "generation": 4,
+    "fitness": 66.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c5"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g4_c2",
+    "generation": 4,
+    "fitness": 66.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c5"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g4_c3",
+    "generation": 4,
+    "fitness": 63.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c7"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g4_c4",
+    "generation": 4,
+    "fitness": 64.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c1",
+      "g3_c7"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g4_c5",
+    "generation": 4,
+    "fitness": 67.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c1",
+      "g3_c7"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g4_c6",
+    "generation": 4,
+    "fitness": 62.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c6"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g4_c7",
+    "generation": 4,
+    "fitness": 61.96095897511986,
+    "learning_rate": 0.010959964160882282,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c1"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.039041024880142605
+    }
+  },
+  {
+    "candidate_id": "g5_elite0",
+    "generation": 5,
+    "fitness": 66.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c5",
+      "g4_c5"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g5_c1",
+    "generation": 5,
+    "fitness": 59.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c5",
+      "g4_c1"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g5_c2",
+    "generation": 5,
+    "fitness": 63.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c5",
+      "g4_c2"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g5_c3",
+    "generation": 5,
+    "fitness": 59.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c1",
+      "g4_c5"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g5_c4",
+    "generation": 5,
+    "fitness": 67.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c4",
+      "g4_c1"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g5_c5",
+    "generation": 5,
+    "fitness": 59.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c1",
+      "g4_c1"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g5_c6",
+    "generation": 5,
+    "fitness": 65.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c4",
+      "g4_c5"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g5_c7",
+    "generation": 5,
+    "fitness": 63.0,
+    "learning_rate": 0.41489860160304487,
+    "parent_ids": [
+      "g4_c5",
+      "g4_c2"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  }
+]

--- a/experiments/evolution_convergence/run_clamp_penalty010_g6/evolution_generation_summaries.json
+++ b/experiments/evolution_convergence/run_clamp_penalty010_g6/evolution_generation_summaries.json
@@ -1,0 +1,212 @@
+[
+  {
+    "generation": 0,
+    "best_fitness": 74.901998001998,
+    "mean_fitness": 66.20106248492273,
+    "min_fitness": 57.9,
+    "best_candidate_id": "g0_c0",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.055658525648276516,
+        "median": 0.02662644272048611,
+        "std": 0.06118633982230562,
+        "min": 1e-06,
+        "max": 0.15942878976101
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.001,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 1,
+    "best_fitness": 77.0,
+    "mean_fitness": 67.42574925074925,
+    "min_fitness": 57.901998001998,
+    "best_candidate_id": "g1_c3",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.05466836458834066,
+        "median": 0.001,
+        "std": 0.09816429171109597,
+        "min": 1e-06,
+        "max": 0.2749151269457153
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.15942878976101,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 2,
+    "best_fitness": 71.9,
+    "mean_fitness": 64.725,
+    "min_fitness": 53.0,
+    "best_candidate_id": "g2_c7",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.13400763446884564,
+        "median": 0.15942878976101,
+        "std": 0.08587902340021279,
+        "min": 1e-06,
+        "max": 0.2749151269457153
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 3,
+    "best_fitness": 70.0,
+    "mean_fitness": 63.81498999353022,
+    "min_fitness": 57.0,
+    "best_candidate_id": "g3_c3",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.05257211961388947,
+        "median": 0.00498098208044114,
+        "std": 0.06822989546526871,
+        "min": 1e-06,
+        "max": 0.15942878976101
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.15942878976101,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 4,
+    "best_fitness": 68.0,
+    "mean_fitness": 64.225,
+    "min_fitness": 56.0,
+    "best_candidate_id": "g4_c5",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.11957184232075749,
+        "median": 0.15942878976101,
+        "std": 0.06903425800111963,
+        "min": 1e-06,
+        "max": 0.15942878976101
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.15942878976101,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 5,
+    "best_fitness": 73.0,
+    "mean_fitness": 64.85,
+    "min_fitness": 59.9,
+    "best_candidate_id": "g5_c6",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.17143404252113809,
+        "median": 0.15942878976101,
+        "std": 0.1665163097722878,
+        "min": 1e-06,
+        "max": 0.5743263913640548
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.15942878976101,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  }
+]

--- a/experiments/evolution_convergence/run_clamp_penalty010_g6/evolution_lineage.json
+++ b/experiments/evolution_convergence/run_clamp_penalty010_g6/evolution_lineage.json
@@ -1,0 +1,722 @@
+[
+  {
+    "candidate_id": "g0_c0",
+    "generation": 0,
+    "fitness": 74.901998001998,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 75,
+      "raw_fitness": 75.0,
+      "boundary_penalty": 0.098001998001998
+    }
+  },
+  {
+    "candidate_id": "g0_c1",
+    "generation": 0,
+    "fitness": 65.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c2",
+    "generation": 0,
+    "fitness": 60.952205312279304,
+    "learning_rate": 0.02610363003699699,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.04779468772069374
+    }
+  },
+  {
+    "candidate_id": "g0_c3",
+    "generation": 0,
+    "fitness": 57.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g0_c4",
+    "generation": 0,
+    "fitness": 72.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 73,
+      "raw_fitness": 73.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g0_c5",
+    "generation": 0,
+    "fitness": 65.0,
+    "learning_rate": 0.13903446179832052,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c6",
+    "generation": 0,
+    "fitness": 67.95429656510451,
+    "learning_rate": 0.02714925540397523,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.045703434895484445
+    }
+  },
+  {
+    "candidate_id": "g0_c7",
+    "generation": 0,
+    "fitness": 65.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_elite0",
+    "generation": 1,
+    "fitness": 61.901998001998,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c0"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.098001998001998
+    }
+  },
+  {
+    "candidate_id": "g1_c1",
+    "generation": 1,
+    "fitness": 57.901998001998,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.098001998001998
+    }
+  },
+  {
+    "candidate_id": "g1_c2",
+    "generation": 1,
+    "fitness": 63.901998001998,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c7"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.098001998001998
+    }
+  },
+  {
+    "candidate_id": "g1_c3",
+    "generation": 1,
+    "fitness": 77.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c1"
+    ],
+    "metadata": {
+      "final_population": 77,
+      "raw_fitness": 77.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c4",
+    "generation": 1,
+    "fitness": 76.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c0"
+    ],
+    "metadata": {
+      "final_population": 77,
+      "raw_fitness": 77.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g1_c5",
+    "generation": 1,
+    "fitness": 71.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 72,
+      "raw_fitness": 72.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g1_c6",
+    "generation": 1,
+    "fitness": 65.0,
+    "learning_rate": 0.2749151269457153,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c7",
+    "generation": 1,
+    "fitness": 64.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g2_elite0",
+    "generation": 2,
+    "fitness": 67.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c3"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c1",
+    "generation": 2,
+    "fitness": 62.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c2",
+    "generation": 2,
+    "fitness": 53.0,
+    "learning_rate": 0.2749151269457153,
+    "parent_ids": [
+      "g1_c6",
+      "g1_c5"
+    ],
+    "metadata": {
+      "final_population": 53,
+      "raw_fitness": 53.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c3",
+    "generation": 2,
+    "fitness": 64.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c6"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c4",
+    "generation": 2,
+    "fitness": 64.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c4",
+      "g1_c6"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g2_c5",
+    "generation": 2,
+    "fitness": 70.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c6",
+    "generation": 2,
+    "fitness": 65.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c3"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c7",
+    "generation": 2,
+    "fitness": 71.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c6",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 72,
+      "raw_fitness": 72.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g3_elite0",
+    "generation": 3,
+    "fitness": 58.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c7",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g3_c1",
+    "generation": 3,
+    "fitness": 62.91991994824171,
+    "learning_rate": 0.00996096416088228,
+    "parent_ids": [
+      "g2_c5",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0800800517582872
+    }
+  },
+  {
+    "candidate_id": "g3_c2",
+    "generation": 3,
+    "fitness": 69.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g2_elite0",
+      "g2_elite0"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c3",
+    "generation": 3,
+    "fitness": 70.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g2_c5",
+      "g2_elite0"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c4",
+    "generation": 3,
+    "fitness": 57.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c5",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g3_c5",
+    "generation": 3,
+    "fitness": 69.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c7",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g3_c6",
+    "generation": 3,
+    "fitness": 57.0,
+    "learning_rate": 0.09175441322821346,
+    "parent_ids": [
+      "g2_c7",
+      "g2_c6"
+    ],
+    "metadata": {
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c7",
+    "generation": 3,
+    "fitness": 64.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_elite0",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g4_elite0",
+    "generation": 4,
+    "fitness": 63.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c1",
+    "generation": 4,
+    "fitness": 56.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c2",
+    "generation": 4,
+    "fitness": 67.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c5",
+      "g3_c5"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g4_c3",
+    "generation": 4,
+    "fitness": 62.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_c2",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c4",
+    "generation": 4,
+    "fitness": 64.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c5",
+    "generation": 4,
+    "fitness": 68.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c6",
+    "generation": 4,
+    "fitness": 65.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c5",
+      "g3_c1"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g4_c7",
+    "generation": 4,
+    "fitness": 67.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c2"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_elite0",
+    "generation": 5,
+    "fitness": 61.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g4_c5",
+      "g4_c5"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c1",
+    "generation": 5,
+    "fitness": 60.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g4_c5",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c2",
+    "generation": 5,
+    "fitness": 71.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c5",
+      "g4_c2"
+    ],
+    "metadata": {
+      "final_population": 72,
+      "raw_fitness": 72.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g5_c3",
+    "generation": 5,
+    "fitness": 62.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g4_c6",
+      "g4_c5"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c4",
+    "generation": 5,
+    "fitness": 67.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g4_c7",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c5",
+    "generation": 5,
+    "fitness": 59.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c2",
+      "g4_c6"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g5_c6",
+    "generation": 5,
+    "fitness": 73.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g4_c7",
+      "g4_c5"
+    ],
+    "metadata": {
+      "final_population": 73,
+      "raw_fitness": 73.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c7",
+    "generation": 5,
+    "fitness": 64.0,
+    "learning_rate": 0.5743263913640548,
+    "parent_ids": [
+      "g4_c5",
+      "g4_c2"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  }
+]

--- a/experiments/evolution_convergence/run_clamp_penalty_g6/evolution_generation_summaries.json
+++ b/experiments/evolution_convergence/run_clamp_penalty_g6/evolution_generation_summaries.json
@@ -1,0 +1,212 @@
+[
+  {
+    "generation": 0,
+    "best_fitness": 75.99,
+    "mean_fitness": 65.74510624849228,
+    "min_fitness": 53.99,
+    "best_candidate_id": "g0_c4",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.055658525648276516,
+        "median": 0.02662644272048611,
+        "std": 0.06118633982230562,
+        "min": 1e-06,
+        "max": 0.15942878976101
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 1,
+    "best_fitness": 72.99,
+    "mean_fitness": 66.61754995004995,
+    "min_fitness": 58.9901998001998,
+    "best_candidate_id": "g1_c7",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.05454348958834066,
+        "median": 0.0005005,
+        "std": 0.09823309522536923,
+        "min": 1e-06,
+        "max": 0.2749151269457153
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 2,
+    "best_fitness": 69.99,
+    "mean_fitness": 62.61875,
+    "min_fitness": 56.0,
+    "best_candidate_id": "g2_c5",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.059786421160378744,
+        "median": 1e-06,
+        "std": 0.07718264683338114,
+        "min": 1e-06,
+        "max": 0.15942878976101
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 3,
+    "best_fitness": 72.99,
+    "mean_fitness": 65.24149899935301,
+    "min_fitness": 59.99199199482417,
+    "best_candidate_id": "g3_c2",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.032643645893763215,
+        "median": 1e-06,
+        "std": 0.08266412384888819,
+        "min": 1e-06,
+        "max": 0.25118220298922345
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 4,
+    "best_fitness": 71.99,
+    "mean_fitness": 64.49,
+    "min_fitness": 57.99,
+    "best_candidate_id": "g4_c4",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 1e-06,
+        "median": 1e-06,
+        "std": 0.0,
+        "min": 1e-06,
+        "max": 1e-06
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 5,
+    "best_fitness": 73.99,
+    "mean_fitness": 64.36625,
+    "min_fitness": 59.99,
+    "best_candidate_id": "g5_elite0",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.051863200200380606,
+        "median": 1e-06,
+        "std": 0.13721448417485127,
+        "min": 1e-06,
+        "max": 0.41489860160304487
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  }
+]

--- a/experiments/evolution_convergence/run_clamp_penalty_g6/evolution_lineage.json
+++ b/experiments/evolution_convergence/run_clamp_penalty_g6/evolution_lineage.json
@@ -1,0 +1,722 @@
+[
+  {
+    "candidate_id": "g0_c0",
+    "generation": 0,
+    "fitness": 69.9901998001998,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.009800199800199801
+    }
+  },
+  {
+    "candidate_id": "g0_c1",
+    "generation": 0,
+    "fitness": 69.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c2",
+    "generation": 0,
+    "fitness": 63.99522053122793,
+    "learning_rate": 0.02610363003699699,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.004779468772069374
+    }
+  },
+  {
+    "candidate_id": "g0_c3",
+    "generation": 0,
+    "fitness": 53.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 54,
+      "raw_fitness": 54.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g0_c4",
+    "generation": 0,
+    "fitness": 75.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 76,
+      "raw_fitness": 76.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g0_c5",
+    "generation": 0,
+    "fitness": 66.0,
+    "learning_rate": 0.13903446179832052,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c6",
+    "generation": 0,
+    "fitness": 59.99542965651045,
+    "learning_rate": 0.02714925540397523,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0045703434895484445
+    }
+  },
+  {
+    "candidate_id": "g0_c7",
+    "generation": 0,
+    "fitness": 67.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_elite0",
+    "generation": 1,
+    "fitness": 64.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g1_c1",
+    "generation": 1,
+    "fitness": 58.9901998001998,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.009800199800199801
+    }
+  },
+  {
+    "candidate_id": "g1_c2",
+    "generation": 1,
+    "fitness": 64.9901998001998,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c7"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.009800199800199801
+    }
+  },
+  {
+    "candidate_id": "g1_c3",
+    "generation": 1,
+    "fitness": 69.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c1"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c4",
+    "generation": 1,
+    "fitness": 68.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g1_c5",
+    "generation": 1,
+    "fitness": 66.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g1_c6",
+    "generation": 1,
+    "fitness": 66.0,
+    "learning_rate": 0.2749151269457153,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c7",
+    "generation": 1,
+    "fitness": 72.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 73,
+      "raw_fitness": 73.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g2_elite0",
+    "generation": 2,
+    "fitness": 65.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c7",
+      "g1_c7"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g2_c1",
+    "generation": 2,
+    "fitness": 64.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c2",
+    "generation": 2,
+    "fitness": 62.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c7",
+      "g1_c7"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g2_c3",
+    "generation": 2,
+    "fitness": 57.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c6"
+    ],
+    "metadata": {
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c4",
+    "generation": 2,
+    "fitness": 61.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c4",
+      "g1_c7"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g2_c5",
+    "generation": 2,
+    "fitness": 69.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c7",
+      "g1_c7"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g2_c6",
+    "generation": 2,
+    "fitness": 56.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c3"
+    ],
+    "metadata": {
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c7",
+    "generation": 2,
+    "fitness": 62.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c7",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g3_elite0",
+    "generation": 3,
+    "fitness": 60.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c5",
+      "g2_c5"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g3_c1",
+    "generation": 3,
+    "fitness": 59.99199199482417,
+    "learning_rate": 0.00996096416088228,
+    "parent_ids": [
+      "g2_c5",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.00800800517582872
+    }
+  },
+  {
+    "candidate_id": "g3_c2",
+    "generation": 3,
+    "fitness": 72.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_elite0",
+      "g2_elite0"
+    ],
+    "metadata": {
+      "final_population": 73,
+      "raw_fitness": 73.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g3_c3",
+    "generation": 3,
+    "fitness": 69.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c5",
+      "g2_elite0"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g3_c4",
+    "generation": 3,
+    "fitness": 67.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c5",
+      "g2_elite0"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g3_c5",
+    "generation": 3,
+    "fitness": 65.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c2",
+      "g2_c1"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g3_c6",
+    "generation": 3,
+    "fitness": 62.0,
+    "learning_rate": 0.25118220298922345,
+    "parent_ids": [
+      "g2_c1",
+      "g2_c2"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c7",
+    "generation": 3,
+    "fitness": 61.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_elite0",
+      "g2_c5"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g4_elite0",
+    "generation": 4,
+    "fitness": 64.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c2",
+      "g3_c2"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g4_c1",
+    "generation": 4,
+    "fitness": 59.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c2",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g4_c2",
+    "generation": 4,
+    "fitness": 67.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c5",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g4_c3",
+    "generation": 4,
+    "fitness": 57.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c2",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g4_c4",
+    "generation": 4,
+    "fitness": 71.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c2",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 72,
+      "raw_fitness": 72.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g4_c5",
+    "generation": 4,
+    "fitness": 67.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c2"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g4_c6",
+    "generation": 4,
+    "fitness": 65.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c5",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g4_c7",
+    "generation": 4,
+    "fitness": 58.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c2"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g5_elite0",
+    "generation": 5,
+    "fitness": 73.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c4",
+      "g4_c4"
+    ],
+    "metadata": {
+      "final_population": 74,
+      "raw_fitness": 74.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g5_c1",
+    "generation": 5,
+    "fitness": 59.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c2",
+      "g4_c1"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g5_c2",
+    "generation": 5,
+    "fitness": 60.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c4",
+      "g4_c2"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g5_c3",
+    "generation": 5,
+    "fitness": 59.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c4",
+      "g4_c2"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g5_c4",
+    "generation": 5,
+    "fitness": 68.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c4",
+      "g4_c4"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g5_c5",
+    "generation": 5,
+    "fitness": 63.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c2",
+      "g4_c4"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g5_c6",
+    "generation": 5,
+    "fitness": 59.99,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c4",
+      "g4_c5"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g5_c7",
+    "generation": 5,
+    "fitness": 67.0,
+    "learning_rate": 0.41489860160304487,
+    "parent_ids": [
+      "g4_c5",
+      "g4_c2"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
+    }
+  }
+]

--- a/experiments/evolution_convergence/run_reflect_g6/evolution_generation_summaries.json
+++ b/experiments/evolution_convergence/run_reflect_g6/evolution_generation_summaries.json
@@ -1,0 +1,212 @@
+[
+  {
+    "generation": 0,
+    "best_fitness": 74.0,
+    "mean_fitness": 62.5,
+    "min_fitness": 54.0,
+    "best_candidate_id": "g0_c4",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.12612675567165654,
+        "median": 0.11579226499211495,
+        "std": 0.11430491469893234,
+        "min": 0.001,
+        "max": 0.3771357835106376
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.3771357835106376,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 1,
+    "best_fitness": 74.0,
+    "mean_fitness": 65.5,
+    "min_fitness": 56.0,
+    "best_candidate_id": "g1_c3",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.29025272928248913,
+        "median": 0.3771357835106376,
+        "std": 0.2078283687024153,
+        "min": 0.001,
+        "max": 0.6520499104563529
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.15942878976101,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 2,
+    "best_fitness": 70.0,
+    "mean_fitness": 63.25,
+    "min_fitness": 59.0,
+    "best_candidate_id": "g2_c7",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.24106891241712033,
+        "median": 0.15942878976101,
+        "std": 0.10539694514314873,
+        "min": 0.15942878976101,
+        "max": 0.3771357835106376
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.3771357835106376,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 3,
+    "best_fitness": 72.0,
+    "mean_fitness": 63.75,
+    "min_fitness": 58.0,
+    "best_candidate_id": "g3_elite0",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.3504165902925657,
+        "median": 0.3771357835106376,
+        "std": 0.08642909402798747,
+        "min": 0.15942878976101,
+        "max": 0.46888919673885104
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.3771357835106376,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 4,
+    "best_fitness": 74.0,
+    "mean_fitness": 64.5,
+    "min_fitness": 56.0,
+    "best_candidate_id": "g4_c6",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.29674065637463753,
+        "median": 0.3771357835106376,
+        "std": 0.10640793822060358,
+        "min": 0.15942878976101,
+        "max": 0.3870957476715199
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.3771357835106376,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  },
+  {
+    "generation": 5,
+    "best_fitness": 75.0,
+    "mean_fitness": 67.0,
+    "min_fitness": 59.0,
+    "best_candidate_id": "g5_c6",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.40178460949231476,
+        "median": 0.3771357835106376,
+        "std": 0.1638123308718163,
+        "min": 0.15942878976101,
+        "max": 0.7920333851136825
+      },
+      "epsilon_decay": {
+        "mean": 0.995,
+        "median": 0.995,
+        "std": 0.0,
+        "min": 0.995,
+        "max": 0.995
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.3771357835106376,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    }
+  }
+]

--- a/experiments/evolution_convergence/run_reflect_g6/evolution_lineage.json
+++ b/experiments/evolution_convergence/run_reflect_g6/evolution_lineage.json
@@ -1,0 +1,722 @@
+[
+  {
+    "candidate_id": "g0_c0",
+    "generation": 0,
+    "fitness": 70.0,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c1",
+    "generation": 0,
+    "fitness": 64.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c2",
+    "generation": 0,
+    "fitness": 54.0,
+    "learning_rate": 0.02610363003699699,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 54,
+      "raw_fitness": 54.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c3",
+    "generation": 0,
+    "fitness": 57.0,
+    "learning_rate": 0.18661205667640257,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c4",
+    "generation": 0,
+    "fitness": 74.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 74,
+      "raw_fitness": 74.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c5",
+    "generation": 0,
+    "fitness": 54.0,
+    "learning_rate": 0.13903446179832052,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 54,
+      "raw_fitness": 54.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c6",
+    "generation": 0,
+    "fitness": 63.0,
+    "learning_rate": 0.02714925540397523,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c7",
+    "generation": 0,
+    "fitness": 64.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_elite0",
+    "generation": 1,
+    "fitness": 63.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c1",
+    "generation": 1,
+    "fitness": 58.0,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c2",
+    "generation": 1,
+    "fitness": 56.0,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c7"
+    ],
+    "metadata": {
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c3",
+    "generation": 1,
+    "fitness": 74.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c1"
+    ],
+    "metadata": {
+      "final_population": 74,
+      "raw_fitness": 74.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c4",
+    "generation": 1,
+    "fitness": 72.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 72,
+      "raw_fitness": 72.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c5",
+    "generation": 1,
+    "fitness": 67.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c6",
+    "generation": 1,
+    "fitness": 63.0,
+    "learning_rate": 0.6520499104563529,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c7",
+    "generation": 1,
+    "fitness": 71.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 71,
+      "raw_fitness": 71.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_elite0",
+    "generation": 2,
+    "fitness": 61.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c3"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c1",
+    "generation": 2,
+    "fitness": 65.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c2",
+    "generation": 2,
+    "fitness": 63.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g1_c7",
+      "g1_c7"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c3",
+    "generation": 2,
+    "fitness": 59.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c6"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c4",
+    "generation": 2,
+    "fitness": 66.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g1_c4",
+      "g1_c7"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c5",
+    "generation": 2,
+    "fitness": 62.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c6",
+    "generation": 2,
+    "fitness": 60.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c3"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c7",
+    "generation": 2,
+    "fitness": 70.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g1_c7",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_elite0",
+    "generation": 3,
+    "fitness": 72.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g2_c7",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 72,
+      "raw_fitness": 72.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c1",
+    "generation": 3,
+    "fitness": 64.0,
+    "learning_rate": 0.3870957476715199,
+    "parent_ids": [
+      "g2_c5",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c2",
+    "generation": 3,
+    "fitness": 64.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g2_c4",
+      "g2_c4"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c3",
+    "generation": 3,
+    "fitness": 65.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g2_c1",
+      "g2_c1"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c4",
+    "generation": 3,
+    "fitness": 62.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g2_c5",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c5",
+    "generation": 3,
+    "fitness": 66.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g2_c7",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c6",
+    "generation": 3,
+    "fitness": 58.0,
+    "learning_rate": 0.46888919673885104,
+    "parent_ids": [
+      "g2_c7",
+      "g2_c2"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c7",
+    "generation": 3,
+    "fitness": 59.0,
+    "learning_rate": 0.2793758541265944,
+    "parent_ids": [
+      "g2_c1",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_elite0",
+    "generation": 4,
+    "fitness": 62.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g3_elite0",
+      "g3_elite0"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c1",
+    "generation": 4,
+    "fitness": 63.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c5"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c2",
+    "generation": 4,
+    "fitness": 68.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g3_elite0",
+      "g3_c5"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c3",
+    "generation": 4,
+    "fitness": 66.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g3_c2",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c4",
+    "generation": 4,
+    "fitness": 65.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c5",
+    "generation": 4,
+    "fitness": 62.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_elite0",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c6",
+    "generation": 4,
+    "fitness": 74.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g3_c5",
+      "g3_c1"
+    ],
+    "metadata": {
+      "final_population": 74,
+      "raw_fitness": 74.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c7",
+    "generation": 4,
+    "fitness": 56.0,
+    "learning_rate": 0.3870957476715199,
+    "parent_ids": [
+      "g3_elite0",
+      "g3_c1"
+    ],
+    "metadata": {
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_elite0",
+    "generation": 5,
+    "fitness": 70.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g4_c6",
+      "g4_c6"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c1",
+    "generation": 5,
+    "fitness": 59.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g4_c2",
+      "g4_c3"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c2",
+    "generation": 5,
+    "fitness": 63.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g4_c6",
+      "g4_c2"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c3",
+    "generation": 5,
+    "fitness": 69.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g4_c6",
+      "g4_c2"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c4",
+    "generation": 5,
+    "fitness": 74.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g4_c4",
+      "g4_c4"
+    ],
+    "metadata": {
+      "final_population": 74,
+      "raw_fitness": 74.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c5",
+    "generation": 5,
+    "fitness": 61.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g4_c2",
+      "g4_c6"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c6",
+    "generation": 5,
+    "fitness": 75.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g4_c3",
+      "g4_elite0"
+    ],
+    "metadata": {
+      "final_population": 75,
+      "raw_fitness": 75.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c7",
+    "generation": 5,
+    "fitness": 65.0,
+    "learning_rate": 0.7920333851136825,
+    "parent_ids": [
+      "g4_c6",
+      "g4_c2"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  }
+]

--- a/farm/core/hyperparameter_chromosome.py
+++ b/farm/core/hyperparameter_chromosome.py
@@ -589,6 +589,7 @@ def _apply_boundary(raw_value: float, min_value: float, max_value: float, mode: 
 
 def mutate_chromosome(
     chromosome: HyperparameterChromosome,
+    *,
     mutation_rate: Optional[float] = None,
     mutation_scale: Optional[float] = None,
     mutation_mode: Optional[Union[MutationMode, str]] = None,

--- a/farm/core/hyperparameter_chromosome.py
+++ b/farm/core/hyperparameter_chromosome.py
@@ -50,6 +50,53 @@ class MutationMode(str, Enum):
     MULTIPLICATIVE = "multiplicative"
 
 
+class BoundaryMode(str, Enum):
+    """Strategies for handling out-of-bound values after mutation.
+
+    - ``CLAMP`` (default): hard-clamp the mutated value to ``[min_value, max_value]``.
+      Simple and safe, but can cause boundary collapse when many mutations push
+      genes against a wall and they stay there.
+    - ``REFLECT``: bounce the mutated value back from the boundary.  If the raw
+      value overshoots by *d*, the reflected result is *d* inside the boundary.
+      This preserves the bounded invariant while avoiding absorbing edge states.
+    """
+
+    CLAMP = "clamp"
+    REFLECT = "reflect"
+
+
+@dataclass(frozen=True)
+class BoundaryPenaltyConfig:
+    """Configuration for soft fitness penalties applied near gene boundaries.
+
+    When ``enabled`` is ``True``, :func:`compute_boundary_penalty` returns a
+    positive float that the caller **subtracts** from the raw fitness score.
+    This discourages prolonged occupation of boundary values without completely
+    forbidding them.
+
+    Attributes:
+        enabled: Whether soft boundary penalties are active.  Default ``False``
+            so existing code is unaffected.
+        penalty_strength: Maximum penalty applied to a single gene sitting
+            exactly on a boundary.  Summed over all evolvable genes.  Default
+            ``0.01``.
+        near_boundary_threshold: Fraction of the gene's range within which the
+            penalty ramps linearly from zero (at the inner edge) to
+            ``penalty_strength`` (at the boundary itself).  Must be in
+            ``(0, 0.5]``.  Default ``0.05`` (5 % of range on each side).
+    """
+
+    enabled: bool = False
+    penalty_strength: float = 0.01
+    near_boundary_threshold: float = 0.05
+
+    def __post_init__(self) -> None:
+        if self.penalty_strength < 0.0:
+            raise ValueError("penalty_strength must be non-negative.")
+        if not 0.0 < self.near_boundary_threshold <= 0.5:
+            raise ValueError("near_boundary_threshold must be in (0, 0.5].")
+
+
 @dataclass(frozen=True)
 class GeneEncodingSpec:
     """Encoding settings for converting gene values to stored representations."""
@@ -509,27 +556,77 @@ def chromosome_from_learning_config(learning_config: Any) -> HyperparameterChrom
     return chromosome_from_values(overrides)
 
 
+def _apply_boundary(raw_value: float, min_value: float, max_value: float, mode: BoundaryMode) -> float:
+    """Apply a boundary strategy to a raw (possibly out-of-range) gene value.
+
+    Args:
+        raw_value: The value produced by a mutation operator before bounding.
+        min_value: Gene's lower bound (inclusive).
+        max_value: Gene's upper bound (inclusive).
+        mode: The :class:`BoundaryMode` strategy to apply.
+
+    Returns:
+        A float guaranteed to lie within ``[min_value, max_value]``.
+    """
+    if mode is BoundaryMode.CLAMP:
+        return max(min_value, min(max_value, raw_value))
+
+    # REFLECT: bounce the value back from each boundary.
+    # The folded space has period = 2 * span; the first half maps straight,
+    # the second half maps in reverse (the "bounce").
+    span = max_value - min_value
+    if span == 0.0:
+        return min_value
+    period = 2.0 * span
+    offset = raw_value - min_value
+    # Python's % operator always returns a non-negative result when the divisor
+    # is positive, so no negative-remainder correction is needed.
+    mod = offset % period
+    if mod <= span:
+        return min_value + mod
+    return max_value - (mod - span)
+
+
 def mutate_chromosome(
     chromosome: HyperparameterChromosome,
     mutation_rate: Optional[float] = None,
     mutation_scale: Optional[float] = None,
     mutation_mode: Optional[Union[MutationMode, str]] = None,
+    boundary_mode: Union[BoundaryMode, str] = BoundaryMode.CLAMP,
     rng: Optional[random.Random] = None,
 ) -> HyperparameterChromosome:
     """Mutate evolvable genes using bounded real-valued perturbations.
+
+    Args:
+        chromosome: Source chromosome to mutate.
+        mutation_rate: Probability of mutating each evolvable gene.  Overrides
+            per-gene ``mutation_probability`` when provided.  Must be in
+            ``[0, 1]``.
+        mutation_scale: Perturbation scale.  Overrides per-gene
+            ``mutation_scale`` when provided.  Must be non-negative.
+        mutation_mode: Perturbation operator to use (``gaussian`` or
+            ``multiplicative``).  Overrides per-gene ``mutation_strategy``
+            when provided.
+        boundary_mode: How to handle raw values that exceed gene bounds after
+            mutation.  ``"clamp"`` (default) reproduces the original behavior;
+            ``"reflect"`` bounces the value back off the boundary so edge states
+            are not absorbing.  See :class:`BoundaryMode`.
+        rng: Optional :class:`random.Random` instance for deterministic tests.
 
     Notes:
         - ``gaussian``: additive Gaussian perturbation where sigma is
           ``mutation_scale * (max_value - min_value)``.
         - ``multiplicative``: legacy multiplicative perturbation using a
           uniform delta in ``[-mutation_scale, mutation_scale]``.
-        - All mutations are clamped to each gene's bounds.
+        - Boundary handling is controlled by ``boundary_mode`` (default:
+          ``BoundaryMode.CLAMP``).
     """
     if mutation_rate is not None and not 0.0 <= mutation_rate <= 1.0:
         raise ValueError("mutation_rate must be between 0 and 1.")
     if mutation_scale is not None and mutation_scale < 0.0:
         raise ValueError("mutation_scale must be non-negative.")
     resolved_mode_override = MutationMode(mutation_mode) if mutation_mode is not None else None
+    resolved_boundary_mode = BoundaryMode(boundary_mode)
     resolved_rng = rng or random
     updated_genes: List[HyperparameterGene] = []
     for gene in chromosome.genes:
@@ -548,10 +645,63 @@ def mutate_chromosome(
             delta = resolved_rng.uniform(-resolved_scale, resolved_scale)
             raw_value = gene.value * (1.0 + delta)
 
-        bounded_value = max(gene.min_value, min(gene.max_value, raw_value))
+        bounded_value = _apply_boundary(raw_value, gene.min_value, gene.max_value, resolved_boundary_mode)
         updated_genes.append(gene.with_value(bounded_value))
 
     return HyperparameterChromosome(genes=tuple(updated_genes))
+
+
+def compute_boundary_penalty(
+    chromosome: HyperparameterChromosome,
+    config: Optional[BoundaryPenaltyConfig] = None,
+) -> float:
+    """Compute a soft fitness penalty for genes sitting near their bounds.
+
+    The returned value is intended to be **subtracted** from the caller's raw
+    fitness score.  A gene resting exactly on a boundary incurs the full
+    ``config.penalty_strength``; a gene at the inner edge of the threshold zone
+    (distance from boundary == ``near_boundary_threshold``) incurs zero penalty.
+    The ramp is linear between those two points.  The total penalty is the sum
+    over all evolvable genes.
+
+    When ``config.enabled`` is ``False`` (the default), this function returns
+    ``0.0`` immediately so callers can include the call unconditionally.
+
+    Args:
+        chromosome: The chromosome to evaluate.
+        config: Penalty settings.  Defaults to :class:`BoundaryPenaltyConfig`
+            with ``enabled=False``.
+
+    Returns:
+        Non-negative float representing the total penalty (0.0 when disabled).
+
+    Example::
+
+        cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.02)
+        penalty = compute_boundary_penalty(chromosome, cfg)
+        adjusted_fitness = raw_fitness - penalty
+    """
+    resolved_config = config if config is not None else BoundaryPenaltyConfig()
+    if not resolved_config.enabled:
+        return 0.0
+
+    total_penalty = 0.0
+    threshold = resolved_config.near_boundary_threshold
+    strength = resolved_config.penalty_strength
+
+    for gene in chromosome.genes:
+        if not gene.evolvable:
+            continue
+        span = gene.max_value - gene.min_value
+        if span == 0.0:
+            continue
+        normalized = (gene.value - gene.min_value) / span
+        distance_from_boundary = min(normalized, 1.0 - normalized)
+        if distance_from_boundary < threshold:
+            fraction = 1.0 - distance_from_boundary / threshold
+            total_penalty += strength * fraction
+
+    return total_penalty
 
 
 def crossover_chromosomes(

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -6,7 +6,7 @@ import json
 import os
 import random
 import statistics
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -15,12 +15,12 @@ from farm.core.genome import Genome, RouletteSelectionConfig, TournamentSelectio
 from farm.core.hyperparameter_chromosome import (
     BoundaryMode,
     BoundaryPenaltyConfig,
-    compute_boundary_penalty,
     CrossoverMode,
     HyperparameterChromosome,
     MutationMode,
     apply_chromosome_to_learning_config,
     chromosome_from_learning_config,
+    compute_boundary_penalty,
     crossover_chromosomes,
     mutate_chromosome,
 )
@@ -55,13 +55,15 @@ class EvolutionExperimentConfig:
     mutation_rate: float = 0.25
     mutation_scale: float = 0.2
     mutation_mode: MutationMode = MutationMode.GAUSSIAN
+    boundary_mode: BoundaryMode = BoundaryMode.CLAMP
+    boundary_penalty: BoundaryPenaltyConfig = field(default_factory=BoundaryPenaltyConfig)
     crossover_mode: CrossoverMode = CrossoverMode.UNIFORM
     selection_method: EvolutionSelectionMethod = EvolutionSelectionMethod.TOURNAMENT
     tournament_size: int = 3
     elitism_count: int = 1
     fitness_metric: EvolutionFitnessMetric = EvolutionFitnessMetric.FINAL_POPULATION
     boundary_mode: BoundaryMode = BoundaryMode.CLAMP
-    boundary_penalty_config: Optional[BoundaryPenaltyConfig] = None
+    boundary_penalty: BoundaryPenaltyConfig = field(default_factory=BoundaryPenaltyConfig)
     seed: Optional[int] = None
     output_dir: Optional[str] = None
 
@@ -76,6 +78,8 @@ class EvolutionExperimentConfig:
             raise ValueError("mutation_rate must be between 0 and 1.")
         if self.mutation_scale < 0.0:
             raise ValueError("mutation_scale must be non-negative.")
+        # Validate enum coercion for string-friendly construction.
+        BoundaryMode(self.boundary_mode)
         if self.tournament_size < 1:
             raise ValueError("tournament_size must be at least 1.")
         if self.elitism_count < 0:
@@ -201,17 +205,16 @@ class EvolutionExperiment:
         generation_evals: List[EvolutionCandidateEvaluation] = []
         for idx, candidate in enumerate(population):
             candidate_config = self._config_for_chromosome(candidate.chromosome)
-            fitness, metadata = evaluator(candidate, candidate_config, generation, idx)
-            penalty_cfg = self.config.boundary_penalty_config
-            if penalty_cfg is not None and penalty_cfg.enabled:
-                penalty = compute_boundary_penalty(candidate.chromosome, penalty_cfg)
-            else:
-                penalty = 0.0
-            adjusted_fitness = float(fitness) - penalty
+            raw_fitness, metadata = evaluator(candidate, candidate_config, generation, idx)
+            boundary_penalty = compute_boundary_penalty(
+                candidate.chromosome,
+                self.config.boundary_penalty,
+            )
+            adjusted_fitness = float(raw_fitness) - boundary_penalty
             metadata_with_lineage = dict(metadata)
+            metadata_with_lineage["raw_fitness"] = float(raw_fitness)
+            metadata_with_lineage["boundary_penalty"] = boundary_penalty
             metadata_with_lineage["chromosome"] = candidate.chromosome
-            if penalty > 0.0:
-                metadata_with_lineage["boundary_penalty"] = penalty
             generation_evals.append(
                 EvolutionCandidateEvaluation(
                     candidate_id=candidate.candidate_id,

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -62,8 +62,6 @@ class EvolutionExperimentConfig:
     tournament_size: int = 3
     elitism_count: int = 1
     fitness_metric: EvolutionFitnessMetric = EvolutionFitnessMetric.FINAL_POPULATION
-    boundary_mode: BoundaryMode = BoundaryMode.CLAMP
-    boundary_penalty: BoundaryPenaltyConfig = field(default_factory=BoundaryPenaltyConfig)
     seed: Optional[int] = None
     output_dir: Optional[str] = None
 

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -202,7 +202,11 @@ class EvolutionExperiment:
         for idx, candidate in enumerate(population):
             candidate_config = self._config_for_chromosome(candidate.chromosome)
             fitness, metadata = evaluator(candidate, candidate_config, generation, idx)
-            penalty = compute_boundary_penalty(candidate.chromosome, self.config.boundary_penalty_config)
+            penalty_cfg = self.config.boundary_penalty_config
+            if penalty_cfg is not None and penalty_cfg.enabled:
+                penalty = compute_boundary_penalty(candidate.chromosome, penalty_cfg)
+            else:
+                penalty = 0.0
             adjusted_fitness = float(fitness) - penalty
             metadata_with_lineage = dict(metadata)
             metadata_with_lineage["chromosome"] = candidate.chromosome

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -13,6 +13,9 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from farm.config import SimulationConfig
 from farm.core.genome import Genome, RouletteSelectionConfig, TournamentSelectionConfig
 from farm.core.hyperparameter_chromosome import (
+    BoundaryMode,
+    BoundaryPenaltyConfig,
+    compute_boundary_penalty,
     CrossoverMode,
     HyperparameterChromosome,
     MutationMode,
@@ -57,6 +60,8 @@ class EvolutionExperimentConfig:
     tournament_size: int = 3
     elitism_count: int = 1
     fitness_metric: EvolutionFitnessMetric = EvolutionFitnessMetric.FINAL_POPULATION
+    boundary_mode: BoundaryMode = BoundaryMode.CLAMP
+    boundary_penalty_config: Optional[BoundaryPenaltyConfig] = None
     seed: Optional[int] = None
     output_dir: Optional[str] = None
 
@@ -174,6 +179,7 @@ class EvolutionExperiment:
                     mutation_rate=1.0,
                     mutation_scale=self.config.mutation_scale,
                     mutation_mode=self.config.mutation_mode,
+                    boundary_mode=self.config.boundary_mode,
                     rng=self._run_rng,
                 )
             population.append(
@@ -196,13 +202,17 @@ class EvolutionExperiment:
         for idx, candidate in enumerate(population):
             candidate_config = self._config_for_chromosome(candidate.chromosome)
             fitness, metadata = evaluator(candidate, candidate_config, generation, idx)
+            penalty = compute_boundary_penalty(candidate.chromosome, self.config.boundary_penalty_config)
+            adjusted_fitness = float(fitness) - penalty
             metadata_with_lineage = dict(metadata)
             metadata_with_lineage["chromosome"] = candidate.chromosome
+            if penalty > 0.0:
+                metadata_with_lineage["boundary_penalty"] = penalty
             generation_evals.append(
                 EvolutionCandidateEvaluation(
                     candidate_id=candidate.candidate_id,
                     generation=generation,
-                    fitness=float(fitness),
+                    fitness=adjusted_fitness,
                     learning_rate=candidate.chromosome.get_value("learning_rate"),
                     parent_ids=candidate.parent_ids,
                     metadata=metadata_with_lineage,
@@ -243,6 +253,7 @@ class EvolutionExperiment:
                 mutation_rate=self.config.mutation_rate,
                 mutation_scale=self.config.mutation_scale,
                 mutation_mode=self.config.mutation_mode,
+                boundary_mode=self.config.boundary_mode,
                 rng=self._run_rng,
             )
             child_idx = len(next_population)

--- a/scripts/run_evolution_experiment.py
+++ b/scripts/run_evolution_experiment.py
@@ -21,6 +21,10 @@ from farm.runners import (  # noqa: E402
     EvolutionFitnessMetric,
     EvolutionSelectionMethod,
 )
+from farm.core.hyperparameter_chromosome import (  # noqa: E402
+    BoundaryMode,
+    BoundaryPenaltyConfig,
+)
 from farm.utils.logging import configure_logging, get_logger  # noqa: E402
 
 
@@ -78,6 +82,30 @@ def _parse_args() -> argparse.Namespace:
         default=3,
         help="Tournament bracket size when tournament selection is used.",
     )
+    parser.add_argument(
+        "--boundary-mode",
+        type=str,
+        default=BoundaryMode.CLAMP.value,
+        choices=[mode.value for mode in BoundaryMode],
+        help="Boundary strategy after mutation overshoots gene bounds.",
+    )
+    parser.add_argument(
+        "--boundary-penalty-enabled",
+        action="store_true",
+        help="Enable soft near-boundary fitness penalty.",
+    )
+    parser.add_argument(
+        "--boundary-penalty-strength",
+        type=float,
+        default=0.01,
+        help="Max per-gene penalty at exact boundary when penalty is enabled.",
+    )
+    parser.add_argument(
+        "--boundary-penalty-threshold",
+        type=float,
+        default=0.05,
+        help="Near-boundary zone width as fraction of gene range (0, 0.5].",
+    )
     parser.add_argument("--elitism-count", type=int, default=1, help="Top candidates copied to next generation.")
     parser.add_argument("--seed", type=int, default=42, help="Global deterministic seed.")
     parser.add_argument(
@@ -112,6 +140,10 @@ def main() -> int:
         steps_per_candidate=args.steps_per_candidate,
         fitness_metric=args.fitness_metric,
         selection_method=args.selection_method,
+        boundary_mode=args.boundary_mode,
+        boundary_penalty_enabled=args.boundary_penalty_enabled,
+        boundary_penalty_strength=args.boundary_penalty_strength,
+        boundary_penalty_threshold=args.boundary_penalty_threshold,
         output_dir=args.output_dir,
     )
 
@@ -127,6 +159,12 @@ def main() -> int:
             num_steps_per_candidate=args.steps_per_candidate,
             mutation_rate=args.mutation_rate,
             mutation_scale=args.mutation_scale,
+            boundary_mode=BoundaryMode(args.boundary_mode),
+            boundary_penalty=BoundaryPenaltyConfig(
+                enabled=args.boundary_penalty_enabled,
+                penalty_strength=args.boundary_penalty_strength,
+                near_boundary_threshold=args.boundary_penalty_threshold,
+            ),
             selection_method=EvolutionSelectionMethod(args.selection_method),
             tournament_size=args.tournament_size,
             elitism_count=args.elitism_count,
@@ -147,6 +185,10 @@ def main() -> int:
             "best_fitness": result.best_candidate.fitness,
             "best_learning_rate": result.best_candidate.learning_rate,
             "best_parent_ids": list(result.best_candidate.parent_ids),
+            "boundary_mode": args.boundary_mode,
+            "boundary_penalty_enabled": args.boundary_penalty_enabled,
+            "boundary_penalty_strength": args.boundary_penalty_strength,
+            "boundary_penalty_threshold": args.boundary_penalty_threshold,
             "output_dir": args.output_dir,
         }
         print(json.dumps(summary, indent=2))

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -32,14 +32,19 @@ class TestEvolutionExperimentConfig(unittest.TestCase):
         config = EvolutionExperimentConfig(boundary_mode=BoundaryMode.REFLECT)
         self.assertEqual(config.boundary_mode, BoundaryMode.REFLECT)
 
-    def test_default_boundary_penalty_config_is_none(self):
+    def test_rejects_invalid_boundary_mode(self):
+        with self.assertRaises(ValueError):
+            EvolutionExperimentConfig(boundary_mode="not-a-mode")
+
+    def test_default_boundary_penalty_config_uses_defaults(self):
         config = EvolutionExperimentConfig()
-        self.assertIsNone(config.boundary_penalty_config)
+        self.assertFalse(config.boundary_penalty.enabled)
+        self.assertEqual(config.boundary_penalty.penalty_strength, 0.01)
 
     def test_accepts_boundary_penalty_config(self):
         penalty_cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.05)
-        config = EvolutionExperimentConfig(boundary_penalty_config=penalty_cfg)
-        self.assertTrue(config.boundary_penalty_config.enabled)
+        config = EvolutionExperimentConfig(boundary_penalty=penalty_cfg)
+        self.assertTrue(config.boundary_penalty.enabled)
 
 
 class TestEvolutionExperiment(unittest.TestCase):
@@ -174,53 +179,56 @@ class TestEvolutionExperiment(unittest.TestCase):
         self.assertEqual(lineage_a, lineage_b)
         self.assertEqual(result_a.best_candidate.candidate_id, result_b.best_candidate.candidate_id)
 
-    def test_boundary_penalty_reduces_fitness_when_enabled(self):
+    def test_boundary_penalty_adjusts_candidate_fitness(self):
         base_config = SimulationConfig()
-        penalty_cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=1000.0, near_boundary_threshold=0.5)
-        config_with_penalty = EvolutionExperimentConfig(
-            num_generations=1,
-            population_size=2,
-            seed=42,
-            boundary_penalty_config=penalty_cfg,
-        )
-        config_without_penalty = EvolutionExperimentConfig(
-            num_generations=1,
-            population_size=2,
-            seed=42,
-        )
-
-        raw_fitness = 10.0
-
-        def evaluator(candidate, candidate_config, generation, member_index):
-            return raw_fitness, {}
-
-        result_with = EvolutionExperiment(base_config, config_with_penalty).run(fitness_evaluator=evaluator)
-        result_without = EvolutionExperiment(base_config, config_without_penalty).run(fitness_evaluator=evaluator)
-
-        for eval_with, eval_without in zip(result_with.evaluations, result_without.evaluations):
-            self.assertLessEqual(eval_with.fitness, eval_without.fitness)
-
-    def test_boundary_penalty_metadata_recorded_when_nonzero(self):
-        base_config = SimulationConfig()
-        penalty_cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=1000.0, near_boundary_threshold=0.5)
+        base_config.learning.learning_rate = 1e-6
         config = EvolutionExperimentConfig(
             num_generations=1,
-            population_size=2,
-            seed=5,
-            boundary_penalty_config=penalty_cfg,
+            population_size=3,
+            num_steps_per_candidate=1,
+            mutation_scale=0.0,
+            boundary_penalty=BoundaryPenaltyConfig(
+                enabled=True,
+                penalty_strength=0.2,
+                near_boundary_threshold=0.05,
+            ),
+            seed=23,
         )
-        raw_fitness = 50.0
+        experiment = EvolutionExperiment(base_config, config)
 
         def evaluator(candidate, candidate_config, generation, member_index):
-            return raw_fitness, {}
+            return 1.0, {"member": member_index}
 
-        result = EvolutionExperiment(base_config, config).run(fitness_evaluator=evaluator)
-        penalized = [ev for ev in result.evaluations if "boundary_penalty" in ev.metadata]
-        self.assertTrue(len(penalized) > 0)
-        for ev in penalized:
-            penalty = ev.metadata["boundary_penalty"]
-            self.assertGreater(penalty, 0.0)
-            self.assertAlmostEqual(ev.fitness, raw_fitness - penalty)
+        result = experiment.run(fitness_evaluator=evaluator)
+        self.assertEqual(len(result.evaluations), 3)
+        for evaluation in result.evaluations:
+            self.assertAlmostEqual(evaluation.metadata["raw_fitness"], 1.0)
+            self.assertAlmostEqual(evaluation.metadata["boundary_penalty"], 0.2)
+            self.assertAlmostEqual(evaluation.fitness, 0.8)
+
+    @patch("farm.runners.evolution_experiment.mutate_chromosome")
+    def test_boundary_mode_is_forwarded_to_mutation_calls(self, mutate_mock):
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=2,
+            population_size=4,
+            num_steps_per_candidate=1,
+            boundary_mode=BoundaryMode.REFLECT,
+            seed=31,
+        )
+        mutate_mock.side_effect = lambda chromosome, **kwargs: chromosome
+        experiment = EvolutionExperiment(base_config, config)
+        experiment.run(
+            fitness_evaluator=lambda candidate, cfg, generation, member: (
+                float(member + generation),
+                {"member": member},
+            )
+        )
+
+        self.assertTrue(mutate_mock.called)
+        self.assertTrue(
+            all(call.kwargs.get("boundary_mode") == BoundaryMode.REFLECT for call in mutate_mock.call_args_list)
+        )
 
 
 if __name__ == "__main__":

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from farm.config import SimulationConfig
+from farm.core.hyperparameter_chromosome import BoundaryMode, BoundaryPenaltyConfig
 from farm.runners.evolution_experiment import (
     EvolutionExperiment,
     EvolutionExperimentConfig,
@@ -22,6 +23,23 @@ class TestEvolutionExperimentConfig(unittest.TestCase):
     def test_rejects_invalid_generation_count(self):
         with self.assertRaises(ValueError):
             EvolutionExperimentConfig(num_generations=0)
+
+    def test_default_boundary_mode_is_clamp(self):
+        config = EvolutionExperimentConfig()
+        self.assertEqual(config.boundary_mode, BoundaryMode.CLAMP)
+
+    def test_accepts_reflect_boundary_mode(self):
+        config = EvolutionExperimentConfig(boundary_mode=BoundaryMode.REFLECT)
+        self.assertEqual(config.boundary_mode, BoundaryMode.REFLECT)
+
+    def test_default_boundary_penalty_config_is_none(self):
+        config = EvolutionExperimentConfig()
+        self.assertIsNone(config.boundary_penalty_config)
+
+    def test_accepts_boundary_penalty_config(self):
+        penalty_cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.05)
+        config = EvolutionExperimentConfig(boundary_penalty_config=penalty_cfg)
+        self.assertTrue(config.boundary_penalty_config.enabled)
 
 
 class TestEvolutionExperiment(unittest.TestCase):
@@ -155,6 +173,49 @@ class TestEvolutionExperiment(unittest.TestCase):
         lineage_b = [(ev.candidate_id, ev.parent_ids, ev.fitness) for ev in result_b.evaluations]
         self.assertEqual(lineage_a, lineage_b)
         self.assertEqual(result_a.best_candidate.candidate_id, result_b.best_candidate.candidate_id)
+
+    def test_boundary_penalty_reduces_fitness_when_enabled(self):
+        base_config = SimulationConfig()
+        penalty_cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=1000.0, near_boundary_threshold=0.5)
+        config_with_penalty = EvolutionExperimentConfig(
+            num_generations=1,
+            population_size=2,
+            seed=42,
+            boundary_penalty_config=penalty_cfg,
+        )
+        config_without_penalty = EvolutionExperimentConfig(
+            num_generations=1,
+            population_size=2,
+            seed=42,
+        )
+
+        raw_fitness = 10.0
+
+        def evaluator(candidate, candidate_config, generation, member_index):
+            return raw_fitness, {}
+
+        result_with = EvolutionExperiment(base_config, config_with_penalty).run(fitness_evaluator=evaluator)
+        result_without = EvolutionExperiment(base_config, config_without_penalty).run(fitness_evaluator=evaluator)
+
+        for eval_with, eval_without in zip(result_with.evaluations, result_without.evaluations):
+            self.assertLessEqual(eval_with.fitness, eval_without.fitness)
+
+    def test_boundary_penalty_metadata_recorded_when_nonzero(self):
+        base_config = SimulationConfig()
+        penalty_cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=1000.0, near_boundary_threshold=0.5)
+        config = EvolutionExperimentConfig(
+            num_generations=1,
+            population_size=2,
+            seed=5,
+            boundary_penalty_config=penalty_cfg,
+        )
+
+        def evaluator(candidate, candidate_config, generation, member_index):
+            return 50.0, {}
+
+        result = EvolutionExperiment(base_config, config).run(fitness_evaluator=evaluator)
+        penalized = [ev for ev in result.evaluations if "boundary_penalty" in ev.metadata]
+        self.assertTrue(len(penalized) > 0)
 
 
 if __name__ == "__main__":

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -3,6 +3,7 @@
 import json
 import tempfile
 import unittest
+from dataclasses import fields
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -16,6 +17,11 @@ from farm.runners.evolution_experiment import (
 
 
 class TestEvolutionExperimentConfig(unittest.TestCase):
+    def test_config_fields_define_boundary_settings_once(self):
+        field_names = [item.name for item in fields(EvolutionExperimentConfig)]
+        self.assertEqual(field_names.count("boundary_mode"), 1)
+        self.assertEqual(field_names.count("boundary_penalty"), 1)
+
     def test_rejects_invalid_population_size(self):
         with self.assertRaises(ValueError):
             EvolutionExperimentConfig(population_size=1)

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -209,13 +209,18 @@ class TestEvolutionExperiment(unittest.TestCase):
             seed=5,
             boundary_penalty_config=penalty_cfg,
         )
+        raw_fitness = 50.0
 
         def evaluator(candidate, candidate_config, generation, member_index):
-            return 50.0, {}
+            return raw_fitness, {}
 
         result = EvolutionExperiment(base_config, config).run(fitness_evaluator=evaluator)
         penalized = [ev for ev in result.evaluations if "boundary_penalty" in ev.metadata]
         self.assertTrue(len(penalized) > 0)
+        for ev in penalized:
+            penalty = ev.metadata["boundary_penalty"]
+            self.assertGreater(penalty, 0.0)
+            self.assertAlmostEqual(ev.fitness, raw_fitness - penalty)
 
 
 if __name__ == "__main__":

--- a/tests/test_hyperparameter_chromosome.py
+++ b/tests/test_hyperparameter_chromosome.py
@@ -6,6 +6,9 @@ import random
 from unittest.mock import patch
 
 from farm.core.hyperparameter_chromosome import (
+    BoundaryMode,
+    BoundaryPenaltyConfig,
+    compute_boundary_penalty,
     CrossoverMode,
     MutationMode,
     apply_chromosome_to_learning_config,
@@ -368,6 +371,222 @@ class TestHyperparameterCrossover(unittest.TestCase):
         learning_rate = mutated.get_value("learning_rate")
         self.assertGreaterEqual(learning_rate, 1e-6)
         self.assertLessEqual(learning_rate, 1.0)
+
+
+class TestBoundaryMode(unittest.TestCase):
+    """Tests for reflective (bounce) mutation boundary handling."""
+
+    def test_reflect_simple_overshoot_above_max(self):
+        # Gene [0, 1], value 0.9, mutation pushes to 1.2 → reflects to 0.8
+        chromosome = chromosome_from_values({"learning_rate": 0.9})
+        # Gaussian perturbation: sigma = (1.0 - 1e-6) * 1.0 ≈ 1.0
+        # gauss returns 0.3 → raw = 0.9 + 0.3 = 1.2; span ≈ 1.0 → reflect to 0.8
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=0.3):
+            mutated = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=1.0,
+                boundary_mode=BoundaryMode.REFLECT,
+            )
+        lr = mutated.get_value("learning_rate")
+        self.assertGreaterEqual(lr, 1e-6)
+        self.assertLessEqual(lr, 1.0)
+        # Should NOT be at the max boundary (was reflected back in)
+        self.assertLess(lr, 1.0)
+
+    def test_reflect_simple_overshoot_below_min(self):
+        # Gene [1e-6, 1], value at min + small amount, mutation pushes below min
+        chromosome = chromosome_from_values({"learning_rate": 0.001})
+        # gauss returns large negative: raw = 0.001 - 5.0 << min
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=-5.0):
+            mutated = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=1.0,
+                boundary_mode=BoundaryMode.REFLECT,
+            )
+        lr = mutated.get_value("learning_rate")
+        self.assertGreaterEqual(lr, 1e-6)
+        self.assertLessEqual(lr, 1.0)
+
+    def test_clamp_stays_at_boundary_on_large_overshoot(self):
+        chromosome = chromosome_from_values({"learning_rate": 0.999})
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=5.0):
+            mutated = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=1.0,
+                boundary_mode=BoundaryMode.CLAMP,
+            )
+        self.assertEqual(mutated.get_value("learning_rate"), 1.0)
+
+    def test_reflect_does_not_stick_at_boundary_on_overshoot(self):
+        chromosome = chromosome_from_values({"learning_rate": 0.999})
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=0.5):
+            mutated = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=1.0,
+                boundary_mode=BoundaryMode.REFLECT,
+            )
+        # With reflect, value should not be exactly at max (1.0)
+        self.assertLess(mutated.get_value("learning_rate"), 1.0)
+
+    def test_reflect_value_stays_in_bounds_for_many_mutations(self):
+        rng = random.Random(42)
+        chromosome = chromosome_from_values({"learning_rate": 0.5})
+        for _ in range(200):
+            chromosome = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=2.0,
+                boundary_mode=BoundaryMode.REFLECT,
+                rng=rng,
+            )
+            lr = chromosome.get_value("learning_rate")
+            self.assertGreaterEqual(lr, 1e-6, msg=f"Fell below min: {lr}")
+            self.assertLessEqual(lr, 1.0, msg=f"Exceeded max: {lr}")
+
+    def test_clamp_default_backward_compatible(self):
+        """mutate_chromosome without boundary_mode still clamps (backward compat)."""
+        chromosome = chromosome_from_values({"learning_rate": 0.999})
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=5.0):
+            mutated = mutate_chromosome(chromosome, mutation_rate=1.0, mutation_scale=1.0)
+        self.assertEqual(mutated.get_value("learning_rate"), 1.0)
+
+    def test_reflect_string_alias_accepted(self):
+        chromosome = chromosome_from_values({"learning_rate": 0.5})
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=0.0):
+            mutated = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=0.1,
+                boundary_mode="reflect",
+            )
+        lr = mutated.get_value("learning_rate")
+        self.assertGreaterEqual(lr, 1e-6)
+        self.assertLessEqual(lr, 1.0)
+
+    def test_clamp_string_alias_accepted(self):
+        chromosome = chromosome_from_values({"learning_rate": 0.5})
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=0.0):
+            mutated = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=0.1,
+                boundary_mode="clamp",
+            )
+        lr = mutated.get_value("learning_rate")
+        self.assertGreaterEqual(lr, 1e-6)
+        self.assertLessEqual(lr, 1.0)
+
+
+class TestBoundaryPenaltyConfig(unittest.TestCase):
+    """Tests for BoundaryPenaltyConfig validation."""
+
+    def test_default_config_is_disabled(self):
+        cfg = BoundaryPenaltyConfig()
+        self.assertFalse(cfg.enabled)
+
+    def test_rejects_negative_penalty_strength(self):
+        with self.assertRaises(ValueError):
+            BoundaryPenaltyConfig(enabled=True, penalty_strength=-0.01)
+
+    def test_rejects_zero_near_boundary_threshold(self):
+        with self.assertRaises(ValueError):
+            BoundaryPenaltyConfig(enabled=True, near_boundary_threshold=0.0)
+
+    def test_rejects_threshold_above_half(self):
+        with self.assertRaises(ValueError):
+            BoundaryPenaltyConfig(enabled=True, near_boundary_threshold=0.6)
+
+    def test_accepts_threshold_at_half(self):
+        cfg = BoundaryPenaltyConfig(enabled=True, near_boundary_threshold=0.5)
+        self.assertEqual(cfg.near_boundary_threshold, 0.5)
+
+
+class TestComputeBoundaryPenalty(unittest.TestCase):
+    """Tests for compute_boundary_penalty()."""
+
+    def test_returns_zero_when_disabled(self):
+        chromosome = chromosome_from_values({"learning_rate": 1.0})
+        self.assertEqual(compute_boundary_penalty(chromosome), 0.0)
+
+    def test_returns_zero_when_config_disabled_explicitly(self):
+        chromosome = chromosome_from_values({"learning_rate": 1.0})
+        cfg = BoundaryPenaltyConfig(enabled=False)
+        self.assertEqual(compute_boundary_penalty(chromosome, cfg), 0.0)
+
+    def test_full_penalty_at_max_boundary(self):
+        chromosome = chromosome_from_values({"learning_rate": 1.0})
+        cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.05, near_boundary_threshold=0.1)
+        penalty = compute_boundary_penalty(chromosome, cfg)
+        self.assertAlmostEqual(penalty, 0.05)
+
+    def test_full_penalty_at_min_boundary(self):
+        chromosome = chromosome_from_values({"learning_rate": 1e-6})
+        cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.05, near_boundary_threshold=0.1)
+        penalty = compute_boundary_penalty(chromosome, cfg)
+        self.assertAlmostEqual(penalty, 0.05)
+
+    def test_zero_penalty_well_inside_bounds(self):
+        chromosome = chromosome_from_values({"learning_rate": 0.5})
+        cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.1, near_boundary_threshold=0.05)
+        penalty = compute_boundary_penalty(chromosome, cfg)
+        self.assertEqual(penalty, 0.0)
+
+    def test_penalty_ramps_linearly(self):
+        """Penalty at half the threshold distance should be ~50% of strength."""
+        gene = HyperparameterGene(
+            name="learning_rate",
+            value_type=GeneValueType.REAL,
+            value=0.05,  # normalized = 0.05 in [0, 1] range
+            min_value=0.0,
+            max_value=1.0,
+            default=0.5,
+        )
+        chromosome = HyperparameterChromosome(genes=(gene,))
+        cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.10, near_boundary_threshold=0.10)
+        penalty = compute_boundary_penalty(chromosome, cfg)
+        # distance = 0.05, threshold = 0.10 → fraction = 1 - 0.05/0.10 = 0.5
+        self.assertAlmostEqual(penalty, 0.05)
+
+    def test_no_penalty_for_fixed_genes(self):
+        chromosome = default_hyperparameter_chromosome()
+        # epsilon_decay and memory_size are fixed (evolvable=False)
+        # Only learning_rate is evolvable; at its default of 0.001 it is very
+        # close to min (1e-6) on a linear scale → may receive a penalty.
+        # Override learning_rate to midpoint to guarantee zero penalty.
+        chromosome = chromosome.with_overrides({"learning_rate": 0.5})
+        cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.1, near_boundary_threshold=0.05)
+        # Even though epsilon_decay is near its min, it is fixed → no penalty
+        penalty = compute_boundary_penalty(chromosome, cfg)
+        self.assertEqual(penalty, 0.0)
+
+    def test_penalty_sums_over_multiple_evolvable_genes(self):
+        gene_a = HyperparameterGene(
+            name="a",
+            value_type=GeneValueType.REAL,
+            value=0.0,
+            min_value=0.0,
+            max_value=1.0,
+            default=0.5,
+            evolvable=True,
+        )
+        gene_b = HyperparameterGene(
+            name="b",
+            value_type=GeneValueType.REAL,
+            value=1.0,
+            min_value=0.0,
+            max_value=1.0,
+            default=0.5,
+            evolvable=True,
+        )
+        chromosome = HyperparameterChromosome(genes=(gene_a, gene_b))
+        cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.10, near_boundary_threshold=0.05)
+        penalty = compute_boundary_penalty(chromosome, cfg)
+        # Both genes exactly on a boundary → 2 × 0.10 = 0.20
+        self.assertAlmostEqual(penalty, 0.20)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces advanced boundary handling strategies and soft boundary penalties for hyperparameter chromosome mutation, improving genetic diversity and fitness evaluation near parameter limits. The main changes include adding a reflective boundary mode to prevent genes from sticking at min/max values, implementing a configurable soft penalty for genes near boundaries, updating documentation, and providing comprehensive tests for these new behaviors.

**Boundary handling improvements:**
- Added `BoundaryMode` enum and support for a new `"reflect"` mode in `mutate_chromosome`, which bounces mutated values off boundaries instead of clamping, reducing "boundary collapse" and improving population diversity. (`farm/core/hyperparameter_chromosome.py`, `docs/design/hyperparameter_chromosome.md`) [[1]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R53-R99) [[2]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R559-R629) [[3]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L112-R112) [[4]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L125-R199)
- Refactored boundary handling logic into a private `_apply_boundary` function, and updated all mutation code to use the selected strategy. (`farm/core/hyperparameter_chromosome.py`) [[1]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R559-R629) [[2]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8L551-R706)

**Soft boundary penalty:**
- Introduced `BoundaryPenaltyConfig` dataclass and `compute_boundary_penalty` function, allowing a configurable, linearly-ramped penalty to be subtracted from fitness when genes approach boundaries. This discourages boundary crowding without hard constraints. (`farm/core/hyperparameter_chromosome.py`, `docs/design/hyperparameter_chromosome.md`) [[1]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R53-R99) [[2]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8L551-R706) [[3]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L125-R199)

**Documentation:**
- Expanded the design documentation to explain the new `boundary_mode` options, their effects, and how to configure and use soft boundary penalties. (`docs/design/hyperparameter_chromosome.md`) [[1]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L112-R112) [[2]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L125-R199) [[3]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12R333-R334)

**Testing:**
- Added extensive unit tests for both reflective boundary handling and soft boundary penalties, verifying correct behavior, validation, and integration with mutation and fitness calculations. (`tests/test_hyperparameter_chromosome.py`) [[1]](diffhunk://#diff-9c7680134b11855929fe6dd4a3d862d1b80e80be48036a6186b545079899f572R9-R11) [[2]](diffhunk://#diff-9c7680134b11855929fe6dd4a3d862d1b80e80be48036a6186b545079899f572R376-R591)

These changes make boundary effects more controllable and observable, improving the robustness and evolvability of hyperparameter search.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mutation behavior for hyperparameter evolution is extended with a new boundary strategy; while the default remains clamping, using `reflect` changes search dynamics and could affect experiment outcomes. The new fitness penalty helper is opt-in but may be easy to misapply (must be subtracted) and should be validated in downstream callers.
> 
> **Overview**
> Adds configurable boundary handling to `mutate_chromosome` via `BoundaryMode`, including a new *reflective* strategy (`"reflect"`) implemented in `_apply_boundary` to avoid genes getting stuck at min/max while keeping the existing clamping default.
> 
> Introduces opt-in *soft boundary penalties* (`BoundaryPenaltyConfig` + `compute_boundary_penalty`) that return a non-negative value to subtract from fitness when evolvable genes sit near bounds, and updates the design docs plus unit tests to cover the new boundary and penalty behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a98d6b535c1ec0ca44075e6d5d5b7f5fc27ab90. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->