### PR TITLE
Potential fix for code scanning alert no. 5: Prototype-polluting function

### DIFF
--- a/farm/editor/components/config-explorer/Explorer.js
+++ b/farm/editor/components/config-explorer/Explorer.js
@@ -878,9 +878,12 @@
 			if (typeof source !== 'object' || Array.isArray(source)) return source
 			if (typeof target !== 'object' || target == null || Array.isArray(target)) target = {}
 			Object.keys(source).forEach((k) => {
+				if (k === '__proto__' || k === 'constructor' || k === 'prototype') return
 				const sv = source[k]
 				if (sv && typeof sv === 'object' && !Array.isArray(sv)) {
-					target[k] = this.deepMerge(target[k], sv)
+					const hasOwn = Object.prototype.hasOwnProperty.call(target, k)
+					const nextTarget = hasOwn ? target[k] : {}
+					target[k] = this.deepMerge(nextTarget, sv)
 				} else {
 					target[k] = Array.isArray(sv) ? this.deepClone(sv) : sv
 				}
@@ -893,7 +896,10 @@
 			if (Array.isArray(value)) return value.map((v) => this.deepClone(v))
 			if (typeof value === 'object') {
 				const out = {}
-				Object.keys(value).forEach((k) => { out[k] = this.deepClone(value[k]) })
+				Object.keys(value).forEach((k) => {
+					if (k === '__proto__' || k === 'constructor' || k === 'prototype') return
+					out[k] = this.deepClone(value[k])
+				})
 				return out
 			}
 			return value


### PR DESCRIPTION
Potential fix for [https://github.com/Dooders/AgentFarm/security/code-scanning/5](https://github.com/Dooders/AgentFarm/security/code-scanning/5)

To fix this safely without changing intended behavior, harden the recursive object operations:

1. **Block dangerous keys** in both `deepMerge` and `deepClone`: `__proto__`, `constructor`, and `prototype`.
2. **Only recurse into destination own properties** when merging nested objects, instead of blindly recursing on `target[k]`. This prevents traversal into inherited prototype properties.
3. Keep existing array/scalar behavior unchanged.

In `farm/editor/components/config-explorer/Explorer.js`, update:
- `deepMerge` (around lines 876–889): add key guard, own-property check before recursive merge, and safe nested target initialization.
- `deepClone` (around lines 891–900): skip dangerous keys while cloning object properties.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recursive merge/clone logic used when applying presets, which could subtly change how nested objects are merged and affect config outcomes. Change is localized but impacts config manipulation paths and addresses a security concern.
> 
> **Overview**
> Hardens `Config Explorer` preset application by preventing prototype pollution during recursive config operations.
> 
> `deepMerge` and `deepClone` now **skip dangerous keys** (`__proto__`, `constructor`, `prototype`), and `deepMerge` only recurses into a destination key if it is an *own property* (otherwise initializes a fresh object) to avoid merging into inherited prototype properties.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f09a89a065d978534bfc163784f2331c07c898c1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->