### PR TITLE
Enhance adaptive mutation rates and telemetry for hyperparameter evolution

### DIFF
--- a/docs/experiments/hyperparameter_evolution_convergence.md
+++ b/docs/experiments/hyperparameter_evolution_convergence.md
@@ -58,8 +58,8 @@ opt-in adaptive mutation schedule driven by
 the controller implementation.
 
 When ``--adaptive-mutation`` is passed, each generation's best fitness and
-population diversity are observed and used to adjust the effective mutation
-rate and scale that will produce the next generation:
+population diversity are observed and used to adjust the mutation rate and
+scale that will produce the **next** generation:
 
 - **Fitness adaptation** (``use_fitness_adaptation``): if best fitness did
   not improve over the trailing ``stall_window`` generations by more than
@@ -71,31 +71,43 @@ rate and scale that will produce the next generation:
   ``diversity_threshold``, the rate/scale multipliers are boosted by
   ``diversity_multiplier`` to escape a collapsed population.
 - **Per-gene multipliers** (``per_gene_rate_multipliers`` /
-  ``per_gene_scale_multipliers``): constant weights applied to specific
-  loci to give individual genes stronger or weaker mutation pressure.
+  ``per_gene_scale_multipliers``, also exposed as
+  ``--adaptive-per-gene-rate`` / ``--adaptive-per-gene-scale``): constant
+  weights applied to specific loci to give individual genes stronger or
+  weaker mutation pressure.
 
 Multipliers are always clamped to ``[min_*_multiplier, max_*_multiplier]``,
-and the effective rate is clamped to ``[0, 1]``.
+and the effective rate is clamped to ``[0, 1]``.  When a clamp actually
+moves a value, the controller adds a ``rate_clamped`` or ``scale_clamped``
+tag to ``adaptive_event`` so saturation is visible in telemetry.
 
 ### Telemetry
 
-Every entry in ``evolution_generation_summaries.json`` records the effective
-mutation values used for that generation's child population, along with the
-currently active multipliers, the measured diversity, and a short string
-describing which adaptation rules fired:
+Every entry in ``evolution_generation_summaries.json`` records the mutation
+parameters that **produced this generation's population** (not the ones
+that will produce the next), along with the multipliers in force, the
+measured diversity of this generation, and a short string describing which
+adaptation rules fired:
 
 ```json
 {
   "generation": 2,
   "best_fitness": 72.0,
-  "effective_mutation_rate": 0.30,
-  "effective_mutation_scale": 0.18,
+  "mutation_rate_used": 0.30,
+  "mutation_scale_used": 0.18,
   "mutation_rate_multiplier": 1.5,
   "mutation_scale_multiplier": 1.5,
   "diversity": 0.034,
   "adaptive_event": "stalled+diversity_collapse"
 }
 ```
+
+Because generation 0 is seeded by ``EvolutionExperiment._initialize_population``
+(which uses ``mutation_rate=1.0`` to spread seed candidates) rather than by
+the adaptive controller, its ``mutation_rate_used`` /
+``mutation_scale_used`` / ``mutation_*_multiplier`` fields are ``null`` and
+its ``adaptive_event`` is ``"initial_seeding"``.  ``diversity`` is still
+recorded for every generation since it describes the evaluated population.
 
 ### Example
 
@@ -112,8 +124,10 @@ python scripts/run_evolution_experiment.py \
   --adaptive-stall-window 3 \
   --adaptive-stall-multiplier 1.5 \
   --adaptive-improve-multiplier 0.8 \
+  --adaptive-improve-threshold 1e-6 \
   --adaptive-diversity-threshold 0.05 \
   --adaptive-diversity-multiplier 1.5 \
