### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   python:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Dooders/AgentFarm/security/code-scanning/3](https://github.com/Dooders/AgentFarm/security/code-scanning/3)

Add an explicit workflow-level `permissions` block in `.github/workflows/tests.yml` so all jobs inherit least-privilege token scopes unless overridden.  
Best minimal fix (without changing functionality): add:

```yml
permissions:
  contents: read
```

Place it near the top-level keys (after `on:` block and before `jobs:`) so both `python` and `js-ui` jobs get read-only repository access, which is sufficient for `actions/checkout` and test execution in the shown steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that restricts workflow token permissions to read-only `contents`, which could only affect jobs that implicitly relied on broader default permissions.
> 
> **Overview**
> Adds an explicit workflow-level `permissions` block to `.github/workflows/tests.yml`, setting `contents: read` so all test jobs run with least-privilege `GITHUB_TOKEN` scopes (addressing a code scanning alert) without changing the test steps themselves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89869293ee90a5757a014f7a719595905d041eab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->