### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deterministic-simulation.yml
+++ b/.github/workflows/deterministic-simulation.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   deterministic-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Dooders/AgentFarm/security/code-scanning/1](https://github.com/Dooders/AgentFarm/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: set workflow-level permissions to `contents: read`, which is sufficient for `actions/checkout@v4` and does not alter workflow behavior.

**Where to change**
- File: `.github/workflows/deterministic-simulation.yml`
- Insert the `permissions` block at the workflow root (after `on:` section and before `jobs:` is clean and conventional).

No imports, methods, or dependencies are needed—this is YAML config only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk YAML-only change that tightens `GITHUB_TOKEN` scope to read-only for repository contents; should not affect job behavior beyond reducing permissions.
> 
> **Overview**
> Updates the `Deterministic Simulation Check` GitHub Actions workflow to explicitly set workflow-level `permissions` to `contents: read`, addressing least-privilege/code-scanning guidance while keeping the existing test steps unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c06129a4a1809acff2b6d10eb142c5f7762a6672. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->