+  --adaptive-per-gene-rate learning_rate=0.5 \
   --fitness-metric final_population \
   --output-dir experiments/evolution_adaptive
 ```
@@ -131,9 +145,15 @@ python scripts/run_evolution_experiment.py \
 - Set ``diversity_threshold`` after inspecting the diversity values logged
   by a non-adaptive baseline run.  Typical collapsing populations report
   ``diversity < 0.05`` on normalized gene ranges.
-- Use ``per_gene_rate_multipliers`` to mute mutation on genes that are
-  known to be sensitive (e.g., halve the rate for ``learning_rate``) while
-  letting coarser knobs keep exploring.
+- Use ``per_gene_rate_multipliers`` (or
+  ``--adaptive-per-gene-rate learning_rate=0.5``) to mute mutation on genes
+  that are known to be sensitive while letting coarser knobs keep exploring.
+- Watch for ``rate_clamped`` / ``scale_clamped`` in ``adaptive_event``: if
+  these appear repeatedly the multiplier is saturating against
+  ``max_*_multiplier``.  Either widen the bound or rebalance
+  ``stall_multiplier`` and ``improve_multiplier`` so their geometric mean
+  is close to ``1`` (defaults of ``1.5`` and ``0.8`` net-grow over equal
+  numbers of stalls and improvements).
 
 ## Interpreting Results
 

--- a/docs/experiments/hyperparameter_evolution_convergence.md
+++ b/docs/experiments/hyperparameter_evolution_convergence.md
@@ -49,6 +49,92 @@ The chart contains:
 - best fitness per generation
 - per-gene mean and `+-1 std` trend over generations
 
+## Adaptive Mutation
+
+Static mutation rates have a trade-off between boundary collapse (too
+exploitative) and stagnation (too exploratory). The runner supports an
+opt-in adaptive mutation schedule driven by
+``AdaptiveMutationConfig``.  See ``farm/runners/adaptive_mutation.py`` for
+the controller implementation.
+
+When ``--adaptive-mutation`` is passed, each generation's best fitness and
+population diversity are observed and used to adjust the effective mutation
+rate and scale that will produce the next generation:
+
+- **Fitness adaptation** (``use_fitness_adaptation``): if best fitness did
+  not improve over the trailing ``stall_window`` generations by more than
+  ``improvement_threshold``, the rate/scale multipliers are grown by
+  ``stall_multiplier``.  When fitness improves clearly, the multipliers are
+  shrunk by ``improve_multiplier``.
+- **Diversity adaptation** (``use_diversity_adaptation``): if the mean
+  normalized gene standard deviation falls at or below
+  ``diversity_threshold``, the rate/scale multipliers are boosted by
+  ``diversity_multiplier`` to escape a collapsed population.
+- **Per-gene multipliers** (``per_gene_rate_multipliers`` /
+  ``per_gene_scale_multipliers``): constant weights applied to specific
+  loci to give individual genes stronger or weaker mutation pressure.
+
+Multipliers are always clamped to ``[min_*_multiplier, max_*_multiplier]``,
+and the effective rate is clamped to ``[0, 1]``.
+
+### Telemetry
+
+Every entry in ``evolution_generation_summaries.json`` records the effective
+mutation values used for that generation's child population, along with the
+currently active multipliers, the measured diversity, and a short string
+describing which adaptation rules fired:
+
+```json
+{
+  "generation": 2,
+  "best_fitness": 72.0,
+  "effective_mutation_rate": 0.30,
+  "effective_mutation_scale": 0.18,
+  "mutation_rate_multiplier": 1.5,
+  "mutation_scale_multiplier": 1.5,
+  "diversity": 0.034,
+  "adaptive_event": "stalled+diversity_collapse"
+}
+```
+
+### Example
+
+```bash
+source venv/bin/activate
+python scripts/run_evolution_experiment.py \
+  --generations 12 \
+  --population-size 10 \
+  --steps-per-candidate 80 \
+  --selection-method tournament \
+  --mutation-rate 0.2 \
+  --mutation-scale 0.15 \
+  --adaptive-mutation \
+  --adaptive-stall-window 3 \
+  --adaptive-stall-multiplier 1.5 \
+  --adaptive-improve-multiplier 0.8 \
+  --adaptive-diversity-threshold 0.05 \
+  --adaptive-diversity-multiplier 1.5 \
+  --fitness-metric final_population \
+  --output-dir experiments/evolution_adaptive
+```
+
+### Tuning guidance
+
+- Start with **fitness adaptation only** (``--adaptive-disable-diversity``)
+  on short runs to confirm the stall/improve rules fire as expected in your
+  fitness regime.
+- Keep ``stall_multiplier`` close to ``1.5`` and ``improve_multiplier``
+  close to ``0.8``: larger values can cause oscillation between exploit
+  and explore regimes.
+- ``stall_window`` should be **at least 2** but smaller than the number of
+  generations; a value of ``3`` is a good default for 8-20 generation runs.
+- Set ``diversity_threshold`` after inspecting the diversity values logged
+  by a non-adaptive baseline run.  Typical collapsing populations report
+  ``diversity < 0.05`` on normalized gene ranges.
+- Use ``per_gene_rate_multipliers`` to mute mutation on genes that are
+  known to be sensitive (e.g., halve the rate for ``learning_rate``) while
+  letting coarser knobs keep exploring.
+
 ## Interpreting Results
 
 When reviewing `learning_rate` convergence:

--- a/farm/core/hyperparameter_chromosome.py
+++ b/farm/core/hyperparameter_chromosome.py
@@ -594,6 +594,8 @@ def mutate_chromosome(
     mutation_scale: Optional[float] = None,
     mutation_mode: Optional[Union[MutationMode, str]] = None,
     boundary_mode: Union[BoundaryMode, str] = BoundaryMode.CLAMP,
+    per_gene_rate_multipliers: Optional[Mapping[str, float]] = None,
+    per_gene_scale_multipliers: Optional[Mapping[str, float]] = None,
     rng: Optional[random.Random] = None,
 ) -> HyperparameterChromosome:
     """Mutate evolvable genes using bounded real-valued perturbations.
@@ -612,6 +614,15 @@ def mutate_chromosome(
             mutation.  ``"clamp"`` (default) reproduces the original behavior;
             ``"reflect"`` bounces the value back off the boundary so edge states
             are not absorbing.  See :class:`BoundaryMode`.
+        per_gene_rate_multipliers: Optional mapping of gene name to a
+            non-negative multiplier applied to the resolved per-gene mutation
+            probability.  After multiplication, the probability is clamped to
+            ``[0, 1]``.  Genes absent from the mapping keep their resolved
+            probability unchanged.  Supports per-gene adaptive mutation.
+        per_gene_scale_multipliers: Optional mapping of gene name to a
+            non-negative multiplier applied to the resolved per-gene mutation
+            scale.  Genes absent from the mapping keep their resolved scale
+            unchanged.  Supports per-gene adaptive mutation.
         rng: Optional :class:`random.Random` instance for deterministic tests.
 
     Notes:
@@ -626,6 +637,18 @@ def mutate_chromosome(
         raise ValueError("mutation_rate must be between 0 and 1.")
     if mutation_scale is not None and mutation_scale < 0.0:
         raise ValueError("mutation_scale must be non-negative.")
+    if per_gene_rate_multipliers:
+        for gene_name, multiplier in per_gene_rate_multipliers.items():
+            if multiplier < 0.0:
+                raise ValueError(
+                    f"per_gene_rate_multipliers['{gene_name}'] must be non-negative."
+                )
+    if per_gene_scale_multipliers:
+        for gene_name, multiplier in per_gene_scale_multipliers.items():
+            if multiplier < 0.0:
+                raise ValueError(
+                    f"per_gene_scale_multipliers['{gene_name}'] must be non-negative."
+                )
     resolved_mode_override = MutationMode(mutation_mode) if mutation_mode is not None else None
     resolved_boundary_mode = BoundaryMode(boundary_mode)
     resolved_rng = rng or random
@@ -634,6 +657,13 @@ def mutate_chromosome(
         resolved_probability = mutation_rate if mutation_rate is not None else gene.mutation_probability
         resolved_scale = mutation_scale if mutation_scale is not None else gene.mutation_scale
         resolved_mode = resolved_mode_override if resolved_mode_override is not None else gene.mutation_strategy
+        if per_gene_rate_multipliers and gene.name in per_gene_rate_multipliers:
+            resolved_probability = max(
+                0.0,
+                min(1.0, resolved_probability * per_gene_rate_multipliers[gene.name]),
+            )
+        if per_gene_scale_multipliers and gene.name in per_gene_scale_multipliers:
+            resolved_scale = max(0.0, resolved_scale * per_gene_scale_multipliers[gene.name])
         if not gene.evolvable or resolved_rng.random() >= resolved_probability:
             updated_genes.append(gene)
             continue

--- a/farm/core/hyperparameter_chromosome.py
+++ b/farm/core/hyperparameter_chromosome.py
@@ -18,6 +18,18 @@ from enum import Enum
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 
+def validate_non_negative_mapping(label: str, mapping: Mapping[str, float]) -> None:
+    """Raise ``ValueError`` if any value in ``mapping`` is negative or NaN.
+
+    Shared between ``mutate_chromosome``'s per-gene multiplier kwargs and
+    :class:`farm.runners.adaptive_mutation.AdaptiveMutationConfig` so both
+    code paths reject the same set of inputs with the same message format.
+    """
+    for name, value in mapping.items():
+        if value < 0.0 or math.isnan(value):
+            raise ValueError(f"{label}['{name}'] must be a non-negative finite number.")
+
+
 class GeneValueType(Enum):
     """Supported gene value kinds.
 
@@ -638,17 +650,9 @@ def mutate_chromosome(
     if mutation_scale is not None and mutation_scale < 0.0:
         raise ValueError("mutation_scale must be non-negative.")
     if per_gene_rate_multipliers:
-        for gene_name, multiplier in per_gene_rate_multipliers.items():
-            if multiplier < 0.0:
-                raise ValueError(
-                    f"per_gene_rate_multipliers['{gene_name}'] must be non-negative."
-                )
+        validate_non_negative_mapping("per_gene_rate_multipliers", per_gene_rate_multipliers)
     if per_gene_scale_multipliers:
-        for gene_name, multiplier in per_gene_scale_multipliers.items():
-            if multiplier < 0.0:
-                raise ValueError(
-                    f"per_gene_scale_multipliers['{gene_name}'] must be non-negative."
-                )
+        validate_non_negative_mapping("per_gene_scale_multipliers", per_gene_scale_multipliers)
     resolved_mode_override = MutationMode(mutation_mode) if mutation_mode is not None else None
     resolved_boundary_mode = BoundaryMode(boundary_mode)
     resolved_rng = rng or random

--- a/farm/core/hyperparameter_chromosome.py
+++ b/farm/core/hyperparameter_chromosome.py
@@ -19,14 +19,14 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 
 def validate_non_negative_mapping(label: str, mapping: Mapping[str, float]) -> None:
-    """Raise ``ValueError`` if any value in ``mapping`` is negative or NaN.
+    """Raise ``ValueError`` if any value in ``mapping`` is negative, NaN, or infinite.
 
     Shared between ``mutate_chromosome``'s per-gene multiplier kwargs and
     :class:`farm.runners.adaptive_mutation.AdaptiveMutationConfig` so both
     code paths reject the same set of inputs with the same message format.
     """
     for name, value in mapping.items():
-        if value < 0.0 or math.isnan(value):
+        if value < 0.0 or math.isnan(value) or math.isinf(value):
             raise ValueError(f"{label}['{name}'] must be a non-negative finite number.")
 
 

--- a/farm/runners/__init__.py
+++ b/farm/runners/__init__.py
@@ -1,5 +1,10 @@
 """Runner exports."""
 
+from farm.runners.adaptive_mutation import (
+    AdaptiveMutationConfig,
+    AdaptiveMutationController,
+    compute_normalized_diversity,
+)
 from farm.runners.evolution_experiment import (
     EvolutionCandidateEvaluation,
     EvolutionExperiment,
@@ -11,6 +16,9 @@ from farm.runners.evolution_experiment import (
 )
 
 __all__ = [
+    "AdaptiveMutationConfig",
+    "AdaptiveMutationController",
+    "compute_normalized_diversity",
     "EvolutionCandidateEvaluation",
     "EvolutionExperiment",
     "EvolutionExperimentConfig",

--- a/farm/runners/adaptive_mutation.py
+++ b/farm/runners/adaptive_mutation.py
@@ -19,7 +19,10 @@ derive effective mutation parameters before each child population is produced.
 
 Design notes:
     - All multipliers are clamped to configurable ``[min, max]`` envelopes
-      to prevent runaway adaptation.
+      to prevent runaway adaptation.  When a clamp actually changes the
+      value, the controller emits a ``rate_clamped``/``scale_clamped`` tag
+      in :attr:`AdaptiveMutationController.last_event` so analysts can see
+      when the bounds bite.
     - Diversity is computed as the mean, across evolvable genes, of the
       per-gene population standard deviation normalized by the gene's bounded
       range.  A value of ``0.0`` means the population has collapsed on every
@@ -35,7 +38,15 @@ from __future__ import annotations
 
 import statistics
 from dataclasses import dataclass, field
-from typing import List, Mapping, Optional, Sequence
+from types import MappingProxyType
+from typing import List, Mapping, Optional, Sequence, Tuple
+
+from farm.core.hyperparameter_chromosome import validate_non_negative_mapping
+
+
+def _freeze_mapping(mapping: Mapping[str, float]) -> Mapping[str, float]:
+    """Return an immutable view of ``mapping`` so frozen dataclasses stay frozen."""
+    return MappingProxyType(dict(mapping))
 
 
 @dataclass(frozen=True)
@@ -127,31 +138,22 @@ class AdaptiveMutationConfig:
         if self.min_rate_multiplier <= 0.0:
             raise ValueError("min_rate_multiplier must be positive.")
         if self.max_rate_multiplier < self.min_rate_multiplier:
-            raise ValueError(
-                "max_rate_multiplier must be >= min_rate_multiplier."
-            )
+            raise ValueError("max_rate_multiplier must be >= min_rate_multiplier.")
         if self.min_scale_multiplier <= 0.0:
             raise ValueError("min_scale_multiplier must be positive.")
         if self.max_scale_multiplier < self.min_scale_multiplier:
-            raise ValueError(
-                "max_scale_multiplier must be >= min_scale_multiplier."
-            )
-        for name, value in self.per_gene_rate_multipliers.items():
-            if value < 0.0:
-                raise ValueError(
-                    f"per_gene_rate_multipliers['{name}'] must be non-negative."
-                )
-        for name, value in self.per_gene_scale_multipliers.items():
-            if value < 0.0:
-                raise ValueError(
-                    f"per_gene_scale_multipliers['{name}'] must be non-negative."
-                )
+            raise ValueError("max_scale_multiplier must be >= min_scale_multiplier.")
+        validate_non_negative_mapping("per_gene_rate_multipliers", self.per_gene_rate_multipliers)
+        validate_non_negative_mapping("per_gene_scale_multipliers", self.per_gene_scale_multipliers)
+        # Re-bind to immutable views so the frozen dataclass is actually immutable.
+        object.__setattr__(self, "per_gene_rate_multipliers", _freeze_mapping(self.per_gene_rate_multipliers))
+        object.__setattr__(self, "per_gene_scale_multipliers", _freeze_mapping(self.per_gene_scale_multipliers))
 
 
 def compute_normalized_diversity(
     gene_statistics: Mapping[str, Mapping[str, float]],
     evolvable_gene_names: Sequence[str],
-    gene_bounds: Mapping[str, tuple],
+    gene_bounds: Mapping[str, Tuple[float, float]],
 ) -> float:
     """Compute mean normalized standard deviation across evolvable genes.
 
@@ -277,14 +279,24 @@ class AdaptiveMutationController:
             self._scale_multiplier *= self._config.diversity_multiplier
             events.append("diversity_collapse")
 
-        self._rate_multiplier = min(
+        # Clamp multipliers and tag whenever the clamp actually moved the
+        # value, so analysts can spot saturation in `evolution_generation_summaries.json`.
+        clamped_rate = min(
             self._config.max_rate_multiplier,
             max(self._config.min_rate_multiplier, self._rate_multiplier),
         )
-        self._scale_multiplier = min(
+        if clamped_rate != self._rate_multiplier:
+            events.append("rate_clamped")
+        self._rate_multiplier = clamped_rate
+
+        clamped_scale = min(
             self._config.max_scale_multiplier,
             max(self._config.min_scale_multiplier, self._scale_multiplier),
         )
+        if clamped_scale != self._scale_multiplier:
+            events.append("scale_clamped")
+        self._scale_multiplier = clamped_scale
+
         self._last_event = "+".join(events) if events else "baseline"
 
     def effective_rate(self, base_rate: float) -> float:

--- a/farm/runners/adaptive_mutation.py
+++ b/farm/runners/adaptive_mutation.py
@@ -1,0 +1,312 @@
+"""Adaptive mutation rate/scale controller for hyperparameter evolution.
+
+This module implements adaptive mutation schedules that respond to search
+state during generation-based hyperparameter evolution:
+
+- **Generation-level adaptation** based on recent best-fitness improvement.
+  Mutation pressure is reduced when fitness is improving and increased when
+  search has stalled.
+- **Diversity-aware adaptation** based on population spread.  When the
+  normalized gene diversity collapses below a configured threshold, the
+  mutation rate and scale are boosted to encourage exploration.
+- **Per-gene adaptation** via user-supplied multipliers that scale the
+  resolved mutation probability and scale for individual loci.
+
+The controller is intentionally stateless apart from the bounded multipliers
+it updates each generation.  It is composed into
+:class:`farm.runners.evolution_experiment.EvolutionExperiment` and used to
+derive effective mutation parameters before each child population is produced.
+
+Design notes:
+    - All multipliers are clamped to configurable ``[min, max]`` envelopes
+      to prevent runaway adaptation.
+    - Diversity is computed as the mean, across evolvable genes, of the
+      per-gene population standard deviation normalized by the gene's bounded
+      range.  A value of ``0.0`` means the population has collapsed on every
+      evolvable gene; ``~0.29`` is the normalized std of a uniform
+      distribution on ``[0, 1]`` and represents a highly diverse population.
+    - Fitness improvement is measured over a trailing window as the
+      difference between the most recent ``best_fitness`` and the maximum
+      ``best_fitness`` observed in the ``stall_window`` generations
+      immediately preceding it.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass, field
+from typing import List, Mapping, Optional, Sequence
+
+
+@dataclass(frozen=True)
+class AdaptiveMutationConfig:
+    """Configuration for adaptive mutation rate/scale schedules.
+
+    When ``enabled`` is ``False`` (default), the experiment behaves exactly as
+    before: ``mutation_rate`` and ``mutation_scale`` are used verbatim and no
+    per-gene multipliers are applied.  This keeps the feature opt-in and
+    existing runs reproducible.
+
+    Attributes:
+        enabled: Master switch for adaptive mutation behavior.
+        use_fitness_adaptation: If ``True`` and ``enabled`` is ``True``,
+            multiply mutation rate/scale by ``stall_multiplier`` when no
+            meaningful improvement is observed over the trailing
+            ``stall_window`` generations, and by ``improve_multiplier``
+            when best fitness improves by more than
+            ``improvement_threshold``.
+        use_diversity_adaptation: If ``True`` and ``enabled`` is ``True``,
+            multiply mutation rate/scale by ``diversity_multiplier`` whenever
+            the mean normalized gene diversity falls below
+            ``diversity_threshold``.
+        stall_window: Number of generations to look back for improvement.
+            Must be >= 1.
+        improvement_threshold: Minimum absolute increase in best fitness over
+            the window that counts as "improving".  Increases smaller than
+            (or equal to) this value are treated as a stall.  Must be >= 0.
+        stall_multiplier: Multiplier applied to the current rate/scale
+            multipliers when the search stalls.  Values > 1 encourage
+            exploration.  Must be > 0.
+        improve_multiplier: Multiplier applied to the current rate/scale
+            multipliers when the search is clearly improving.  Values < 1
+            encourage exploitation.  Must be > 0.
+        diversity_threshold: Normalized diversity value at or below which the
+            population is considered to be collapsing.  Must be in
+            ``[0.0, 1.0]``.
+        diversity_multiplier: Multiplier applied to the current rate/scale
+            multipliers when diversity collapses.  Values > 1 broaden the
+            search.  Must be > 0.
+        min_rate_multiplier: Lower bound on the accumulated rate multiplier.
+            Must be > 0.
+        max_rate_multiplier: Upper bound on the accumulated rate multiplier.
+            Must be >= ``min_rate_multiplier``.
+        min_scale_multiplier: Lower bound on the accumulated scale
+            multiplier.  Must be > 0.
+        max_scale_multiplier: Upper bound on the accumulated scale multiplier.
+            Must be >= ``min_scale_multiplier``.
+        per_gene_rate_multipliers: Optional mapping of gene name to a
+            non-negative multiplier applied to that gene's mutation
+            probability at mutation time.  Missing genes keep their resolved
+            probability unchanged.  Always applied when ``enabled`` is
+            ``True``, regardless of fitness/diversity adaptation flags.
+        per_gene_scale_multipliers: Optional mapping of gene name to a
+            non-negative multiplier applied to that gene's mutation scale at
+            mutation time.  Missing genes keep their resolved scale
+            unchanged.
+    """
+
+    enabled: bool = False
+    use_fitness_adaptation: bool = True
+    use_diversity_adaptation: bool = True
+    stall_window: int = 3
+    improvement_threshold: float = 1e-6
+    stall_multiplier: float = 1.5
+    improve_multiplier: float = 0.8
+    diversity_threshold: float = 0.05
+    diversity_multiplier: float = 1.5
+    min_rate_multiplier: float = 0.1
+    max_rate_multiplier: float = 5.0
+    min_scale_multiplier: float = 0.1
+    max_scale_multiplier: float = 5.0
+    per_gene_rate_multipliers: Mapping[str, float] = field(default_factory=dict)
+    per_gene_scale_multipliers: Mapping[str, float] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.stall_window < 1:
+            raise ValueError("stall_window must be at least 1.")
+        if self.improvement_threshold < 0.0:
+            raise ValueError("improvement_threshold must be non-negative.")
+        if self.stall_multiplier <= 0.0:
+            raise ValueError("stall_multiplier must be positive.")
+        if self.improve_multiplier <= 0.0:
+            raise ValueError("improve_multiplier must be positive.")
+        if not 0.0 <= self.diversity_threshold <= 1.0:
+            raise ValueError("diversity_threshold must be in [0.0, 1.0].")
+        if self.diversity_multiplier <= 0.0:
+            raise ValueError("diversity_multiplier must be positive.")
+        if self.min_rate_multiplier <= 0.0:
+            raise ValueError("min_rate_multiplier must be positive.")
+        if self.max_rate_multiplier < self.min_rate_multiplier:
+            raise ValueError(
+                "max_rate_multiplier must be >= min_rate_multiplier."
+            )
+        if self.min_scale_multiplier <= 0.0:
+            raise ValueError("min_scale_multiplier must be positive.")
+        if self.max_scale_multiplier < self.min_scale_multiplier:
+            raise ValueError(
+                "max_scale_multiplier must be >= min_scale_multiplier."
+            )
+        for name, value in self.per_gene_rate_multipliers.items():
+            if value < 0.0:
+                raise ValueError(
+                    f"per_gene_rate_multipliers['{name}'] must be non-negative."
+                )
+        for name, value in self.per_gene_scale_multipliers.items():
+            if value < 0.0:
+                raise ValueError(
+                    f"per_gene_scale_multipliers['{name}'] must be non-negative."
+                )
+
+
+def compute_normalized_diversity(
+    gene_statistics: Mapping[str, Mapping[str, float]],
+    evolvable_gene_names: Sequence[str],
+    gene_bounds: Mapping[str, tuple],
+) -> float:
+    """Compute mean normalized standard deviation across evolvable genes.
+
+    For each evolvable gene, divides the gene's population standard deviation
+    by its ``(max_value - min_value)`` range.  Genes with a zero span are
+    skipped.  Returns ``0.0`` when no evolvable gene contributes (e.g., empty
+    population or all spans zero).
+
+    Args:
+        gene_statistics: Mapping from gene name to per-gene stats dict as
+            produced by ``EvolutionExperiment._build_gene_statistics``.  Must
+            contain a ``"std"`` key for each included gene.
+        evolvable_gene_names: Names of genes that should contribute to the
+            diversity measure.
+        gene_bounds: Mapping from gene name to a ``(min_value, max_value)``
+            tuple describing the allowable range.
+
+    Returns:
+        A non-negative float, typically in ``[0, ~0.29]``.
+    """
+    normalized_values: List[float] = []
+    for gene_name in evolvable_gene_names:
+        stats = gene_statistics.get(gene_name)
+        if stats is None:
+            continue
+        bounds = gene_bounds.get(gene_name)
+        if bounds is None:
+            continue
+        min_value, max_value = bounds
+        span = max_value - min_value
+        if span <= 0.0:
+            continue
+        std = stats.get("std", 0.0)
+        normalized_values.append(max(0.0, std) / span)
+    if not normalized_values:
+        return 0.0
+    return statistics.mean(normalized_values)
+
+
+class AdaptiveMutationController:
+    """Stateful controller that updates mutation multipliers per generation.
+
+    The controller maintains accumulated ``rate_multiplier`` and
+    ``scale_multiplier`` values.  Call :meth:`observe` once per evaluated
+    generation (after fitness has been computed) to update those multipliers
+    based on best-fitness history and population diversity.  Use
+    :meth:`effective_rate` and :meth:`effective_scale` to derive the
+    mutation parameters that should be passed to
+    :func:`farm.core.hyperparameter_chromosome.mutate_chromosome` when
+    producing the next generation.
+
+    The controller always applies its bounds to keep adaptation stable across
+    many generations, even when the ``enabled`` flag is ``False`` (in which
+    case multipliers stay pinned at ``1.0``).
+    """
+
+    def __init__(self, config: AdaptiveMutationConfig):
+        self._config = config
+        self._best_fitness_history: List[float] = []
+        self._rate_multiplier = 1.0
+        self._scale_multiplier = 1.0
+        self._last_diversity: Optional[float] = None
+        self._last_event: str = "baseline"
+
+    @property
+    def config(self) -> AdaptiveMutationConfig:
+        return self._config
+
+    @property
+    def rate_multiplier(self) -> float:
+        return self._rate_multiplier
+
+    @property
+    def scale_multiplier(self) -> float:
+        return self._scale_multiplier
+
+    @property
+    def last_diversity(self) -> Optional[float]:
+        return self._last_diversity
+
+    @property
+    def last_event(self) -> str:
+        """Human-readable tag describing the most recent adaptation action."""
+        return self._last_event
+
+    def observe(self, *, best_fitness: float, diversity: Optional[float]) -> None:
+        """Update state based on a newly completed generation.
+
+        Args:
+            best_fitness: Best (adjusted) fitness observed in the generation.
+            diversity: Normalized diversity measure for the generation (see
+                :func:`compute_normalized_diversity`).  May be ``None`` when
+                diversity cannot be computed (e.g., all genes fixed).
+        """
+        self._best_fitness_history.append(float(best_fitness))
+        self._last_diversity = diversity
+        events: List[str] = []
+
+        if not self._config.enabled:
+            self._last_event = "disabled"
+            return
+
+        if self._config.use_fitness_adaptation and len(self._best_fitness_history) >= 2:
+            window = self._best_fitness_history[-(self._config.stall_window + 1):]
+            prior_best = max(window[:-1])
+            latest_best = window[-1]
+            improvement = latest_best - prior_best
+            if improvement > self._config.improvement_threshold:
+                self._rate_multiplier *= self._config.improve_multiplier
+                self._scale_multiplier *= self._config.improve_multiplier
+                events.append("improving")
+            else:
+                self._rate_multiplier *= self._config.stall_multiplier
+                self._scale_multiplier *= self._config.stall_multiplier
+                events.append("stalled")
+
+        if (
+            self._config.use_diversity_adaptation
+            and diversity is not None
+            and diversity <= self._config.diversity_threshold
+        ):
+            self._rate_multiplier *= self._config.diversity_multiplier
+            self._scale_multiplier *= self._config.diversity_multiplier
+            events.append("diversity_collapse")
+
+        self._rate_multiplier = min(
+            self._config.max_rate_multiplier,
+            max(self._config.min_rate_multiplier, self._rate_multiplier),
+        )
+        self._scale_multiplier = min(
+            self._config.max_scale_multiplier,
+            max(self._config.min_scale_multiplier, self._scale_multiplier),
+        )
+        self._last_event = "+".join(events) if events else "baseline"
+
+    def effective_rate(self, base_rate: float) -> float:
+        """Return the current effective mutation rate, clamped to ``[0, 1]``."""
+        if base_rate is None:
+            return base_rate  # type: ignore[return-value]
+        return max(0.0, min(1.0, base_rate * self._rate_multiplier))
+
+    def effective_scale(self, base_scale: float) -> float:
+        """Return the current effective mutation scale, clamped to ``>= 0``."""
+        if base_scale is None:
+            return base_scale  # type: ignore[return-value]
+        return max(0.0, base_scale * self._scale_multiplier)
+
+    def per_gene_rate_multipliers(self) -> Mapping[str, float]:
+        """Return the configured per-gene rate multipliers (empty if disabled)."""
+        if not self._config.enabled:
+            return {}
+        return self._config.per_gene_rate_multipliers
+
+    def per_gene_scale_multipliers(self) -> Mapping[str, float]:
+        """Return the configured per-gene scale multipliers (empty if disabled)."""
+        if not self._config.enabled:
+            return {}
+        return self._config.per_gene_scale_multipliers

--- a/farm/runners/adaptive_mutation.py
+++ b/farm/runners/adaptive_mutation.py
@@ -289,14 +289,10 @@ class AdaptiveMutationController:
 
     def effective_rate(self, base_rate: float) -> float:
         """Return the current effective mutation rate, clamped to ``[0, 1]``."""
-        if base_rate is None:
-            return base_rate  # type: ignore[return-value]
         return max(0.0, min(1.0, base_rate * self._rate_multiplier))
 
     def effective_scale(self, base_scale: float) -> float:
         """Return the current effective mutation scale, clamped to ``>= 0``."""
-        if base_scale is None:
-            return base_scale  # type: ignore[return-value]
         return max(0.0, base_scale * self._scale_multiplier)
 
     def per_gene_rate_multipliers(self) -> Mapping[str, float]:

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -8,7 +8,7 @@ import random
 import statistics
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 from farm.config import SimulationConfig
 from farm.core.genome import Genome, RouletteSelectionConfig, TournamentSelectionConfig
@@ -25,6 +25,11 @@ from farm.core.hyperparameter_chromosome import (
     mutate_chromosome,
 )
 from farm.core.simulation import run_simulation
+from farm.runners.adaptive_mutation import (
+    AdaptiveMutationConfig,
+    AdaptiveMutationController,
+    compute_normalized_diversity,
+)
 from farm.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -62,6 +67,7 @@ class EvolutionExperimentConfig:
     tournament_size: int = 3
     elitism_count: int = 1
     fitness_metric: EvolutionFitnessMetric = EvolutionFitnessMetric.FINAL_POPULATION
+    adaptive_mutation: AdaptiveMutationConfig = field(default_factory=AdaptiveMutationConfig)
     seed: Optional[int] = None
     output_dir: Optional[str] = None
 
@@ -119,6 +125,12 @@ class EvolutionGenerationSummary:
     best_candidate_id: str
     gene_statistics: Dict[str, Dict[str, float]]
     best_chromosome: Dict[str, float]
+    effective_mutation_rate: float = 0.0
+    effective_mutation_scale: float = 0.0
+    mutation_rate_multiplier: float = 1.0
+    mutation_scale_multiplier: float = 1.0
+    diversity: Optional[float] = None
+    adaptive_event: str = "baseline"
 
 
 @dataclass
@@ -152,6 +164,7 @@ class EvolutionExperiment:
         self._selection_call_count = 0
         self._run_rng = random.Random(self.config.seed) if self.config.seed is not None else random.Random()
         evaluator = fitness_evaluator or self._default_fitness_evaluator
+        controller = AdaptiveMutationController(self.config.adaptive_mutation)
         population = self._initialize_population()
         generation_summaries: List[EvolutionGenerationSummary] = []
         evaluations: List[EvolutionCandidateEvaluation] = []
@@ -159,8 +172,44 @@ class EvolutionExperiment:
         for generation in range(self.config.num_generations):
             generation_evals = self._evaluate_generation(generation, population, evaluator)
             evaluations.extend(generation_evals)
-            generation_summaries.append(self._build_generation_summary(generation, generation_evals))
-            population = self._next_generation(generation, generation_evals)
+            gene_statistics = self._build_gene_statistics(generation_evals)
+            diversity = self._compute_diversity(gene_statistics)
+            best_fitness = max(evaluation.fitness for evaluation in generation_evals)
+            controller.observe(best_fitness=best_fitness, diversity=diversity)
+            effective_rate = controller.effective_rate(self.config.mutation_rate)
+            effective_scale = controller.effective_scale(self.config.mutation_scale)
+            summary = self._build_generation_summary(
+                generation,
+                generation_evals,
+                gene_statistics=gene_statistics,
+                effective_rate=effective_rate,
+                effective_scale=effective_scale,
+                rate_multiplier=controller.rate_multiplier,
+                scale_multiplier=controller.scale_multiplier,
+                diversity=diversity,
+                adaptive_event=controller.last_event,
+            )
+            generation_summaries.append(summary)
+            logger.info(
+                "evolution_generation_completed",
+                generation=generation,
+                best_fitness=summary.best_fitness,
+                mean_fitness=summary.mean_fitness,
+                effective_mutation_rate=effective_rate,
+                effective_mutation_scale=effective_scale,
+                mutation_rate_multiplier=controller.rate_multiplier,
+                mutation_scale_multiplier=controller.scale_multiplier,
+                diversity=diversity,
+                adaptive_event=controller.last_event,
+            )
+            population = self._next_generation(
+                generation,
+                generation_evals,
+                effective_rate=effective_rate,
+                effective_scale=effective_scale,
+                per_gene_rate_multipliers=controller.per_gene_rate_multipliers(),
+                per_gene_scale_multipliers=controller.per_gene_scale_multipliers(),
+            )
 
         best_candidate = max(evaluations, key=lambda item: item.fitness)
         result = EvolutionExperimentResult(
@@ -229,6 +278,11 @@ class EvolutionExperiment:
         self,
         generation: int,
         generation_evals: List[EvolutionCandidateEvaluation],
+        *,
+        effective_rate: Optional[float] = None,
+        effective_scale: Optional[float] = None,
+        per_gene_rate_multipliers: Optional[Mapping[str, float]] = None,
+        per_gene_scale_multipliers: Optional[Mapping[str, float]] = None,
     ) -> List[EvolutionCandidate]:
         ranked = sorted(generation_evals, key=lambda item: item.fitness, reverse=True)
         next_population: List[EvolutionCandidate] = []
@@ -244,6 +298,9 @@ class EvolutionExperiment:
                 )
             )
 
+        resolved_rate = effective_rate if effective_rate is not None else self.config.mutation_rate
+        resolved_scale = effective_scale if effective_scale is not None else self.config.mutation_scale
+
         while len(next_population) < self.config.population_size:
             parent_a, parent_b = self._select_parents(generation_evals)
             child_chromosome = crossover_chromosomes(
@@ -255,10 +312,12 @@ class EvolutionExperiment:
             )
             child_chromosome = mutate_chromosome(
                 child_chromosome,
-                mutation_rate=self.config.mutation_rate,
-                mutation_scale=self.config.mutation_scale,
+                mutation_rate=resolved_rate,
+                mutation_scale=resolved_scale,
                 mutation_mode=self.config.mutation_mode,
                 boundary_mode=self.config.boundary_mode,
+                per_gene_rate_multipliers=per_gene_rate_multipliers,
+                per_gene_scale_multipliers=per_gene_scale_multipliers,
                 rng=self._run_rng,
             )
             child_idx = len(next_population)
@@ -313,11 +372,23 @@ class EvolutionExperiment:
         return population[parent_indices[0]], population[parent_indices[1]]
 
     def _build_generation_summary(
-        self, generation: int, generation_evals: List[EvolutionCandidateEvaluation]
+        self,
+        generation: int,
+        generation_evals: List[EvolutionCandidateEvaluation],
+        *,
+        gene_statistics: Optional[Dict[str, Dict[str, float]]] = None,
+        effective_rate: float = 0.0,
+        effective_scale: float = 0.0,
+        rate_multiplier: float = 1.0,
+        scale_multiplier: float = 1.0,
+        diversity: Optional[float] = None,
+        adaptive_event: str = "baseline",
     ) -> EvolutionGenerationSummary:
         best = max(generation_evals, key=lambda item: item.fitness)
         fitness_values = [evaluation.fitness for evaluation in generation_evals]
-        gene_statistics = self._build_gene_statistics(generation_evals)
+        resolved_gene_statistics = (
+            gene_statistics if gene_statistics is not None else self._build_gene_statistics(generation_evals)
+        )
         best_chromosome = {
             gene.name: gene.value
             for gene in best.metadata["chromosome"].genes
@@ -328,9 +399,34 @@ class EvolutionExperiment:
             mean_fitness=statistics.mean(fitness_values),
             min_fitness=min(fitness_values),
             best_candidate_id=best.candidate_id,
-            gene_statistics=gene_statistics,
+            gene_statistics=resolved_gene_statistics,
             best_chromosome=best_chromosome,
+            effective_mutation_rate=effective_rate,
+            effective_mutation_scale=effective_scale,
+            mutation_rate_multiplier=rate_multiplier,
+            mutation_scale_multiplier=scale_multiplier,
+            diversity=diversity,
+            adaptive_event=adaptive_event,
         )
+
+    def _compute_diversity(
+        self,
+        gene_statistics: Dict[str, Dict[str, float]],
+    ) -> Optional[float]:
+        """Compute mean normalized gene-std diversity over evolvable genes.
+
+        Returns ``None`` when no evolvable gene has a non-zero span, so
+        callers can decide whether to record the measure in telemetry.
+        """
+        evolvable_names: List[str] = []
+        gene_bounds: Dict[str, Tuple[float, float]] = {}
+        for gene in self._initial_chromosome.genes:
+            if gene.evolvable and gene.max_value > gene.min_value:
+                evolvable_names.append(gene.name)
+                gene_bounds[gene.name] = (gene.min_value, gene.max_value)
+        if not evolvable_names:
+            return None
+        return compute_normalized_diversity(gene_statistics, evolvable_names, gene_bounds)
 
     def _build_gene_statistics(
         self,

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -116,7 +116,17 @@ class EvolutionCandidateEvaluation:
 
 @dataclass(frozen=True)
 class EvolutionGenerationSummary:
-    """Aggregate stats for one evolved generation."""
+    """Aggregate stats for one evolved generation.
+
+    The ``mutation_rate_used`` / ``mutation_scale_used`` /
+    ``mutation_*_multiplier`` / ``adaptive_event`` fields describe the
+    mutation parameters that **produced this generation's children**.  For
+    generation 0 these are ``None`` because the initial population is seeded
+    via :meth:`EvolutionExperiment._initialize_population` (which uses
+    ``mutation_rate=1.0`` to spread seed candidates) rather than via the
+    adaptive controller.  ``diversity`` is measured **on this generation**
+    and therefore is recorded for every generation.
+    """
 
     generation: int
     best_fitness: float
@@ -125,12 +135,12 @@ class EvolutionGenerationSummary:
     best_candidate_id: str
     gene_statistics: Dict[str, Dict[str, float]]
     best_chromosome: Dict[str, float]
-    effective_mutation_rate: float = 0.0
-    effective_mutation_scale: float = 0.0
-    mutation_rate_multiplier: float = 1.0
-    mutation_scale_multiplier: float = 1.0
+    mutation_rate_used: Optional[float] = None
+    mutation_scale_used: Optional[float] = None
+    mutation_rate_multiplier: Optional[float] = None
+    mutation_scale_multiplier: Optional[float] = None
     diversity: Optional[float] = None
-    adaptive_event: str = "baseline"
+    adaptive_event: str = "initial_seeding"
 
 
 @dataclass
@@ -146,6 +156,27 @@ FitnessEvaluator = Callable[
     [EvolutionCandidate, SimulationConfig, int, int],
     Tuple[float, Dict[str, Any]],
 ]
+
+
+@dataclass(frozen=True)
+class _ProducedWith:
+    """Mutation parameters that produced a generation's population.
+
+    All four numeric fields are ``None`` for the initial population because
+    seeding bypasses the adaptive controller.  ``event`` is a short tag
+    matching :attr:`AdaptiveMutationController.last_event` from the
+    observation that yielded these parameters.
+    """
+
+    rate: Optional[float]
+    scale: Optional[float]
+    rate_multiplier: Optional[float]
+    scale_multiplier: Optional[float]
+    event: str
+
+    @classmethod
+    def initial(cls) -> "_ProducedWith":
+        return cls(rate=None, scale=None, rate_multiplier=None, scale_multiplier=None, event="initial_seeding")
 
 
 class EvolutionExperiment:
@@ -169,25 +200,24 @@ class EvolutionExperiment:
         generation_summaries: List[EvolutionGenerationSummary] = []
         evaluations: List[EvolutionCandidateEvaluation] = []
 
+        # Tracks the mutation parameters that produced the *current* population.
+        # `None` for generation 0 since the initial population is seeded by
+        # `_initialize_population`, not by the adaptive controller.
+        produced_with: _ProducedWith = _ProducedWith.initial()
+
         for generation in range(self.config.num_generations):
             generation_evals = self._evaluate_generation(generation, population, evaluator)
             evaluations.extend(generation_evals)
             gene_statistics = self._build_gene_statistics(generation_evals)
             diversity = self._compute_diversity(gene_statistics)
             best_fitness = max(evaluation.fitness for evaluation in generation_evals)
-            controller.observe(best_fitness=best_fitness, diversity=diversity)
-            effective_rate = controller.effective_rate(self.config.mutation_rate)
-            effective_scale = controller.effective_scale(self.config.mutation_scale)
+
             summary = self._build_generation_summary(
                 generation,
                 generation_evals,
                 gene_statistics=gene_statistics,
-                effective_rate=effective_rate,
-                effective_scale=effective_scale,
-                rate_multiplier=controller.rate_multiplier,
-                scale_multiplier=controller.scale_multiplier,
                 diversity=diversity,
-                adaptive_event=controller.last_event,
+                produced_with=produced_with,
             )
             generation_summaries.append(summary)
             logger.info(
@@ -195,20 +225,33 @@ class EvolutionExperiment:
                 generation=generation,
                 best_fitness=summary.best_fitness,
                 mean_fitness=summary.mean_fitness,
-                effective_mutation_rate=effective_rate,
-                effective_mutation_scale=effective_scale,
-                mutation_rate_multiplier=controller.rate_multiplier,
-                mutation_scale_multiplier=controller.scale_multiplier,
+                mutation_rate_used=produced_with.rate,
+                mutation_scale_used=produced_with.scale,
+                mutation_rate_multiplier=produced_with.rate_multiplier,
+                mutation_scale_multiplier=produced_with.scale_multiplier,
                 diversity=diversity,
-                adaptive_event=controller.last_event,
+                adaptive_event=produced_with.event,
             )
+
+            controller.observe(best_fitness=best_fitness, diversity=diversity)
+            next_rate = controller.effective_rate(self.config.mutation_rate)
+            next_scale = controller.effective_scale(self.config.mutation_scale)
             population = self._next_generation(
                 generation,
                 generation_evals,
-                effective_rate=effective_rate,
-                effective_scale=effective_scale,
+                effective_rate=next_rate,
+                effective_scale=next_scale,
                 per_gene_rate_multipliers=controller.per_gene_rate_multipliers(),
                 per_gene_scale_multipliers=controller.per_gene_scale_multipliers(),
+            )
+            # Carry forward into next iteration: these are the params that
+            # produced the population we just generated.
+            produced_with = _ProducedWith(
+                rate=next_rate,
+                scale=next_scale,
+                rate_multiplier=controller.rate_multiplier,
+                scale_multiplier=controller.scale_multiplier,
+                event=controller.last_event,
             )
 
         best_candidate = max(evaluations, key=lambda item: item.fitness)
@@ -377,12 +420,8 @@ class EvolutionExperiment:
         generation_evals: List[EvolutionCandidateEvaluation],
         *,
         gene_statistics: Optional[Dict[str, Dict[str, float]]] = None,
-        effective_rate: float = 0.0,
-        effective_scale: float = 0.0,
-        rate_multiplier: float = 1.0,
-        scale_multiplier: float = 1.0,
         diversity: Optional[float] = None,
-        adaptive_event: str = "baseline",
+        produced_with: Optional[_ProducedWith] = None,
     ) -> EvolutionGenerationSummary:
         best = max(generation_evals, key=lambda item: item.fitness)
         fitness_values = [evaluation.fitness for evaluation in generation_evals]
@@ -393,6 +432,7 @@ class EvolutionExperiment:
             gene.name: gene.value
             for gene in best.metadata["chromosome"].genes
         }
+        produced = produced_with or _ProducedWith.initial()
         return EvolutionGenerationSummary(
             generation=generation,
             best_fitness=max(fitness_values),
@@ -401,12 +441,12 @@ class EvolutionExperiment:
             best_candidate_id=best.candidate_id,
             gene_statistics=resolved_gene_statistics,
             best_chromosome=best_chromosome,
-            effective_mutation_rate=effective_rate,
-            effective_mutation_scale=effective_scale,
-            mutation_rate_multiplier=rate_multiplier,
-            mutation_scale_multiplier=scale_multiplier,
+            mutation_rate_used=produced.rate,
+            mutation_scale_used=produced.scale,
+            mutation_rate_multiplier=produced.rate_multiplier,
+            mutation_scale_multiplier=produced.scale_multiplier,
             diversity=diversity,
-            adaptive_event=adaptive_event,
+            adaptive_event=produced.event,
         )
 
     def _compute_diversity(

--- a/scripts/run_evolution_experiment.py
+++ b/scripts/run_evolution_experiment.py
@@ -29,6 +29,36 @@ from farm.core.hyperparameter_chromosome import (  # noqa: E402
 from farm.utils.logging import configure_logging, get_logger  # noqa: E402
 
 
+def _parse_per_gene_multipliers(raw: str | None, *, label: str) -> dict[str, float]:
+    """Parse a comma-separated ``gene=value`` string into a multiplier dict.
+
+    Returns an empty dict for ``None`` or empty input.  Raises ``ValueError``
+    on malformed entries; ``argparse`` will surface this as a CLI error.
+    """
+    if not raw:
+        return {}
+    multipliers: dict[str, float] = {}
+    for entry in raw.split(","):
+        token = entry.strip()
+        if not token:
+            continue
+        if "=" not in token:
+            raise ValueError(
+                f"{label} entry '{token}' must be of the form 'gene_name=value'."
+            )
+        name, _, value_str = token.partition("=")
+        name = name.strip()
+        if not name:
+            raise ValueError(f"{label} entry '{token}' has an empty gene name.")
+        try:
+            multipliers[name] = float(value_str)
+        except ValueError as exc:
+            raise ValueError(
+                f"{label} entry '{token}' has a non-numeric value."
+            ) from exc
+    return multipliers
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run multi-generation hyperparameter evolution experiments.",
@@ -120,7 +150,7 @@ def _parse_args() -> argparse.Namespace:
         help="Generations to look back when detecting a fitness stall.",
     )
     parser.add_argument(
-        "--adaptive-improvement-threshold",
+        "--adaptive-improve-threshold",
         type=float,
         default=1e-6,
         help="Minimum best-fitness improvement over the window that counts as progress.",
@@ -158,6 +188,24 @@ def _parse_args() -> argparse.Namespace:
         "--adaptive-disable-diversity",
         action="store_true",
         help="When --adaptive-mutation is set, skip the diversity-collapse adaptation rule.",
+    )
+    parser.add_argument(
+        "--adaptive-per-gene-rate",
+        type=str,
+        default=None,
+        help=(
+            "Comma-separated per-gene mutation-rate multipliers, e.g. "
+            "'learning_rate=0.5,gamma=2.0'.  Each value must be non-negative."
+        ),
+    )
+    parser.add_argument(
+        "--adaptive-per-gene-scale",
+        type=str,
+        default=None,
+        help=(
+            "Comma-separated per-gene mutation-scale multipliers, e.g. "
+            "'learning_rate=0.5,gamma=2.0'.  Each value must be non-negative."
+        ),
     )
     parser.add_argument("--seed", type=int, default=42, help="Global deterministic seed.")
     parser.add_argument(
@@ -223,11 +271,17 @@ def main() -> int:
                 use_fitness_adaptation=not args.adaptive_disable_fitness,
                 use_diversity_adaptation=not args.adaptive_disable_diversity,
                 stall_window=args.adaptive_stall_window,
-                improvement_threshold=args.adaptive_improvement_threshold,
+                improvement_threshold=args.adaptive_improve_threshold,
                 stall_multiplier=args.adaptive_stall_multiplier,
                 improve_multiplier=args.adaptive_improve_multiplier,
                 diversity_threshold=args.adaptive_diversity_threshold,
                 diversity_multiplier=args.adaptive_diversity_multiplier,
+                per_gene_rate_multipliers=_parse_per_gene_multipliers(
+                    args.adaptive_per_gene_rate, label="--adaptive-per-gene-rate"
+                ),
+                per_gene_scale_multipliers=_parse_per_gene_multipliers(
+                    args.adaptive_per_gene_scale, label="--adaptive-per-gene-scale"
+                ),
             ),
             selection_method=EvolutionSelectionMethod(args.selection_method),
             tournament_size=args.tournament_size,
@@ -241,6 +295,7 @@ def main() -> int:
         result = EvolutionExperiment(base_config, experiment_config).run()
         elapsed = time.time() - start
 
+        last_summary = result.generation_summaries[-1] if result.generation_summaries else None
         summary = {
             "elapsed_seconds": round(elapsed, 3),
             "num_generations": len(result.generation_summaries),
@@ -253,6 +308,14 @@ def main() -> int:
             "boundary_penalty_enabled": args.boundary_penalty_enabled,
             "boundary_penalty_strength": args.boundary_penalty_strength,
             "boundary_penalty_threshold": args.boundary_penalty_threshold,
+            "adaptive_mutation_enabled": args.adaptive_mutation,
+            "final_mutation_rate_multiplier": (
+                last_summary.mutation_rate_multiplier if last_summary else None
+            ),
+            "final_mutation_scale_multiplier": (
+                last_summary.mutation_scale_multiplier if last_summary else None
+            ),
+            "final_adaptive_event": last_summary.adaptive_event if last_summary else None,
             "output_dir": args.output_dir,
         }
         print(json.dumps(summary, indent=2))

--- a/scripts/run_evolution_experiment.py
+++ b/scripts/run_evolution_experiment.py
@@ -16,6 +16,7 @@ if _repo_root not in sys.path:
 
 from farm.config import SimulationConfig  # noqa: E402
 from farm.runners import (  # noqa: E402
+    AdaptiveMutationConfig,
     EvolutionExperiment,
     EvolutionExperimentConfig,
     EvolutionFitnessMetric,
@@ -107,6 +108,57 @@ def _parse_args() -> argparse.Namespace:
         help="Near-boundary zone width as fraction of gene range (0, 0.5].",
     )
     parser.add_argument("--elitism-count", type=int, default=1, help="Top candidates copied to next generation.")
+    parser.add_argument(
+        "--adaptive-mutation",
+        action="store_true",
+        help="Enable adaptive mutation rate/scale based on fitness progress and diversity.",
+    )
+    parser.add_argument(
+        "--adaptive-stall-window",
+        type=int,
+        default=3,
+        help="Generations to look back when detecting a fitness stall.",
+    )
+    parser.add_argument(
+        "--adaptive-improvement-threshold",
+        type=float,
+        default=1e-6,
+        help="Minimum best-fitness improvement over the window that counts as progress.",
+    )
+    parser.add_argument(
+        "--adaptive-stall-multiplier",
+        type=float,
+        default=1.5,
+        help="Multiplier applied to mutation rate/scale when the search stalls.",
+    )
+    parser.add_argument(
+        "--adaptive-improve-multiplier",
+        type=float,
+        default=0.8,
+        help="Multiplier applied to mutation rate/scale when fitness is improving.",
+    )
+    parser.add_argument(
+        "--adaptive-diversity-threshold",
+        type=float,
+        default=0.05,
+        help="Normalized diversity at or below which mutation is boosted.",
+    )
+    parser.add_argument(
+        "--adaptive-diversity-multiplier",
+        type=float,
+        default=1.5,
+        help="Multiplier applied to mutation rate/scale when diversity collapses.",
+    )
+    parser.add_argument(
+        "--adaptive-disable-fitness",
+        action="store_true",
+        help="When --adaptive-mutation is set, skip the fitness-progress adaptation rule.",
+    )
+    parser.add_argument(
+        "--adaptive-disable-diversity",
+        action="store_true",
+        help="When --adaptive-mutation is set, skip the diversity-collapse adaptation rule.",
+    )
     parser.add_argument("--seed", type=int, default=42, help="Global deterministic seed.")
     parser.add_argument(
         "--output-dir",
@@ -144,6 +196,7 @@ def main() -> int:
         boundary_penalty_enabled=args.boundary_penalty_enabled,
         boundary_penalty_strength=args.boundary_penalty_strength,
         boundary_penalty_threshold=args.boundary_penalty_threshold,
+        adaptive_mutation=args.adaptive_mutation,
         output_dir=args.output_dir,
     )
 
@@ -164,6 +217,17 @@ def main() -> int:
                 enabled=args.boundary_penalty_enabled,
                 penalty_strength=args.boundary_penalty_strength,
                 near_boundary_threshold=args.boundary_penalty_threshold,
+            ),
+            adaptive_mutation=AdaptiveMutationConfig(
+                enabled=args.adaptive_mutation,
+                use_fitness_adaptation=not args.adaptive_disable_fitness,
+                use_diversity_adaptation=not args.adaptive_disable_diversity,
+                stall_window=args.adaptive_stall_window,
+                improvement_threshold=args.adaptive_improvement_threshold,
+                stall_multiplier=args.adaptive_stall_multiplier,
+                improve_multiplier=args.adaptive_improve_multiplier,
+                diversity_threshold=args.adaptive_diversity_threshold,
+                diversity_multiplier=args.adaptive_diversity_multiplier,
             ),
             selection_method=EvolutionSelectionMethod(args.selection_method),
             tournament_size=args.tournament_size,

--- a/tests/runners/test_adaptive_mutation.py
+++ b/tests/runners/test_adaptive_mutation.py
@@ -1,0 +1,198 @@
+"""Tests for adaptive mutation rate/scale controller and config."""
+
+import unittest
+
+from farm.runners.adaptive_mutation import (
+    AdaptiveMutationConfig,
+    AdaptiveMutationController,
+    compute_normalized_diversity,
+)
+
+
+class TestAdaptiveMutationConfig(unittest.TestCase):
+    def test_defaults_are_disabled(self):
+        config = AdaptiveMutationConfig()
+        self.assertFalse(config.enabled)
+        self.assertEqual(config.per_gene_rate_multipliers, {})
+        self.assertEqual(config.per_gene_scale_multipliers, {})
+
+    def test_rejects_invalid_stall_window(self):
+        with self.assertRaises(ValueError):
+            AdaptiveMutationConfig(stall_window=0)
+
+    def test_rejects_negative_improvement_threshold(self):
+        with self.assertRaises(ValueError):
+            AdaptiveMutationConfig(improvement_threshold=-0.1)
+
+    def test_rejects_inverted_rate_bounds(self):
+        with self.assertRaises(ValueError):
+            AdaptiveMutationConfig(min_rate_multiplier=2.0, max_rate_multiplier=1.0)
+
+    def test_rejects_diversity_threshold_out_of_range(self):
+        with self.assertRaises(ValueError):
+            AdaptiveMutationConfig(diversity_threshold=1.5)
+
+    def test_rejects_negative_per_gene_multiplier(self):
+        with self.assertRaises(ValueError):
+            AdaptiveMutationConfig(per_gene_rate_multipliers={"learning_rate": -0.1})
+
+
+class TestComputeNormalizedDiversity(unittest.TestCase):
+    def test_returns_zero_when_no_genes(self):
+        self.assertEqual(compute_normalized_diversity({}, [], {}), 0.0)
+
+    def test_normalizes_std_by_span(self):
+        stats = {
+            "learning_rate": {"std": 0.01},
+            "gamma": {"std": 0.1},
+        }
+        bounds = {
+            "learning_rate": (0.0, 0.1),
+            "gamma": (0.5, 1.0),
+        }
+        diversity = compute_normalized_diversity(stats, ["learning_rate", "gamma"], bounds)
+        # (0.01 / 0.1 + 0.1 / 0.5) / 2 == (0.1 + 0.2) / 2 == 0.15
+        self.assertAlmostEqual(diversity, 0.15)
+
+    def test_skips_zero_span_genes(self):
+        stats = {
+            "learning_rate": {"std": 0.01},
+            "fixed_gene": {"std": 0.0},
+        }
+        bounds = {
+            "learning_rate": (0.0, 0.1),
+            "fixed_gene": (0.5, 0.5),
+        }
+        diversity = compute_normalized_diversity(stats, ["learning_rate", "fixed_gene"], bounds)
+        self.assertAlmostEqual(diversity, 0.1)
+
+
+class TestAdaptiveMutationController(unittest.TestCase):
+    def test_disabled_controller_keeps_multipliers_at_unity(self):
+        controller = AdaptiveMutationController(AdaptiveMutationConfig(enabled=False))
+        controller.observe(best_fitness=1.0, diversity=0.2)
+        controller.observe(best_fitness=1.0, diversity=0.2)
+        self.assertEqual(controller.rate_multiplier, 1.0)
+        self.assertEqual(controller.scale_multiplier, 1.0)
+        self.assertEqual(controller.effective_rate(0.25), 0.25)
+        self.assertEqual(controller.effective_scale(0.2), 0.2)
+        self.assertEqual(controller.last_event, "disabled")
+
+    def test_stalled_fitness_increases_multipliers(self):
+        config = AdaptiveMutationConfig(
+            enabled=True,
+            use_fitness_adaptation=True,
+            use_diversity_adaptation=False,
+            stall_window=2,
+            stall_multiplier=2.0,
+            improvement_threshold=1e-6,
+        )
+        controller = AdaptiveMutationController(config)
+        # No improvement across three generations => two stall events.
+        controller.observe(best_fitness=1.0, diversity=None)
+        controller.observe(best_fitness=1.0, diversity=None)
+        controller.observe(best_fitness=1.0, diversity=None)
+        self.assertGreater(controller.rate_multiplier, 1.0)
+        self.assertAlmostEqual(controller.rate_multiplier, 4.0)
+        self.assertIn("stalled", controller.last_event)
+
+    def test_improving_fitness_tightens_multipliers(self):
+        config = AdaptiveMutationConfig(
+            enabled=True,
+            use_fitness_adaptation=True,
+            use_diversity_adaptation=False,
+            stall_window=1,
+            improve_multiplier=0.5,
+            min_rate_multiplier=0.01,
+            min_scale_multiplier=0.01,
+        )
+        controller = AdaptiveMutationController(config)
+        controller.observe(best_fitness=1.0, diversity=None)
+        controller.observe(best_fitness=2.0, diversity=None)
+        self.assertAlmostEqual(controller.rate_multiplier, 0.5)
+        self.assertAlmostEqual(controller.scale_multiplier, 0.5)
+        self.assertEqual(controller.last_event, "improving")
+
+    def test_diversity_collapse_boosts_multipliers(self):
+        config = AdaptiveMutationConfig(
+            enabled=True,
+            use_fitness_adaptation=False,
+            use_diversity_adaptation=True,
+            diversity_threshold=0.1,
+            diversity_multiplier=3.0,
+        )
+        controller = AdaptiveMutationController(config)
+        controller.observe(best_fitness=1.0, diversity=0.05)
+        self.assertAlmostEqual(controller.rate_multiplier, 3.0)
+        self.assertAlmostEqual(controller.scale_multiplier, 3.0)
+        self.assertEqual(controller.last_event, "diversity_collapse")
+
+    def test_high_diversity_does_not_boost(self):
+        config = AdaptiveMutationConfig(
+            enabled=True,
+            use_fitness_adaptation=False,
+            use_diversity_adaptation=True,
+            diversity_threshold=0.1,
+            diversity_multiplier=3.0,
+        )
+        controller = AdaptiveMutationController(config)
+        controller.observe(best_fitness=1.0, diversity=0.2)
+        self.assertEqual(controller.rate_multiplier, 1.0)
+        self.assertEqual(controller.last_event, "baseline")
+
+    def test_multipliers_are_clamped(self):
+        config = AdaptiveMutationConfig(
+            enabled=True,
+            use_fitness_adaptation=True,
+            use_diversity_adaptation=False,
+            stall_window=1,
+            stall_multiplier=10.0,
+            max_rate_multiplier=4.0,
+            max_scale_multiplier=4.0,
+        )
+        controller = AdaptiveMutationController(config)
+        for _ in range(5):
+            controller.observe(best_fitness=0.0, diversity=None)
+        self.assertLessEqual(controller.rate_multiplier, 4.0)
+        self.assertLessEqual(controller.scale_multiplier, 4.0)
+
+    def test_effective_rate_is_clamped_to_unit_interval(self):
+        config = AdaptiveMutationConfig(
+            enabled=True,
+            use_fitness_adaptation=True,
+            use_diversity_adaptation=False,
+            stall_window=1,
+            stall_multiplier=5.0,
+            max_rate_multiplier=5.0,
+            max_scale_multiplier=5.0,
+        )
+        controller = AdaptiveMutationController(config)
+        controller.observe(best_fitness=0.0, diversity=None)
+        controller.observe(best_fitness=0.0, diversity=None)
+        self.assertLessEqual(controller.effective_rate(0.5), 1.0)
+        self.assertGreaterEqual(controller.effective_scale(0.1), 0.0)
+
+    def test_per_gene_multipliers_only_active_when_enabled(self):
+        config_disabled = AdaptiveMutationConfig(
+            enabled=False,
+            per_gene_rate_multipliers={"learning_rate": 2.0},
+        )
+        controller = AdaptiveMutationController(config_disabled)
+        self.assertEqual(controller.per_gene_rate_multipliers(), {})
+
+        config_enabled = AdaptiveMutationConfig(
+            enabled=True,
+            per_gene_rate_multipliers={"learning_rate": 2.0},
+            per_gene_scale_multipliers={"learning_rate": 0.5},
+        )
+        controller_enabled = AdaptiveMutationController(config_enabled)
+        self.assertEqual(
+            controller_enabled.per_gene_rate_multipliers()["learning_rate"], 2.0
+        )
+        self.assertEqual(
+            controller_enabled.per_gene_scale_multipliers()["learning_rate"], 0.5
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runners/test_adaptive_mutation.py
+++ b/tests/runners/test_adaptive_mutation.py
@@ -172,6 +172,65 @@ class TestAdaptiveMutationController(unittest.TestCase):
         self.assertLessEqual(controller.effective_rate(0.5), 1.0)
         self.assertGreaterEqual(controller.effective_scale(0.1), 0.0)
 
+    def test_combined_stall_and_diversity_collapse_event_tag(self):
+        config = AdaptiveMutationConfig(
+            enabled=True,
+            use_fitness_adaptation=True,
+            use_diversity_adaptation=True,
+            stall_window=1,
+            stall_multiplier=1.5,
+            improvement_threshold=1e-6,
+            diversity_threshold=0.1,
+            diversity_multiplier=1.5,
+        )
+        controller = AdaptiveMutationController(config)
+        controller.observe(best_fitness=1.0, diversity=0.05)
+        # First observation only records baseline (fitness adaptation needs >=2 points).
+        # Diversity collapse can still fire on the first observation.
+        self.assertIn("diversity_collapse", controller.last_event)
+
+        controller.observe(best_fitness=1.0, diversity=0.05)
+        # Now both stalled and diversity_collapse should fire together.
+        self.assertIn("stalled", controller.last_event)
+        self.assertIn("diversity_collapse", controller.last_event)
+        # And multipliers compounded: 1.5 (initial diversity) * 1.5 (stall) * 1.5 (diversity).
+        self.assertAlmostEqual(controller.rate_multiplier, 1.5 * 1.5 * 1.5)
+
+    def test_clamp_emits_saturation_event_tag(self):
+        config = AdaptiveMutationConfig(
+            enabled=True,
+            use_fitness_adaptation=True,
+            use_diversity_adaptation=False,
+            stall_window=1,
+            stall_multiplier=10.0,
+            max_rate_multiplier=2.0,
+            max_scale_multiplier=2.0,
+        )
+        controller = AdaptiveMutationController(config)
+        controller.observe(best_fitness=0.0, diversity=None)
+        controller.observe(best_fitness=0.0, diversity=None)
+        self.assertEqual(controller.rate_multiplier, 2.0)
+        self.assertEqual(controller.scale_multiplier, 2.0)
+        self.assertIn("rate_clamped", controller.last_event)
+        self.assertIn("scale_clamped", controller.last_event)
+
+    def test_per_gene_mapping_is_immutable_after_construction(self):
+        original = {"learning_rate": 2.0}
+        config = AdaptiveMutationConfig(
+            enabled=True,
+            per_gene_rate_multipliers=original,
+        )
+        # Frozen via MappingProxyType: write attempts raise TypeError.
+        with self.assertRaises(TypeError):
+            config.per_gene_rate_multipliers["learning_rate"] = 9.9  # type: ignore[index]
+        # Mutating the original dict does not bleed through into the config.
+        original["learning_rate"] = 9.9
+        self.assertEqual(config.per_gene_rate_multipliers["learning_rate"], 2.0)
+
+    def test_rejects_nan_per_gene_multiplier(self):
+        with self.assertRaises(ValueError):
+            AdaptiveMutationConfig(per_gene_scale_multipliers={"learning_rate": float("nan")})
+
     def test_per_gene_multipliers_only_active_when_enabled(self):
         config_disabled = AdaptiveMutationConfig(
             enabled=False,

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from farm.config import SimulationConfig
 from farm.core.hyperparameter_chromosome import BoundaryMode, BoundaryPenaltyConfig
+from farm.runners.adaptive_mutation import AdaptiveMutationConfig
 from farm.runners.evolution_experiment import (
     EvolutionExperiment,
     EvolutionExperimentConfig,
@@ -235,6 +236,185 @@ class TestEvolutionExperiment(unittest.TestCase):
         self.assertTrue(
             all(call.kwargs.get("boundary_mode") == BoundaryMode.REFLECT for call in mutate_mock.call_args_list)
         )
+
+
+class TestEvolutionExperimentAdaptiveMutation(unittest.TestCase):
+    def test_summary_includes_effective_mutation_telemetry(self):
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=2,
+            population_size=4,
+            num_steps_per_candidate=1,
+            mutation_rate=0.25,
+            mutation_scale=0.2,
+            seed=5,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, generation, member: (
+                float(member + generation),
+                {"member": member},
+            )
+        )
+        for summary in result.generation_summaries:
+            # Without adaptive mutation, telemetry still reports base values and
+            # unity multipliers for every generation.
+            self.assertAlmostEqual(summary.effective_mutation_rate, 0.25)
+            self.assertAlmostEqual(summary.effective_mutation_scale, 0.2)
+            self.assertAlmostEqual(summary.mutation_rate_multiplier, 1.0)
+            self.assertAlmostEqual(summary.mutation_scale_multiplier, 1.0)
+            # Diversity is computed from the evaluated generation.
+            self.assertIsNotNone(summary.diversity)
+            self.assertGreaterEqual(summary.diversity, 0.0)
+            self.assertEqual(summary.adaptive_event, "disabled")
+
+    @patch("farm.runners.evolution_experiment.mutate_chromosome")
+    def test_adaptive_stall_boosts_effective_mutation_for_next_generation(self, mutate_mock):
+        mutate_mock.side_effect = lambda chromosome, **kwargs: chromosome
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=3,
+            population_size=3,
+            num_steps_per_candidate=1,
+            mutation_rate=0.2,
+            mutation_scale=0.1,
+            adaptive_mutation=AdaptiveMutationConfig(
+                enabled=True,
+                use_fitness_adaptation=True,
+                use_diversity_adaptation=False,
+                stall_window=1,
+                stall_multiplier=2.0,
+                improvement_threshold=1e-6,
+                max_rate_multiplier=4.0,
+                max_scale_multiplier=4.0,
+            ),
+            seed=42,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        # Flat fitness => every generation after the first is a stall.
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, generation, member: (1.0, {"member": member})
+        )
+        gen0, gen1, gen2 = result.generation_summaries
+        self.assertAlmostEqual(gen0.mutation_rate_multiplier, 1.0)
+        # Second generation's effective rate is boosted relative to the first.
+        self.assertGreater(gen1.mutation_rate_multiplier, gen0.mutation_rate_multiplier)
+        self.assertGreater(gen2.mutation_rate_multiplier, gen1.mutation_rate_multiplier)
+        self.assertAlmostEqual(gen1.effective_mutation_rate, 0.2 * gen1.mutation_rate_multiplier)
+        self.assertIn("stalled", gen1.adaptive_event)
+
+    @patch("farm.runners.evolution_experiment.mutate_chromosome")
+    def test_adaptive_improving_tightens_effective_mutation(self, mutate_mock):
+        mutate_mock.side_effect = lambda chromosome, **kwargs: chromosome
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=3,
+            population_size=3,
+            num_steps_per_candidate=1,
+            mutation_rate=0.4,
+            mutation_scale=0.2,
+            adaptive_mutation=AdaptiveMutationConfig(
+                enabled=True,
+                use_fitness_adaptation=True,
+                use_diversity_adaptation=False,
+                stall_window=1,
+                improve_multiplier=0.5,
+                min_rate_multiplier=0.01,
+                min_scale_multiplier=0.01,
+            ),
+            seed=99,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        fitness_by_generation = {0: 1.0, 1: 2.0, 2: 3.0}
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, generation, member: (
+                fitness_by_generation[generation],
+                {"member": member},
+            )
+        )
+        self.assertAlmostEqual(result.generation_summaries[0].mutation_rate_multiplier, 1.0)
+        self.assertLess(
+            result.generation_summaries[1].mutation_rate_multiplier,
+            result.generation_summaries[0].mutation_rate_multiplier,
+        )
+        self.assertIn("improving", result.generation_summaries[1].adaptive_event)
+
+    @patch("farm.runners.evolution_experiment.mutate_chromosome")
+    def test_per_gene_multipliers_forwarded_to_mutate(self, mutate_mock):
+        mutate_mock.side_effect = lambda chromosome, **kwargs: chromosome
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=2,
+            population_size=3,
+            num_steps_per_candidate=1,
+            adaptive_mutation=AdaptiveMutationConfig(
+                enabled=True,
+                use_fitness_adaptation=False,
+                use_diversity_adaptation=False,
+                per_gene_rate_multipliers={"learning_rate": 2.0},
+                per_gene_scale_multipliers={"learning_rate": 0.5},
+            ),
+            seed=8,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        experiment.run(
+            fitness_evaluator=lambda candidate, cfg, generation, member: (
+                float(member),
+                {"member": member},
+            )
+        )
+        self.assertTrue(mutate_mock.called)
+        # Child generations call mutate_chromosome with per-gene multiplier dicts.
+        # The initial population seeding uses mutation_rate=1.0 with no
+        # adaptive per-gene multipliers, so filter those out.
+        child_calls = [
+            call for call in mutate_mock.call_args_list
+            if call.kwargs.get("per_gene_rate_multipliers") is not None
+        ]
+        self.assertGreater(len(child_calls), 0)
+        for call in child_calls:
+            self.assertEqual(call.kwargs.get("per_gene_rate_multipliers"), {"learning_rate": 2.0})
+            self.assertEqual(call.kwargs.get("per_gene_scale_multipliers"), {"learning_rate": 0.5})
+
+    def test_adaptive_telemetry_persisted_to_generation_summaries(self):
+        base_config = SimulationConfig()
+        with tempfile.TemporaryDirectory() as output_dir:
+            config = EvolutionExperimentConfig(
+                num_generations=2,
+                population_size=3,
+                num_steps_per_candidate=1,
+                mutation_rate=0.2,
+                mutation_scale=0.1,
+                adaptive_mutation=AdaptiveMutationConfig(
+                    enabled=True,
+                    use_fitness_adaptation=True,
+                    use_diversity_adaptation=False,
+                    stall_window=1,
+                    stall_multiplier=2.0,
+                ),
+                output_dir=output_dir,
+                seed=1,
+            )
+            experiment = EvolutionExperiment(base_config, config)
+            experiment.run(
+                fitness_evaluator=lambda candidate, cfg, generation, member: (
+                    1.0,
+                    {"member": member},
+                )
+            )
+            with open(
+                f"{output_dir}/evolution_generation_summaries.json",
+                encoding="utf-8",
+            ) as summaries_file:
+                summaries = json.load(summaries_file)
+            self.assertEqual(len(summaries), 2)
+            for summary in summaries:
+                self.assertIn("effective_mutation_rate", summary)
+                self.assertIn("effective_mutation_scale", summary)
+                self.assertIn("mutation_rate_multiplier", summary)
+                self.assertIn("mutation_scale_multiplier", summary)
+                self.assertIn("diversity", summary)
+                self.assertIn("adaptive_event", summary)
 
 
 if __name__ == "__main__":

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -239,7 +239,7 @@ class TestEvolutionExperiment(unittest.TestCase):
 
 
 class TestEvolutionExperimentAdaptiveMutation(unittest.TestCase):
-    def test_summary_includes_effective_mutation_telemetry(self):
+    def test_summary_telemetry_describes_what_produced_each_generation(self):
         base_config = SimulationConfig()
         config = EvolutionExperimentConfig(
             num_generations=2,
@@ -256,17 +256,27 @@ class TestEvolutionExperimentAdaptiveMutation(unittest.TestCase):
                 {"member": member},
             )
         )
-        for summary in result.generation_summaries:
-            # Without adaptive mutation, telemetry still reports base values and
-            # unity multipliers for every generation.
-            self.assertAlmostEqual(summary.effective_mutation_rate, 0.25)
-            self.assertAlmostEqual(summary.effective_mutation_scale, 0.2)
-            self.assertAlmostEqual(summary.mutation_rate_multiplier, 1.0)
-            self.assertAlmostEqual(summary.mutation_scale_multiplier, 1.0)
-            # Diversity is computed from the evaluated generation.
-            self.assertIsNotNone(summary.diversity)
-            self.assertGreaterEqual(summary.diversity, 0.0)
-            self.assertEqual(summary.adaptive_event, "disabled")
+        # Generation 0 is seeded by `_initialize_population`, not by the
+        # adaptive controller, so its mutation telemetry is None and the
+        # event is the special `initial_seeding` tag.
+        gen0 = result.generation_summaries[0]
+        self.assertIsNone(gen0.mutation_rate_used)
+        self.assertIsNone(gen0.mutation_scale_used)
+        self.assertIsNone(gen0.mutation_rate_multiplier)
+        self.assertIsNone(gen0.mutation_scale_multiplier)
+        self.assertEqual(gen0.adaptive_event, "initial_seeding")
+        # Diversity is always measured on the current generation.
+        self.assertIsNotNone(gen0.diversity)
+        self.assertGreaterEqual(gen0.diversity, 0.0)
+
+        # Subsequent generations were produced by the controller (in this
+        # case "disabled" because adaptive_mutation defaults to off).
+        gen1 = result.generation_summaries[1]
+        self.assertAlmostEqual(gen1.mutation_rate_used, 0.25)
+        self.assertAlmostEqual(gen1.mutation_scale_used, 0.2)
+        self.assertAlmostEqual(gen1.mutation_rate_multiplier, 1.0)
+        self.assertAlmostEqual(gen1.mutation_scale_multiplier, 1.0)
+        self.assertEqual(gen1.adaptive_event, "disabled")
 
     @patch("farm.runners.evolution_experiment.mutate_chromosome")
     def test_adaptive_stall_boosts_effective_mutation_for_next_generation(self, mutate_mock):
@@ -296,12 +306,14 @@ class TestEvolutionExperimentAdaptiveMutation(unittest.TestCase):
             fitness_evaluator=lambda candidate, cfg, generation, member: (1.0, {"member": member})
         )
         gen0, gen1, gen2 = result.generation_summaries
-        self.assertAlmostEqual(gen0.mutation_rate_multiplier, 1.0)
-        # Second generation's effective rate is boosted relative to the first.
-        self.assertGreater(gen1.mutation_rate_multiplier, gen0.mutation_rate_multiplier)
+        # Gen 0 is seeded; gen 1 was produced before any stall observation
+        # had taken effect, so its multiplier is still 1.0.  Gen 2 reflects
+        # the post-gen-1 stall.
+        self.assertIsNone(gen0.mutation_rate_multiplier)
+        self.assertAlmostEqual(gen1.mutation_rate_multiplier, 1.0)
         self.assertGreater(gen2.mutation_rate_multiplier, gen1.mutation_rate_multiplier)
-        self.assertAlmostEqual(gen1.effective_mutation_rate, 0.2 * gen1.mutation_rate_multiplier)
-        self.assertIn("stalled", gen1.adaptive_event)
+        self.assertAlmostEqual(gen2.mutation_rate_used, 0.2 * gen2.mutation_rate_multiplier)
+        self.assertIn("stalled", gen2.adaptive_event)
 
     @patch("farm.runners.evolution_experiment.mutate_chromosome")
     def test_adaptive_improving_tightens_effective_mutation(self, mutate_mock):
@@ -332,12 +344,13 @@ class TestEvolutionExperimentAdaptiveMutation(unittest.TestCase):
                 {"member": member},
             )
         )
-        self.assertAlmostEqual(result.generation_summaries[0].mutation_rate_multiplier, 1.0)
-        self.assertLess(
-            result.generation_summaries[1].mutation_rate_multiplier,
-            result.generation_summaries[0].mutation_rate_multiplier,
-        )
-        self.assertIn("improving", result.generation_summaries[1].adaptive_event)
+        gen0, gen1, gen2 = result.generation_summaries
+        self.assertIsNone(gen0.mutation_rate_multiplier)
+        # Gen 1 was produced before any observe() had been called, so the
+        # multiplier is still 1.0.  Gen 2 reflects the gen-1 improvement.
+        self.assertAlmostEqual(gen1.mutation_rate_multiplier, 1.0)
+        self.assertLess(gen2.mutation_rate_multiplier, gen1.mutation_rate_multiplier)
+        self.assertIn("improving", gen2.adaptive_event)
 
     @patch("farm.runners.evolution_experiment.mutate_chromosome")
     def test_per_gene_multipliers_forwarded_to_mutate(self, mutate_mock):
@@ -409,12 +422,53 @@ class TestEvolutionExperimentAdaptiveMutation(unittest.TestCase):
                 summaries = json.load(summaries_file)
             self.assertEqual(len(summaries), 2)
             for summary in summaries:
-                self.assertIn("effective_mutation_rate", summary)
-                self.assertIn("effective_mutation_scale", summary)
+                self.assertIn("mutation_rate_used", summary)
+                self.assertIn("mutation_scale_used", summary)
                 self.assertIn("mutation_rate_multiplier", summary)
                 self.assertIn("mutation_scale_multiplier", summary)
                 self.assertIn("diversity", summary)
                 self.assertIn("adaptive_event", summary)
+            # Generation 0 was seeded, so its mutation telemetry is null.
+            self.assertIsNone(summaries[0]["mutation_rate_used"])
+            self.assertEqual(summaries[0]["adaptive_event"], "initial_seeding")
+            # Generation 1 was produced before any controller observation
+            # took effect, so multiplier is unity but event reflects the
+            # very first observation made on gen 0.
+            self.assertEqual(summaries[1]["mutation_rate_multiplier"], 1.0)
+
+    def test_none_diversity_persists_as_json_null_and_skips_diversity_rule(self):
+        base_config = SimulationConfig()
+        with tempfile.TemporaryDirectory() as output_dir:
+            config = EvolutionExperimentConfig(
+                num_generations=2,
+                population_size=3,
+                num_steps_per_candidate=1,
+                adaptive_mutation=AdaptiveMutationConfig(
+                    enabled=True,
+                    use_fitness_adaptation=False,
+                    use_diversity_adaptation=True,
+                    diversity_threshold=0.99,  # would always fire if diversity were measured
+                ),
+                output_dir=output_dir,
+                seed=1,
+            )
+            experiment = EvolutionExperiment(base_config, config)
+            with patch.object(EvolutionExperiment, "_compute_diversity", return_value=None):
+                experiment.run(
+                    fitness_evaluator=lambda candidate, cfg, generation, member: (
+                        1.0,
+                        {"member": member},
+                    )
+                )
+            with open(
+                f"{output_dir}/evolution_generation_summaries.json",
+                encoding="utf-8",
+            ) as summaries_file:
+                summaries = json.load(summaries_file)
+            for summary in summaries:
+                self.assertIsNone(summary["diversity"])
+            # No diversity_collapse fired because diversity was None.
+            self.assertNotIn("diversity_collapse", summaries[1]["adaptive_event"])
 
 
 if __name__ == "__main__":

--- a/tests/test_hyperparameter_chromosome.py
+++ b/tests/test_hyperparameter_chromosome.py
@@ -210,6 +210,79 @@ class TestHyperparameterChromosome(unittest.TestCase):
             )
         self.assertAlmostEqual(mutated.get_value("learning_rate"), 0.011)
 
+    def test_per_gene_rate_multiplier_can_suppress_mutation(self):
+        chromosome = HyperparameterChromosome(
+            genes=(
+                HyperparameterGene(
+                    name="learning_rate",
+                    value_type=GeneValueType.REAL,
+                    value=0.01,
+                    min_value=1e-6,
+                    max_value=1.0,
+                    default=0.001,
+                    evolvable=True,
+                    mutation_scale=0.1,
+                    mutation_probability=0.5,
+                    mutation_strategy=MutationMode.GAUSSIAN,
+                ),
+            )
+        )
+        # Rate multiplier of 0.0 suppresses mutation for this gene even when
+        # the global rate override is 1.0.
+        mutated = mutate_chromosome(
+            chromosome,
+            mutation_rate=1.0,
+            mutation_scale=0.1,
+            per_gene_rate_multipliers={"learning_rate": 0.0},
+        )
+        self.assertEqual(mutated.get_value("learning_rate"), 0.01)
+
+    def test_per_gene_scale_multiplier_scales_perturbation(self):
+        chromosome = HyperparameterChromosome(
+            genes=(
+                HyperparameterGene(
+                    name="learning_rate",
+                    value_type=GeneValueType.REAL,
+                    value=0.5,
+                    min_value=0.0,
+                    max_value=1.0,
+                    default=0.5,
+                    evolvable=True,
+                    mutation_scale=0.1,
+                    mutation_probability=1.0,
+                    mutation_strategy=MutationMode.GAUSSIAN,
+                ),
+            )
+        )
+        # Force a deterministic Gaussian perturbation of sigma-magnitude by
+        # returning the sigma value from random.gauss.
+        with patch(
+            "farm.core.hyperparameter_chromosome.random.gauss",
+            side_effect=lambda mu, sigma: sigma,
+        ):
+            mutated_base = mutate_chromosome(chromosome, mutation_rate=1.0)
+            mutated_scaled = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                per_gene_scale_multipliers={"learning_rate": 2.0},
+            )
+        delta_base = mutated_base.get_value("learning_rate") - 0.5
+        delta_scaled = mutated_scaled.get_value("learning_rate") - 0.5
+        self.assertAlmostEqual(delta_scaled, delta_base * 2.0)
+
+    def test_per_gene_multiplier_rejects_negative_values(self):
+        chromosome = default_hyperparameter_chromosome()
+        with self.assertRaises(ValueError):
+            mutate_chromosome(
+                chromosome,
+                per_gene_rate_multipliers={"learning_rate": -0.1},
+            )
+        with self.assertRaises(ValueError):
+            mutate_chromosome(
+                chromosome,
+                per_gene_scale_multipliers={"learning_rate": -0.1},
+            )
+
     def test_fixed_genes_remain_unchanged_even_with_full_global_mutation(self):
         chromosome = default_hyperparameter_chromosome()
         with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=1000.0):

--- a/tests/test_run_evolution_experiment_cli.py
+++ b/tests/test_run_evolution_experiment_cli.py
@@ -1,0 +1,92 @@
+"""Smoke tests for the run_evolution_experiment CLI helpers."""
+
+import importlib
+import os
+import sys
+import unittest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_SCRIPT_PATH = os.path.join(_REPO_ROOT, "scripts")
+if _SCRIPT_PATH not in sys.path:
+    sys.path.insert(0, _SCRIPT_PATH)
+
+run_evolution_experiment = importlib.import_module("run_evolution_experiment")
+
+
+class TestParsePerGeneMultipliers(unittest.TestCase):
+    def test_returns_empty_for_none(self):
+        self.assertEqual(
+            run_evolution_experiment._parse_per_gene_multipliers(None, label="x"),
+            {},
+        )
+
+    def test_returns_empty_for_blank(self):
+        self.assertEqual(
+            run_evolution_experiment._parse_per_gene_multipliers("", label="x"),
+            {},
+        )
+
+    def test_parses_single_pair(self):
+        self.assertEqual(
+            run_evolution_experiment._parse_per_gene_multipliers(
+                "learning_rate=0.5", label="x"
+            ),
+            {"learning_rate": 0.5},
+        )
+
+    def test_parses_multiple_pairs_with_whitespace(self):
+        result = run_evolution_experiment._parse_per_gene_multipliers(
+            " learning_rate=0.5 , gamma=2.0 ", label="x"
+        )
+        self.assertEqual(result, {"learning_rate": 0.5, "gamma": 2.0})
+
+    def test_rejects_missing_equals(self):
+        with self.assertRaises(ValueError):
+            run_evolution_experiment._parse_per_gene_multipliers(
+                "learning_rate0.5", label="x"
+            )
+
+    def test_rejects_non_numeric_value(self):
+        with self.assertRaises(ValueError):
+            run_evolution_experiment._parse_per_gene_multipliers(
+                "learning_rate=abc", label="x"
+            )
+
+    def test_rejects_empty_gene_name(self):
+        with self.assertRaises(ValueError):
+            run_evolution_experiment._parse_per_gene_multipliers(
+                "=0.5", label="x"
+            )
+
+
+class TestAdaptiveCliFlags(unittest.TestCase):
+    def test_adaptive_flags_round_trip_into_namespace(self):
+        argv = sys.argv[:]
+        try:
+            sys.argv = [
+                "run_evolution_experiment.py",
+                "--generations", "1",
+                "--population-size", "2",
+                "--steps-per-candidate", "1",
+                "--adaptive-mutation",
+                "--adaptive-improve-threshold", "0.01",
+                "--adaptive-stall-multiplier", "1.7",
+                "--adaptive-improve-multiplier", "0.7",
+                "--adaptive-diversity-threshold", "0.04",
+                "--adaptive-diversity-multiplier", "1.6",
+                "--adaptive-per-gene-rate", "learning_rate=0.5,gamma=2.0",
+                "--adaptive-per-gene-scale", "learning_rate=0.25",
+            ]
+            args = run_evolution_experiment._parse_args()
+        finally:
+            sys.argv = argv
+        self.assertTrue(args.adaptive_mutation)
+        self.assertAlmostEqual(args.adaptive_improve_threshold, 0.01)
+        self.assertAlmostEqual(args.adaptive_stall_multiplier, 1.7)
+        self.assertAlmostEqual(args.adaptive_improve_multiplier, 0.7)
+        self.assertEqual(args.adaptive_per_gene_rate, "learning_rate=0.5,gamma=2.0")
+        self.assertEqual(args.adaptive_per_gene_scale, "learning_rate=0.25")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces adaptive mutation capabilities to the hyperparameter evolution framework, allowing mutation rates and scales to be dynamically adjusted during evolutionary runs based on recent fitness improvements and population diversity. It also adds support for per-gene mutation multipliers and exposes these features via configuration and telemetry. The changes are grouped below by theme.

**Adaptive Mutation Framework**

* Added a new `AdaptiveMutationConfig` dataclass and `AdaptiveMutationController` class in `farm/runners/adaptive_mutation.py` to control and track adaptive mutation schedules based on fitness and diversity, supporting both global and per-gene mutation multipliers. Also included a utility function `compute_normalized_diversity` for measuring population diversity.
* Updated the documentation (`docs/experiments/hyperparameter_evolution_convergence.md`) with a comprehensive explanation of adaptive mutation, configuration options, telemetry, and practical tuning guidance.

**Per-Gene Mutation Multipliers**

* Extended `mutate_chromosome` in `farm/core/hyperparameter_chromosome.py` to accept `per_gene_rate_multipliers` and `per_gene_scale_multipliers`, which allow fine-grained control over mutation pressure for individual genes. These multipliers are validated to ensure all values are non-negative. [[1]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R609-R610) [[2]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R629-R637) [[3]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R652-R655) [[4]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R664-R670) [[5]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R21-R32)

**Validation and API Exposure**

* Added a shared validation function `validate_non_negative_mapping` to ensure per-gene multiplier mappings contain only non-negative and finite values, used both in chromosome mutation and adaptive mutation configuration.
* Exposed the new adaptive mutation classes and functions (`AdaptiveMutationConfig`, `AdaptiveMutationController`, `compute_normalized_diversity`) through the `farm.runners` module API for easier import and usage. [[1]](diffhunk://#diff-c8139a827bd991793bde210cf38e1257269e4a1665fe89dcc4aa8823325337b4R3-R7) [[2]](diffhunk://#diff-c8139a827bd991793bde210cf38e1257269e4a1665fe89dcc4aa8823325337b4R19-R21)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new adaptive mutation logic into the evolution loop and changes the persisted `evolution_generation_summaries.json` schema, which could affect experiment behavior and downstream consumers despite being opt-in for adaptation.
> 
> **Overview**
> Adds an opt-in **adaptive mutation controller** that adjusts mutation rate/scale each generation based on fitness stall/improvement and population diversity (plus optional per-gene rate/scale multipliers with clamping and event tagging).
> 
> Extends `EvolutionExperiment` to compute diversity, drive the controller, forward effective mutation parameters into `mutate_chromosome`, and persist/log new telemetry fields (`mutation_*_used`, `mutation_*_multiplier`, `diversity`, `adaptive_event`) in generation summaries.
> 
> Updates the CLI (`run_evolution_experiment.py`) with `--adaptive-*` flags and per-gene multiplier parsing, exports the new APIs from `farm.runners`, adds validation/shared helpers in `mutate_chromosome`, and includes docs + comprehensive unit tests for controller behavior and telemetry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e4ce8a758a37d78624f8e6dfda5b7a7e2af9387. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->