### PR TITLE
Promote gamma and epsilon_decay to evolvable genes with tests

### DIFF
--- a/docs/design/evolvable_loci_roadmap.md
+++ b/docs/design/evolvable_loci_roadmap.md
@@ -1,0 +1,200 @@
+# Evolvable Loci Roadmap
+
+This design note proposes a forward roadmap for expanding evolvable loci in AgentFarm's hyperparameter chromosome model.
+
+It is aligned to project goals:
+
+- improve research value for complex adaptive systems
+- maintain reproducible, experiment-grade outputs
+- scale evolution across more parameters without losing stability
+
+## Current State
+
+The current chromosome model supports real-valued loci and already evolves:
+
+- `learning_rate`
+- `gamma`
+- `epsilon_decay`
+
+`memory_size` exists as a fixed placeholder. Mutation, crossover, and per-generation statistics are in place, and convergence artifacts now report multi-gene stats.
+
+## Roadmap Goals
+
+1. Expand expressive search space while preserving bounded, typed validation.
+2. Keep outputs interpretable for research comparisons and post-hoc analysis.
+3. Prevent regressions in reproducibility, runtime cost, and boundary behavior.
+4. Enable mixed-gene evolution (continuous + integer + categorical) in a staged way.
+
+## Guiding Principles
+
+- Keep schema strict: add types only when invariants and tests are ready.
+- Prefer incremental rollout with per-phase exit criteria.
+- Add loci by hypothesis, not by volume: each new gene should map to a research question.
+- Keep telemetry first-class: every evolved locus must appear in summary artifacts.
+
+## Locus Selection Framework
+
+Add a locus only when it passes all checks:
+
+- Has a clear mechanistic effect on adaptation or emergent behavior.
+- Has safe numeric/categorical bounds and stable defaults.
+- Can be projected to runtime config without ambiguous coercion.
+- Can be measured with existing metrics or a planned metric addition.
+
+## Phase Plan
+
+### Phase 1: Continuous Gene Expansion (near-term)
+
+Scope:
+
+- Add 3-6 additional continuous decision-policy loci.
+- Recommended first candidates:
+  - `tau` (target network update smoothing)
+  - `gradient_clip_norm`
+  - `batch_size` as continuous proxy only if represented as derived integer later (otherwise defer to Phase 2)
+  - optional action module learning rates (`move_learning_rate`, `attack_learning_rate`, etc.) behind feature flag
+
+Implementation targets:
+
+- Extend default chromosome registry and encoding specs.
+- Use log-scale encoding for order-of-magnitude parameters.
+- Add per-gene mutation scale defaults to reduce early collapse.
+
+Exit criteria:
+
+- New loci appear in `gene_statistics` and `best_chromosome`.
+- No loss of determinism for seeded runs.
+- Regression tests cover serialize/encode/decode/mutation/crossover/projection for each new locus.
+
+### Phase 2: Integer Gene Type (short-term)
+
+Scope:
+
+- Introduce `GeneValueType.INTEGER`.
+- Migrate `memory_size` from fixed to evolvable.
+- Add 1-2 more integer loci after `memory_size` validation.
+
+Implementation targets:
+
+- Enforce integer bounds/default/value validation in schema.
+- Enforce projection-time integer bound checks after rounding.
+- Ensure mutation operators for integer genes use discrete-safe steps.
+
+Exit criteria:
+
+- `memory_size` evolves end-to-end in experiment runs.
+- Integer loci never violate config bounds in lineage or runtime config.
+- Mixed real+integer crossover is deterministic under seed.
+
+### Phase 3: Categorical/Binary Gene Support (mid-term)
+
+Scope:
+
+- Add discrete categorical support for strategy toggles with small cardinality.
+- Example candidates:
+  - boundary strategy (`clamp` vs `reflect`)
+  - selection strategy (`tournament` vs `roulette`) in controlled meta-runs
+  - crossover operator family (`uniform`, `blend`, `multi_point`)
+
+Implementation targets:
+
+- Introduce explicit categorical encoding map per gene.
+- Add mutation as category flip/sampled transition matrix, not numeric perturbation.
+- Ensure summaries report category frequencies per generation.
+
+Exit criteria:
+
+- Categorical loci can co-evolve with real/integer loci.
+- Summaries remain machine-readable and comparable across runs.
+- No runtime failures from invalid categorical projection.
+
+### Phase 4: Hierarchical and Module-Specific Loci (mid-to-long term)
+
+Scope:
+
+- Evolve module-scoped hyperparameters separately from global policy parameters.
+- Candidate groups:
+  - movement module exploration profile
+  - attack/share module learning dynamics
+  - reproduction thresholds or costs where biologically meaningful
+
+Implementation targets:
+
+- Add namespace-aware loci (for example `decision.gamma`, `attack.learning_rate`).
+- Add compatibility guardrails so absent modules cannot receive locus updates.
+- Add weighted fitness decomposition to avoid overfitting one module.
+
+Exit criteria:
+
+- Multi-module loci evolve without schema collisions.
+- Cross-module effects are observable in analysis pipelines.
+- Run-time overhead remains acceptable for baseline experiment sizes.
+
+### Phase 5: Meta-Evolution and Curriculum Coupling (long-term)
+
+Scope:
+
+- Evolve adaptation schedules, not only fixed scalar values.
+- Candidate meta-loci:
+  - mutation-rate schedule parameters
+  - exploration decay schedule parameters
+  - curriculum phase transition thresholds
+
+Implementation targets:
+
+- Represent schedule genes as compact parameterized functions.
+- Persist schedule state and values in summaries for reproducibility.
+- Add replay tooling to reconstruct schedule behavior from lineage artifacts.
+
+Exit criteria:
+
+- Meta-loci improve convergence or robustness on at least one benchmark family.
+- Replay and analysis tooling can fully reconstruct evolved schedules.
+
+## Cross-Cutting Workstreams
+
+### Testing
+
+- Add a mixed-loci test matrix:
+  - real only
+  - real + integer
+  - real + integer + categorical
+- Keep deterministic seeded tests for mutation and crossover edge cases.
+
+### Telemetry and Analysis
+
+- Maintain required summary fields for every evolvable locus.
+- Add per-locus diversity and boundary-pressure indicators.
+- Add categorical distribution summaries once categorical genes are introduced.
+
+### Runtime and Performance
+
+- Track per-generation overhead as locus count increases.
+- Set practical max-locus guardrails for smoke and convergence suites.
+- Add profiling checkpoints when moving from each phase.
+
+## Suggested Milestones
+
+- M1: Phase 1 complete (expanded continuous set in production artifacts)
+- M2: Phase 2 complete (`memory_size` evolvable with integer-safe invariants)
+- M3: Phase 3 complete (first mixed-type convergence experiments)
+- M4: Phase 4 complete (module-scoped evolution enabled)
+- M5: Phase 5 pilot (meta-loci on one benchmark track)
+
+## Risks and Mitigations
+
+- Search-space explosion
+  - Mitigation: phase gates, per-gene mutation scaling, adaptive mutation defaults.
+- Boundary collapse in larger loci sets
+  - Mitigation: reflective boundaries and calibrated soft penalties.
+- Reduced interpretability
+  - Mitigation: mandatory per-locus telemetry and run manifests.
+- Regression in reproducibility
+  - Mitigation: seeded test coverage and deterministic artifact checks in CI.
+
+## Immediate Next Steps
+
+1. Approve Phase 1 candidate loci list.
+2. Implement Phase 1 schema/test updates.
+3. Run convergence suite and compare against current regenerated baseline artifacts.
+4. Open Phase 2 implementation branch for integer gene type and `memory_size` activation.

--- a/docs/design/hyperparameter_chromosome.md
+++ b/docs/design/hyperparameter_chromosome.md
@@ -56,14 +56,17 @@ The chromosome model is intentionally narrow and strict:
 The default registry is defined in `DEFAULT_HYPERPARAMETER_GENES`:
 
 - `learning_rate` (evolvable) — range `[1e-6, 1.0]`, encoded with **log-scale 8-bit quantization** by default so that equal bucket steps map to multiplicative LR changes
-- `epsilon_decay` (fixed placeholder)
-- `memory_size` (fixed placeholder)
+- `gamma` (evolvable) — discount factor, range `[0.0, 1.0]`, default `0.99`, encoded with **linear 8-bit quantization**
+- `epsilon_decay` (evolvable) — exploration decay rate, range `(0, 1.0]`, default `0.995`, encoded with **linear 8-bit quantization**
+- `memory_size` (fixed placeholder) — integer-rounding concerns are kept separate from the continuous-gene evolution phase
 
 Default encoding policies per gene name are stored in `DEFAULT_GENE_ENCODINGS`:
 
 ```python
 DEFAULT_GENE_ENCODINGS = {
     "learning_rate": GeneEncodingSpec(scale=GeneEncodingScale.LOG, bit_width=8),
+    "epsilon_decay": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "gamma": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
 }
 ```
 
@@ -254,12 +257,12 @@ from farm.core.hyperparameter_chromosome import (
 
 chrom = default_hyperparameter_chromosome()
 
-# Round-trip via dict
-encoded = encode_chromosome(chrom)          # {"learning_rate": 102}
+# Round-trip via dict (three evolvable genes: learning_rate, gamma, epsilon_decay)
+encoded = encode_chromosome(chrom)          # {"learning_rate": 102, "gamma": 252, "epsilon_decay": 253}
 restored = decode_chromosome(encoded, template=chrom)
 
-# Round-trip via vector (preserves gene order)
-vec = encode_chromosome_vector(chrom)       # (102,)
+# Round-trip via vector (preserves gene order, length == number of evolvable genes)
+vec = encode_chromosome_vector(chrom)       # (102, 252, 253)
 restored_vec = decode_chromosome_vector(vec, template=chrom)
 ```
 
@@ -372,7 +375,18 @@ They are parallel tracks today; a future unification step can compose both into 
 - mutation rate is currently a constant in `AgentCore` (`DEFAULT_HYPERPARAMETER_MUTATION_RATE`)
 - log-scale encoding requires strictly positive gene bounds; genes with `min_value ≤ 0` must use `GeneEncodingScale.LINEAR`
 
-These are deliberate for a small, verifiable first increment.
+The schema now supports three continuously evolvable genes (`learning_rate`, `gamma`, `epsilon_decay`).  `memory_size` remains fixed pending integer-gene support.
+
+## Discrete-gene roadmap
+
+`memory_size` and other integer/discrete parameters require rounding during config projection (`int(round(gene.value))`).  The planned migration path is:
+
+1. **Integer rounding guard** — validate that after rounding, the projected integer falls within the gene's declared bounds.  This can be added to `apply_chromosome_to_learning_config` without schema changes.
+2. **Dedicated `GeneValueType.INTEGER` variant** — extend the `GeneValueType` enum and add a validation branch in `HyperparameterGene.__post_init__` that enforces integer-valued `min_value`, `max_value`, `default`, and `value`.  Encode/decode methods already round when `bit_width` is set, so no encoding changes are needed.
+3. **Enable `memory_size`** — once the integer guard is in place, flip `evolvable=True` for `memory_size` and add coverage to the chromosome and evolution-experiment test suites.
+4. **Binary/categorical genes** — implement `GeneValueType.BINARY` or `GeneValueType.CATEGORICAL` when needed; keep separate from the real/integer path to preserve existing validation.
+
+Until step 1 is validated in integration tests, `memory_size` stays fixed to avoid undetected rounding drift.
 
 ## Evolution experiment outputs
 

--- a/docs/design/hyperparameter_chromosome.md
+++ b/docs/design/hyperparameter_chromosome.md
@@ -258,11 +258,11 @@ from farm.core.hyperparameter_chromosome import (
 chrom = default_hyperparameter_chromosome()
 
 # Round-trip via dict (three evolvable genes: learning_rate, gamma, epsilon_decay)
-encoded = encode_chromosome(chrom)          # {"learning_rate": 102, "gamma": 252, "epsilon_decay": 253}
+encoded = encode_chromosome(chrom)          # {"learning_rate": 128, "gamma": 252, "epsilon_decay": 254}
 restored = decode_chromosome(encoded, template=chrom)
 
 # Round-trip via vector (preserves gene order, length == number of evolvable genes)
-vec = encode_chromosome_vector(chrom)       # (102, 252, 253)
+vec = encode_chromosome_vector(chrom)       # (128, 252, 254)
 restored_vec = decode_chromosome_vector(vec, template=chrom)
 ```
 

--- a/docs/experiments/hyperparameter_evolution_convergence.md
+++ b/docs/experiments/hyperparameter_evolution_convergence.md
@@ -163,6 +163,43 @@ When reviewing `learning_rate` convergence:
 - unstable or growing spread suggests mutation pressure dominates selection
 - rising best fitness with shrinking spread usually indicates useful convergence
 
+## Artifact Refresh for Multi-Gene Reporting (2026-04-18)
+
+To close the multi-gene acceptance criteria, all checked-in convergence artifacts
+under `experiments/evolution_convergence` were regenerated from the current
+chromosome schema and runner wiring.
+
+What changed in persisted outputs:
+
+- every `evolution_generation_summaries.json` now includes per-gene stats for
+  all loci in the active schema: `learning_rate`, `gamma`, `epsilon_decay`,
+  and `memory_size`
+- every `best_chromosome` snapshot now includes `gamma` and `epsilon_decay`
+  alongside `learning_rate`
+- `evolution_lineage.json` remains intentionally compact and still stores
+  top-level `learning_rate` + metadata (full per-gene stats live in summaries)
+
+Current final-generation snapshots from regenerated runs:
+
+- `run_clamp_baseline_g6`: final best fitness `76.0`; best chromosome
+  (`learning_rate=1e-06`, `gamma=1.0`, `epsilon_decay=0.7241990478892087`)
+- `run_clamp_penalty_g6`: final best fitness `66.99`; best chromosome
+  (`learning_rate=0.20027491749951848`, `gamma=1.0`, `epsilon_decay=0.7592339511733013`)
+- `run_clamp_penalty002_g6`: final best fitness `76.98`; best chromosome
+  (`learning_rate=1e-06`, `gamma=0.95`, `epsilon_decay=0.9320406841297989`)
+- `run_clamp_penalty005_g6`: final best fitness `68.95`; best chromosome
+  (`learning_rate=1e-06`, `gamma=0.8369660526170754`, `epsilon_decay=0.8288524477063025`)
+- `run_clamp_penalty010_g6`: final best fitness `72.9`; best chromosome
+  (`learning_rate=1e-06`, `gamma=0.8618623974764232`, `epsilon_decay=0.5743829534957358`)
+- `run_reflect_g6`: final best fitness `78.0`; best chromosome
+  (`learning_rate=0.19271257710715683`, `gamma=0.9751036551406521`, `epsilon_decay=0.8970057808457064`)
+- `run_roulette_mut040_g6`: final best fitness `76.0`; best chromosome
+  (`learning_rate=1e-06`, `gamma=1.0`, `epsilon_decay=1.0`)
+- `run_tournament_mut020_g6`: final best fitness `71.0`; best chromosome
+  (`learning_rate=0.03602658902654344`, `gamma=0.9751036551406521`, `epsilon_decay=0.9688639803415231`)
+- `run_tournament_mut025`: final best fitness `71.0`; best chromosome
+  (`learning_rate=0.2269703882742677`, `gamma=1.0`, `epsilon_decay=1.0`)
+
 ## Findings From Current Smoke Run
 
 Using the checked-in artifacts in `experiments/evolution_smoke`:

--- a/experiments/evolution_convergence/run_clamp_baseline_g6/evolution_generation_summaries.json
+++ b/experiments/evolution_convergence/run_clamp_baseline_g6/evolution_generation_summaries.json
@@ -1,59 +1,31 @@
 [
   {
     "generation": 0,
-    "best_fitness": 72.0,
-    "mean_fitness": 65.25,
-    "min_fitness": 55.0,
-    "best_candidate_id": "g0_c0",
+    "best_fitness": 70.0,
+    "mean_fitness": 65.125,
+    "min_fitness": 61.0,
+    "best_candidate_id": "g0_c1",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.055658525648276516,
-        "median": 0.02662644272048611,
-        "std": 0.06118633982230562,
+        "mean": 0.03162298224336492,
+        "median": 1e-06,
+        "std": 0.05699117265327523,
         "min": 1e-06,
         "max": 0.15942878976101
       },
-      "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
-      },
-      "memory_size": {
-        "mean": 2000,
-        "median": 2000.0,
-        "std": 0.0,
-        "min": 2000,
-        "max": 2000
-      }
-    },
-    "best_chromosome": {
-      "learning_rate": 0.001,
-      "epsilon_decay": 0.995,
-      "memory_size": 2000
-    }
-  },
-  {
-    "generation": 1,
-    "best_fitness": 75.0,
-    "mean_fitness": 62.25,
-    "min_fitness": 54.0,
-    "best_candidate_id": "g1_c3",
-    "gene_statistics": {
-      "learning_rate": {
-        "mean": 0.05793119334296529,
-        "median": 0.001,
-        "std": 0.10558411559595705,
-        "min": 1e-06,
-        "max": 0.3010177569827123
+      "gamma": {
+        "mean": 0.9371359275229121,
+        "median": 0.9875518275703261,
+        "std": 0.10332826581741346,
+        "min": 0.6803741749126586,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.8724919919611355,
+        "median": 0.8921990333611127,
+        "std": 0.12471650716431597,
+        "min": 0.6866249283632477,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -65,30 +37,93 @@
     },
     "best_chromosome": {
       "learning_rate": 0.15942878976101,
-      "epsilon_decay": 0.995,
+      "gamma": 0.9751036551406521,
+      "epsilon_decay": 0.8073897557133531,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": null,
+    "mutation_scale_used": null,
+    "mutation_rate_multiplier": null,
+    "mutation_scale_multiplier": null,
+    "diversity": 0.09501200087541144,
+    "adaptive_event": "initial_seeding"
+  },
+  {
+    "generation": 1,
+    "best_fitness": 73.0,
+    "mean_fitness": 64.625,
+    "min_fitness": 55.0,
+    "best_candidate_id": "g1_elite0",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.04496371340756606,
+        "median": 1e-06,
+        "std": 0.07854433254770628,
+        "min": 1e-06,
+        "max": 0.20027491749951848
+      },
+      "gamma": {
+        "mean": 0.9677530263365743,
+        "median": 0.9751036551406521,
+        "std": 0.032420777322603116,
+        "min": 0.8916095901299863,
+        "max": 1.0
+      },
+      "epsilon_decay": {
+        "mean": 0.83701735299799,
+        "median": 0.8147915113784278,
+        "std": 0.06198163223929973,
+        "min": 0.8073897557133531,
+        "max": 1.0
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.15942878976101,
+      "gamma": 0.9751036551406521,
+      "epsilon_decay": 0.8073897557133531,
+      "memory_size": 2000
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.05764894021800674,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 2,
-    "best_fitness": 72.0,
-    "mean_fitness": 63.375,
-    "min_fitness": 55.0,
-    "best_candidate_id": "g2_c7",
+    "best_fitness": 71.0,
+    "mean_fitness": 65.5,
+    "min_fitness": 60.0,
+    "best_candidate_id": "g2_c2",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.09964336860063125,
-        "median": 0.15942878976101,
-        "std": 0.07718264683338114,
+        "mean": 0.0398579474402525,
+        "median": 1e-06,
+        "std": 0.06903425800111963,
         "min": 1e-06,
         "max": 0.15942878976101
       },
+      "gamma": {
+        "mean": 0.9875518275703261,
+        "median": 0.9875518275703261,
+        "std": 0.012448172429673943,
+        "min": 0.9751036551406521,
+        "max": 1.0
+      },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.7666310843631674,
+        "median": 0.8073897557133531,
+        "std": 0.08182692555061685,
+        "min": 0.5677237728329356,
+        "max": 0.8221932670435024
       },
       "memory_size": {
         "mean": 2000,
@@ -100,30 +135,44 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 0.9751036551406521,
+      "epsilon_decay": 0.7520317749623443,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.05443647500524582,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 3,
-    "best_fitness": 73.0,
-    "mean_fitness": 65.0,
-    "min_fitness": 60.0,
+    "best_fitness": 77.0,
+    "mean_fitness": 63.875,
+    "min_fitness": 58.0,
     "best_candidate_id": "g3_c4",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.032643645893763215,
+        "mean": 0.0398579474402525,
         "median": 1e-06,
-        "std": 0.05635908447804713,
+        "std": 0.06903425800111963,
         "min": 1e-06,
         "max": 0.15942878976101
       },
+      "gamma": {
+        "mean": 0.9906638706777445,
+        "median": 1.0,
+        "std": 0.012052891127711374,
+        "min": 0.9751036551406521,
+        "max": 1.0
+      },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.7789145109528255,
+        "median": 0.7797107653378488,
+        "std": 0.03551081279163061,
+        "min": 0.7241990478892087,
+        "max": 0.8288524477063025
       },
       "memory_size": {
         "mean": 2000,
@@ -135,30 +184,44 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 0.9751036551406521,
+      "epsilon_decay": 0.7241990478892087,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.03886601031826288,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 4,
-    "best_fitness": 70.0,
-    "mean_fitness": 63.75,
-    "min_fitness": 59.0,
-    "best_candidate_id": "g4_c2",
+    "best_fitness": 67.0,
+    "mean_fitness": 60.625,
+    "min_fitness": 49.0,
+    "best_candidate_id": "g4_c7",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 1e-06,
+        "mean": 0.0398579474402525,
         "median": 1e-06,
-        "std": 0.0,
+        "std": 0.06903425800111963,
         "min": 1e-06,
-        "max": 1e-06
+        "max": 0.15942878976101
+      },
+      "gamma": {
+        "mean": 0.9601700133987507,
+        "median": 0.9751036551406521,
+        "std": 0.049303275265681554,
+        "min": 0.8618623974764232,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.7410808261393703,
+        "median": 0.7443637240709298,
+        "std": 0.08308536166499336,
+        "min": 0.5478891060616772,
+        "max": 0.8288524477063025
       },
       "memory_size": {
         "mean": 2000,
@@ -170,30 +233,44 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 0.9751036551406521,
+      "epsilon_decay": 0.5478891060616772,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.0671409879887072,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 5,
-    "best_fitness": 69.0,
-    "mean_fitness": 65.5,
-    "min_fitness": 56.0,
-    "best_candidate_id": "g5_elite0",
+    "best_fitness": 76.0,
+    "mean_fitness": 66.625,
+    "min_fitness": 58.0,
+    "best_candidate_id": "g5_c7",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.051863200200380606,
+        "mean": 0.0095189187930223,
         "median": 1e-06,
-        "std": 0.13721448417485127,
+        "std": 0.016517231958789277,
         "min": 1e-06,
-        "max": 0.41489860160304487
+        "max": 0.04011876131763496
+      },
+      "gamma": {
+        "mean": 0.9534346427632643,
+        "median": 0.9751036551406521,
+        "std": 0.08633330696994412,
+        "min": 0.7270625215435063,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.642042916900127,
+        "median": 0.7241990478892087,
+        "std": 0.12688389730041189,
+        "min": 0.37924053126817614,
+        "max": 0.7645284002526507
       },
       "memory_size": {
         "mean": 2000,
@@ -205,8 +282,15 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 1.0,
+      "epsilon_decay": 0.7241990478892087,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.07657815091546459,
+    "adaptive_event": "disabled"
   }
 ]

--- a/experiments/evolution_convergence/run_clamp_baseline_g6/evolution_lineage.json
+++ b/experiments/evolution_convergence/run_clamp_baseline_g6/evolution_lineage.json
@@ -2,38 +2,23 @@
   {
     "candidate_id": "g0_c0",
     "generation": 0,
-    "fitness": 72.0,
+    "fitness": 66.0,
     "learning_rate": 0.001,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 72,
-      "raw_fitness": 72.0,
+      "final_population": 66,
+      "raw_fitness": 66.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g0_c1",
     "generation": 0,
-    "fitness": 69.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 69,
-      "raw_fitness": 69.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g0_c2",
-    "generation": 0,
     "fitness": 70.0,
-    "learning_rate": 0.02610363003699699,
+    "learning_rate": 0.15942878976101,
     "parent_ids": [
       "seed",
       "seed"
@@ -45,17 +30,32 @@
     }
   },
   {
-    "candidate_id": "g0_c3",
+    "candidate_id": "g0_c2",
     "generation": 0,
-    "fitness": 55.0,
+    "fitness": 65.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 55,
-      "raw_fitness": 55.0,
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c3",
+    "generation": 0,
+    "fitness": 65.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
       "boundary_penalty": 0.0
     }
   },
@@ -77,8 +77,23 @@
   {
     "candidate_id": "g0_c5",
     "generation": 0,
+    "fitness": 62.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c6",
+    "generation": 0,
     "fitness": 61.0,
-    "learning_rate": 0.13903446179832052,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "seed",
       "seed"
@@ -90,47 +105,32 @@
     }
   },
   {
-    "candidate_id": "g0_c6",
-    "generation": 0,
-    "fitness": 66.0,
-    "learning_rate": 0.02714925540397523,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 66,
-      "raw_fitness": 66.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
     "candidate_id": "g0_c7",
     "generation": 0,
-    "fitness": 60.0,
-    "learning_rate": 0.09255006818590938,
+    "fitness": 63.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
+      "final_population": 63,
+      "raw_fitness": 63.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_elite0",
     "generation": 1,
-    "fitness": 62.0,
-    "learning_rate": 0.001,
+    "fitness": 73.0,
+    "learning_rate": 0.15942878976101,
     "parent_ids": [
-      "g0_c0",
-      "g0_c0"
+      "g0_c1",
+      "g0_c1"
     ],
     "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
+      "final_population": 73,
+      "raw_fitness": 73.0,
       "boundary_penalty": 0.0
     }
   },
@@ -138,10 +138,10 @@
     "candidate_id": "g1_c1",
     "generation": 1,
     "fitness": 59.0,
-    "learning_rate": 0.001,
+    "learning_rate": 0.20027491749951848,
     "parent_ids": [
-      "g0_c0",
-      "g0_c4"
+      "g0_c1",
+      "g0_c1"
     ],
     "metadata": {
       "final_population": 59,
@@ -152,60 +152,60 @@
   {
     "candidate_id": "g1_c2",
     "generation": 1,
-    "fitness": 54.0,
-    "learning_rate": 0.001,
+    "fitness": 57.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g0_c0",
       "g0_c2"
     ],
     "metadata": {
-      "final_population": 54,
-      "raw_fitness": 54.0,
+      "final_population": 57,
+      "raw_fitness": 57.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c3",
     "generation": 1,
-    "fitness": 75.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 67.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g0_c4",
       "g0_c1"
     ],
     "metadata": {
-      "final_population": 75,
-      "raw_fitness": 75.0,
+      "final_population": 67,
+      "raw_fitness": 67.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c4",
     "generation": 1,
-    "fitness": 65.0,
+    "fitness": 72.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g0_c4",
-      "g0_c0"
+      "g0_c4"
     ],
     "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
+      "final_population": 72,
+      "raw_fitness": 72.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c5",
     "generation": 1,
-    "fitness": 63.0,
+    "fitness": 66.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g0_c0",
+      "g0_c1",
       "g0_c4"
     ],
     "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
+      "final_population": 66,
+      "raw_fitness": 66.0,
       "boundary_penalty": 0.0
     }
   },
@@ -213,10 +213,10 @@
     "candidate_id": "g1_c6",
     "generation": 1,
     "fitness": 55.0,
-    "learning_rate": 0.3010177569827123,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g0_c0",
-      "g0_c2"
+      "g0_c4"
     ],
     "metadata": {
       "final_population": 55,
@@ -227,446 +227,11 @@
   {
     "candidate_id": "g1_c7",
     "generation": 1,
-    "fitness": 65.0,
+    "fitness": 68.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g0_c1",
       "g0_c4"
-    ],
-    "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_elite0",
-    "generation": 2,
-    "fitness": 64.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g1_c3",
-      "g1_c3"
-    ],
-    "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c1",
-    "generation": 2,
-    "fitness": 63.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g1_c3",
-      "g1_c4"
-    ],
-    "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c2",
-    "generation": 2,
-    "fitness": 62.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g1_c7",
-      "g1_c7"
-    ],
-    "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c3",
-    "generation": 2,
-    "fitness": 63.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g1_c3",
-      "g1_c1"
-    ],
-    "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c4",
-    "generation": 2,
-    "fitness": 67.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g1_c4",
-      "g1_c7"
-    ],
-    "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c5",
-    "generation": 2,
-    "fitness": 61.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g1_c3",
-      "g1_c7"
-    ],
-    "metadata": {
-      "final_population": 61,
-      "raw_fitness": 61.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c6",
-    "generation": 2,
-    "fitness": 55.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g1_c3",
-      "g1_c3"
-    ],
-    "metadata": {
-      "final_population": 55,
-      "raw_fitness": 55.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c7",
-    "generation": 2,
-    "fitness": 72.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g1_c7",
-      "g1_c4"
-    ],
-    "metadata": {
-      "final_population": 72,
-      "raw_fitness": 72.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g3_elite0",
-    "generation": 3,
-    "fitness": 65.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g2_c7",
-      "g2_c7"
-    ],
-    "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g3_c1",
-    "generation": 3,
-    "fitness": 64.0,
-    "learning_rate": 0.00996096416088228,
-    "parent_ids": [
-      "g2_elite0",
-      "g2_c7"
-    ],
-    "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g3_c2",
-    "generation": 3,
-    "fitness": 64.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g2_c4",
-      "g2_c4"
-    ],
-    "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g3_c3",
-    "generation": 3,
-    "fitness": 63.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g2_c3",
-      "g2_elite0"
-    ],
-    "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g3_c4",
-    "generation": 3,
-    "fitness": 73.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g2_elite0",
-      "g2_c7"
-    ],
-    "metadata": {
-      "final_population": 73,
-      "raw_fitness": 73.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g3_c5",
-    "generation": 3,
-    "fitness": 67.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g2_c7",
-      "g2_c7"
-    ],
-    "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g3_c6",
-    "generation": 3,
-    "fitness": 60.0,
-    "learning_rate": 0.09175441322821346,
-    "parent_ids": [
-      "g2_c7",
-      "g2_c3"
-    ],
-    "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g3_c7",
-    "generation": 3,
-    "fitness": 64.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g2_elite0",
-      "g2_c7"
-    ],
-    "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_elite0",
-    "generation": 4,
-    "fitness": 60.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c4",
-      "g3_c4"
-    ],
-    "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c1",
-    "generation": 4,
-    "fitness": 62.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c7",
-      "g3_c4"
-    ],
-    "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c2",
-    "generation": 4,
-    "fitness": 70.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c5",
-      "g3_c4"
-    ],
-    "metadata": {
-      "final_population": 70,
-      "raw_fitness": 70.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c3",
-    "generation": 4,
-    "fitness": 65.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c2",
-      "g3_c7"
-    ],
-    "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c4",
-    "generation": 4,
-    "fitness": 63.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c1",
-      "g3_c7"
-    ],
-    "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c5",
-    "generation": 4,
-    "fitness": 66.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_elite0",
-      "g3_c7"
-    ],
-    "metadata": {
-      "final_population": 66,
-      "raw_fitness": 66.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c6",
-    "generation": 4,
-    "fitness": 65.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c5",
-      "g3_c4"
-    ],
-    "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c7",
-    "generation": 4,
-    "fitness": 59.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_elite0",
-      "g3_c4"
-    ],
-    "metadata": {
-      "final_population": 59,
-      "raw_fitness": 59.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_elite0",
-    "generation": 5,
-    "fitness": 69.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c2",
-      "g4_c2"
-    ],
-    "metadata": {
-      "final_population": 69,
-      "raw_fitness": 69.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_c1",
-    "generation": 5,
-    "fitness": 65.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c2",
-      "g4_c3"
-    ],
-    "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_c2",
-    "generation": 5,
-    "fitness": 69.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c5",
-      "g4_c2"
-    ],
-    "metadata": {
-      "final_population": 69,
-      "raw_fitness": 69.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_c3",
-    "generation": 5,
-    "fitness": 56.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c6",
-      "g4_c2"
-    ],
-    "metadata": {
-      "final_population": 56,
-      "raw_fitness": 56.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_c4",
-    "generation": 5,
-    "fitness": 68.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c4",
-      "g4_c4"
     ],
     "metadata": {
       "final_population": 68,
@@ -675,13 +240,58 @@
     }
   },
   {
-    "candidate_id": "g5_c5",
-    "generation": 5,
+    "candidate_id": "g2_elite0",
+    "generation": 2,
+    "fitness": 63.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_elite0",
+      "g1_elite0"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c1",
+    "generation": 2,
+    "fitness": 61.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c2",
+    "generation": 2,
+    "fitness": 71.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c7",
+      "g1_c7"
+    ],
+    "metadata": {
+      "final_population": 71,
+      "raw_fitness": 71.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c3",
+    "generation": 2,
     "fitness": 62.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g4_c2",
-      "g4_c6"
+      "g1_c4",
+      "g1_c1"
     ],
     "metadata": {
       "final_population": 62,
@@ -690,13 +300,103 @@
     }
   },
   {
-    "candidate_id": "g5_c6",
-    "generation": 5,
+    "candidate_id": "g2_c4",
+    "generation": 2,
+    "fitness": 71.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g1_elite0",
+      "g1_c7"
+    ],
+    "metadata": {
+      "final_population": 71,
+      "raw_fitness": 71.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c5",
+    "generation": 2,
+    "fitness": 68.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c4",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c6",
+    "generation": 2,
+    "fitness": 60.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c4",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c7",
+    "generation": 2,
+    "fitness": 68.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c7",
+      "g1_elite0"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_elite0",
+    "generation": 3,
+    "fitness": 58.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c2",
+      "g2_c2"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c1",
+    "generation": 3,
+    "fitness": 59.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c5",
+      "g2_c4"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c2",
+    "generation": 3,
     "fitness": 69.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g4_c3",
-      "g4_c5"
+      "g2_c2",
+      "g2_c4"
     ],
     "metadata": {
       "final_population": 69,
@@ -705,17 +405,317 @@
     }
   },
   {
-    "candidate_id": "g5_c7",
+    "candidate_id": "g3_c3",
+    "generation": 3,
+    "fitness": 69.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g2_c5",
+      "g2_elite0"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c4",
+    "generation": 3,
+    "fitness": 77.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c5",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 77,
+      "raw_fitness": 77.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c5",
+    "generation": 3,
+    "fitness": 62.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g2_c4",
+      "g2_c2"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c6",
+    "generation": 3,
+    "fitness": 58.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c4",
+      "g2_c2"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g3_c7",
+    "generation": 3,
+    "fitness": 59.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c2",
+      "g2_c2"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_elite0",
+    "generation": 4,
+    "fitness": 65.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c4",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c1",
+    "generation": 4,
+    "fitness": 61.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c2",
+    "generation": 4,
+    "fitness": 49.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c5",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 49,
+      "raw_fitness": 49.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c3",
+    "generation": 4,
+    "fitness": 63.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c2",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c4",
+    "generation": 4,
+    "fitness": 58.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c2",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c5",
+    "generation": 4,
+    "fitness": 58.0,
+    "learning_rate": 0.15942878976101,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c6",
+    "generation": 4,
+    "fitness": 64.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c5",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c7",
+    "generation": 4,
+    "fitness": 67.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_elite0",
+    "generation": 5,
+    "fitness": 71.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c7",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 71,
+      "raw_fitness": 71.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c1",
+    "generation": 5,
+    "fitness": 58.0,
+    "learning_rate": 0.04011876131763496,
+    "parent_ids": [
+      "g4_c1",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c2",
+    "generation": 5,
+    "fitness": 65.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c6",
+      "g4_elite0"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c3",
+    "generation": 5,
+    "fitness": 70.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c6",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c4",
+    "generation": 5,
+    "fitness": 62.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c7",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c5",
     "generation": 5,
     "fitness": 66.0,
-    "learning_rate": 0.41489860160304487,
+    "learning_rate": 0.03602658902654344,
     "parent_ids": [
-      "g4_c5",
-      "g4_c2"
+      "g4_elite0",
+      "g4_c6"
     ],
     "metadata": {
       "final_population": 66,
       "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c6",
+    "generation": 5,
+    "fitness": 65.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c7",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c7",
+    "generation": 5,
+    "fitness": 76.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c6",
+      "g4_elite0"
+    ],
+    "metadata": {
+      "final_population": 76,
+      "raw_fitness": 76.0,
       "boundary_penalty": 0.0
     }
   }

--- a/experiments/evolution_convergence/run_clamp_penalty002_g6/evolution_generation_summaries.json
+++ b/experiments/evolution_convergence/run_clamp_penalty002_g6/evolution_generation_summaries.json
@@ -1,24 +1,31 @@
 [
   {
     "generation": 0,
-    "best_fitness": 70.0,
-    "mean_fitness": 63.61521249698455,
-    "min_fitness": 54.98,
-    "best_candidate_id": "g0_c1",
+    "best_fitness": 74.9623996003996,
+    "mean_fitness": 64.09093452730899,
+    "min_fitness": 53.96,
+    "best_candidate_id": "g0_c0",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.055658525648276516,
-        "median": 0.02662644272048611,
-        "std": 0.06118633982230562,
+        "mean": 0.03162298224336492,
+        "median": 1e-06,
+        "std": 0.05699117265327523,
         "min": 1e-06,
         "max": 0.15942878976101
       },
+      "gamma": {
+        "mean": 0.9371359275229121,
+        "median": 0.9875518275703261,
+        "std": 0.10332826581741346,
+        "min": 0.6803741749126586,
+        "max": 1.0
+      },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.8724919919611355,
+        "median": 0.8921990333611127,
+        "std": 0.12471650716431597,
+        "min": 0.6866249283632477,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -29,31 +36,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.15942878976101,
+      "learning_rate": 0.001,
+      "gamma": 0.95,
       "epsilon_decay": 0.995,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": null,
+    "mutation_scale_used": null,
+    "mutation_rate_multiplier": null,
+    "mutation_scale_multiplier": null,
+    "diversity": 0.09501200087541144,
+    "adaptive_event": "initial_seeding"
   },
   {
     "generation": 1,
-    "best_fitness": 75.0,
-    "mean_fitness": 65.2425,
-    "min_fitness": 57.0,
-    "best_candidate_id": "g1_c3",
+    "best_fitness": 74.9623996003996,
+    "mean_fitness": 65.21992934455196,
+    "min_fitness": 56.98995853794374,
+    "best_candidate_id": "g1_elite0",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.11152986975338322,
-        "median": 0.14923162577966526,
-        "std": 0.09463761859750551,
+        "mean": 0.059866015257155826,
+        "median": 0.04677503409295469,
+        "std": 0.06813228831098388,
         "min": 1e-06,
-        "max": 0.2749151269457153
+        "max": 0.20027491749951848
+      },
+      "gamma": {
+        "mean": 0.981275913785163,
+        "median": 0.9875518275703261,
+        "std": 0.02072113877802683,
+        "min": 0.95,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.8675292709789906,
+        "median": 0.884797277696038,
+        "std": 0.12830423231691668,
+        "min": 0.6866249283632477,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -64,31 +85,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.15942878976101,
+      "learning_rate": 0.001,
+      "gamma": 0.95,
       "epsilon_decay": 0.995,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.07238590917942794,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 2,
-    "best_fitness": 69.0,
-    "mean_fitness": 63.870000000000005,
-    "min_fitness": 56.0,
-    "best_candidate_id": "g2_elite0",
+    "best_fitness": 68.98,
+    "mean_fitness": 62.464129420132025,
+    "min_fitness": 58.955118080128514,
+    "best_candidate_id": "g2_c7",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.13400763446884564,
-        "median": 0.15942878976101,
-        "std": 0.08587902340021279,
+        "mean": 0.00025075,
+        "median": 1e-06,
+        "std": 0.0004325796891903271,
         "min": 1e-06,
-        "max": 0.2749151269457153
+        "max": 0.001
+      },
+      "gamma": {
+        "mean": 0.975,
+        "median": 0.975,
+        "std": 0.025000000000000022,
+        "min": 0.95,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.8778926084139955,
+        "median": 0.9534234094638571,
+        "std": 0.17772311869959834,
+        "min": 0.43215543415268104,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -99,31 +134,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.15942878976101,
-      "epsilon_decay": 0.995,
+      "learning_rate": 1e-06,
+      "gamma": 0.95,
+      "epsilon_decay": 0.9195440588394925,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.0677185662737896,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 3,
-    "best_fitness": 70.0,
-    "mean_fitness": 62.742997998706045,
-    "min_fitness": 58.0,
-    "best_candidate_id": "g3_c2",
+    "best_fitness": 68.98,
+    "mean_fitness": 61.5975,
+    "min_fitness": 55.96,
+    "best_candidate_id": "g3_c4",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.09242906705414196,
-        "median": 0.12559160149461174,
-        "std": 0.07232149549279666,
+        "mean": 1e-06,
+        "median": 1e-06,
+        "std": 0.0,
         "min": 1e-06,
-        "max": 0.15942878976101
+        "max": 1e-06
+      },
+      "gamma": {
+        "mean": 0.96875,
+        "median": 0.95,
+        "std": 0.024206145913796377,
+        "min": 0.95,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.8191650251606696,
+        "median": 0.9195440588394925,
+        "std": 0.16287713564829778,
+        "min": 0.43215543415268104,
+        "max": 0.9195440588394925
       },
       "memory_size": {
         "mean": 2000,
@@ -134,31 +183,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.15942878976101,
-      "epsilon_decay": 0.995,
+      "learning_rate": 1e-06,
+      "gamma": 0.95,
+      "epsilon_decay": 0.7093955365590595,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.06236109385403139,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 4,
-    "best_fitness": 74.0,
-    "mean_fitness": 65.6225,
-    "min_fitness": 61.0,
-    "best_candidate_id": "g4_c5",
+    "best_fitness": 66.98,
+    "mean_fitness": 60.98,
+    "min_fitness": 51.98,
+    "best_candidate_id": "g4_c7",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.13950031604088375,
-        "median": 0.15942878976101,
-        "std": 0.05272578547254026,
+        "mean": 1e-06,
+        "median": 1e-06,
+        "std": 0.0,
         "min": 1e-06,
-        "max": 0.15942878976101
+        "max": 1e-06
+      },
+      "gamma": {
+        "mean": 0.9257561427210061,
+        "median": 0.95,
+        "std": 0.042223460800981126,
+        "min": 0.8441867442916262,
+        "max": 0.95
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.7904088269172003,
+        "median": 0.7647251631574894,
+        "std": 0.0888599852982199,
+        "min": 0.7093955365590595,
+        "max": 0.9320406841297989
       },
       "memory_size": {
         "mean": 2000,
@@ -169,31 +232,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.15942878976101,
-      "epsilon_decay": 0.995,
+      "learning_rate": 1e-06,
+      "gamma": 0.95,
+      "epsilon_decay": 0.7154013899388254,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.04369448203306701,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 5,
-    "best_fitness": 79.0,
-    "mean_fitness": 70.0,
-    "min_fitness": 60.0,
+    "best_fitness": 76.98,
+    "mean_fitness": 66.10680128125261,
+    "min_fitness": 58.98,
     "best_candidate_id": "g5_c3",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.2112909899613906,
-        "median": 0.15942878976101,
-        "std": 0.13721448417485127,
-        "min": 0.15942878976101,
-        "max": 0.5743263913640548
+        "mean": 0.00450419862831793,
+        "median": 1e-06,
+        "std": 0.011914343674856429,
+        "min": 1e-06,
+        "max": 0.03602658902654344
+      },
+      "gamma": {
+        "mean": 0.9189948583003568,
+        "median": 0.95,
+        "std": 0.08203189430157445,
+        "min": 0.7019588664028542,
+        "max": 0.95
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.7314789781507632,
+        "median": 0.7123984632489424,
+        "std": 0.10194763611059333,
+        "min": 0.5467528151453244,
+        "max": 0.9320406841297989
       },
       "memory_size": {
         "mean": 2000,
@@ -204,9 +281,16 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.15942878976101,
-      "epsilon_decay": 0.995,
+      "learning_rate": 1e-06,
+      "gamma": 0.95,
+      "epsilon_decay": 0.9320406841297989,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.06529796200045994,
+    "adaptive_event": "disabled"
   }
 ]

--- a/experiments/evolution_convergence/run_clamp_penalty002_g6/evolution_lineage.json
+++ b/experiments/evolution_convergence/run_clamp_penalty002_g6/evolution_lineage.json
@@ -2,38 +2,23 @@
   {
     "candidate_id": "g0_c0",
     "generation": 0,
-    "fitness": 63.9803996003996,
+    "fitness": 74.9623996003996,
     "learning_rate": 0.001,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.019600399600399603
+      "final_population": 75,
+      "raw_fitness": 75.0,
+      "boundary_penalty": 0.0376003996003996
     }
   },
   {
     "candidate_id": "g0_c1",
     "generation": 0,
-    "fitness": 70.0,
+    "fitness": 62.98995853794374,
     "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 70,
-      "raw_fitness": 70.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g0_c2",
-    "generation": 0,
-    "fitness": 62.99044106245586,
-    "learning_rate": 0.02610363003699699,
     "parent_ids": [
       "seed",
       "seed"
@@ -41,307 +26,322 @@
     "metadata": {
       "final_population": 63,
       "raw_fitness": 63.0,
-      "boundary_penalty": 0.009558937544138748
+      "boundary_penalty": 0.010041462056260846
+    }
+  },
+  {
+    "candidate_id": "g0_c2",
+    "generation": 0,
+    "fitness": 65.94,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.06
     }
   },
   {
     "candidate_id": "g0_c3",
     "generation": 0,
-    "fitness": 54.98,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 55,
-      "raw_fitness": 55.0,
-      "boundary_penalty": 0.02
-    }
-  },
-  {
-    "candidate_id": "g0_c4",
-    "generation": 0,
     "fitness": 69.98,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 70,
-      "raw_fitness": 70.0,
-      "boundary_penalty": 0.02
-    }
-  },
-  {
-    "candidate_id": "g0_c5",
-    "generation": 0,
-    "fitness": 64.0,
-    "learning_rate": 0.13903446179832052,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g0_c6",
-    "generation": 0,
-    "fitness": 60.990859313020906,
-    "learning_rate": 0.02714925540397523,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 61,
-      "raw_fitness": 61.0,
-      "boundary_penalty": 0.009140686979096889
-    }
-  },
-  {
-    "candidate_id": "g0_c7",
-    "generation": 0,
-    "fitness": 62.0,
     "learning_rate": 0.09255006818590938,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g0_c4",
+    "generation": 0,
+    "fitness": 61.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
       "final_population": 62,
       "raw_fitness": 62.0,
-      "boundary_penalty": 0.0
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g0_c5",
+    "generation": 0,
+    "fitness": 59.96,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.04
+    }
+  },
+  {
+    "candidate_id": "g0_c6",
+    "generation": 0,
+    "fitness": 62.955118080128514,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.044881919871489186
+    }
+  },
+  {
+    "candidate_id": "g0_c7",
+    "generation": 0,
+    "fitness": 53.96,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 54,
+      "raw_fitness": 54.0,
+      "boundary_penalty": 0.04
     }
   },
   {
     "candidate_id": "g1_elite0",
     "generation": 1,
-    "fitness": 63.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 74.9623996003996,
+    "learning_rate": 0.001,
     "parent_ids": [
-      "g0_c1",
-      "g0_c1"
+      "g0_c0",
+      "g0_c0"
     ],
     "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.0
+      "final_population": 75,
+      "raw_fitness": 75.0,
+      "boundary_penalty": 0.0376003996003996
     }
   },
   {
     "candidate_id": "g1_c1",
     "generation": 1,
-    "fitness": 57.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 56.98995853794374,
+    "learning_rate": 0.20027491749951848,
     "parent_ids": [
-      "g0_c1",
+      "g0_c0",
       "g0_c1"
     ],
     "metadata": {
       "final_population": 57,
       "raw_fitness": 57.0,
-      "boundary_penalty": 0.0
+      "boundary_penalty": 0.010041462056260846
     }
   },
   {
     "candidate_id": "g1_c2",
     "generation": 1,
-    "fitness": 58.0,
-    "learning_rate": 0.13903446179832052,
+    "fitness": 64.98,
+    "learning_rate": 0.09255006818590938,
     "parent_ids": [
-      "g0_c5",
-      "g0_c2"
+      "g0_c0",
+      "g0_c3"
     ],
     "metadata": {
-      "final_population": 58,
-      "raw_fitness": 58.0,
-      "boundary_penalty": 0.0
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.02
     }
   },
   {
     "candidate_id": "g1_c3",
     "generation": 1,
-    "fitness": 75.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 68.95511808012851,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g0_c4",
-      "g0_c1"
+      "g0_c6",
+      "g0_c3"
     ],
     "metadata": {
-      "final_population": 75,
-      "raw_fitness": 75.0,
-      "boundary_penalty": 0.0
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.044881919871489186
     }
   },
   {
     "candidate_id": "g1_c4",
     "generation": 1,
-    "fitness": 71.98,
-    "learning_rate": 1e-06,
+    "fitness": 62.98,
+    "learning_rate": 0.09255006818590938,
     "parent_ids": [
-      "g0_c4",
-      "g0_c4"
+      "g0_c3",
+      "g0_c0"
     ],
     "metadata": {
-      "final_population": 72,
-      "raw_fitness": 72.0,
+      "final_population": 63,
+      "raw_fitness": 63.0,
       "boundary_penalty": 0.02
     }
   },
   {
     "candidate_id": "g1_c5",
     "generation": 1,
-    "fitness": 60.98,
-    "learning_rate": 1e-06,
+    "fitness": 61.962,
+    "learning_rate": 0.09255006818590938,
     "parent_ids": [
-      "g0_c1",
-      "g0_c4"
+      "g0_c0",
+      "g0_c3"
     ],
     "metadata": {
-      "final_population": 61,
-      "raw_fitness": 61.0,
-      "boundary_penalty": 0.02
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.038
     }
   },
   {
     "candidate_id": "g1_c6",
     "generation": 1,
-    "fitness": 69.0,
-    "learning_rate": 0.2749151269457153,
+    "fitness": 65.96,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g0_c5",
-      "g0_c4"
+      "g0_c0",
+      "g0_c2"
     ],
     "metadata": {
-      "final_population": 69,
-      "raw_fitness": 69.0,
-      "boundary_penalty": 0.0
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.04
     }
   },
   {
     "candidate_id": "g1_c7",
     "generation": 1,
-    "fitness": 66.98,
+    "fitness": 64.96995853794374,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g0_c1",
-      "g0_c4"
+      "g0_c6"
     ],
     "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.02
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.030041462056260848
     }
   },
   {
     "candidate_id": "g2_elite0",
     "generation": 2,
-    "fitness": 69.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 58.9623996003996,
+    "learning_rate": 0.001,
     "parent_ids": [
-      "g1_c3",
-      "g1_c3"
+      "g1_elite0",
+      "g1_elite0"
     ],
     "metadata": {
-      "final_population": 69,
-      "raw_fitness": 69.0,
-      "boundary_penalty": 0.0
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0376003996003996
     }
   },
   {
     "candidate_id": "g2_c1",
     "generation": 2,
-    "fitness": 63.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 59.96,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
-      "g1_c4"
+      "g1_c2"
     ],
     "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.0
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.04
     }
   },
   {
     "candidate_id": "g2_c2",
     "generation": 2,
-    "fitness": 63.0,
-    "learning_rate": 0.2749151269457153,
+    "fitness": 64.98,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c6",
       "g1_c7"
     ],
     "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.0
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.02
     }
   },
   {
     "candidate_id": "g2_c3",
     "generation": 2,
-    "fitness": 56.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 60.97511808012851,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
       "g1_c6"
     ],
     "metadata": {
-      "final_population": 56,
-      "raw_fitness": 56.0,
-      "boundary_penalty": 0.0
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.02488191987148919
     }
   },
   {
     "candidate_id": "g2_c4",
     "generation": 2,
-    "fitness": 65.98,
-    "learning_rate": 1e-06,
+    "fitness": 59.9403996003996,
+    "learning_rate": 0.001,
     "parent_ids": [
-      "g1_c4",
+      "g1_elite0",
       "g1_c6"
     ],
     "metadata": {
-      "final_population": 66,
-      "raw_fitness": 66.0,
-      "boundary_penalty": 0.02
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0596003996003996
     }
   },
   {
     "candidate_id": "g2_c5",
     "generation": 2,
-    "fitness": 63.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 66.96,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
-      "g1_c4"
+      "g1_c7"
     ],
     "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.0
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.04
     }
   },
   {
     "candidate_id": "g2_c6",
     "generation": 2,
-    "fitness": 62.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 58.955118080128514,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
       "g1_c3"
     ],
     "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
-      "boundary_penalty": 0.0
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.044881919871489186
     }
   },
   {
@@ -351,7 +351,7 @@
     "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c6",
-      "g1_c4"
+      "g1_elite0"
     ],
     "metadata": {
       "final_population": 69,
@@ -362,116 +362,221 @@
   {
     "candidate_id": "g3_elite0",
     "generation": 3,
-    "fitness": 63.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g2_elite0",
-      "g2_elite0"
-    ],
-    "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g3_c1",
-    "generation": 3,
-    "fitness": 61.983983989648344,
-    "learning_rate": 0.00996096416088228,
-    "parent_ids": [
-      "g2_elite0",
-      "g2_c7"
-    ],
-    "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
-      "boundary_penalty": 0.01601601035165744
-    }
-  },
-  {
-    "candidate_id": "g3_c2",
-    "generation": 3,
-    "fitness": 70.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g2_elite0",
-      "g2_elite0"
-    ],
-    "metadata": {
-      "final_population": 70,
-      "raw_fitness": 70.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g3_c3",
-    "generation": 3,
-    "fitness": 62.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g2_c1",
-      "g2_elite0"
-    ],
-    "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g3_c4",
-    "generation": 3,
-    "fitness": 64.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g2_elite0",
-      "g2_elite0"
-    ],
-    "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g3_c5",
-    "generation": 3,
-    "fitness": 60.98,
+    "fitness": 56.98,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g2_c7",
       "g2_c7"
     ],
     "metadata": {
-      "final_population": 61,
-      "raw_fitness": 61.0,
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g3_c1",
+    "generation": 3,
+    "fitness": 55.96,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c5",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.04
+    }
+  },
+  {
+    "candidate_id": "g3_c2",
+    "generation": 3,
+    "fitness": 56.96,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c2",
+      "g2_c1"
+    ],
+    "metadata": {
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.04
+    }
+  },
+  {
+    "candidate_id": "g3_c3",
+    "generation": 3,
+    "fitness": 61.96,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c5",
+      "g2_c3"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.04
+    }
+  },
+  {
+    "candidate_id": "g3_c4",
+    "generation": 3,
+    "fitness": 68.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c5",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g3_c5",
+    "generation": 3,
+    "fitness": 63.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c7",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
       "boundary_penalty": 0.02
     }
   },
   {
     "candidate_id": "g3_c6",
     "generation": 3,
-    "fitness": 58.0,
-    "learning_rate": 0.09175441322821346,
+    "fitness": 58.98,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g2_c7",
       "g2_c2"
     ],
     "metadata": {
-      "final_population": 58,
-      "raw_fitness": 58.0,
-      "boundary_penalty": 0.0
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.02
     }
   },
   {
     "candidate_id": "g3_c7",
     "generation": 3,
+    "fitness": 68.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c2",
+      "g2_c7"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g4_elite0",
+    "generation": 4,
+    "fitness": 64.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c4",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g4_c1",
+    "generation": 4,
+    "fitness": 58.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g4_c2",
+    "generation": 4,
+    "fitness": 51.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 52,
+      "raw_fitness": 52.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g4_c3",
+    "generation": 4,
+    "fitness": 59.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c7"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g4_c4",
+    "generation": 4,
+    "fitness": 59.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c7"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g4_c5",
+    "generation": 4,
+    "fitness": 62.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c7"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g4_c6",
+    "generation": 4,
     "fitness": 61.98,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_elite0",
-      "g2_c7"
+      "g3_c7",
+      "g3_c4"
     ],
     "metadata": {
       "final_population": 62,
@@ -480,103 +585,43 @@
     }
   },
   {
-    "candidate_id": "g4_elite0",
+    "candidate_id": "g4_c7",
     "generation": 4,
-    "fitness": 64.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g3_c2",
-      "g3_c2"
-    ],
-    "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c1",
-    "generation": 4,
-    "fitness": 65.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g3_c2",
-      "g3_c4"
-    ],
-    "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c2",
-    "generation": 4,
-    "fitness": 63.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g3_elite0",
-      "g3_c4"
-    ],
-    "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c3",
-    "generation": 4,
-    "fitness": 61.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g3_c2",
-      "g3_c3"
-    ],
-    "metadata": {
-      "final_population": 61,
-      "raw_fitness": 61.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c4",
-    "generation": 4,
-    "fitness": 67.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g3_c2",
-      "g3_c3"
-    ],
-    "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c5",
-    "generation": 4,
-    "fitness": 74.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g3_elite0",
-      "g3_c2"
-    ],
-    "metadata": {
-      "final_population": 74,
-      "raw_fitness": 74.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c6",
-    "generation": 4,
-    "fitness": 63.98,
+    "fitness": 66.98,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g3_c7",
       "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g5_elite0",
+    "generation": 5,
+    "fitness": 58.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c7",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g5_c1",
+    "generation": 5,
+    "fitness": 63.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c5",
+      "g4_c7"
     ],
     "metadata": {
       "final_population": 64,
@@ -585,138 +630,93 @@
     }
   },
   {
-    "candidate_id": "g4_c7",
-    "generation": 4,
-    "fitness": 67.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g3_elite0",
-      "g3_c2"
-    ],
-    "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_elite0",
-    "generation": 5,
-    "fitness": 68.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g4_c5",
-      "g4_c5"
-    ],
-    "metadata": {
-      "final_population": 68,
-      "raw_fitness": 68.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_c1",
-    "generation": 5,
-    "fitness": 70.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g4_c5",
-      "g4_c7"
-    ],
-    "metadata": {
-      "final_population": 70,
-      "raw_fitness": 70.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
     "candidate_id": "g5_c2",
     "generation": 5,
-    "fitness": 66.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g4_c5",
-      "g4_c1"
-    ],
-    "metadata": {
-      "final_population": 66,
-      "raw_fitness": 66.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_c3",
-    "generation": 5,
-    "fitness": 79.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g4_c4",
-      "g4_c5"
-    ],
-    "metadata": {
-      "final_population": 79,
-      "raw_fitness": 79.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_c4",
-    "generation": 5,
-    "fitness": 67.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g4_c4",
-      "g4_c7"
-    ],
-    "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_c5",
-    "generation": 5,
-    "fitness": 60.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g4_c1",
-      "g4_c4"
-    ],
-    "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_c6",
-    "generation": 5,
-    "fitness": 75.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g4_c7",
-      "g4_c5"
-    ],
-    "metadata": {
-      "final_population": 75,
-      "raw_fitness": 75.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_c7",
-    "generation": 5,
-    "fitness": 75.0,
-    "learning_rate": 0.5743263913640548,
+    "fitness": 60.98,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g4_c5",
       "g4_elite0"
     ],
     "metadata": {
-      "final_population": 75,
-      "raw_fitness": 75.0,
-      "boundary_penalty": 0.0
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g5_c3",
+    "generation": 5,
+    "fitness": 76.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c6",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 77,
+      "raw_fitness": 77.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g5_c4",
+    "generation": 5,
+    "fitness": 60.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c7",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g5_c5",
+    "generation": 5,
+    "fitness": 68.99441025002086,
+    "learning_rate": 0.03602658902654344,
+    "parent_ids": [
+      "g4_elite0",
+      "g4_c6"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0055897499791326055
+    }
+  },
+  {
+    "candidate_id": "g5_c6",
+    "generation": 5,
+    "fitness": 68.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c7",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g5_c7",
+    "generation": 5,
+    "fitness": 68.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c5",
+      "g4_elite0"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.02
     }
   }
 ]

--- a/experiments/evolution_convergence/run_clamp_penalty005_g6/evolution_generation_summaries.json
+++ b/experiments/evolution_convergence/run_clamp_penalty005_g6/evolution_generation_summaries.json
@@ -1,23 +1,79 @@
 [
   {
     "generation": 0,
-    "best_fitness": 68.950999000999,
-    "mean_fitness": 63.850531242461365,
-    "min_fitness": 60.95,
+    "best_fitness": 74.905999000999,
+    "mean_fitness": 62.28983631827246,
+    "min_fitness": 51.9,
     "best_candidate_id": "g0_c0",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.055658525648276516,
-        "median": 0.02662644272048611,
-        "std": 0.06118633982230562,
+        "mean": 0.03162298224336492,
+        "median": 1e-06,
+        "std": 0.05699117265327523,
         "min": 1e-06,
         "max": 0.15942878976101
       },
+      "gamma": {
+        "mean": 0.9371359275229121,
+        "median": 0.9875518275703261,
+        "std": 0.10332826581741346,
+        "min": 0.6803741749126586,
+        "max": 1.0
+      },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
+        "mean": 0.8724919919611355,
+        "median": 0.8921990333611127,
+        "std": 0.12471650716431597,
+        "min": 0.6866249283632477,
+        "max": 1.0
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
         "std": 0.0,
-        "min": 0.995,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.001,
+      "gamma": 0.95,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    },
+    "mutation_rate_used": null,
+    "mutation_scale_used": null,
+    "mutation_rate_multiplier": null,
+    "mutation_scale_multiplier": null,
+    "diversity": 0.09501200087541144,
+    "adaptive_event": "initial_seeding"
+  },
+  {
+    "generation": 1,
+    "best_fitness": 67.905999000999,
+    "mean_fitness": 62.43459268930538,
+    "min_fitness": 56.990846168584675,
+    "best_candidate_id": "g1_elite0",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.016800274490552235,
+        "median": 1e-06,
+        "std": 0.0315773043241489,
+        "min": 1e-06,
+        "max": 0.09255006818590938
+      },
+      "gamma": {
+        "mean": 0.9437415531913264,
+        "median": 0.95,
+        "std": 0.04408112995394031,
+        "min": 0.8916095901299863,
+        "max": 1.0
+      },
+      "epsilon_decay": {
+        "mean": 0.848448907947595,
+        "median": 0.8221932670435024,
+        "std": 0.09525507790168165,
+        "min": 0.6866249283632477,
         "max": 0.995
       },
       "memory_size": {
@@ -30,64 +86,43 @@
     },
     "best_chromosome": {
       "learning_rate": 0.001,
+      "gamma": 0.95,
       "epsilon_decay": 0.995,
       "memory_size": 2000
-    }
-  },
-  {
-    "generation": 1,
-    "best_fitness": 67.0,
-    "mean_fitness": 62.587874625374624,
-    "min_fitness": 56.95,
-    "best_candidate_id": "g1_c3",
-    "gene_statistics": {
-      "learning_rate": {
-        "mean": 0.04630852439145308,
-        "median": 0.001,
-        "std": 0.09150888392478951,
-        "min": 1e-06,
-        "max": 0.2749151269457153
-      },
-      "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
-      },
-      "memory_size": {
-        "mean": 2000,
-        "median": 2000.0,
-        "std": 0.0,
-        "min": 2000,
-        "max": 2000
-      }
     },
-    "best_chromosome": {
-      "learning_rate": 0.09255006818590938,
-      "epsilon_decay": 0.995,
-      "memory_size": 2000
-    }
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.05697118125236893,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 2,
-    "best_fitness": 73.0,
-    "mean_fitness": 66.23774975024975,
-    "min_fitness": 56.0,
+    "best_fitness": 71.92489634485935,
+    "mean_fitness": 65.54459883646459,
+    "min_fitness": 56.905999000999,
     "best_candidate_id": "g2_c5",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.09245818348440778,
-        "median": 0.09255006818590938,
-        "std": 0.07907257511597322,
-        "min": 0.001,
-        "max": 0.2749151269457153
+        "mean": 0.00025075,
+        "median": 1e-06,
+        "std": 0.0004325796891903271,
+        "min": 1e-06,
+        "max": 0.001
+      },
+      "gamma": {
+        "mean": 0.9677271125514113,
+        "median": 0.9751036551406521,
+        "std": 0.03474158677353867,
+        "min": 0.8916095901299863,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
+        "mean": 0.8172345232673663,
+        "median": 0.8221932670435024,
+        "std": 0.11562972153403958,
+        "min": 0.5677237728329356,
         "max": 0.995
       },
       "memory_size": {
@@ -99,31 +134,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.09255006818590938,
-      "epsilon_decay": 0.995,
+      "learning_rate": 1e-06,
+      "gamma": 0.9751036551406521,
+      "epsilon_decay": 0.8221932670435024,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.0502679628097829,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 3,
-    "best_fitness": 70.95,
-    "mean_fitness": 64.59549449726461,
-    "min_fitness": 59.0,
-    "best_candidate_id": "g3_c7",
+    "best_fitness": 71.9,
+    "mean_fitness": 61.79369817242967,
+    "min_fitness": 54.92489634485935,
+    "best_candidate_id": "g3_c4",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.03647681422011431,
-        "median": 0.005979982080441142,
-        "std": 0.04360745767373774,
+        "mean": 1e-06,
+        "median": 1e-06,
+        "std": 0.0,
         "min": 1e-06,
-        "max": 0.09275341322821345
+        "max": 1e-06
+      },
+      "gamma": {
+        "mean": 0.9740030263365743,
+        "median": 0.9751036551406521,
+        "std": 0.03320589515424388,
+        "min": 0.8916095901299863,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.8038566396381895,
+        "median": 0.8221932670435024,
+        "std": 0.03539396571235424,
+        "min": 0.7241990478892087,
+        "max": 0.8288524477063025
       },
       "memory_size": {
         "mean": 2000,
@@ -135,30 +184,44 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 1.0,
+      "epsilon_decay": 0.7241990478892087,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.02286662028886604,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 4,
-    "best_fitness": 67.95,
-    "mean_fitness": 64.20136987188998,
-    "min_fitness": 57.95,
-    "best_candidate_id": "g4_c5",
+    "best_fitness": 65.95,
+    "mean_fitness": 61.92494817242967,
+    "min_fitness": 54.9,
+    "best_candidate_id": "g4_c4",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.0013708705201102853,
+        "mean": 1e-06,
         "median": 1e-06,
-        "std": 0.00362433672457052,
+        "std": 0.0,
         "min": 1e-06,
-        "max": 0.010959964160882282
+        "max": 1e-06
+      },
+      "gamma": {
+        "mean": 0.9508338840764953,
+        "median": 0.9751036551406521,
+        "std": 0.05788558109454572,
+        "min": 0.8369660526170754,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.7631544745750471,
+        "median": 0.7731961574663555,
+        "std": 0.07318047307653694,
+        "min": 0.6180505981428353,
+        "max": 0.8346898923338087
       },
       "memory_size": {
         "mean": 2000,
@@ -170,30 +233,44 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 0.8369660526170754,
+      "epsilon_decay": 0.8288524477063025,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.04368868472369422,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 5,
-    "best_fitness": 67.95,
-    "mean_fitness": 63.456250000000004,
-    "min_fitness": 59.95,
-    "best_candidate_id": "g5_c4",
+    "best_fitness": 68.95,
+    "mean_fitness": 62.695089332453776,
+    "min_fitness": 53.95,
+    "best_candidate_id": "g5_c3",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.051863200200380606,
+        "mean": 0.00450419862831793,
         "median": 1e-06,
-        "std": 0.13721448417485127,
+        "std": 0.011914343674856429,
         "min": 1e-06,
-        "max": 0.41489860160304487
+        "max": 0.03602658902654344
+      },
+      "gamma": {
+        "mean": 0.8750297121792205,
+        "median": 0.8369660526170754,
+        "std": 0.08495148645051843,
+        "min": 0.7270625215435063,
+        "max": 0.9751036551406521
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.7421761197302713,
+        "median": 0.7241990478892087,
+        "std": 0.07552688030414983,
+        "min": 0.6180505981428353,
+        "max": 0.8288524477063025
       },
       "memory_size": {
         "mean": 2000,
@@ -205,8 +282,15 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 0.8369660526170754,
+      "epsilon_decay": 0.8288524477063025,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.05746424078129343,
+    "adaptive_event": "disabled"
   }
 ]

--- a/experiments/evolution_convergence/run_clamp_penalty005_g6/evolution_lineage.json
+++ b/experiments/evolution_convergence/run_clamp_penalty005_g6/evolution_lineage.json
@@ -2,22 +2,22 @@
   {
     "candidate_id": "g0_c0",
     "generation": 0,
-    "fitness": 68.950999000999,
+    "fitness": 74.905999000999,
     "learning_rate": 0.001,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 69,
-      "raw_fitness": 69.0,
-      "boundary_penalty": 0.049000999000999
+      "final_population": 75,
+      "raw_fitness": 75.0,
+      "boundary_penalty": 0.09400099900099901
     }
   },
   {
     "candidate_id": "g0_c1",
     "generation": 0,
-    "fitness": 62.0,
+    "fitness": 61.974896344859346,
     "learning_rate": 0.15942878976101,
     "parent_ids": [
       "seed",
@@ -26,28 +26,73 @@
     "metadata": {
       "final_population": 62,
       "raw_fitness": 62.0,
-      "boundary_penalty": 0.0
+      "boundary_penalty": 0.025103655140652117
     }
   },
   {
     "candidate_id": "g0_c2",
     "generation": 0,
-    "fitness": 63.97610265613965,
-    "learning_rate": 0.02610363003699699,
+    "fitness": 61.85,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.02389734386034687
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.15000000000000002
     }
   },
   {
     "candidate_id": "g0_c3",
     "generation": 0,
-    "fitness": 60.95,
+    "fitness": 61.95,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g0_c4",
+    "generation": 0,
+    "fitness": 62.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g0_c5",
+    "generation": 0,
+    "fitness": 51.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 52,
+      "raw_fitness": 52.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g0_c6",
+    "generation": 0,
+    "fitness": 60.88779520032128,
     "learning_rate": 1e-06,
     "parent_ids": [
       "seed",
@@ -56,149 +101,44 @@
     "metadata": {
       "final_population": 61,
       "raw_fitness": 61.0,
-      "boundary_penalty": 0.05
-    }
-  },
-  {
-    "candidate_id": "g0_c4",
-    "generation": 0,
-    "fitness": 66.95,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.05
-    }
-  },
-  {
-    "candidate_id": "g0_c5",
-    "generation": 0,
-    "fitness": 62.0,
-    "learning_rate": 0.13903446179832052,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g0_c6",
-    "generation": 0,
-    "fitness": 61.97714828255226,
-    "learning_rate": 0.02714925540397523,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
-      "boundary_penalty": 0.022851717447742222
+      "boundary_penalty": 0.11220479967872297
     }
   },
   {
     "candidate_id": "g0_c7",
     "generation": 0,
-    "fitness": 64.0,
-    "learning_rate": 0.09255006818590938,
+    "fitness": 61.9,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.0
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.1
     }
   },
   {
     "candidate_id": "g1_elite0",
     "generation": 1,
-    "fitness": 66.950999000999,
+    "fitness": 67.905999000999,
     "learning_rate": 0.001,
     "parent_ids": [
       "g0_c0",
       "g0_c0"
     ],
     "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.049000999000999
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.09400099900099901
     }
   },
   {
     "candidate_id": "g1_c1",
     "generation": 1,
-    "fitness": 62.950999000999,
-    "learning_rate": 0.001,
-    "parent_ids": [
-      "g0_c0",
-      "g0_c4"
-    ],
-    "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.049000999000999
-    }
-  },
-  {
-    "candidate_id": "g1_c2",
-    "generation": 1,
-    "fitness": 59.950999000999,
-    "learning_rate": 0.001,
-    "parent_ids": [
-      "g0_c0",
-      "g0_c7"
-    ],
-    "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.049000999000999
-    }
-  },
-  {
-    "candidate_id": "g1_c3",
-    "generation": 1,
-    "fitness": 67.0,
-    "learning_rate": 0.09255006818590938,
-    "parent_ids": [
-      "g0_c4",
-      "g0_c7"
-    ],
-    "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g1_c4",
-    "generation": 1,
-    "fitness": 63.95,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g0_c4",
-      "g0_c0"
-    ],
-    "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.05
-    }
-  },
-  {
-    "candidate_id": "g1_c5",
-    "generation": 1,
-    "fitness": 56.95,
-    "learning_rate": 1e-06,
+    "fitness": 56.990846168584675,
+    "learning_rate": 0.04084712773850849,
     "parent_ids": [
       "g0_c0",
       "g0_c4"
@@ -206,497 +146,407 @@
     "metadata": {
       "final_population": 57,
       "raw_fitness": 57.0,
+      "boundary_penalty": 0.009153831415322928
+    }
+  },
+  {
+    "candidate_id": "g1_c2",
+    "generation": 1,
+    "fitness": 59.95,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c3"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
       "boundary_penalty": 0.05
     }
   },
   {
-    "candidate_id": "g1_c6",
+    "candidate_id": "g1_c3",
     "generation": 1,
-    "fitness": 65.0,
-    "learning_rate": 0.2749151269457153,
+    "fitness": 64.92489634485935,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c1"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.07510365514065212
+    }
+  },
+  {
+    "candidate_id": "g1_c4",
+    "generation": 1,
+    "fitness": 64.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c0"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g1_c5",
+    "generation": 1,
+    "fitness": 61.905,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g0_c0",
       "g0_c4"
     ],
     "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.0
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.095
+    }
+  },
+  {
+    "candidate_id": "g1_c6",
+    "generation": 1,
+    "fitness": 58.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.05
     }
   },
   {
     "candidate_id": "g1_c7",
     "generation": 1,
-    "fitness": 57.95,
+    "fitness": 63.95,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g0_c4",
       "g0_c4"
     ],
     "metadata": {
-      "final_population": 58,
-      "raw_fitness": 58.0,
+      "final_population": 64,
+      "raw_fitness": 64.0,
       "boundary_penalty": 0.05
     }
   },
   {
     "candidate_id": "g2_elite0",
     "generation": 2,
-    "fitness": 66.0,
-    "learning_rate": 0.09255006818590938,
+    "fitness": 56.905999000999,
+    "learning_rate": 0.001,
     "parent_ids": [
-      "g1_c3",
-      "g1_c3"
+      "g1_elite0",
+      "g1_elite0"
     ],
     "metadata": {
-      "final_population": 66,
-      "raw_fitness": 66.0,
-      "boundary_penalty": 0.0
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.09400099900099901
     }
   },
   {
     "candidate_id": "g2_c1",
     "generation": 2,
-    "fitness": 69.0,
-    "learning_rate": 0.09255006818590938,
+    "fitness": 65.9,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
       "g1_c4"
     ],
     "metadata": {
-      "final_population": 69,
-      "raw_fitness": 69.0,
-      "boundary_penalty": 0.0
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.1
     }
   },
   {
     "candidate_id": "g2_c2",
     "generation": 2,
-    "fitness": 60.0,
-    "learning_rate": 0.2749151269457153,
+    "fitness": 68.95,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g1_c6",
-      "g1_c1"
+      "g1_c7",
+      "g1_c7"
     ],
     "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.0
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.05
     }
   },
   {
     "candidate_id": "g2_c3",
     "generation": 2,
-    "fitness": 63.0,
-    "learning_rate": 0.09255006818590938,
+    "fitness": 60.9,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
-      "g1_c6"
+      "g1_c2"
     ],
     "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.0
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.1
     }
   },
   {
     "candidate_id": "g2_c4",
     "generation": 2,
-    "fitness": 72.950999000999,
+    "fitness": 65.90099900099901,
     "learning_rate": 0.001,
     "parent_ids": [
       "g1_elite0",
-      "g1_c6"
+      "g1_c7"
     ],
     "metadata": {
-      "final_population": 73,
-      "raw_fitness": 73.0,
-      "boundary_penalty": 0.049000999000999
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.09900099900099901
     }
   },
   {
     "candidate_id": "g2_c5",
     "generation": 2,
-    "fitness": 73.0,
-    "learning_rate": 0.09255006818590938,
+    "fitness": 71.92489634485935,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
       "g1_c4"
     ],
     "metadata": {
-      "final_population": 73,
-      "raw_fitness": 73.0,
-      "boundary_penalty": 0.0
+      "final_population": 72,
+      "raw_fitness": 72.0,
+      "boundary_penalty": 0.07510365514065212
     }
   },
   {
     "candidate_id": "g2_c6",
     "generation": 2,
-    "fitness": 56.0,
-    "learning_rate": 0.09255006818590938,
+    "fitness": 69.92489634485935,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
       "g1_c3"
     ],
     "metadata": {
-      "final_population": 56,
-      "raw_fitness": 56.0,
-      "boundary_penalty": 0.0
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.07510365514065212
     }
   },
   {
     "candidate_id": "g2_c7",
     "generation": 2,
-    "fitness": 69.950999000999,
-    "learning_rate": 0.001,
+    "fitness": 63.95,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g1_c6",
+      "g1_c7",
       "g1_elite0"
     ],
     "metadata": {
-      "final_population": 70,
-      "raw_fitness": 70.0,
-      "boundary_penalty": 0.049000999000999
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.05
     }
   },
   {
     "candidate_id": "g3_elite0",
     "generation": 3,
-    "fitness": 60.0,
-    "learning_rate": 0.09255006818590938,
+    "fitness": 54.92489634485935,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g2_c5",
       "g2_c5"
     ],
     "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.0
+      "final_population": 55,
+      "raw_fitness": 55.0,
+      "boundary_penalty": 0.07510365514065212
     }
   },
   {
     "candidate_id": "g3_c1",
     "generation": 3,
-    "fitness": 63.96095897511986,
-    "learning_rate": 0.010959964160882282,
+    "fitness": 56.92489634485935,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g2_c5",
-      "g2_c4"
+      "g2_c6"
     ],
     "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.039041024880142605
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.07510365514065212
     }
   },
   {
     "candidate_id": "g3_c2",
     "generation": 3,
-    "fitness": 62.950999000999,
-    "learning_rate": 0.001,
+    "fitness": 61.9,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_c4",
+      "g2_c2",
       "g2_c4"
     ],
     "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.049000999000999
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.1
     }
   },
   {
     "candidate_id": "g3_c3",
     "generation": 3,
-    "fitness": 59.0,
-    "learning_rate": 0.09255006818590938,
+    "fitness": 70.92489634485935,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g2_c5",
       "g2_c1"
     ],
     "metadata": {
-      "final_population": 59,
-      "raw_fitness": 59.0,
-      "boundary_penalty": 0.0
+      "final_population": 71,
+      "raw_fitness": 71.0,
+      "boundary_penalty": 0.07510365514065212
     }
   },
   {
     "candidate_id": "g3_c4",
     "generation": 3,
-    "fitness": 63.950999000999,
-    "learning_rate": 0.001,
+    "fitness": 71.9,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g2_c5",
-      "g2_c7"
+      "g2_c1"
     ],
     "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.049000999000999
+      "final_population": 72,
+      "raw_fitness": 72.0,
+      "boundary_penalty": 0.1
     }
   },
   {
     "candidate_id": "g3_c5",
     "generation": 3,
-    "fitness": 69.950999000999,
-    "learning_rate": 0.001,
+    "fitness": 54.95,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_c4",
-      "g2_c7"
+      "g2_c2",
+      "g2_c2"
     ],
     "metadata": {
-      "final_population": 70,
-      "raw_fitness": 70.0,
-      "boundary_penalty": 0.049000999000999
+      "final_population": 55,
+      "raw_fitness": 55.0,
+      "boundary_penalty": 0.05
     }
   },
   {
     "candidate_id": "g3_c6",
     "generation": 3,
-    "fitness": 66.0,
-    "learning_rate": 0.09275341322821345,
+    "fitness": 59.9,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g2_c4",
-      "g2_c3"
+      "g2_c6"
     ],
     "metadata": {
-      "final_population": 66,
-      "raw_fitness": 66.0,
-      "boundary_penalty": 0.0
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.1
     }
   },
   {
     "candidate_id": "g3_c7",
     "generation": 3,
-    "fitness": 70.95,
+    "fitness": 62.92489634485935,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_c1",
+      "g2_c2",
       "g2_c5"
     ],
     "metadata": {
-      "final_population": 71,
-      "raw_fitness": 71.0,
-      "boundary_penalty": 0.05
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.07510365514065212
     }
   },
   {
     "candidate_id": "g4_elite0",
     "generation": 4,
-    "fitness": 57.95,
+    "fitness": 61.9,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g3_c7",
-      "g3_c7"
+      "g3_c4",
+      "g3_c4"
     ],
     "metadata": {
-      "final_population": 58,
-      "raw_fitness": 58.0,
-      "boundary_penalty": 0.05
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.1
     }
   },
   {
     "candidate_id": "g4_c1",
     "generation": 4,
-    "fitness": 66.95,
+    "fitness": 61.92489634485935,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g3_c7",
-      "g3_c5"
+      "g3_c3",
+      "g3_c4"
     ],
     "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.05
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.07510365514065212
     }
   },
   {
     "candidate_id": "g4_c2",
     "generation": 4,
-    "fitness": 66.95,
+    "fitness": 54.9,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g3_c7",
-      "g3_c5"
+      "g3_c4"
     ],
     "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.05
+      "final_population": 55,
+      "raw_fitness": 55.0,
+      "boundary_penalty": 0.1
     }
   },
   {
     "candidate_id": "g4_c3",
     "generation": 4,
-    "fitness": 63.95,
+    "fitness": 59.95,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g3_c7",
-      "g3_c7"
+      "g3_c3"
     ],
     "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
+      "final_population": 60,
+      "raw_fitness": 60.0,
       "boundary_penalty": 0.05
     }
   },
   {
     "candidate_id": "g4_c4",
     "generation": 4,
-    "fitness": 64.95,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c1",
-      "g3_c7"
-    ],
-    "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.05
-    }
-  },
-  {
-    "candidate_id": "g4_c5",
-    "generation": 4,
-    "fitness": 67.95,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c1",
-      "g3_c7"
-    ],
-    "metadata": {
-      "final_population": 68,
-      "raw_fitness": 68.0,
-      "boundary_penalty": 0.05
-    }
-  },
-  {
-    "candidate_id": "g4_c6",
-    "generation": 4,
-    "fitness": 62.95,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c7",
-      "g3_c6"
-    ],
-    "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.05
-    }
-  },
-  {
-    "candidate_id": "g4_c7",
-    "generation": 4,
-    "fitness": 61.96095897511986,
-    "learning_rate": 0.010959964160882282,
-    "parent_ids": [
-      "g3_c7",
-      "g3_c1"
-    ],
-    "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
-      "boundary_penalty": 0.039041024880142605
-    }
-  },
-  {
-    "candidate_id": "g5_elite0",
-    "generation": 5,
-    "fitness": 66.95,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c5",
-      "g4_c5"
-    ],
-    "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.05
-    }
-  },
-  {
-    "candidate_id": "g5_c1",
-    "generation": 5,
-    "fitness": 59.95,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c5",
-      "g4_c1"
-    ],
-    "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.05
-    }
-  },
-  {
-    "candidate_id": "g5_c2",
-    "generation": 5,
-    "fitness": 63.95,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c5",
-      "g4_c2"
-    ],
-    "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.05
-    }
-  },
-  {
-    "candidate_id": "g5_c3",
-    "generation": 5,
-    "fitness": 59.95,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c1",
-      "g4_c5"
-    ],
-    "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.05
-    }
-  },
-  {
-    "candidate_id": "g5_c4",
-    "generation": 5,
-    "fitness": 67.95,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c4",
-      "g4_c1"
-    ],
-    "metadata": {
-      "final_population": 68,
-      "raw_fitness": 68.0,
-      "boundary_penalty": 0.05
-    }
-  },
-  {
-    "candidate_id": "g5_c5",
-    "generation": 5,
-    "fitness": 59.95,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c1",
-      "g4_c1"
-    ],
-    "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.05
-    }
-  },
-  {
-    "candidate_id": "g5_c6",
-    "generation": 5,
     "fitness": 65.95,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g4_c4",
-      "g4_c5"
+      "g3_c3",
+      "g3_c3"
     ],
     "metadata": {
       "final_population": 66,
@@ -705,18 +555,168 @@
     }
   },
   {
-    "candidate_id": "g5_c7",
+    "candidate_id": "g4_c5",
+    "generation": 4,
+    "fitness": 63.92489634485935,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.07510365514065212
+    }
+  },
+  {
+    "candidate_id": "g4_c6",
+    "generation": 4,
+    "fitness": 61.92489634485935,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.07510365514065212
+    }
+  },
+  {
+    "candidate_id": "g4_c7",
+    "generation": 4,
+    "fitness": 64.92489634485935,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.07510365514065212
+    }
+  },
+  {
+    "candidate_id": "g5_elite0",
     "generation": 5,
-    "fitness": 63.0,
-    "learning_rate": 0.41489860160304487,
+    "fitness": 53.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c4",
+      "g4_c4"
+    ],
+    "metadata": {
+      "final_population": 54,
+      "raw_fitness": 54.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g5_c1",
+    "generation": 5,
+    "fitness": 62.95,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g4_c5",
-      "g4_c2"
+      "g4_c7"
     ],
     "metadata": {
       "final_population": 63,
       "raw_fitness": 63.0,
-      "boundary_penalty": 0.0
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g5_c2",
+    "generation": 5,
+    "fitness": 59.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c4",
+      "g4_c1"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g5_c3",
+    "generation": 5,
+    "fitness": 68.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c4",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g5_c4",
+    "generation": 5,
+    "fitness": 59.95,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c4",
+      "g4_c4"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.05
+    }
+  },
+  {
+    "candidate_id": "g5_c5",
+    "generation": 5,
+    "fitness": 61.96092196991152,
+    "learning_rate": 0.03602658902654344,
+    "parent_ids": [
+      "g4_c1",
+      "g4_c4"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.03907803008848363
+    }
+  },
+  {
+    "candidate_id": "g5_c6",
+    "generation": 5,
+    "fitness": 68.92489634485935,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c4",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.07510365514065212
+    }
+  },
+  {
+    "candidate_id": "g5_c7",
+    "generation": 5,
+    "fitness": 64.92489634485935,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c5",
+      "g4_elite0"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.07510365514065212
     }
   }
 ]

--- a/experiments/evolution_convergence/run_clamp_penalty010_g6/evolution_generation_summaries.json
+++ b/experiments/evolution_convergence/run_clamp_penalty010_g6/evolution_generation_summaries.json
@@ -1,94 +1,31 @@
 [
   {
     "generation": 0,
-    "best_fitness": 74.901998001998,
-    "mean_fitness": 66.20106248492273,
-    "min_fitness": 57.9,
-    "best_candidate_id": "g0_c0",
+    "best_fitness": 69.9,
+    "mean_fitness": 61.579672636544906,
+    "min_fitness": 55.77559040064256,
+    "best_candidate_id": "g0_c4",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.055658525648276516,
-        "median": 0.02662644272048611,
-        "std": 0.06118633982230562,
+        "mean": 0.03162298224336492,
+        "median": 1e-06,
+        "std": 0.05699117265327523,
         "min": 1e-06,
         "max": 0.15942878976101
       },
-      "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
-      },
-      "memory_size": {
-        "mean": 2000,
-        "median": 2000.0,
-        "std": 0.0,
-        "min": 2000,
-        "max": 2000
-      }
-    },
-    "best_chromosome": {
-      "learning_rate": 0.001,
-      "epsilon_decay": 0.995,
-      "memory_size": 2000
-    }
-  },
-  {
-    "generation": 1,
-    "best_fitness": 77.0,
-    "mean_fitness": 67.42574925074925,
-    "min_fitness": 57.901998001998,
-    "best_candidate_id": "g1_c3",
-    "gene_statistics": {
-      "learning_rate": {
-        "mean": 0.05466836458834066,
-        "median": 0.001,
-        "std": 0.09816429171109597,
-        "min": 1e-06,
-        "max": 0.2749151269457153
+      "gamma": {
+        "mean": 0.9371359275229121,
+        "median": 0.9875518275703261,
+        "std": 0.10332826581741346,
+        "min": 0.6803741749126586,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
-      },
-      "memory_size": {
-        "mean": 2000,
-        "median": 2000.0,
-        "std": 0.0,
-        "min": 2000,
-        "max": 2000
-      }
-    },
-    "best_chromosome": {
-      "learning_rate": 0.15942878976101,
-      "epsilon_decay": 0.995,
-      "memory_size": 2000
-    }
-  },
-  {
-    "generation": 2,
-    "best_fitness": 71.9,
-    "mean_fitness": 64.725,
-    "min_fitness": 53.0,
-    "best_candidate_id": "g2_c7",
-    "gene_statistics": {
-      "learning_rate": {
-        "mean": 0.13400763446884564,
-        "median": 0.15942878976101,
-        "std": 0.08587902340021279,
-        "min": 1e-06,
-        "max": 0.2749151269457153
-      },
-      "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.8724919919611355,
+        "median": 0.8921990333611127,
+        "std": 0.12471650716431597,
+        "min": 0.6866249283632477,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -100,30 +37,142 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 0.8916095901299863,
+      "epsilon_decay": 0.8221932670435024,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": null,
+    "mutation_scale_used": null,
+    "mutation_rate_multiplier": null,
+    "mutation_scale_multiplier": null,
+    "diversity": 0.09501200087541144,
+    "adaptive_event": "initial_seeding"
+  },
+  {
+    "generation": 1,
+    "best_fitness": 72.8,
+    "mean_fitness": 63.628935628361006,
+    "min_fitness": 58.981692337169356,
+    "best_candidate_id": "g1_c4",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.016675399490552235,
+        "median": 1e-06,
+        "std": 0.03164145103014878,
+        "min": 1e-06,
+        "max": 0.09255006818590938
+      },
+      "gamma": {
+        "mean": 0.9426927519575746,
+        "median": 0.9333566226353192,
+        "std": 0.05164879762509642,
+        "min": 0.8916095901299863,
+        "max": 1.0
+      },
+      "epsilon_decay": {
+        "mean": 0.8033967857922019,
+        "median": 0.8221932670435024,
+        "std": 0.044400811846156255,
+        "min": 0.6866249283632477,
+        "max": 0.8221932670435024
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "gamma": 1.0,
+      "epsilon_decay": 0.8221932670435024,
+      "memory_size": 2000
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.04256369738096138,
+    "adaptive_event": "disabled"
+  },
+  {
+    "generation": 2,
+    "best_fitness": 66.8,
+    "mean_fitness": 62.9375,
+    "min_fitness": 58.8,
+    "best_candidate_id": "g2_c1",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 1e-06,
+        "median": 1e-06,
+        "std": 0.0,
+        "min": 1e-06,
+        "max": 1e-06
+      },
+      "gamma": {
+        "mean": 0.9864511987662483,
+        "median": 1.0,
+        "std": 0.035846758627552135,
+        "min": 0.8916095901299863,
+        "max": 1.0
+      },
+      "epsilon_decay": {
+        "mean": 0.774032840028242,
+        "median": 0.8221932670435024,
+        "std": 0.08288351368840709,
+        "min": 0.5677237728329356,
+        "max": 0.8221932670435024
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "gamma": 1.0,
+      "epsilon_decay": 0.5677237728329356,
+      "memory_size": 2000
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.039576757438653076,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 3,
-    "best_fitness": 70.0,
-    "mean_fitness": 63.81498999353022,
-    "min_fitness": 57.0,
+    "best_fitness": 68.8,
+    "mean_fitness": 63.925,
+    "min_fitness": 56.8,
     "best_candidate_id": "g3_c3",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.05257211961388947,
-        "median": 0.00498098208044114,
-        "std": 0.06822989546526871,
+        "mean": 1e-06,
+        "median": 1e-06,
+        "std": 0.0,
         "min": 1e-06,
-        "max": 0.15942878976101
+        "max": 1e-06
+      },
+      "gamma": {
+        "mean": 1.0,
+        "median": 1.0,
+        "std": 0.0,
+        "min": 1.0,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.6517329533504614,
+        "median": 0.5710533631643357,
+        "std": 0.11044114047128764,
+        "min": 0.5677237728329356,
+        "max": 0.8221932670435024
       },
       "memory_size": {
         "mean": 2000,
@@ -134,31 +183,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.15942878976101,
-      "epsilon_decay": 0.995,
+      "learning_rate": 1e-06,
+      "gamma": 1.0,
+      "epsilon_decay": 0.5743829534957358,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.036813713490429216,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 4,
-    "best_fitness": 68.0,
-    "mean_fitness": 64.225,
-    "min_fitness": 56.0,
-    "best_candidate_id": "g4_c5",
+    "best_fitness": 69.8,
+    "mean_fitness": 61.574999999999996,
+    "min_fitness": 53.8,
+    "best_candidate_id": "g4_c7",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.11957184232075749,
-        "median": 0.15942878976101,
-        "std": 0.06903425800111963,
+        "mean": 1e-06,
+        "median": 1e-06,
+        "std": 0.0,
         "min": 1e-06,
-        "max": 0.15942878976101
+        "max": 1e-06
+      },
+      "gamma": {
+        "mean": 0.9695061427210062,
+        "median": 1.0,
+        "std": 0.05343154459277101,
+        "min": 0.8618623974764232,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.6620830774240373,
+        "median": 0.5962167758192856,
+        "std": 0.10723274065083532,
+        "min": 0.5743829534957358,
+        "max": 0.8346898923338087
       },
       "memory_size": {
         "mean": 2000,
@@ -169,31 +232,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.15942878976101,
-      "epsilon_decay": 0.995,
+      "learning_rate": 1e-06,
+      "gamma": 1.0,
+      "epsilon_decay": 0.6180505981428353,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.05355476174786878,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 5,
-    "best_fitness": 73.0,
-    "mean_fitness": 64.85,
-    "min_fitness": 59.9,
-    "best_candidate_id": "g5_c6",
+    "best_fitness": 72.9,
+    "mean_fitness": 64.47150640626305,
+    "min_fitness": 53.8,
+    "best_candidate_id": "g5_c3",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.17143404252113809,
-        "median": 0.15942878976101,
-        "std": 0.1665163097722878,
+        "mean": 0.00450419862831793,
+        "median": 1e-06,
+        "std": 0.011914343674856429,
         "min": 1e-06,
-        "max": 0.5743263913640548
+        "max": 0.03602658902654344
+      },
+      "gamma": {
+        "mean": 0.9344604576694626,
+        "median": 1.0,
+        "std": 0.0903638101972452,
+        "min": 0.7519588664028543,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.5696772483892104,
+        "median": 0.5743829534957358,
+        "std": 0.0490622181443035,
+        "min": 0.4494020233493342,
+        "max": 0.6180505981428353
       },
       "memory_size": {
         "mean": 2000,
@@ -204,9 +281,16 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.15942878976101,
-      "epsilon_decay": 0.995,
+      "learning_rate": 1e-06,
+      "gamma": 0.8618623974764232,
+      "epsilon_decay": 0.5743829534957358,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.0504467946435869,
+    "adaptive_event": "disabled"
   }
 ]

--- a/experiments/evolution_convergence/run_clamp_penalty010_g6/evolution_lineage.json
+++ b/experiments/evolution_convergence/run_clamp_penalty010_g6/evolution_lineage.json
@@ -2,53 +2,8 @@
   {
     "candidate_id": "g0_c0",
     "generation": 0,
-    "fitness": 74.901998001998,
+    "fitness": 57.811998001998,
     "learning_rate": 0.001,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 75,
-      "raw_fitness": 75.0,
-      "boundary_penalty": 0.098001998001998
-    }
-  },
-  {
-    "candidate_id": "g0_c1",
-    "generation": 0,
-    "fitness": 65.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g0_c2",
-    "generation": 0,
-    "fitness": 60.952205312279304,
-    "learning_rate": 0.02610363003699699,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 61,
-      "raw_fitness": 61.0,
-      "boundary_penalty": 0.04779468772069374
-    }
-  },
-  {
-    "candidate_id": "g0_c3",
-    "generation": 0,
-    "fitness": 57.9,
-    "learning_rate": 1e-06,
     "parent_ids": [
       "seed",
       "seed"
@@ -56,44 +11,14 @@
     "metadata": {
       "final_population": 58,
       "raw_fitness": 58.0,
-      "boundary_penalty": 0.1
+      "boundary_penalty": 0.18800199800199802
     }
   },
   {
-    "candidate_id": "g0_c4",
+    "candidate_id": "g0_c1",
     "generation": 0,
-    "fitness": 72.9,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 73,
-      "raw_fitness": 73.0,
-      "boundary_penalty": 0.1
-    }
-  },
-  {
-    "candidate_id": "g0_c5",
-    "generation": 0,
-    "fitness": 65.0,
-    "learning_rate": 0.13903446179832052,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g0_c6",
-    "generation": 0,
-    "fitness": 67.95429656510451,
-    "learning_rate": 0.02714925540397523,
+    "fitness": 67.94979268971869,
+    "learning_rate": 0.15942878976101,
     "parent_ids": [
       "seed",
       "seed"
@@ -101,272 +26,257 @@
     "metadata": {
       "final_population": 68,
       "raw_fitness": 68.0,
-      "boundary_penalty": 0.045703434895484445
+      "boundary_penalty": 0.050207310281304235
     }
   },
   {
-    "candidate_id": "g0_c7",
+    "candidate_id": "g0_c2",
     "generation": 0,
-    "fitness": 65.0,
+    "fitness": 61.7,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.30000000000000004
+    }
+  },
+  {
+    "candidate_id": "g0_c3",
+    "generation": 0,
+    "fitness": 61.9,
     "learning_rate": 0.09255006818590938,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.0
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g0_c4",
+    "generation": 0,
+    "fitness": 69.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g0_c5",
+    "generation": 0,
+    "fitness": 57.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g0_c6",
+    "generation": 0,
+    "fitness": 55.77559040064256,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.22440959935744595
+    }
+  },
+  {
+    "candidate_id": "g0_c7",
+    "generation": 0,
+    "fitness": 59.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.2
     }
   },
   {
     "candidate_id": "g1_elite0",
     "generation": 1,
-    "fitness": 61.901998001998,
-    "learning_rate": 0.001,
+    "fitness": 67.9,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g0_c0",
-      "g0_c0"
+      "g0_c4",
+      "g0_c4"
     ],
     "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
-      "boundary_penalty": 0.098001998001998
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.1
     }
   },
   {
     "candidate_id": "g1_c1",
     "generation": 1,
-    "fitness": 57.901998001998,
-    "learning_rate": 0.001,
+    "fitness": 58.981692337169356,
+    "learning_rate": 0.04084712773850849,
     "parent_ids": [
-      "g0_c0",
+      "g0_c1",
       "g0_c4"
     ],
     "metadata": {
-      "final_population": 58,
-      "raw_fitness": 58.0,
-      "boundary_penalty": 0.098001998001998
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.018307662830645857
     }
   },
   {
     "candidate_id": "g1_c2",
     "generation": 1,
-    "fitness": 63.901998001998,
-    "learning_rate": 0.001,
+    "fitness": 60.9,
+    "learning_rate": 0.09255006818590938,
     "parent_ids": [
-      "g0_c0",
-      "g0_c7"
+      "g0_c2",
+      "g0_c3"
     ],
     "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.098001998001998
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.1
     }
   },
   {
     "candidate_id": "g1_c3",
     "generation": 1,
-    "fitness": 77.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 64.8497926897187,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g0_c4",
       "g0_c1"
     ],
     "metadata": {
-      "final_population": 77,
-      "raw_fitness": 77.0,
-      "boundary_penalty": 0.0
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.15020731028130424
     }
   },
   {
     "candidate_id": "g1_c4",
     "generation": 1,
-    "fitness": 76.9,
+    "fitness": 72.8,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g0_c4",
-      "g0_c0"
+      "g0_c4"
     ],
     "metadata": {
-      "final_population": 77,
-      "raw_fitness": 77.0,
-      "boundary_penalty": 0.1
+      "final_population": 73,
+      "raw_fitness": 73.0,
+      "boundary_penalty": 0.2
     }
   },
   {
     "candidate_id": "g1_c5",
     "generation": 1,
-    "fitness": 71.9,
+    "fitness": 60.9,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g0_c0",
+      "g0_c1",
       "g0_c4"
     ],
     "metadata": {
-      "final_population": 72,
-      "raw_fitness": 72.0,
+      "final_population": 61,
+      "raw_fitness": 61.0,
       "boundary_penalty": 0.1
     }
   },
   {
     "candidate_id": "g1_c6",
     "generation": 1,
-    "fitness": 65.0,
-    "learning_rate": 0.2749151269457153,
+    "fitness": 60.8,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g0_c0",
+      "g0_c3",
       "g0_c4"
     ],
     "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.0
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.2
     }
   },
   {
     "candidate_id": "g1_c7",
     "generation": 1,
-    "fitness": 64.9,
+    "fitness": 61.9,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g0_c4",
       "g0_c4"
     ],
     "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
+      "final_population": 62,
+      "raw_fitness": 62.0,
       "boundary_penalty": 0.1
     }
   },
   {
     "candidate_id": "g2_elite0",
     "generation": 2,
-    "fitness": 67.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 58.8,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g1_c3",
-      "g1_c3"
+      "g1_c4",
+      "g1_c4"
     ],
     "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.0
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.2
     }
   },
   {
     "candidate_id": "g2_c1",
     "generation": 2,
-    "fitness": 62.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 66.8,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
       "g1_c4"
     ],
     "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
-      "boundary_penalty": 0.0
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.2
     }
   },
   {
     "candidate_id": "g2_c2",
     "generation": 2,
-    "fitness": 53.0,
-    "learning_rate": 0.2749151269457153,
-    "parent_ids": [
-      "g1_c6",
-      "g1_c5"
-    ],
-    "metadata": {
-      "final_population": 53,
-      "raw_fitness": 53.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c3",
-    "generation": 2,
-    "fitness": 64.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g1_c3",
-      "g1_c6"
-    ],
-    "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c4",
-    "generation": 2,
-    "fitness": 64.9,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g1_c4",
-      "g1_c6"
-    ],
-    "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.1
-    }
-  },
-  {
-    "candidate_id": "g2_c5",
-    "generation": 2,
-    "fitness": 70.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g1_c3",
-      "g1_c4"
-    ],
-    "metadata": {
-      "final_population": 70,
-      "raw_fitness": 70.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c6",
-    "generation": 2,
-    "fitness": 65.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g1_c3",
-      "g1_c3"
-    ],
-    "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c7",
-    "generation": 2,
-    "fitness": 71.9,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g1_c6",
-      "g1_c4"
-    ],
-    "metadata": {
-      "final_population": 72,
-      "raw_fitness": 72.0,
-      "boundary_penalty": 0.1
-    }
-  },
-  {
-    "candidate_id": "g3_elite0",
-    "generation": 3,
     "fitness": 58.9,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_c7",
-      "g2_c7"
+      "g1_c7",
+      "g1_c7"
     ],
     "metadata": {
       "final_population": 59,
@@ -375,58 +285,343 @@
     }
   },
   {
-    "candidate_id": "g3_c1",
-    "generation": 3,
-    "fitness": 62.91991994824171,
-    "learning_rate": 0.00996096416088228,
+    "candidate_id": "g2_c3",
+    "generation": 2,
+    "fitness": 61.8,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_c5",
-      "g2_c7"
+      "g1_c4",
+      "g1_c2"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g2_c4",
+    "generation": 2,
+    "fitness": 65.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c4",
+      "g1_c7"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g2_c5",
+    "generation": 2,
+    "fitness": 65.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c4",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g2_c6",
+    "generation": 2,
+    "fitness": 60.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c4",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g2_c7",
+    "generation": 2,
+    "fitness": 64.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c7",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g3_elite0",
+    "generation": 3,
+    "fitness": 62.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c1",
+      "g2_c1"
     ],
     "metadata": {
       "final_population": 63,
       "raw_fitness": 63.0,
-      "boundary_penalty": 0.0800800517582872
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g3_c1",
+    "generation": 3,
+    "fitness": 56.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c5",
+      "g2_c4"
+    ],
+    "metadata": {
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.2
     }
   },
   {
     "candidate_id": "g3_c2",
     "generation": 3,
-    "fitness": 69.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 63.8,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_elite0",
-      "g2_elite0"
+      "g2_c4",
+      "g2_c1"
     ],
     "metadata": {
-      "final_population": 69,
-      "raw_fitness": 69.0,
-      "boundary_penalty": 0.0
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.2
     }
   },
   {
     "candidate_id": "g3_c3",
     "generation": 3,
-    "fitness": 70.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 68.8,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_c5",
-      "g2_elite0"
+      "g2_c1",
+      "g2_c1"
     ],
     "metadata": {
-      "final_population": 70,
-      "raw_fitness": 70.0,
-      "boundary_penalty": 0.0
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.2
     }
   },
   {
     "candidate_id": "g3_c4",
     "generation": 3,
-    "fitness": 57.9,
+    "fitness": 65.8,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g2_c5",
-      "g2_c7"
+      "g2_c1"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g3_c5",
+    "generation": 3,
+    "fitness": 63.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c4",
+      "g2_c1"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g3_c6",
+    "generation": 3,
+    "fitness": 61.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c1",
+      "g2_c3"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g3_c7",
+    "generation": 3,
+    "fitness": 67.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g2_c1",
+      "g2_c5"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g4_elite0",
+    "generation": 4,
+    "fitness": 66.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g4_c1",
+    "generation": 4,
+    "fitness": 58.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g4_c2",
+    "generation": 4,
+    "fitness": 54.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 55,
+      "raw_fitness": 55.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g4_c3",
+    "generation": 4,
+    "fitness": 61.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g4_c4",
+    "generation": 4,
+    "fitness": 63.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.1
+    }
+  },
+  {
+    "candidate_id": "g4_c5",
+    "generation": 4,
+    "fitness": 53.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 54,
+      "raw_fitness": 54.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g4_c6",
+    "generation": 4,
+    "fitness": 62.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g4_c7",
+    "generation": 4,
+    "fitness": 69.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g5_elite0",
+    "generation": 5,
+    "fitness": 53.8,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c7",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 54,
+      "raw_fitness": 54.0,
+      "boundary_penalty": 0.2
+    }
+  },
+  {
+    "candidate_id": "g5_c1",
+    "generation": 5,
+    "fitness": 57.9,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c1",
+      "g4_c7"
     ],
     "metadata": {
       "final_population": 58,
@@ -435,13 +630,13 @@
     }
   },
   {
-    "candidate_id": "g3_c5",
-    "generation": 3,
+    "candidate_id": "g5_c2",
+    "generation": 5,
     "fitness": 69.9,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_c7",
-      "g2_c7"
+      "g4_c4",
+      "g4_elite0"
     ],
     "metadata": {
       "final_population": 70,
@@ -450,273 +645,78 @@
     }
   },
   {
-    "candidate_id": "g3_c6",
-    "generation": 3,
-    "fitness": 57.0,
-    "learning_rate": 0.09175441322821346,
-    "parent_ids": [
-      "g2_c7",
-      "g2_c6"
-    ],
-    "metadata": {
-      "final_population": 57,
-      "raw_fitness": 57.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g3_c7",
-    "generation": 3,
-    "fitness": 64.9,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g2_elite0",
-      "g2_c7"
-    ],
-    "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.1
-    }
-  },
-  {
-    "candidate_id": "g4_elite0",
-    "generation": 4,
-    "fitness": 63.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g3_c3",
-      "g3_c3"
-    ],
-    "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c1",
-    "generation": 4,
-    "fitness": 56.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g3_c3",
-      "g3_c3"
-    ],
-    "metadata": {
-      "final_population": 56,
-      "raw_fitness": 56.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c2",
-    "generation": 4,
-    "fitness": 67.9,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c5",
-      "g3_c5"
-    ],
-    "metadata": {
-      "final_population": 68,
-      "raw_fitness": 68.0,
-      "boundary_penalty": 0.1
-    }
-  },
-  {
-    "candidate_id": "g4_c3",
-    "generation": 4,
-    "fitness": 62.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g3_c2",
-      "g3_c3"
-    ],
-    "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c4",
-    "generation": 4,
-    "fitness": 64.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g3_c3",
-      "g3_c3"
-    ],
-    "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c5",
-    "generation": 4,
-    "fitness": 68.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g3_c3",
-      "g3_c3"
-    ],
-    "metadata": {
-      "final_population": 68,
-      "raw_fitness": 68.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c6",
-    "generation": 4,
-    "fitness": 65.9,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c5",
-      "g3_c1"
-    ],
-    "metadata": {
-      "final_population": 66,
-      "raw_fitness": 66.0,
-      "boundary_penalty": 0.1
-    }
-  },
-  {
-    "candidate_id": "g4_c7",
-    "generation": 4,
-    "fitness": 67.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g3_c7",
-      "g3_c2"
-    ],
-    "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_elite0",
+    "candidate_id": "g5_c3",
     "generation": 5,
-    "fitness": 61.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 72.9,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g4_c5",
-      "g4_c5"
-    ],
-    "metadata": {
-      "final_population": 61,
-      "raw_fitness": 61.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_c1",
-    "generation": 5,
-    "fitness": 60.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g4_c5",
+      "g4_c4",
       "g4_c7"
     ],
     "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_c2",
-    "generation": 5,
-    "fitness": 71.9,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c5",
-      "g4_c2"
-    ],
-    "metadata": {
-      "final_population": 72,
-      "raw_fitness": 72.0,
+      "final_population": 73,
+      "raw_fitness": 73.0,
       "boundary_penalty": 0.1
-    }
-  },
-  {
-    "candidate_id": "g5_c3",
-    "generation": 5,
-    "fitness": 62.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g4_c6",
-      "g4_c5"
-    ],
-    "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
-      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c4",
     "generation": 5,
-    "fitness": 67.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 60.8,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g4_c7",
       "g4_c7"
     ],
     "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.0
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.2
     }
   },
   {
     "candidate_id": "g5_c5",
     "generation": 5,
-    "fitness": 59.9,
-    "learning_rate": 1e-06,
+    "fitness": 71.87205125010433,
+    "learning_rate": 0.03602658902654344,
     "parent_ids": [
-      "g4_c2",
-      "g4_c6"
+      "g4_elite0",
+      "g4_c4"
     ],
     "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.1
+      "final_population": 72,
+      "raw_fitness": 72.0,
+      "boundary_penalty": 0.12794874989566304
     }
   },
   {
     "candidate_id": "g5_c6",
     "generation": 5,
-    "fitness": 73.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 64.8,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g4_c7",
-      "g4_c5"
+      "g4_c7"
     ],
     "metadata": {
-      "final_population": 73,
-      "raw_fitness": 73.0,
-      "boundary_penalty": 0.0
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.2
     }
   },
   {
     "candidate_id": "g5_c7",
     "generation": 5,
-    "fitness": 64.0,
-    "learning_rate": 0.5743263913640548,
+    "fitness": 63.8,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g4_c5",
-      "g4_c2"
+      "g4_c6",
+      "g4_elite0"
     ],
     "metadata": {
       "final_population": 64,
       "raw_fitness": 64.0,
-      "boundary_penalty": 0.0
+      "boundary_penalty": 0.2
     }
   }
 ]

--- a/experiments/evolution_convergence/run_clamp_penalty_g6/evolution_generation_summaries.json
+++ b/experiments/evolution_convergence/run_clamp_penalty_g6/evolution_generation_summaries.json
@@ -1,24 +1,31 @@
 [
   {
     "generation": 0,
-    "best_fitness": 75.99,
-    "mean_fitness": 65.74510624849228,
-    "min_fitness": 53.99,
-    "best_candidate_id": "g0_c4",
+    "best_fitness": 77.9811998001998,
+    "mean_fitness": 61.73296726365449,
+    "min_fitness": 51.98,
+    "best_candidate_id": "g0_c0",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.055658525648276516,
-        "median": 0.02662644272048611,
-        "std": 0.06118633982230562,
+        "mean": 0.03162298224336492,
+        "median": 1e-06,
+        "std": 0.05699117265327523,
         "min": 1e-06,
         "max": 0.15942878976101
       },
+      "gamma": {
+        "mean": 0.9371359275229121,
+        "median": 0.9875518275703261,
+        "std": 0.10332826581741346,
+        "min": 0.6803741749126586,
+        "max": 1.0
+      },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.8724919919611355,
+        "median": 0.8921990333611127,
+        "std": 0.12471650716431597,
+        "min": 0.6866249283632477,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -29,31 +36,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 1e-06,
+      "learning_rate": 0.001,
+      "gamma": 0.95,
       "epsilon_decay": 0.995,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": null,
+    "mutation_scale_used": null,
+    "mutation_rate_multiplier": null,
+    "mutation_scale_multiplier": null,
+    "diversity": 0.09501200087541144,
+    "adaptive_event": "initial_seeding"
   },
   {
     "generation": 1,
-    "best_fitness": 72.99,
-    "mean_fitness": 66.61754995004995,
-    "min_fitness": 58.9901998001998,
-    "best_candidate_id": "g1_c7",
+    "best_fitness": 77.98,
+    "mean_fitness": 64.98214220088943,
+    "min_fitness": 59.98,
+    "best_candidate_id": "g1_c4",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.05454348958834066,
-        "median": 0.0005005,
-        "std": 0.09823309522536923,
+        "mean": 0.02516011468743981,
+        "median": 1e-06,
+        "std": 0.0661879819309725,
         "min": 1e-06,
-        "max": 0.2749151269457153
+        "max": 0.20027491749951848
+      },
+      "gamma": {
+        "mean": 0.9646150694439928,
+        "median": 0.9751036551406521,
+        "std": 0.032770448635601364,
+        "min": 0.8916095901299863,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.9061457556892138,
+        "median": 0.9085966335217512,
+        "std": 0.091521122955619,
+        "min": 0.8073897557133531,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -65,30 +86,44 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 1.0,
+      "epsilon_decay": 0.8221932670435024,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.06349320657008033,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 2,
-    "best_fitness": 69.99,
-    "mean_fitness": 62.61875,
-    "min_fitness": 56.0,
-    "best_candidate_id": "g2_c5",
+    "best_fitness": 71.98,
+    "mean_fitness": 66.60749481724297,
+    "min_fitness": 57.98,
+    "best_candidate_id": "g2_c6",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.059786421160378744,
+        "mean": 0.02503523968743981,
         "median": 1e-06,
-        "std": 0.07718264683338114,
+        "std": 0.06623437247454908,
         "min": 1e-06,
-        "max": 0.15942878976101
+        "max": 0.20027491749951848
+      },
+      "gamma": {
+        "mean": 0.9937759137851631,
+        "median": 1.0,
+        "std": 0.010780433554786693,
+        "min": 0.9751036551406521,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.7703319621957047,
+        "median": 0.8147915113784278,
+        "std": 0.08221415779446556,
+        "min": 0.5677237728329356,
+        "max": 0.8221932670435024
       },
       "memory_size": {
         "mean": 2000,
@@ -100,30 +135,44 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 1.0,
+      "epsilon_decay": 0.8221932670435024,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.053076343352746684,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 3,
-    "best_fitness": 72.99,
-    "mean_fitness": 65.24149899935301,
-    "min_fitness": 59.99199199482417,
+    "best_fitness": 70.98,
+    "mean_fitness": 64.10999481724296,
+    "min_fitness": 57.98497926897187,
     "best_candidate_id": "g3_c2",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.032643645893763215,
+        "mean": 0.07510371906231943,
         "median": 1e-06,
-        "std": 0.08266412384888819,
+        "std": 0.09695719339441915,
         "min": 1e-06,
-        "max": 0.25118220298922345
+        "max": 0.20027491749951848
+      },
+      "gamma": {
+        "mean": 0.9937759137851631,
+        "median": 1.0,
+        "std": 0.010780433554786693,
+        "min": 0.9751036551406521,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.7806299703806068,
+        "median": 0.7770635407981741,
+        "std": 0.040507856885751675,
+        "min": 0.7241990478892087,
+        "max": 0.8288524477063025
       },
       "memory_size": {
         "mean": 2000,
@@ -135,30 +184,44 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 1.0,
+      "epsilon_decay": 0.8073897557133531,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.04941519359741595,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 4,
-    "best_fitness": 71.99,
-    "mean_fitness": 64.49,
-    "min_fitness": 57.99,
-    "best_candidate_id": "g4_c4",
+    "best_fitness": 76.98,
+    "mean_fitness": 62.985,
+    "min_fitness": 55.98,
+    "best_candidate_id": "g4_c7",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 1e-06,
+        "mean": 0.05006947937487962,
         "median": 1e-06,
-        "std": 0.0,
+        "std": 0.08672115013500592,
         "min": 1e-06,
-        "max": 1e-06
+        "max": 0.20027491749951848
+      },
+      "gamma": {
+        "mean": 0.9663940996135877,
+        "median": 1.0,
+        "std": 0.05823674160837304,
+        "min": 0.8618623974764232,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.7632377273246878,
+        "median": 0.8073897557133531,
+        "std": 0.08991815799635218,
+        "min": 0.5425946569823278,
+        "max": 0.8288524477063025
       },
       "memory_size": {
         "mean": 2000,
@@ -170,30 +233,44 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 1.0,
+      "epsilon_decay": 0.5425946569823278,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.07829204548698933,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 5,
-    "best_fitness": 73.99,
-    "mean_fitness": 64.36625,
-    "min_fitness": 59.99,
-    "best_candidate_id": "g5_elite0",
+    "best_fitness": 66.99,
+    "mean_fitness": 62.73625,
+    "min_fitness": 55.98,
+    "best_candidate_id": "g5_c3",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.051863200200380606,
-        "median": 1e-06,
-        "std": 0.13721448417485127,
+        "mean": 0.08972740382265529,
+        "median": 0.040482944528071725,
+        "std": 0.09887193221106412,
         "min": 1e-06,
-        "max": 0.41489860160304487
+        "max": 0.2363005065260619
+      },
+      "gamma": {
+        "mean": 0.9689948583003568,
+        "median": 1.0,
+        "std": 0.08203189430157445,
+        "min": 0.7519588664028543,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.6705922077945065,
+        "median": 0.7417164995312551,
+        "std": 0.1531492038783959,
+        "min": 0.37394608218882674,
+        "max": 0.8073897557133531
       },
       "memory_size": {
         "mean": 2000,
@@ -204,9 +281,16 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "learning_rate": 0.20027491749951848,
+      "gamma": 1.0,
+      "epsilon_decay": 0.7592339511733013,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.11135104308768852,
+    "adaptive_event": "disabled"
   }
 ]

--- a/experiments/evolution_convergence/run_clamp_penalty_g6/evolution_lineage.json
+++ b/experiments/evolution_convergence/run_clamp_penalty_g6/evolution_lineage.json
@@ -2,83 +2,38 @@
   {
     "candidate_id": "g0_c0",
     "generation": 0,
-    "fitness": 69.9901998001998,
+    "fitness": 77.9811998001998,
     "learning_rate": 0.001,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 70,
-      "raw_fitness": 70.0,
-      "boundary_penalty": 0.009800199800199801
+      "final_population": 78,
+      "raw_fitness": 78.0,
+      "boundary_penalty": 0.0188001998001998
     }
   },
   {
     "candidate_id": "g0_c1",
     "generation": 0,
-    "fitness": 69.0,
+    "fitness": 62.99497926897187,
     "learning_rate": 0.15942878976101,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 69,
-      "raw_fitness": 69.0,
-      "boundary_penalty": 0.0
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.005020731028130423
     }
   },
   {
     "candidate_id": "g0_c2",
     "generation": 0,
-    "fitness": 63.99522053122793,
-    "learning_rate": 0.02610363003699699,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.004779468772069374
-    }
-  },
-  {
-    "candidate_id": "g0_c3",
-    "generation": 0,
-    "fitness": 53.99,
+    "fitness": 65.97,
     "learning_rate": 1e-06,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 54,
-      "raw_fitness": 54.0,
-      "boundary_penalty": 0.01
-    }
-  },
-  {
-    "candidate_id": "g0_c4",
-    "generation": 0,
-    "fitness": 75.99,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 76,
-      "raw_fitness": 76.0,
-      "boundary_penalty": 0.01
-    }
-  },
-  {
-    "candidate_id": "g0_c5",
-    "generation": 0,
-    "fitness": 66.0,
-    "learning_rate": 0.13903446179832052,
     "parent_ids": [
       "seed",
       "seed"
@@ -86,227 +41,32 @@
     "metadata": {
       "final_population": 66,
       "raw_fitness": 66.0,
-      "boundary_penalty": 0.0
+      "boundary_penalty": 0.03
     }
   },
   {
-    "candidate_id": "g0_c6",
+    "candidate_id": "g0_c3",
     "generation": 0,
-    "fitness": 59.99542965651045,
-    "learning_rate": 0.02714925540397523,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.0045703434895484445
-    }
-  },
-  {
-    "candidate_id": "g0_c7",
-    "generation": 0,
-    "fitness": 67.0,
+    "fitness": 57.99,
     "learning_rate": 0.09255006818590938,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g1_elite0",
-    "generation": 1,
-    "fitness": 64.99,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g0_c4",
-      "g0_c4"
-    ],
-    "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
+      "final_population": 58,
+      "raw_fitness": 58.0,
       "boundary_penalty": 0.01
     }
   },
   {
-    "candidate_id": "g1_c1",
-    "generation": 1,
-    "fitness": 58.9901998001998,
-    "learning_rate": 0.001,
-    "parent_ids": [
-      "g0_c0",
-      "g0_c4"
-    ],
-    "metadata": {
-      "final_population": 59,
-      "raw_fitness": 59.0,
-      "boundary_penalty": 0.009800199800199801
-    }
-  },
-  {
-    "candidate_id": "g1_c2",
-    "generation": 1,
-    "fitness": 64.9901998001998,
-    "learning_rate": 0.001,
-    "parent_ids": [
-      "g0_c0",
-      "g0_c7"
-    ],
-    "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.009800199800199801
-    }
-  },
-  {
-    "candidate_id": "g1_c3",
-    "generation": 1,
-    "fitness": 69.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g0_c4",
-      "g0_c1"
-    ],
-    "metadata": {
-      "final_population": 69,
-      "raw_fitness": 69.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g1_c4",
-    "generation": 1,
-    "fitness": 68.99,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g0_c4",
-      "g0_c4"
-    ],
-    "metadata": {
-      "final_population": 69,
-      "raw_fitness": 69.0,
-      "boundary_penalty": 0.01
-    }
-  },
-  {
-    "candidate_id": "g1_c5",
-    "generation": 1,
-    "fitness": 66.99,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g0_c0",
-      "g0_c4"
-    ],
-    "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.01
-    }
-  },
-  {
-    "candidate_id": "g1_c6",
-    "generation": 1,
-    "fitness": 66.0,
-    "learning_rate": 0.2749151269457153,
-    "parent_ids": [
-      "g0_c0",
-      "g0_c4"
-    ],
-    "metadata": {
-      "final_population": 66,
-      "raw_fitness": 66.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g1_c7",
-    "generation": 1,
-    "fitness": 72.99,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g0_c4",
-      "g0_c4"
-    ],
-    "metadata": {
-      "final_population": 73,
-      "raw_fitness": 73.0,
-      "boundary_penalty": 0.01
-    }
-  },
-  {
-    "candidate_id": "g2_elite0",
-    "generation": 2,
-    "fitness": 65.99,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g1_c7",
-      "g1_c7"
-    ],
-    "metadata": {
-      "final_population": 66,
-      "raw_fitness": 66.0,
-      "boundary_penalty": 0.01
-    }
-  },
-  {
-    "candidate_id": "g2_c1",
-    "generation": 2,
-    "fitness": 64.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g1_c3",
-      "g1_c4"
-    ],
-    "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c2",
-    "generation": 2,
-    "fitness": 62.99,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g1_c7",
-      "g1_c7"
-    ],
-    "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.01
-    }
-  },
-  {
-    "candidate_id": "g2_c3",
-    "generation": 2,
-    "fitness": 57.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g1_c3",
-      "g1_c6"
-    ],
-    "metadata": {
-      "final_population": 57,
-      "raw_fitness": 57.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c4",
-    "generation": 2,
+    "candidate_id": "g0_c4",
+    "generation": 0,
     "fitness": 61.99,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g1_c4",
-      "g1_c7"
+      "seed",
+      "seed"
     ],
     "metadata": {
       "final_population": 62,
@@ -315,118 +75,358 @@
     }
   },
   {
-    "candidate_id": "g2_c5",
+    "candidate_id": "g0_c5",
+    "generation": 0,
+    "fitness": 51.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 52,
+      "raw_fitness": 52.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g0_c6",
+    "generation": 0,
+    "fitness": 54.97755904006426,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 55,
+      "raw_fitness": 55.0,
+      "boundary_penalty": 0.022440959935744593
+    }
+  },
+  {
+    "candidate_id": "g0_c7",
+    "generation": 0,
+    "fitness": 59.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g1_elite0",
+    "generation": 1,
+    "fitness": 66.9811998001998,
+    "learning_rate": 0.001,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c0"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0188001998001998
+    }
+  },
+  {
+    "candidate_id": "g1_c1",
+    "generation": 1,
+    "fitness": 62.99497926897187,
+    "learning_rate": 0.20027491749951848,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c1"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.005020731028130423
+    }
+  },
+  {
+    "candidate_id": "g1_c2",
+    "generation": 1,
+    "fitness": 62.97,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c2"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.03
+    }
+  },
+  {
+    "candidate_id": "g1_c3",
+    "generation": 1,
+    "fitness": 61.98497926897187,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c1"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.015020731028130424
+    }
+  },
+  {
+    "candidate_id": "g1_c4",
+    "generation": 1,
+    "fitness": 77.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c4",
+      "g0_c0"
+    ],
+    "metadata": {
+      "final_population": 78,
+      "raw_fitness": 78.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g1_c5",
+    "generation": 1,
+    "fitness": 63.981,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.019
+    }
+  },
+  {
+    "candidate_id": "g1_c6",
+    "generation": 1,
+    "fitness": 59.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c2"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g1_c7",
+    "generation": 1,
+    "fitness": 62.98497926897187,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g0_c1",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.015020731028130424
+    }
+  },
+  {
+    "candidate_id": "g2_elite0",
     "generation": 2,
-    "fitness": 69.99,
+    "fitness": 57.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c4",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g2_c1",
+    "generation": 2,
+    "fitness": 61.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c1",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g2_c2",
+    "generation": 2,
+    "fitness": 65.98497926897187,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c7",
-      "g1_c7"
+      "g1_c5"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.015020731028130424
+    }
+  },
+  {
+    "candidate_id": "g2_c3",
+    "generation": 2,
+    "fitness": 69.98497926897187,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c4",
+      "g1_c1"
     ],
     "metadata": {
       "final_population": 70,
       "raw_fitness": 70.0,
-      "boundary_penalty": 0.01
+      "boundary_penalty": 0.015020731028130424
+    }
+  },
+  {
+    "candidate_id": "g2_c4",
+    "generation": 2,
+    "fitness": 67.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c4",
+      "g1_c7"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g2_c5",
+    "generation": 2,
+    "fitness": 67.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g1_c4",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.02
     }
   },
   {
     "candidate_id": "g2_c6",
     "generation": 2,
-    "fitness": 56.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 71.98,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g1_c3",
-      "g1_c3"
+      "g1_c4",
+      "g1_c4"
     ],
     "metadata": {
-      "final_population": 56,
-      "raw_fitness": 56.0,
-      "boundary_penalty": 0.0
+      "final_population": 72,
+      "raw_fitness": 72.0,
+      "boundary_penalty": 0.02
     }
   },
   {
     "candidate_id": "g2_c7",
     "generation": 2,
-    "fitness": 62.99,
-    "learning_rate": 1e-06,
+    "fitness": 68.99,
+    "learning_rate": 0.20027491749951848,
     "parent_ids": [
-      "g1_c7",
+      "g1_c1",
       "g1_c4"
     ],
     "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
+      "final_population": 69,
+      "raw_fitness": 69.0,
       "boundary_penalty": 0.01
     }
   },
   {
     "candidate_id": "g3_elite0",
     "generation": 3,
-    "fitness": 60.99,
+    "fitness": 60.98,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_c5",
-      "g2_c5"
+      "g2_c6",
+      "g2_c6"
     ],
     "metadata": {
       "final_population": 61,
       "raw_fitness": 61.0,
-      "boundary_penalty": 0.01
+      "boundary_penalty": 0.02
     }
   },
   {
     "candidate_id": "g3_c1",
     "generation": 3,
-    "fitness": 59.99199199482417,
-    "learning_rate": 0.00996096416088228,
+    "fitness": 57.98497926897187,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_c5",
-      "g2_c7"
+      "g2_c3",
+      "g2_c6"
     ],
     "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.00800800517582872
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.015020731028130424
     }
   },
   {
     "candidate_id": "g3_c2",
     "generation": 3,
-    "fitness": 72.99,
+    "fitness": 70.98,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_elite0",
-      "g2_elite0"
+      "g2_c4",
+      "g2_c4"
     ],
     "metadata": {
-      "final_population": 73,
-      "raw_fitness": 73.0,
-      "boundary_penalty": 0.01
+      "final_population": 71,
+      "raw_fitness": 71.0,
+      "boundary_penalty": 0.02
     }
   },
   {
     "candidate_id": "g3_c3",
     "generation": 3,
-    "fitness": 69.99,
+    "fitness": 69.98497926897187,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_c5",
-      "g2_elite0"
+      "g2_c3",
+      "g2_c3"
     ],
     "metadata": {
       "final_population": 70,
       "raw_fitness": 70.0,
-      "boundary_penalty": 0.01
+      "boundary_penalty": 0.015020731028130424
     }
   },
   {
     "candidate_id": "g3_c4",
     "generation": 3,
     "fitness": 67.99,
-    "learning_rate": 1e-06,
+    "learning_rate": 0.20027491749951848,
     "parent_ids": [
-      "g2_c5",
-      "g2_elite0"
+      "g2_c3",
+      "g2_c7"
     ],
     "metadata": {
       "final_population": 68,
@@ -437,41 +437,41 @@
   {
     "candidate_id": "g3_c5",
     "generation": 3,
-    "fitness": 65.99,
-    "learning_rate": 1e-06,
+    "fitness": 60.99,
+    "learning_rate": 0.20027491749951848,
     "parent_ids": [
-      "g2_c2",
-      "g2_c1"
+      "g2_c7",
+      "g2_c7"
     ],
     "metadata": {
-      "final_population": 66,
-      "raw_fitness": 66.0,
+      "final_population": 61,
+      "raw_fitness": 61.0,
       "boundary_penalty": 0.01
     }
   },
   {
     "candidate_id": "g3_c6",
     "generation": 3,
-    "fitness": 62.0,
-    "learning_rate": 0.25118220298922345,
+    "fitness": 61.98,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_c1",
-      "g2_c2"
+      "g2_c7",
+      "g2_c6"
     ],
     "metadata": {
       "final_population": 62,
       "raw_fitness": 62.0,
-      "boundary_penalty": 0.0
+      "boundary_penalty": 0.02
     }
   },
   {
     "candidate_id": "g3_c7",
     "generation": 3,
     "fitness": 61.99,
-    "learning_rate": 1e-06,
+    "learning_rate": 0.20027491749951848,
     "parent_ids": [
-      "g2_elite0",
-      "g2_c5"
+      "g2_c2",
+      "g2_c7"
     ],
     "metadata": {
       "final_population": 62,
@@ -482,7 +482,7 @@
   {
     "candidate_id": "g4_elite0",
     "generation": 4,
-    "fitness": 64.99,
+    "fitness": 64.98,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g3_c2",
@@ -491,197 +491,62 @@
     "metadata": {
       "final_population": 65,
       "raw_fitness": 65.0,
-      "boundary_penalty": 0.01
+      "boundary_penalty": 0.02
     }
   },
   {
     "candidate_id": "g4_c1",
     "generation": 4,
-    "fitness": 59.99,
+    "fitness": 55.98,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g3_c2",
       "g3_c3"
     ],
     "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.01
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.02
     }
   },
   {
     "candidate_id": "g4_c2",
     "generation": 4,
-    "fitness": 67.99,
-    "learning_rate": 1e-06,
+    "fitness": 56.99,
+    "learning_rate": 0.20027491749951848,
     "parent_ids": [
-      "g3_c5",
+      "g3_c7",
       "g3_c4"
     ],
     "metadata": {
-      "final_population": 68,
-      "raw_fitness": 68.0,
+      "final_population": 57,
+      "raw_fitness": 57.0,
       "boundary_penalty": 0.01
     }
   },
   {
     "candidate_id": "g4_c3",
     "generation": 4,
-    "fitness": 57.99,
+    "fitness": 56.99,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g3_c2",
       "g3_c3"
     ],
     "metadata": {
-      "final_population": 58,
-      "raw_fitness": 58.0,
+      "final_population": 57,
+      "raw_fitness": 57.0,
       "boundary_penalty": 0.01
     }
   },
   {
     "candidate_id": "g4_c4",
     "generation": 4,
-    "fitness": 71.99,
+    "fitness": 63.99,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g3_c2",
       "g3_c3"
-    ],
-    "metadata": {
-      "final_population": 72,
-      "raw_fitness": 72.0,
-      "boundary_penalty": 0.01
-    }
-  },
-  {
-    "candidate_id": "g4_c5",
-    "generation": 4,
-    "fitness": 67.99,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c3",
-      "g3_c2"
-    ],
-    "metadata": {
-      "final_population": 68,
-      "raw_fitness": 68.0,
-      "boundary_penalty": 0.01
-    }
-  },
-  {
-    "candidate_id": "g4_c6",
-    "generation": 4,
-    "fitness": 65.99,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c5",
-      "g3_c4"
-    ],
-    "metadata": {
-      "final_population": 66,
-      "raw_fitness": 66.0,
-      "boundary_penalty": 0.01
-    }
-  },
-  {
-    "candidate_id": "g4_c7",
-    "generation": 4,
-    "fitness": 58.99,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c7",
-      "g3_c2"
-    ],
-    "metadata": {
-      "final_population": 59,
-      "raw_fitness": 59.0,
-      "boundary_penalty": 0.01
-    }
-  },
-  {
-    "candidate_id": "g5_elite0",
-    "generation": 5,
-    "fitness": 73.99,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c4",
-      "g4_c4"
-    ],
-    "metadata": {
-      "final_population": 74,
-      "raw_fitness": 74.0,
-      "boundary_penalty": 0.01
-    }
-  },
-  {
-    "candidate_id": "g5_c1",
-    "generation": 5,
-    "fitness": 59.99,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c2",
-      "g4_c1"
-    ],
-    "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.01
-    }
-  },
-  {
-    "candidate_id": "g5_c2",
-    "generation": 5,
-    "fitness": 60.99,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c4",
-      "g4_c2"
-    ],
-    "metadata": {
-      "final_population": 61,
-      "raw_fitness": 61.0,
-      "boundary_penalty": 0.01
-    }
-  },
-  {
-    "candidate_id": "g5_c3",
-    "generation": 5,
-    "fitness": 59.99,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c4",
-      "g4_c2"
-    ],
-    "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.01
-    }
-  },
-  {
-    "candidate_id": "g5_c4",
-    "generation": 5,
-    "fitness": 68.99,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c4",
-      "g4_c4"
-    ],
-    "metadata": {
-      "final_population": 69,
-      "raw_fitness": 69.0,
-      "boundary_penalty": 0.01
-    }
-  },
-  {
-    "candidate_id": "g5_c5",
-    "generation": 5,
-    "fitness": 63.99,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g4_c2",
-      "g4_c4"
     ],
     "metadata": {
       "final_population": 64,
@@ -690,33 +555,168 @@
     }
   },
   {
-    "candidate_id": "g5_c6",
-    "generation": 5,
-    "fitness": 59.99,
+    "candidate_id": "g4_c5",
+    "generation": 4,
+    "fitness": 56.98,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g4_c4",
-      "g4_c5"
+      "g3_c3",
+      "g3_c2"
+    ],
+    "metadata": {
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g4_c6",
+    "generation": 4,
+    "fitness": 70.99,
+    "learning_rate": 0.20027491749951848,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 71,
+      "raw_fitness": 71.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g4_c7",
+    "generation": 4,
+    "fitness": 76.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c2"
+    ],
+    "metadata": {
+      "final_population": 77,
+      "raw_fitness": 77.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g5_elite0",
+    "generation": 5,
+    "fitness": 55.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c7",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g5_c1",
+    "generation": 5,
+    "fitness": 66.0,
+    "learning_rate": 0.08096488905614345,
+    "parent_ids": [
+      "g4_c2",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c2",
+    "generation": 5,
+    "fitness": 59.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c6",
+      "g4_elite0"
     ],
     "metadata": {
       "final_population": 60,
       "raw_fitness": 60.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g5_c3",
+    "generation": 5,
+    "fitness": 66.99,
+    "learning_rate": 0.20027491749951848,
+    "parent_ids": [
+      "g4_c6",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
       "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g5_c4",
+    "generation": 5,
+    "fitness": 56.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c7",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.02
+    }
+  },
+  {
+    "candidate_id": "g5_c5",
+    "generation": 5,
+    "fitness": 65.99,
+    "learning_rate": 0.2363005065260619,
+    "parent_ids": [
+      "g4_elite0",
+      "g4_c6"
+    ],
+    "metadata": {
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.01
+    }
+  },
+  {
+    "candidate_id": "g5_c6",
+    "generation": 5,
+    "fitness": 66.98,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g4_c7",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.02
     }
   },
   {
     "candidate_id": "g5_c7",
     "generation": 5,
-    "fitness": 67.0,
-    "learning_rate": 0.41489860160304487,
+    "fitness": 62.99,
+    "learning_rate": 0.20027491749951848,
     "parent_ids": [
-      "g4_c5",
-      "g4_c2"
+      "g4_c6",
+      "g4_elite0"
     ],
     "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
-      "boundary_penalty": 0.0
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.01
     }
   }
 ]

--- a/experiments/evolution_convergence/run_reflect_g6/evolution_generation_summaries.json
+++ b/experiments/evolution_convergence/run_reflect_g6/evolution_generation_summaries.json
@@ -1,23 +1,30 @@
 [
   {
     "generation": 0,
-    "best_fitness": 74.0,
-    "mean_fitness": 62.5,
-    "min_fitness": 54.0,
-    "best_candidate_id": "g0_c4",
+    "best_fitness": 63.0,
+    "mean_fitness": 59.25,
+    "min_fitness": 49.0,
+    "best_candidate_id": "g0_c6",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.12612675567165654,
-        "median": 0.11579226499211495,
-        "std": 0.11430491469893234,
+        "mean": 0.17226591676370254,
+        "median": 0.1760706834340834,
+        "std": 0.11775814247428866,
         "min": 0.001,
         "max": 0.3771357835106376
       },
+      "gamma": {
+        "mean": 0.8770426288391829,
+        "median": 0.901787495148533,
+        "std": 0.09702855971420496,
+        "min": 0.6803741749126586,
+        "max": 0.9751036551406521
+      },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
+        "mean": 0.8532329775164645,
+        "median": 0.844635216519696,
+        "std": 0.11196611931009007,
+        "min": 0.6866249283632477,
         "max": 0.995
       },
       "memory_size": {
@@ -29,30 +36,44 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.3771357835106376,
-      "epsilon_decay": 0.995,
+      "learning_rate": 0.21909158498203396,
+      "gamma": 0.8577021854939426,
+      "epsilon_decay": 0.962204799678723,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": null,
+    "mutation_scale_used": null,
+    "mutation_rate_multiplier": null,
+    "mutation_scale_multiplier": null,
+    "diversity": 0.10891764641894798,
+    "adaptive_event": "initial_seeding"
   },
   {
     "generation": 1,
-    "best_fitness": 74.0,
-    "mean_fitness": 65.5,
-    "min_fitness": 56.0,
-    "best_candidate_id": "g1_c3",
+    "best_fitness": 73.0,
+    "mean_fitness": 65.875,
+    "min_fitness": 57.0,
+    "best_candidate_id": "g1_c5",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.29025272928248913,
-        "median": 0.3771357835106376,
-        "std": 0.2078283687024153,
-        "min": 0.001,
-        "max": 0.6520499104563529
+        "mean": 0.23743580803714576,
+        "median": 0.21909158498203396,
+        "std": 0.05628763299626412,
+        "min": 0.19271257710715683,
+        "max": 0.3771357835106376
+      },
+      "gamma": {
+        "mean": 0.8828865505700731,
+        "median": 0.8916095901299863,
+        "std": 0.07022339933543034,
+        "min": 0.727399798004996,
+        "max": 0.9751036551406521
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
+        "mean": 0.93338205640608,
+        "median": 0.962204799678723,
+        "std": 0.06510862661677945,
+        "min": 0.8221932670435024,
         "max": 0.995
       },
       "memory_size": {
@@ -64,30 +85,44 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.15942878976101,
+      "learning_rate": 0.19271257710715683,
+      "gamma": 0.8916095901299863,
       "epsilon_decay": 0.995,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.0638732384120544,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 2,
-    "best_fitness": 70.0,
-    "mean_fitness": 63.25,
-    "min_fitness": 59.0,
-    "best_candidate_id": "g2_c7",
+    "best_fitness": 69.0,
+    "mean_fitness": 61.875,
+    "min_fitness": 58.0,
+    "best_candidate_id": "g2_c5",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.24106891241712033,
-        "median": 0.15942878976101,
-        "std": 0.10539694514314873,
-        "min": 0.15942878976101,
-        "max": 0.3771357835106376
+        "mean": 0.14131245892877412,
+        "median": 0.19271257710715683,
+        "std": 0.0827628934188587,
+        "min": 0.008693130041245362,
+        "max": 0.21971305890557036
+      },
+      "gamma": {
+        "mean": 0.8742386289309453,
+        "median": 0.8916095901299863,
+        "std": 0.08403217760570182,
+        "min": 0.727399798004996,
+        "max": 0.9751036551406521
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
+        "mean": 0.8872402895849767,
+        "median": 0.9244768290984693,
+        "std": 0.10332861819898771,
+        "min": 0.7077353054681563,
         "max": 0.995
       },
       "memory_size": {
@@ -99,31 +134,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.3771357835106376,
+      "learning_rate": 0.21971305890557036,
+      "gamma": 0.9751036551406521,
       "epsilon_decay": 0.995,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.09004125732884147,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 3,
-    "best_fitness": 72.0,
-    "mean_fitness": 63.75,
+    "best_fitness": 69.0,
+    "mean_fitness": 64.5,
     "min_fitness": 58.0,
-    "best_candidate_id": "g3_elite0",
+    "best_candidate_id": "g3_c2",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.3504165902925657,
-        "median": 0.3771357835106376,
-        "std": 0.08642909402798747,
-        "min": 0.15942878976101,
-        "max": 0.46888919673885104
+        "mean": 0.1884749394572986,
+        "median": 0.19271257710715683,
+        "std": 0.043654914790659916,
+        "min": 0.07781003051305035,
+        "max": 0.21971305890557036
+      },
+      "gamma": {
+        "mean": 0.8852837103016745,
+        "median": 0.9333566226353192,
+        "std": 0.09802189767786157,
+        "min": 0.7634151572402672,
+        "max": 0.9751036551406521
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.8898452109507383,
+        "median": 0.8595995239446044,
+        "std": 0.08859982239546889,
+        "min": 0.7668352862924935,
+        "max": 0.9983408193371999
       },
       "memory_size": {
         "mean": 2000,
@@ -134,30 +183,44 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.3771357835106376,
-      "epsilon_decay": 0.995,
+      "learning_rate": 0.19271257710715683,
+      "gamma": 0.7634151572402672,
+      "epsilon_decay": 0.8221932670435024,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.07675889283964961,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 4,
-    "best_fitness": 74.0,
-    "mean_fitness": 64.5,
-    "min_fitness": 56.0,
-    "best_candidate_id": "g4_c6",
+    "best_fitness": 71.0,
+    "mean_fitness": 60.375,
+    "min_fitness": 49.0,
+    "best_candidate_id": "g4_c7",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.29674065637463753,
-        "median": 0.3771357835106376,
-        "std": 0.10640793822060358,
-        "min": 0.15942878976101,
-        "max": 0.3870957476715199
+        "mean": 0.19271257710715683,
+        "median": 0.19271257710715683,
+        "std": 0.0,
+        "min": 0.19271257710715683,
+        "max": 0.19271257710715683
+      },
+      "gamma": {
+        "mean": 0.8283287907851327,
+        "median": 0.8163527783362728,
+        "std": 0.11326913662311179,
+        "min": 0.6252775547166904,
+        "max": 0.9751036551406521
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
+        "mean": 0.8798690085788683,
+        "median": 0.8595995239446044,
+        "std": 0.07452477420247602,
+        "min": 0.7908573310993329,
         "max": 0.995
       },
       "memory_size": {
@@ -169,31 +232,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.3771357835106376,
-      "epsilon_decay": 0.995,
+      "learning_rate": 0.19271257710715683,
+      "gamma": 0.9751036551406521,
+      "epsilon_decay": 0.7908573310993329,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.06259797027519594,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 5,
-    "best_fitness": 75.0,
-    "mean_fitness": 67.0,
+    "best_fitness": 78.0,
+    "mean_fitness": 67.125,
     "min_fitness": 59.0,
-    "best_candidate_id": "g5_c6",
+    "best_candidate_id": "g5_c2",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.40178460949231476,
-        "median": 0.3771357835106376,
-        "std": 0.1638123308718163,
-        "min": 0.15942878976101,
-        "max": 0.7920333851136825
+        "mean": 0.1823020221800529,
+        "median": 0.19271257710715683,
+        "std": 0.04281601441158784,
+        "min": 0.0734025486637818,
+        "max": 0.22873816613370027
+      },
+      "gamma": {
+        "mean": 0.9176374512034607,
+        "median": 0.9751036551406521,
+        "std": 0.09994842878947091,
+        "min": 0.7270625215435063,
+        "max": 0.9751036551406521
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.8387046753493516,
+        "median": 0.8595995239446044,
+        "std": 0.10342445485807773,
+        "min": 0.6222087563058318,
+        "max": 0.9925033747096936
       },
       "memory_size": {
         "mean": 2000,
@@ -204,9 +281,16 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.3771357835106376,
-      "epsilon_decay": 0.995,
+      "learning_rate": 0.19271257710715683,
+      "gamma": 0.9751036551406521,
+      "epsilon_decay": 0.8970057808457064,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.08206298029173123,
+    "adaptive_event": "disabled"
   }
 ]

--- a/experiments/evolution_convergence/run_reflect_g6/evolution_lineage.json
+++ b/experiments/evolution_convergence/run_reflect_g6/evolution_lineage.json
@@ -2,90 +2,90 @@
   {
     "candidate_id": "g0_c0",
     "generation": 0,
-    "fitness": 70.0,
+    "fitness": 62.0,
     "learning_rate": 0.001,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 70,
-      "raw_fitness": 70.0,
+      "final_population": 62,
+      "raw_fitness": 62.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g0_c1",
     "generation": 0,
-    "fitness": 64.0,
+    "fitness": 61.0,
     "learning_rate": 0.15942878976101,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
+      "final_population": 61,
+      "raw_fitness": 61.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g0_c2",
     "generation": 0,
-    "fitness": 54.0,
-    "learning_rate": 0.02610363003699699,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 54,
-      "raw_fitness": 54.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g0_c3",
-    "generation": 0,
-    "fitness": 57.0,
-    "learning_rate": 0.18661205667640257,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 57,
-      "raw_fitness": 57.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g0_c4",
-    "generation": 0,
-    "fitness": 74.0,
+    "fitness": 60.0,
     "learning_rate": 0.3771357835106376,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 74,
-      "raw_fitness": 74.0,
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c3",
+    "generation": 0,
+    "fitness": 59.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c4",
+    "generation": 0,
+    "fitness": 62.0,
+    "learning_rate": 0.19271257710715683,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g0_c5",
     "generation": 0,
-    "fitness": 54.0,
-    "learning_rate": 0.13903446179832052,
+    "fitness": 49.0,
+    "learning_rate": 0.044679372628928626,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 54,
-      "raw_fitness": 54.0,
+      "final_population": 49,
+      "raw_fitness": 49.0,
       "boundary_penalty": 0.0
     }
   },
@@ -93,7 +93,7 @@
     "candidate_id": "g0_c6",
     "generation": 0,
     "fitness": 63.0,
-    "learning_rate": 0.02714925540397523,
+    "learning_rate": 0.21909158498203396,
     "parent_ids": [
       "seed",
       "seed"
@@ -107,41 +107,11 @@
   {
     "candidate_id": "g0_c7",
     "generation": 0,
-    "fitness": 64.0,
-    "learning_rate": 0.09255006818590938,
+    "fitness": 58.0,
+    "learning_rate": 0.29152915793394396,
     "parent_ids": [
       "seed",
       "seed"
-    ],
-    "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g1_elite0",
-    "generation": 1,
-    "fitness": 63.0,
-    "learning_rate": 0.3771357835106376,
-    "parent_ids": [
-      "g0_c4",
-      "g0_c4"
-    ],
-    "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g1_c1",
-    "generation": 1,
-    "fitness": 58.0,
-    "learning_rate": 0.001,
-    "parent_ids": [
-      "g0_c0",
-      "g0_c4"
     ],
     "metadata": {
       "final_population": 58,
@@ -150,43 +120,13 @@
     }
   },
   {
-    "candidate_id": "g1_c2",
-    "generation": 1,
-    "fitness": 56.0,
-    "learning_rate": 0.001,
-    "parent_ids": [
-      "g0_c0",
-      "g0_c7"
-    ],
-    "metadata": {
-      "final_population": 56,
-      "raw_fitness": 56.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g1_c3",
-    "generation": 1,
-    "fitness": 74.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g0_c4",
-      "g0_c1"
-    ],
-    "metadata": {
-      "final_population": 74,
-      "raw_fitness": 74.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g1_c4",
+    "candidate_id": "g1_elite0",
     "generation": 1,
     "fitness": 72.0,
-    "learning_rate": 0.3771357835106376,
+    "learning_rate": 0.21909158498203396,
     "parent_ids": [
-      "g0_c4",
-      "g0_c4"
+      "g0_c6",
+      "g0_c6"
     ],
     "metadata": {
       "final_population": 72,
@@ -195,55 +135,205 @@
     }
   },
   {
+    "candidate_id": "g1_c1",
+    "generation": 1,
+    "fitness": 57.0,
+    "learning_rate": 0.25993771272054245,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c6"
+    ],
+    "metadata": {
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c2",
+    "generation": 1,
+    "fitness": 64.0,
+    "learning_rate": 0.3771357835106376,
+    "parent_ids": [
+      "g0_c0",
+      "g0_c2"
+    ],
+    "metadata": {
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c3",
+    "generation": 1,
+    "fitness": 70.0,
+    "learning_rate": 0.21971305890557036,
+    "parent_ids": [
+      "g0_c6",
+      "g0_c1"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g1_c4",
+    "generation": 1,
+    "fitness": 69.0,
+    "learning_rate": 0.21909158498203396,
+    "parent_ids": [
+      "g0_c6",
+      "g0_c4"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
     "candidate_id": "g1_c5",
     "generation": 1,
-    "fitness": 67.0,
-    "learning_rate": 0.3771357835106376,
+    "fitness": 73.0,
+    "learning_rate": 0.19271257710715683,
     "parent_ids": [
       "g0_c0",
       "g0_c4"
     ],
     "metadata": {
-      "final_population": 67,
-      "raw_fitness": 67.0,
+      "final_population": 73,
+      "raw_fitness": 73.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c6",
     "generation": 1,
-    "fitness": 63.0,
-    "learning_rate": 0.6520499104563529,
+    "fitness": 57.0,
+    "learning_rate": 0.19271257710715683,
     "parent_ids": [
       "g0_c0",
       "g0_c4"
     ],
     "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
+      "final_population": 57,
+      "raw_fitness": 57.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c7",
     "generation": 1,
-    "fitness": 71.0,
-    "learning_rate": 0.3771357835106376,
+    "fitness": 65.0,
+    "learning_rate": 0.21909158498203396,
     "parent_ids": [
       "g0_c4",
-      "g0_c4"
+      "g0_c6"
     ],
     "metadata": {
-      "final_population": 71,
-      "raw_fitness": 71.0,
+      "final_population": 65,
+      "raw_fitness": 65.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_elite0",
     "generation": 2,
+    "fitness": 62.0,
+    "learning_rate": 0.19271257710715683,
+    "parent_ids": [
+      "g1_c5",
+      "g1_c5"
+    ],
+    "metadata": {
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c1",
+    "generation": 2,
+    "fitness": 59.0,
+    "learning_rate": 0.027054135666822465,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c4"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c2",
+    "generation": 2,
+    "fitness": 60.0,
+    "learning_rate": 0.19271257710715683,
+    "parent_ids": [
+      "g1_c7",
+      "g1_c5"
+    ],
+    "metadata": {
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c3",
+    "generation": 2,
     "fitness": 61.0,
-    "learning_rate": 0.15942878976101,
+    "learning_rate": 0.07781003051305035,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c2"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c4",
+    "generation": 2,
+    "fitness": 65.0,
+    "learning_rate": 0.19271257710715683,
+    "parent_ids": [
+      "g1_c5",
+      "g1_c7"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c5",
+    "generation": 2,
+    "fitness": 69.0,
+    "learning_rate": 0.21971305890557036,
+    "parent_ids": [
+      "g1_c3",
+      "g1_c5"
+    ],
+    "metadata": {
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g2_c6",
+    "generation": 2,
+    "fitness": 61.0,
+    "learning_rate": 0.008693130041245362,
     "parent_ids": [
       "g1_c3",
       "g1_c3"
@@ -255,207 +345,102 @@
     }
   },
   {
-    "candidate_id": "g2_c1",
-    "generation": 2,
-    "fitness": 65.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g1_c3",
-      "g1_c4"
-    ],
-    "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c2",
-    "generation": 2,
-    "fitness": 63.0,
-    "learning_rate": 0.3771357835106376,
-    "parent_ids": [
-      "g1_c7",
-      "g1_c7"
-    ],
-    "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c3",
-    "generation": 2,
-    "fitness": 59.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g1_c3",
-      "g1_c6"
-    ],
-    "metadata": {
-      "final_population": 59,
-      "raw_fitness": 59.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c4",
-    "generation": 2,
-    "fitness": 66.0,
-    "learning_rate": 0.3771357835106376,
-    "parent_ids": [
-      "g1_c4",
-      "g1_c7"
-    ],
-    "metadata": {
-      "final_population": 66,
-      "raw_fitness": 66.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c5",
-    "generation": 2,
-    "fitness": 62.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g1_c3",
-      "g1_c4"
-    ],
-    "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g2_c6",
-    "generation": 2,
-    "fitness": 60.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g1_c3",
-      "g1_c3"
-    ],
-    "metadata": {
-      "final_population": 60,
-      "raw_fitness": 60.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
     "candidate_id": "g2_c7",
     "generation": 2,
-    "fitness": 70.0,
-    "learning_rate": 0.3771357835106376,
+    "fitness": 58.0,
+    "learning_rate": 0.21909158498203396,
     "parent_ids": [
       "g1_c7",
-      "g1_c4"
+      "g1_elite0"
     ],
     "metadata": {
-      "final_population": 70,
-      "raw_fitness": 70.0,
+      "final_population": 58,
+      "raw_fitness": 58.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_elite0",
     "generation": 3,
-    "fitness": 72.0,
-    "learning_rate": 0.3771357835106376,
+    "fitness": 67.0,
+    "learning_rate": 0.21971305890557036,
     "parent_ids": [
-      "g2_c7",
-      "g2_c7"
+      "g2_c5",
+      "g2_c5"
     ],
     "metadata": {
-      "final_population": 72,
-      "raw_fitness": 72.0,
+      "final_population": 67,
+      "raw_fitness": 67.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c1",
     "generation": 3,
-    "fitness": 64.0,
-    "learning_rate": 0.3870957476715199,
+    "fitness": 61.0,
+    "learning_rate": 0.21971305890557036,
     "parent_ids": [
       "g2_c5",
-      "g2_c7"
+      "g2_c4"
     ],
     "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
+      "final_population": 61,
+      "raw_fitness": 61.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c2",
     "generation": 3,
-    "fitness": 64.0,
-    "learning_rate": 0.3771357835106376,
+    "fitness": 69.0,
+    "learning_rate": 0.19271257710715683,
     "parent_ids": [
       "g2_c4",
       "g2_c4"
     ],
     "metadata": {
-      "final_population": 64,
-      "raw_fitness": 64.0,
+      "final_population": 69,
+      "raw_fitness": 69.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c3",
     "generation": 3,
-    "fitness": 65.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 67.0,
+    "learning_rate": 0.19271257710715683,
     "parent_ids": [
-      "g2_c1",
-      "g2_c1"
+      "g2_c5",
+      "g2_elite0"
     ],
     "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
+      "final_population": 67,
+      "raw_fitness": 67.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c4",
     "generation": 3,
-    "fitness": 62.0,
-    "learning_rate": 0.3771357835106376,
+    "fitness": 67.0,
+    "learning_rate": 0.19271257710715683,
     "parent_ids": [
       "g2_c5",
-      "g2_c7"
+      "g2_elite0"
     ],
     "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
+      "final_population": 67,
+      "raw_fitness": 67.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c5",
     "generation": 3,
-    "fitness": 66.0,
-    "learning_rate": 0.3771357835106376,
-    "parent_ids": [
-      "g2_c7",
-      "g2_c7"
-    ],
-    "metadata": {
-      "final_population": 66,
-      "raw_fitness": 66.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g3_c6",
-    "generation": 3,
     "fitness": 58.0,
-    "learning_rate": 0.46888919673885104,
+    "learning_rate": 0.19271257710715683,
     "parent_ids": [
-      "g2_c7",
+      "g2_c4",
       "g2_c2"
     ],
     "metadata": {
@@ -465,13 +450,13 @@
     }
   },
   {
-    "candidate_id": "g3_c7",
+    "candidate_id": "g3_c6",
     "generation": 3,
     "fitness": 59.0,
-    "learning_rate": 0.2793758541265944,
+    "learning_rate": 0.07781003051305035,
     "parent_ids": [
-      "g2_c1",
-      "g2_c7"
+      "g2_c4",
+      "g2_c3"
     ],
     "metadata": {
       "final_population": 59,
@@ -480,43 +465,13 @@
     }
   },
   {
-    "candidate_id": "g4_elite0",
-    "generation": 4,
-    "fitness": 62.0,
-    "learning_rate": 0.3771357835106376,
-    "parent_ids": [
-      "g3_elite0",
-      "g3_elite0"
-    ],
-    "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c1",
-    "generation": 4,
-    "fitness": 63.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g3_c3",
-      "g3_c5"
-    ],
-    "metadata": {
-      "final_population": 63,
-      "raw_fitness": 63.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c2",
-    "generation": 4,
+    "candidate_id": "g3_c7",
+    "generation": 3,
     "fitness": 68.0,
-    "learning_rate": 0.3771357835106376,
+    "learning_rate": 0.21971305890557036,
     "parent_ids": [
-      "g3_elite0",
-      "g3_c5"
+      "g2_elite0",
+      "g2_c5"
     ],
     "metadata": {
       "final_population": 68,
@@ -525,118 +480,13 @@
     }
   },
   {
-    "candidate_id": "g4_c3",
+    "candidate_id": "g4_elite0",
     "generation": 4,
-    "fitness": 66.0,
-    "learning_rate": 0.3771357835106376,
+    "fitness": 63.0,
+    "learning_rate": 0.19271257710715683,
     "parent_ids": [
       "g3_c2",
-      "g3_c3"
-    ],
-    "metadata": {
-      "final_population": 66,
-      "raw_fitness": 66.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c4",
-    "generation": 4,
-    "fitness": 65.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g3_c3",
-      "g3_c3"
-    ],
-    "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c5",
-    "generation": 4,
-    "fitness": 62.0,
-    "learning_rate": 0.15942878976101,
-    "parent_ids": [
-      "g3_elite0",
-      "g3_c3"
-    ],
-    "metadata": {
-      "final_population": 62,
-      "raw_fitness": 62.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c6",
-    "generation": 4,
-    "fitness": 74.0,
-    "learning_rate": 0.3771357835106376,
-    "parent_ids": [
-      "g3_c5",
-      "g3_c1"
-    ],
-    "metadata": {
-      "final_population": 74,
-      "raw_fitness": 74.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g4_c7",
-    "generation": 4,
-    "fitness": 56.0,
-    "learning_rate": 0.3870957476715199,
-    "parent_ids": [
-      "g3_elite0",
-      "g3_c1"
-    ],
-    "metadata": {
-      "final_population": 56,
-      "raw_fitness": 56.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_elite0",
-    "generation": 5,
-    "fitness": 70.0,
-    "learning_rate": 0.3771357835106376,
-    "parent_ids": [
-      "g4_c6",
-      "g4_c6"
-    ],
-    "metadata": {
-      "final_population": 70,
-      "raw_fitness": 70.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_c1",
-    "generation": 5,
-    "fitness": 59.0,
-    "learning_rate": 0.3771357835106376,
-    "parent_ids": [
-      "g4_c2",
-      "g4_c3"
-    ],
-    "metadata": {
-      "final_population": 59,
-      "raw_fitness": 59.0,
-      "boundary_penalty": 0.0
-    }
-  },
-  {
-    "candidate_id": "g5_c2",
-    "generation": 5,
-    "fitness": 63.0,
-    "learning_rate": 0.3771357835106376,
-    "parent_ids": [
-      "g4_c6",
-      "g4_c2"
+      "g3_c2"
     ],
     "metadata": {
       "final_population": 63,
@@ -645,43 +495,133 @@
     }
   },
   {
-    "candidate_id": "g5_c3",
-    "generation": 5,
-    "fitness": 69.0,
-    "learning_rate": 0.3771357835106376,
+    "candidate_id": "g4_c1",
+    "generation": 4,
+    "fitness": 64.0,
+    "learning_rate": 0.19271257710715683,
     "parent_ids": [
-      "g4_c6",
-      "g4_c2"
+      "g3_c2",
+      "g3_c4"
     ],
     "metadata": {
-      "final_population": 69,
-      "raw_fitness": 69.0,
+      "final_population": 64,
+      "raw_fitness": 64.0,
       "boundary_penalty": 0.0
     }
   },
   {
-    "candidate_id": "g5_c4",
-    "generation": 5,
-    "fitness": 74.0,
-    "learning_rate": 0.15942878976101,
+    "candidate_id": "g4_c2",
+    "generation": 4,
+    "fitness": 49.0,
+    "learning_rate": 0.19271257710715683,
     "parent_ids": [
-      "g4_c4",
-      "g4_c4"
+      "g3_c7",
+      "g3_c4"
     ],
     "metadata": {
-      "final_population": 74,
-      "raw_fitness": 74.0,
+      "final_population": 49,
+      "raw_fitness": 49.0,
       "boundary_penalty": 0.0
     }
   },
   {
-    "candidate_id": "g5_c5",
+    "candidate_id": "g4_c3",
+    "generation": 4,
+    "fitness": 58.0,
+    "learning_rate": 0.19271257710715683,
+    "parent_ids": [
+      "g3_c2",
+      "g3_c7"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c4",
+    "generation": 4,
+    "fitness": 56.0,
+    "learning_rate": 0.19271257710715683,
+    "parent_ids": [
+      "g3_c2",
+      "g3_c7"
+    ],
+    "metadata": {
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c5",
+    "generation": 4,
+    "fitness": 54.0,
+    "learning_rate": 0.19271257710715683,
+    "parent_ids": [
+      "g3_elite0",
+      "g3_c2"
+    ],
+    "metadata": {
+      "final_population": 54,
+      "raw_fitness": 54.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c6",
+    "generation": 4,
+    "fitness": 68.0,
+    "learning_rate": 0.19271257710715683,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c7",
+    "generation": 4,
+    "fitness": 71.0,
+    "learning_rate": 0.19271257710715683,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c2"
+    ],
+    "metadata": {
+      "final_population": 71,
+      "raw_fitness": 71.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_elite0",
+    "generation": 5,
+    "fitness": 59.0,
+    "learning_rate": 0.19271257710715683,
+    "parent_ids": [
+      "g4_c7",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c1",
     "generation": 5,
     "fitness": 61.0,
-    "learning_rate": 0.3771357835106376,
+    "learning_rate": 0.0734025486637818,
     "parent_ids": [
-      "g4_c2",
-      "g4_c6"
+      "g4_c1",
+      "g4_c7"
     ],
     "metadata": {
       "final_population": 61,
@@ -690,32 +630,92 @@
     }
   },
   {
-    "candidate_id": "g5_c6",
+    "candidate_id": "g5_c2",
     "generation": 5,
-    "fitness": 75.0,
-    "learning_rate": 0.3771357835106376,
+    "fitness": 78.0,
+    "learning_rate": 0.19271257710715683,
     "parent_ids": [
-      "g4_c3",
-      "g4_elite0"
+      "g4_c6",
+      "g4_c1"
     ],
     "metadata": {
-      "final_population": 75,
-      "raw_fitness": 75.0,
+      "final_population": 78,
+      "raw_fitness": 78.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c3",
+    "generation": 5,
+    "fitness": 65.0,
+    "learning_rate": 0.19271257710715683,
+    "parent_ids": [
+      "g4_c6",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c4",
+    "generation": 5,
+    "fitness": 67.0,
+    "learning_rate": 0.19271257710715683,
+    "parent_ids": [
+      "g4_c7",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c5",
+    "generation": 5,
+    "fitness": 68.0,
+    "learning_rate": 0.22873816613370027,
+    "parent_ids": [
+      "g4_c1",
+      "g4_c6"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g5_c6",
+    "generation": 5,
+    "fitness": 65.0,
+    "learning_rate": 0.19271257710715683,
+    "parent_ids": [
+      "g4_c7",
+      "g4_c7"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
       "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c7",
     "generation": 5,
-    "fitness": 65.0,
-    "learning_rate": 0.7920333851136825,
+    "fitness": 74.0,
+    "learning_rate": 0.19271257710715683,
     "parent_ids": [
       "g4_c6",
-      "g4_c2"
+      "g4_elite0"
     ],
     "metadata": {
-      "final_population": 65,
-      "raw_fitness": 65.0,
+      "final_population": 74,
+      "raw_fitness": 74.0,
       "boundary_penalty": 0.0
     }
   }

--- a/experiments/evolution_convergence/run_roulette_mut040_g6/evolution_generation_summaries.json
+++ b/experiments/evolution_convergence/run_roulette_mut040_g6/evolution_generation_summaries.json
@@ -2,23 +2,30 @@
   {
     "generation": 0,
     "best_fitness": 72.0,
-    "mean_fitness": 63.0,
-    "min_fitness": 58.0,
-    "best_candidate_id": "g0_c2",
+    "mean_fitness": 63.75,
+    "min_fitness": 44.0,
+    "best_candidate_id": "g0_c5",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.1448962806330751,
+        "mean": 0.2176808854315746,
         "median": 0.11325627044810499,
-        "std": 0.14433309573419484,
+        "std": 0.3158498270233472,
         "min": 1e-06,
-        "max": 0.3767001685825608
+        "max": 1.0
+      },
+      "gamma": {
+        "mean": 0.9313779372897512,
+        "median": 1.0,
+        "std": 0.1634799870419629,
+        "min": 0.5010234983180095,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.8283928429699695,
+        "median": 0.9522859253404239,
+        "std": 0.2660091433751002,
+        "min": 0.17077870468481426,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -29,31 +36,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.20996782651986898,
-      "epsilon_decay": 0.995,
+      "learning_rate": 1e-06,
+      "gamma": 1.0,
+      "epsilon_decay": 1.0,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": null,
+    "mutation_scale_used": null,
+    "mutation_rate_multiplier": null,
+    "mutation_scale_multiplier": null,
+    "diversity": 0.2484464244301844,
+    "adaptive_event": "initial_seeding"
   },
   {
     "generation": 1,
-    "best_fitness": 67.0,
-    "mean_fitness": 64.125,
-    "min_fitness": 59.0,
-    "best_candidate_id": "g1_elite0",
+    "best_fitness": 75.0,
+    "mean_fitness": 64.0,
+    "min_fitness": 57.0,
+    "best_candidate_id": "g1_c7",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.17052723084268548,
-        "median": 0.06878826430714721,
-        "std": 0.25391177728468406,
+        "mean": 0.16746307763016105,
+        "median": 0.15635179236283442,
+        "std": 0.1644505160622976,
         "min": 1e-06,
-        "max": 0.8067026650874515
+        "max": 0.4705853303171553
+      },
+      "gamma": {
+        "mean": 0.9747860975511533,
+        "median": 1.0,
+        "std": 0.06670971546109093,
+        "min": 0.7982887804092261,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.8327396066736782,
+        "median": 0.9578592059575831,
+        "std": 0.2945446540648997,
+        "min": 0.07685554311468816,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -64,31 +85,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.20996782651986898,
-      "epsilon_decay": 0.995,
+      "learning_rate": 0.2888887021776168,
+      "gamma": 1.0,
+      "epsilon_decay": 0.7722588122757014,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.4,
+    "mutation_scale_used": 0.35,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.17523501667965624,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 2,
-    "best_fitness": 68.0,
-    "mean_fitness": 61.375,
-    "min_fitness": 55.0,
-    "best_candidate_id": "g2_c5",
+    "best_fitness": 71.0,
+    "mean_fitness": 64.125,
+    "min_fitness": 51.0,
+    "best_candidate_id": "g2_c4",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.3054217175300557,
-        "median": 0.20996782651986898,
-        "std": 0.30273392060111687,
+        "mean": 0.21768771088141206,
+        "median": 0.25571966211968455,
+        "std": 0.18652012253144867,
         "min": 1e-06,
-        "max": 0.8067026650874515
+        "max": 0.4705853303171553
+      },
+      "gamma": {
+        "mean": 0.9981115986226712,
+        "median": 1.0,
+        "std": 0.0049962404198838645,
+        "min": 0.9848927889813696,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.5930312599874308,
+        "median": 0.7722588122757014,
+        "std": 0.3549818854138856,
+        "min": 5e-324,
+        "max": 0.9925122354030217
       },
       "memory_size": {
         "mean": 2000,
@@ -99,31 +134,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.20996782651986898,
-      "epsilon_decay": 0.995,
+      "learning_rate": 0.4705853303171553,
+      "gamma": 0.9848927889813696,
+      "epsilon_decay": 0.9232061765121445,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.4,
+    "mutation_scale_used": 0.35,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.18216614496184239,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 3,
-    "best_fitness": 72.0,
-    "mean_fitness": 61.75,
-    "min_fitness": 56.0,
-    "best_candidate_id": "g3_c4",
+    "best_fitness": 76.0,
+    "mean_fitness": 60.25,
+    "min_fitness": 53.0,
+    "best_candidate_id": "g3_c1",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.10109568710621707,
-        "median": 0.03798239504095301,
-        "std": 0.11652171464715731,
+        "mean": 0.17838856059070882,
+        "median": 0.234344756785736,
+        "std": 0.15647612167191688,
         "min": 1e-06,
-        "max": 0.31286205372809256
+        "max": 0.4705853303171553
+      },
+      "gamma": {
+        "mean": 0.8606215988840619,
+        "median": 0.9848927889813696,
+        "std": 0.32593869072785947,
+        "min": 0.0,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.702238717176353,
+        "median": 0.8704417516893235,
+        "std": 0.35507021370808084,
+        "min": 0.07332817569134262,
+        "max": 0.9925122354030217
       },
       "memory_size": {
         "mean": 2000,
@@ -134,31 +183,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.011147550087757306,
-      "epsilon_decay": 0.995,
+      "learning_rate": 1e-06,
+      "gamma": 0.9825524770085332,
+      "epsilon_decay": 0.07332817569134262,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.4,
+    "mutation_scale_used": 0.35,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.27916172752804513,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 4,
-    "best_fitness": 68.0,
-    "mean_fitness": 59.375,
-    "min_fitness": 43.0,
-    "best_candidate_id": "g4_c2",
+    "best_fitness": 69.0,
+    "mean_fitness": 61.125,
+    "min_fitness": 52.0,
+    "best_candidate_id": "g4_c7",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.13024913628097687,
-        "median": 0.09612306876501085,
-        "std": 0.12974981543440384,
+        "mean": 0.16004538152967954,
+        "median": 1e-06,
+        "std": 0.2928351316392589,
         "min": 1e-06,
-        "max": 0.3440981458951802
+        "max": 0.8289620226911592
+      },
+      "gamma": {
+        "mean": 0.9073011888949625,
+        "median": 0.9848927889813696,
+        "std": 0.17010664803077916,
+        "min": 0.47505439105061886,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.6884710229351206,
+        "median": 0.8250679719369896,
+        "std": 0.37025638307422815,
+        "min": 0.07332817569134262,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -169,31 +232,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.20996782651986898,
-      "epsilon_decay": 0.995,
+      "learning_rate": 1e-06,
+      "gamma": 0.9848927889813696,
+      "epsilon_decay": 0.7259514174182575,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.4,
+    "mutation_scale_used": 0.35,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.27773281852656356,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 5,
-    "best_fitness": 72.0,
-    "mean_fitness": 65.125,
-    "min_fitness": 59.0,
-    "best_candidate_id": "g5_c4",
+    "best_fitness": 76.0,
+    "mean_fitness": 64.875,
+    "min_fitness": 58.0,
+    "best_candidate_id": "g5_c2",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.2653628786469561,
-        "median": 0.15984727346902405,
-        "std": 0.2525581570315779,
-        "min": 0.011147550087757306,
-        "max": 0.689468417351838
+        "mean": 0.2628923349158464,
+        "median": 0.26820226435887196,
+        "std": 0.2466450110270562,
+        "min": 1e-06,
+        "max": 0.7054186962733702
+      },
+      "gamma": {
+        "mean": 0.9486437566805563,
+        "median": 0.9924463944906847,
+        "std": 0.08124132274081519,
+        "min": 0.7807305396359163,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.7925919778624122,
+        "median": 0.9232061765121445,
+        "std": 0.29368705029064773,
+        "min": 0.07332817569134262,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -204,9 +281,16 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.689468417351838,
-      "epsilon_decay": 0.995,
+      "learning_rate": 1e-06,
+      "gamma": 1.0,
+      "epsilon_decay": 1.0,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.4,
+    "mutation_scale_used": 0.35,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.20719121023459228,
+    "adaptive_event": "disabled"
   }
 ]

--- a/experiments/evolution_convergence/run_roulette_mut040_g6/evolution_lineage.json
+++ b/experiments/evolution_convergence/run_roulette_mut040_g6/evolution_lineage.json
@@ -2,495 +2,571 @@
   {
     "candidate_id": "g0_c0",
     "generation": 0,
-    "fitness": 65.0,
+    "fitness": 70.0,
     "learning_rate": 0.001,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 65
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g0_c1",
     "generation": 0,
-    "fitness": 58.0,
+    "fitness": 69.0,
     "learning_rate": 0.06878826430714721,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 58
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g0_c2",
     "generation": 0,
-    "fitness": 72.0,
-    "learning_rate": 0.20996782651986898,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 72
-    }
-  },
-  {
-    "candidate_id": "g0_c3",
-    "generation": 0,
-    "fitness": 62.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 62
-    }
-  },
-  {
-    "candidate_id": "g0_c4",
-    "generation": 0,
-    "fitness": 60.0,
+    "fitness": 69.0,
     "learning_rate": 0.3449877090659612,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 60
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
     }
   },
   {
-    "candidate_id": "g0_c5",
+    "candidate_id": "g0_c3",
     "generation": 0,
-    "fitness": 60.0,
-    "learning_rate": 0.3767001685825608,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 60
-    }
-  },
-  {
-    "candidate_id": "g0_c6",
-    "generation": 0,
-    "fitness": 65.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 65
-    }
-  },
-  {
-    "candidate_id": "g0_c7",
-    "generation": 0,
-    "fitness": 62.0,
+    "fitness": 44.0,
     "learning_rate": 0.15772427658906277,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 62
+      "final_population": 44,
+      "raw_fitness": 44.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c4",
+    "generation": 0,
+    "fitness": 53.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 53,
+      "raw_fitness": 53.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c5",
+    "generation": 0,
+    "fitness": 72.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 72,
+      "raw_fitness": 72.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c6",
+    "generation": 0,
+    "fitness": 70.0,
+    "learning_rate": 1.0,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c7",
+    "generation": 0,
+    "fitness": 63.0,
+    "learning_rate": 0.16894483349042558,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_elite0",
     "generation": 1,
-    "fitness": 67.0,
-    "learning_rate": 0.20996782651986898,
+    "fitness": 61.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g0_c2",
-      "g0_c2"
+      "g0_c5",
+      "g0_c5"
     ],
     "metadata": {
-      "final_population": 67
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c1",
     "generation": 1,
-    "fitness": 62.0,
-    "learning_rate": 0.8067026650874515,
+    "fitness": 58.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g0_c3",
+      "g0_c2",
       "g0_c1"
     ],
     "metadata": {
-      "final_population": 62
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c2",
     "generation": 1,
-    "fitness": 67.0,
-    "learning_rate": 1e-06,
+    "fitness": 59.0,
+    "learning_rate": 0.4705853303171553,
     "parent_ids": [
       "g0_c1",
       "g0_c3"
     ],
     "metadata": {
-      "final_population": 67
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c3",
     "generation": 1,
-    "fitness": 61.0,
-    "learning_rate": 0.06878826430714721,
+    "fitness": 57.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g0_c4",
       "g0_c1"
     ],
     "metadata": {
-      "final_population": 61
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c4",
     "generation": 1,
-    "fitness": 59.0,
+    "fitness": 64.0,
     "learning_rate": 0.06878826430714721,
     "parent_ids": [
       "g0_c1",
-      "g0_c4"
+      "g0_c5"
     ],
     "metadata": {
-      "final_population": 59
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c5",
     "generation": 1,
-    "fitness": 65.0,
-    "learning_rate": 1e-06,
+    "fitness": 67.0,
+    "learning_rate": 0.24391532041852165,
     "parent_ids": [
       "g0_c7",
       "g0_c3"
     ],
     "metadata": {
-      "final_population": 65
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c6",
     "generation": 1,
-    "fitness": 65.0,
-    "learning_rate": 1e-06,
+    "fitness": 71.0,
+    "learning_rate": 0.2675240038208474,
     "parent_ids": [
       "g0_c7",
       "g0_c6"
     ],
     "metadata": {
-      "final_population": 65
+      "final_population": 71,
+      "raw_fitness": 71.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c7",
     "generation": 1,
-    "fitness": 67.0,
-    "learning_rate": 0.20996782651986898,
+    "fitness": 75.0,
+    "learning_rate": 0.2888887021776168,
     "parent_ids": [
       "g0_c7",
       "g0_c2"
     ],
     "metadata": {
-      "final_population": 67
+      "final_population": 75,
+      "raw_fitness": 75.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_elite0",
     "generation": 2,
     "fitness": 63.0,
-    "learning_rate": 0.20996782651986898,
+    "learning_rate": 0.2888887021776168,
     "parent_ids": [
-      "g1_elite0",
-      "g1_elite0"
+      "g1_c7",
+      "g1_c7"
     ],
     "metadata": {
-      "final_population": 63
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c1",
     "generation": 2,
-    "fitness": 65.0,
-    "learning_rate": 1e-06,
+    "fitness": 62.0,
+    "learning_rate": 0.24391532041852165,
     "parent_ids": [
       "g1_c5",
       "g1_c7"
     ],
     "metadata": {
-      "final_population": 65
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c2",
     "generation": 2,
-    "fitness": 65.0,
-    "learning_rate": 0.8067026650874515,
+    "fitness": 68.0,
+    "learning_rate": 0.4705853303171553,
     "parent_ids": [
-      "g1_c1",
+      "g1_c2",
       "g1_c4"
     ],
     "metadata": {
-      "final_population": 65
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c3",
     "generation": 2,
-    "fitness": 59.0,
-    "learning_rate": 0.37791266001029455,
+    "fitness": 68.0,
+    "learning_rate": 0.2675240038208474,
     "parent_ids": [
-      "g1_elite0",
+      "g1_c1",
       "g1_c6"
     ],
     "metadata": {
-      "final_population": 59
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c4",
     "generation": 2,
-    "fitness": 55.0,
-    "learning_rate": 0.06878826430714721,
+    "fitness": 71.0,
+    "learning_rate": 0.4705853303171553,
     "parent_ids": [
       "g1_c2",
-      "g1_c3"
+      "g1_c4"
     ],
     "metadata": {
-      "final_population": 55
+      "final_population": 71,
+      "raw_fitness": 71.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c5",
     "generation": 2,
-    "fitness": 68.0,
-    "learning_rate": 0.20996782651986898,
+    "fitness": 67.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c7",
       "g1_c3"
     ],
     "metadata": {
-      "final_population": 68
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c6",
     "generation": 2,
-    "fitness": 59.0,
+    "fitness": 51.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c6",
       "g1_c1"
     ],
     "metadata": {
-      "final_population": 59
+      "final_population": 51,
+      "raw_fitness": 51.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c7",
     "generation": 2,
-    "fitness": 57.0,
-    "learning_rate": 0.7700324977958143,
+    "fitness": 63.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g1_c3",
+      "g1_c4",
       "g1_c5"
     ],
     "metadata": {
-      "final_population": 57
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_elite0",
     "generation": 3,
-    "fitness": 57.0,
-    "learning_rate": 0.20996782651986898,
+    "fitness": 54.0,
+    "learning_rate": 0.4705853303171553,
     "parent_ids": [
-      "g2_c5",
-      "g2_c5"
+      "g2_c4",
+      "g2_c4"
     ],
     "metadata": {
-      "final_population": 57
+      "final_population": 54,
+      "raw_fitness": 54.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c1",
     "generation": 3,
-    "fitness": 66.0,
+    "fitness": 76.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g2_elite0",
       "g2_c6"
     ],
     "metadata": {
-      "final_population": 66
+      "final_population": 76,
+      "raw_fitness": 76.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c2",
     "generation": 3,
-    "fitness": 56.0,
-    "learning_rate": 0.20996782651986898,
+    "fitness": 62.0,
+    "learning_rate": 0.24391532041852165,
     "parent_ids": [
       "g2_c1",
       "g2_elite0"
     ],
     "metadata": {
-      "final_population": 56
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c3",
     "generation": 3,
-    "fitness": 58.0,
-    "learning_rate": 0.31286205372809256,
+    "fitness": 66.0,
+    "learning_rate": 0.24391532041852165,
     "parent_ids": [
       "g2_c7",
       "g2_c1"
     ],
     "metadata": {
-      "final_population": 58
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c4",
     "generation": 3,
-    "fitness": 72.0,
-    "learning_rate": 0.011147550087757306,
+    "fitness": 62.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g2_c6",
       "g2_c4"
     ],
     "metadata": {
-      "final_population": 72
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c5",
     "generation": 3,
-    "fitness": 66.0,
-    "learning_rate": 0.0648172399941487,
+    "fitness": 53.0,
+    "learning_rate": 0.24391532041852165,
     "parent_ids": [
       "g2_c1",
       "g2_c1"
     ],
     "metadata": {
-      "final_population": 66
+      "final_population": 53,
+      "raw_fitness": 53.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c6",
     "generation": 3,
-    "fitness": 57.0,
+    "fitness": 54.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g2_c5",
       "g2_c1"
     ],
     "metadata": {
-      "final_population": 57
+      "final_population": 54,
+      "raw_fitness": 54.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c7",
     "generation": 3,
-    "fitness": 62.0,
-    "learning_rate": 1e-06,
+    "fitness": 55.0,
+    "learning_rate": 0.22477419315295033,
     "parent_ids": [
       "g2_c7",
       "g2_c1"
     ],
     "metadata": {
-      "final_population": 62
+      "final_population": 55,
+      "raw_fitness": 55.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_elite0",
     "generation": 4,
-    "fitness": 62.0,
-    "learning_rate": 0.011147550087757306,
+    "fitness": 66.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g3_c4",
-      "g3_c4"
+      "g3_c1",
+      "g3_c1"
     ],
     "metadata": {
-      "final_population": 62
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c1",
     "generation": 4,
-    "fitness": 59.0,
-    "learning_rate": 0.27338488012722945,
+    "fitness": 56.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g3_c4",
+      "g3_c3",
       "g3_c1"
     ],
     "metadata": {
-      "final_population": 59
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c2",
     "generation": 4,
-    "fitness": 68.0,
-    "learning_rate": 0.20996782651986898,
+    "fitness": 65.0,
+    "learning_rate": 0.45139502954627714,
     "parent_ids": [
       "g3_elite0",
       "g3_c4"
     ],
     "metadata": {
-      "final_population": 68
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c3",
     "generation": 4,
-    "fitness": 43.0,
-    "learning_rate": 0.011147550087757306,
+    "fitness": 52.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g3_c4",
+      "g3_c3",
       "g3_c4"
     ],
     "metadata": {
-      "final_population": 43
+      "final_population": 52,
+      "raw_fitness": 52.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c4",
     "generation": 4,
-    "fitness": 50.0,
-    "learning_rate": 0.3440981458951802,
+    "fitness": 60.0,
+    "learning_rate": 0.8289620226911592,
     "parent_ids": [
       "g3_elite0",
       "g3_elite0"
     ],
     "metadata": {
-      "final_population": 50
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c5",
     "generation": 4,
-    "fitness": 62.0,
-    "learning_rate": 0.1810985874422644,
+    "fitness": 55.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g3_c7",
       "g3_c4"
     ],
     "metadata": {
-      "final_population": 62
+      "final_population": 55,
+      "raw_fitness": 55.0,
+      "boundary_penalty": 0.0
     }
   },
   {
@@ -503,124 +579,144 @@
       "g3_c1"
     ],
     "metadata": {
-      "final_population": 66
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c7",
     "generation": 4,
-    "fitness": 65.0,
-    "learning_rate": 0.011147550087757306,
+    "fitness": 69.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g3_c4",
       "g3_c4"
     ],
     "metadata": {
-      "final_population": 65
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_elite0",
     "generation": 5,
-    "fitness": 65.0,
-    "learning_rate": 0.20996782651986898,
+    "fitness": 59.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g4_c2",
-      "g4_c2"
+      "g4_c7",
+      "g4_c7"
     ],
     "metadata": {
-      "final_population": 65
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c1",
     "generation": 5,
-    "fitness": 60.0,
-    "learning_rate": 0.10972672041817914,
+    "fitness": 65.0,
+    "learning_rate": 0.38287334977673715,
     "parent_ids": [
       "g4_elite0",
       "g4_c5"
     ],
     "metadata": {
-      "final_population": 60
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c2",
     "generation": 5,
-    "fitness": 62.0,
-    "learning_rate": 0.07167386224767514,
+    "fitness": 76.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g4_c7",
       "g4_c1"
     ],
     "metadata": {
-      "final_population": 62
+      "final_population": 76,
+      "raw_fitness": 76.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c3",
     "generation": 5,
-    "fitness": 69.0,
-    "learning_rate": 0.4182905963517936,
+    "fitness": 58.0,
+    "learning_rate": 0.15353117894100682,
     "parent_ids": [
       "g4_c4",
       "g4_c6"
     ],
     "metadata": {
-      "final_population": 69
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c4",
     "generation": 5,
-    "fitness": 72.0,
-    "learning_rate": 0.689468417351838,
+    "fitness": 64.0,
+    "learning_rate": 0.45139502954627714,
     "parent_ids": [
       "g4_c4",
       "g4_c2"
     ],
     "metadata": {
-      "final_population": 72
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c5",
     "generation": 5,
-    "fitness": 70.0,
-    "learning_rate": 0.6014805061107795,
+    "fitness": 65.0,
+    "learning_rate": 0.40991742478938,
     "parent_ids": [
       "g4_c2",
       "g4_c6"
     ],
     "metadata": {
-      "final_population": 70
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c6",
     "generation": 5,
-    "fitness": 59.0,
-    "learning_rate": 0.011147550087757306,
+    "fitness": 64.0,
+    "learning_rate": 0.7054186962733702,
     "parent_ids": [
       "g4_c3",
       "g4_c3"
     ],
     "metadata": {
-      "final_population": 59
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c7",
     "generation": 5,
-    "fitness": 64.0,
-    "learning_rate": 0.011147550087757306,
+    "fitness": 68.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g4_c4",
       "g4_c3"
     ],
     "metadata": {
-      "final_population": 64
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
     }
   }
 ]

--- a/experiments/evolution_convergence/run_tournament_mut020_g6/evolution_generation_summaries.json
+++ b/experiments/evolution_convergence/run_tournament_mut020_g6/evolution_generation_summaries.json
@@ -1,24 +1,31 @@
 [
   {
     "generation": 0,
-    "best_fitness": 68.0,
-    "mean_fitness": 64.125,
-    "min_fitness": 57.0,
+    "best_fitness": 71.0,
+    "mean_fitness": 62.125,
+    "min_fitness": 52.0,
     "best_candidate_id": "g0_c0",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.055658525648276516,
-        "median": 0.02662644272048611,
-        "std": 0.06118633982230562,
+        "mean": 0.03162298224336492,
+        "median": 1e-06,
+        "std": 0.05699117265327523,
         "min": 1e-06,
         "max": 0.15942878976101
       },
+      "gamma": {
+        "mean": 0.9371359275229121,
+        "median": 0.9875518275703261,
+        "std": 0.10332826581741346,
+        "min": 0.6803741749126586,
+        "max": 1.0
+      },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.8724919919611355,
+        "median": 0.8921990333611127,
+        "std": 0.12471650716431597,
+        "min": 0.6866249283632477,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -30,30 +37,44 @@
     },
     "best_chromosome": {
       "learning_rate": 0.001,
+      "gamma": 0.95,
       "epsilon_decay": 0.995,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": null,
+    "mutation_scale_used": null,
+    "mutation_rate_multiplier": null,
+    "mutation_scale_multiplier": null,
+    "diversity": 0.09501200087541144,
+    "adaptive_event": "initial_seeding"
   },
   {
     "generation": 1,
     "best_fitness": 73.0,
-    "mean_fitness": 65.0,
-    "min_fitness": 56.0,
-    "best_candidate_id": "g1_c3",
+    "mean_fitness": 63.625,
+    "min_fitness": 53.0,
+    "best_candidate_id": "g1_elite0",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.0744719633084669,
-        "median": 0.001,
-        "std": 0.10127118203353698,
+        "mean": 0.028368908013790908,
+        "median": 0.0005005,
+        "std": 0.03930992011528315,
         "min": 1e-06,
-        "max": 0.2749151269457153
+        "max": 0.09255006818590938
+      },
+      "gamma": {
+        "mean": 0.981275913785163,
+        "median": 0.9875518275703261,
+        "std": 0.02072113877802683,
+        "min": 0.95,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.9213286353890963,
+        "median": 0.962204799678723,
+        "std": 0.10613941560015751,
+        "min": 0.6866249283632477,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -64,30 +85,44 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.15942878976101,
+      "learning_rate": 0.001,
+      "gamma": 0.95,
       "epsilon_decay": 0.995,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.05539017126780897,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 2,
-    "best_fitness": 75.0,
-    "mean_fitness": 64.0,
-    "min_fitness": 57.0,
-    "best_candidate_id": "g2_c4",
+    "best_fitness": 73.0,
+    "mean_fitness": 65.625,
+    "min_fitness": 60.0,
+    "best_candidate_id": "g2_c5",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.13400763446884564,
-        "median": 0.15942878976101,
-        "std": 0.08587902340021279,
+        "mean": 0.011819383523238674,
+        "median": 1e-06,
+        "std": 0.03051625081669853,
         "min": 1e-06,
-        "max": 0.2749151269457153
+        "max": 0.09255006818590938
+      },
+      "gamma": {
+        "mean": 0.9781638706777446,
+        "median": 0.9751036551406521,
+        "std": 0.019509458000674385,
+        "min": 0.95,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
+        "mean": 0.8835394117524394,
+        "median": 0.9408744292591078,
+        "std": 0.10385364675381875,
+        "min": 0.7077353054681563,
         "max": 0.995
       },
       "memory_size": {
@@ -100,30 +135,44 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 0.9751036551406521,
+      "epsilon_decay": 0.962204799678723,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.051293128695824336,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 3,
-    "best_fitness": 70.0,
-    "mean_fitness": 64.0,
-    "min_fitness": 60.0,
-    "best_candidate_id": "g3_c7",
+    "best_fitness": 71.0,
+    "mean_fitness": 62.5,
+    "min_fitness": 53.0,
+    "best_candidate_id": "g3_c3",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.032643645893763215,
+        "mean": 0.011819383523238674,
         "median": 1e-06,
-        "std": 0.05635908447804713,
+        "std": 0.03051625081669853,
         "min": 1e-06,
-        "max": 0.15942878976101
+        "max": 0.09255006818590938
+      },
+      "gamma": {
+        "mean": 0.981301827570326,
+        "median": 0.9751036551406521,
+        "std": 0.01651642641336105,
+        "min": 0.95,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.8664606502907253,
+        "median": 0.8358001681188912,
+        "std": 0.08092239211965643,
+        "min": 0.7520317749623443,
+        "max": 0.9688639803415231
       },
       "memory_size": {
         "mean": 2000,
@@ -135,15 +184,22 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 0.9751036551406521,
+      "epsilon_decay": 0.9688639803415231,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.04265169995533245,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 4,
-    "best_fitness": 71.0,
-    "mean_fitness": 64.75,
-    "min_fitness": 59.0,
+    "best_fitness": 72.0,
+    "mean_fitness": 61.75,
+    "min_fitness": 49.0,
     "best_candidate_id": "g4_c5",
     "gene_statistics": {
       "learning_rate": {
@@ -153,12 +209,19 @@
         "min": 1e-06,
         "max": 1e-06
       },
+      "gamma": {
+        "mean": 0.9414718409690768,
+        "median": 0.9751036551406521,
+        "std": 0.05227313413721376,
+        "min": 0.8369660526170754,
+        "max": 0.9751036551406521
+      },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.9293293571645412,
+        "median": 0.9688639803415231,
+        "std": 0.07328393657682303,
+        "min": 0.7580621307780558,
+        "max": 0.9747014249690293
       },
       "memory_size": {
         "mean": 2000,
@@ -170,30 +233,44 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 0.9751036551406521,
+      "epsilon_decay": 0.9688639803415231,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.04185235690467893,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 5,
-    "best_fitness": 72.0,
-    "mean_fitness": 66.25,
-    "min_fitness": 55.0,
-    "best_candidate_id": "g5_c2",
+    "best_fitness": 71.0,
+    "mean_fitness": 64.375,
+    "min_fitness": 58.0,
+    "best_candidate_id": "g5_c5",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.051863200200380606,
+        "mean": 0.00450419862831793,
         "median": 1e-06,
-        "std": 0.13721448417485127,
+        "std": 0.011914343674856429,
         "min": 1e-06,
-        "max": 0.41489860160304487
+        "max": 0.03602658902654344
+      },
+      "gamma": {
+        "mean": 0.9268313131255618,
+        "median": 0.9751036551406521,
+        "std": 0.08800898331856812,
+        "min": 0.7270625215435063,
+        "max": 0.9751036551406521
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.921432677296902,
+        "median": 0.9688639803415231,
+        "std": 0.12549143221580802,
+        "min": 0.5894135559845548,
+        "max": 0.9688639803415231
       },
       "memory_size": {
         "mean": 2000,
@@ -204,9 +281,16 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "learning_rate": 0.03602658902654344,
+      "gamma": 0.9751036551406521,
+      "epsilon_decay": 0.9688639803415231,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.2,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.07513825704119605,
+    "adaptive_event": "disabled"
   }
 ]

--- a/experiments/evolution_convergence/run_tournament_mut020_g6/evolution_lineage.json
+++ b/experiments/evolution_convergence/run_tournament_mut020_g6/evolution_lineage.json
@@ -2,417 +2,481 @@
   {
     "candidate_id": "g0_c0",
     "generation": 0,
-    "fitness": 68.0,
+    "fitness": 71.0,
     "learning_rate": 0.001,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 68
+      "final_population": 71,
+      "raw_fitness": 71.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g0_c1",
     "generation": 0,
-    "fitness": 68.0,
+    "fitness": 65.0,
     "learning_rate": 0.15942878976101,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 68
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g0_c2",
     "generation": 0,
-    "fitness": 64.0,
-    "learning_rate": 0.02610363003699699,
+    "fitness": 60.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 64
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g0_c3",
     "generation": 0,
-    "fitness": 57.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 57
-    }
-  },
-  {
-    "candidate_id": "g0_c4",
-    "generation": 0,
-    "fitness": 67.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 67
-    }
-  },
-  {
-    "candidate_id": "g0_c5",
-    "generation": 0,
     "fitness": 61.0,
-    "learning_rate": 0.13903446179832052,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 61
-    }
-  },
-  {
-    "candidate_id": "g0_c6",
-    "generation": 0,
-    "fitness": 63.0,
-    "learning_rate": 0.02714925540397523,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 63
-    }
-  },
-  {
-    "candidate_id": "g0_c7",
-    "generation": 0,
-    "fitness": 65.0,
     "learning_rate": 0.09255006818590938,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 65
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c4",
+    "generation": 0,
+    "fitness": 59.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c5",
+    "generation": 0,
+    "fitness": 61.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c6",
+    "generation": 0,
+    "fitness": 68.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c7",
+    "generation": 0,
+    "fitness": 52.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 52,
+      "raw_fitness": 52.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_elite0",
     "generation": 1,
-    "fitness": 63.0,
+    "fitness": 73.0,
     "learning_rate": 0.001,
     "parent_ids": [
       "g0_c0",
       "g0_c0"
     ],
     "metadata": {
-      "final_population": 63
+      "final_population": 73,
+      "raw_fitness": 73.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c1",
     "generation": 1,
-    "fitness": 59.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 53.0,
+    "learning_rate": 0.04084712773850849,
     "parent_ids": [
-      "g0_c1",
-      "g0_c1"
+      "g0_c0",
+      "g0_c6"
     ],
     "metadata": {
-      "final_population": 59
+      "final_population": 53,
+      "raw_fitness": 53.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c2",
     "generation": 1,
-    "fitness": 56.0,
-    "learning_rate": 0.001,
+    "fitness": 60.0,
+    "learning_rate": 0.09255006818590938,
     "parent_ids": [
       "g0_c0",
-      "g0_c7"
+      "g0_c3"
     ],
     "metadata": {
-      "final_population": 56
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c3",
     "generation": 1,
-    "fitness": 73.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 68.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g0_c4",
+      "g0_c6",
       "g0_c1"
     ],
     "metadata": {
-      "final_population": 73
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c4",
     "generation": 1,
-    "fitness": 70.0,
+    "fitness": 67.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g0_c4",
+      "g0_c6",
       "g0_c0"
     ],
     "metadata": {
-      "final_population": 70
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c5",
     "generation": 1,
-    "fitness": 69.0,
-    "learning_rate": 1e-06,
+    "fitness": 65.0,
+    "learning_rate": 0.09255006818590938,
     "parent_ids": [
-      "g0_c1",
-      "g0_c4"
+      "g0_c0",
+      "g0_c3"
     ],
     "metadata": {
-      "final_population": 69
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c6",
     "generation": 1,
-    "fitness": 67.0,
-    "learning_rate": 0.2749151269457153,
+    "fitness": 59.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g0_c0",
-      "g0_c4"
+      "g0_c2"
     ],
     "metadata": {
-      "final_population": 67
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c7",
     "generation": 1,
-    "fitness": 63.0,
+    "fitness": 64.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g0_c1",
-      "g0_c4"
+      "g0_c6"
     ],
     "metadata": {
-      "final_population": 63
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_elite0",
     "generation": 2,
-    "fitness": 64.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 61.0,
+    "learning_rate": 0.001,
     "parent_ids": [
-      "g1_c3",
-      "g1_c3"
+      "g1_elite0",
+      "g1_elite0"
     ],
     "metadata": {
-      "final_population": 64
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c1",
     "generation": 2,
-    "fitness": 58.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 60.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
       "g1_c4"
     ],
     "metadata": {
-      "final_population": 58
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c2",
     "generation": 2,
-    "fitness": 64.0,
-    "learning_rate": 0.2749151269457153,
+    "fitness": 69.0,
+    "learning_rate": 0.09255006818590938,
     "parent_ids": [
-      "g1_c6",
+      "g1_c7",
       "g1_c5"
     ],
     "metadata": {
-      "final_population": 64
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c3",
     "generation": 2,
-    "fitness": 58.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 65.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
-      "g1_c6"
+      "g1_c2"
     ],
     "metadata": {
-      "final_population": 58
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c4",
     "generation": 2,
-    "fitness": 75.0,
-    "learning_rate": 1e-06,
+    "fitness": 70.0,
+    "learning_rate": 0.001,
     "parent_ids": [
-      "g1_c4",
-      "g1_c6"
+      "g1_elite0",
+      "g1_c7"
     ],
     "metadata": {
-      "final_population": 75
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c5",
     "generation": 2,
-    "fitness": 57.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 73.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
       "g1_c4"
     ],
     "metadata": {
-      "final_population": 57
+      "final_population": 73,
+      "raw_fitness": 73.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c6",
     "generation": 2,
-    "fitness": 67.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 62.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
       "g1_c3"
     ],
     "metadata": {
-      "final_population": 67
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c7",
     "generation": 2,
-    "fitness": 69.0,
+    "fitness": 65.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g1_c6",
-      "g1_c4"
+      "g1_c7",
+      "g1_elite0"
     ],
     "metadata": {
-      "final_population": 69
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_elite0",
     "generation": 3,
-    "fitness": 62.0,
+    "fitness": 64.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_c4",
-      "g2_c4"
+      "g2_c5",
+      "g2_c5"
     ],
     "metadata": {
-      "final_population": 62
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c1",
     "generation": 3,
-    "fitness": 61.0,
-    "learning_rate": 0.00996096416088228,
+    "fitness": 55.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_elite0",
+      "g2_c5",
       "g2_c4"
     ],
     "metadata": {
-      "final_population": 61
+      "final_population": 55,
+      "raw_fitness": 55.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c2",
     "generation": 3,
-    "fitness": 64.0,
-    "learning_rate": 1e-06,
+    "fitness": 62.0,
+    "learning_rate": 0.001,
     "parent_ids": [
       "g2_c4",
       "g2_c4"
     ],
     "metadata": {
-      "final_population": 64
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c3",
     "generation": 3,
-    "fitness": 64.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 71.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_c3",
-      "g2_elite0"
+      "g2_c5",
+      "g2_c3"
     ],
     "metadata": {
-      "final_population": 64
+      "final_population": 71,
+      "raw_fitness": 71.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c4",
     "generation": 3,
-    "fitness": 62.0,
+    "fitness": 66.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_elite0",
+      "g2_c5",
       "g2_c7"
     ],
     "metadata": {
-      "final_population": 62
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c5",
     "generation": 3,
-    "fitness": 69.0,
-    "learning_rate": 1e-06,
+    "fitness": 61.0,
+    "learning_rate": 0.001,
     "parent_ids": [
       "g2_c4",
-      "g2_c7"
+      "g2_c2"
     ],
     "metadata": {
-      "final_population": 69
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c6",
     "generation": 3,
-    "fitness": 60.0,
-    "learning_rate": 0.09175441322821346,
+    "fitness": 53.0,
+    "learning_rate": 0.09255006818590938,
     "parent_ids": [
       "g2_c4",
-      "g2_c6"
+      "g2_c2"
     ],
     "metadata": {
-      "final_population": 60
+      "final_population": 53,
+      "raw_fitness": 53.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c7",
     "generation": 3,
-    "fitness": 70.0,
+    "fitness": 68.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g2_c2",
-      "g2_c7"
+      "g2_c5"
     ],
     "metadata": {
-      "final_population": 70
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
     }
   },
   {
@@ -421,206 +485,238 @@
     "fitness": 63.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g3_c7",
-      "g3_c7"
+      "g3_c3",
+      "g3_c3"
     ],
     "metadata": {
-      "final_population": 63
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c1",
     "generation": 4,
-    "fitness": 67.0,
+    "fitness": 58.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g3_c7",
-      "g3_c5"
+      "g3_c3",
+      "g3_c3"
     ],
     "metadata": {
-      "final_population": 67
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c2",
     "generation": 4,
-    "fitness": 68.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c7",
-      "g3_c5"
-    ],
-    "metadata": {
-      "final_population": 68
-    }
-  },
-  {
-    "candidate_id": "g4_c3",
-    "generation": 4,
-    "fitness": 64.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c7",
-      "g3_c7"
-    ],
-    "metadata": {
-      "final_population": 64
-    }
-  },
-  {
-    "candidate_id": "g4_c4",
-    "generation": 4,
-    "fitness": 64.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c2",
-      "g3_c7"
-    ],
-    "metadata": {
-      "final_population": 64
-    }
-  },
-  {
-    "candidate_id": "g4_c5",
-    "generation": 4,
-    "fitness": 71.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "g3_c3",
-      "g3_c7"
-    ],
-    "metadata": {
-      "final_population": 71
-    }
-  },
-  {
-    "candidate_id": "g4_c6",
-    "generation": 4,
-    "fitness": 62.0,
+    "fitness": 49.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g3_c7",
       "g3_c4"
     ],
     "metadata": {
-      "final_population": 62
+      "final_population": 49,
+      "raw_fitness": 49.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c3",
+    "generation": 4,
+    "fitness": 57.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c4",
+    "generation": 4,
+    "fitness": 65.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c5",
+    "generation": 4,
+    "fitness": 72.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c3",
+      "g3_c3"
+    ],
+    "metadata": {
+      "final_population": 72,
+      "raw_fitness": 72.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g4_c6",
+    "generation": 4,
+    "fitness": 63.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "g3_c7",
+      "g3_c4"
+    ],
+    "metadata": {
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c7",
     "generation": 4,
-    "fitness": 59.0,
+    "fitness": 67.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g3_c7",
-      "g3_c2"
+      "g3_c4"
     ],
     "metadata": {
-      "final_population": 59
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_elite0",
     "generation": 5,
-    "fitness": 68.0,
+    "fitness": 58.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g4_c5",
       "g4_c5"
     ],
     "metadata": {
-      "final_population": 68
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c1",
     "generation": 5,
-    "fitness": 68.0,
+    "fitness": 61.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g4_c5",
-      "g4_c1"
+      "g4_c7"
     ],
     "metadata": {
-      "final_population": 68
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c2",
     "generation": 5,
-    "fitness": 72.0,
+    "fitness": 62.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g4_c5",
-      "g4_c2"
+      "g4_elite0"
     ],
     "metadata": {
-      "final_population": 72
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c3",
     "generation": 5,
-    "fitness": 71.0,
+    "fitness": 70.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g4_c1",
+      "g4_c4",
       "g4_c5"
     ],
     "metadata": {
-      "final_population": 71
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c4",
     "generation": 5,
-    "fitness": 69.0,
+    "fitness": 59.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g4_c4",
-      "g4_c1"
+      "g4_c7",
+      "g4_c7"
     ],
     "metadata": {
-      "final_population": 69
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c5",
     "generation": 5,
-    "fitness": 58.0,
-    "learning_rate": 1e-06,
+    "fitness": 71.0,
+    "learning_rate": 0.03602658902654344,
     "parent_ids": [
-      "g4_c2",
-      "g4_c1"
+      "g4_elite0",
+      "g4_c4"
     ],
     "metadata": {
-      "final_population": 58
+      "final_population": 71,
+      "raw_fitness": 71.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c6",
     "generation": 5,
-    "fitness": 69.0,
+    "fitness": 67.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g4_c4",
+      "g4_c7",
       "g4_c5"
     ],
     "metadata": {
-      "final_population": 69
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c7",
     "generation": 5,
-    "fitness": 55.0,
-    "learning_rate": 0.41489860160304487,
+    "fitness": 67.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g4_c5",
-      "g4_c2"
+      "g4_elite0"
     ],
     "metadata": {
-      "final_population": 55
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
     }
   }
 ]

--- a/experiments/evolution_convergence/run_tournament_mut025/evolution_generation_summaries.json
+++ b/experiments/evolution_convergence/run_tournament_mut025/evolution_generation_summaries.json
@@ -1,59 +1,31 @@
 [
   {
     "generation": 0,
-    "best_fitness": 88.0,
-    "mean_fitness": 80.6,
-    "min_fitness": 70.0,
-    "best_candidate_id": "g0_c1",
+    "best_fitness": 70.0,
+    "mean_fitness": 63.5,
+    "min_fitness": 54.0,
+    "best_candidate_id": "g0_c4",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.07211833321319275,
-        "median": 0.02662644272048611,
-        "std": 0.08879818852896125,
-        "min": 1e-06,
-        "max": 0.2759141269457153
-      },
-      "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
-      },
-      "memory_size": {
-        "mean": 2000,
-        "median": 2000.0,
-        "std": 0.0,
-        "min": 2000,
-        "max": 2000
-      }
-    },
-    "best_chromosome": {
-      "learning_rate": 0.15942878976101,
-      "epsilon_decay": 0.995,
-      "memory_size": 2000
-    }
-  },
-  {
-    "generation": 1,
-    "best_fitness": 89.0,
-    "mean_fitness": 79.9,
-    "min_fitness": 72.0,
-    "best_candidate_id": "g1_c3",
-    "gene_statistics": {
-      "learning_rate": {
-        "mean": 0.0505394999320027,
-        "median": 0.0005005,
-        "std": 0.07168863646793708,
+        "mean": 0.029483098568542785,
+        "median": 1e-06,
+        "std": 0.05200252063752321,
         "min": 1e-06,
         "max": 0.15942878976101
       },
+      "gamma": {
+        "mean": 0.9457047394304153,
+        "median": 0.9875518275703261,
+        "std": 0.09442056315820216,
+        "min": 0.6803741749126586,
+        "max": 1.0
+      },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.8979935935689084,
+        "median": 0.9786023998393615,
+        "std": 0.12265680766129439,
+        "min": 0.6866249283632477,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -65,30 +37,93 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 0.8916095901299863,
+      "epsilon_decay": 0.8221932670435024,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": null,
+    "mutation_scale_used": null,
+    "mutation_rate_multiplier": null,
+    "mutation_scale_multiplier": null,
+    "diversity": 0.0896933144865308,
+    "adaptive_event": "initial_seeding"
+  },
+  {
+    "generation": 1,
+    "best_fitness": 70.0,
+    "mean_fitness": 64.3,
+    "min_fitness": 59.0,
+    "best_candidate_id": "g1_c3",
+    "gene_statistics": {
+      "learning_rate": {
+        "mean": 0.07200613998069594,
+        "median": 1e-06,
+        "std": 0.14497927659269938,
+        "min": 1e-06,
+        "max": 0.4931091356966321
+      },
+      "gamma": {
+        "mean": 0.9471240454267893,
+        "median": 0.9549799870604281,
+        "std": 0.042891315449244974,
+        "min": 0.8916095901299863,
+        "max": 1.0
+      },
+      "epsilon_decay": {
+        "mean": 0.8261628188489253,
+        "median": 0.8221932670435024,
+        "std": 0.19865964926488863,
+        "min": 0.31693755210852265,
+        "max": 1.0
+      },
+      "memory_size": {
+        "mean": 2000,
+        "median": 2000.0,
+        "std": 0.0,
+        "min": 2000,
+        "max": 2000
+      }
+    },
+    "best_chromosome": {
+      "learning_rate": 1e-06,
+      "gamma": 1.0,
+      "epsilon_decay": 1.0,
+      "memory_size": 2000
+    },
+    "mutation_rate_used": 0.25,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.1288434620954182,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 2,
-    "best_fitness": 89.0,
-    "mean_fitness": 80.6,
-    "min_fitness": 75.0,
-    "best_candidate_id": "g2_c3",
+    "best_fitness": 76.0,
+    "mean_fitness": 64.9,
+    "min_fitness": 56.0,
+    "best_candidate_id": "g2_elite0",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.04240456145636382,
+        "mean": 0.02670471936814796,
         "median": 1e-06,
-        "std": 0.08062423651191036,
+        "std": 0.0572124260516193,
         "min": 1e-06,
-        "max": 0.23850619476563123
+        "max": 0.17939481794869772
+      },
+      "gamma": {
+        "mean": 0.9683219180259972,
+        "median": 1.0,
+        "std": 0.04296737498156334,
+        "min": 0.8916095901299863,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.8727950513396153,
+        "median": 0.8325026181965276,
+        "std": 0.11296914957066602,
+        "min": 0.6866249283632477,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -100,30 +135,44 @@
     },
     "best_chromosome": {
       "learning_rate": 1e-06,
-      "epsilon_decay": 0.995,
+      "gamma": 1.0,
+      "epsilon_decay": 1.0,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.25,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.07104966927211065,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 3,
-    "best_fitness": 92.0,
-    "mean_fitness": 82.9,
-    "min_fitness": 72.0,
-    "best_candidate_id": "g3_c6",
+    "best_fitness": 69.0,
+    "mean_fitness": 61.3,
+    "min_fitness": 54.0,
+    "best_candidate_id": "g3_c7",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.06624144898404537,
-        "median": 1e-06,
-        "std": 0.11940600364096203,
+        "mean": 0.1147656316787672,
+        "median": 0.052760527652472036,
+        "std": 0.15163537416381065,
         "min": 1e-06,
-        "max": 0.38291595942999984
+        "max": 0.5039468076366348
+      },
+      "gamma": {
+        "mean": 0.9740838380039853,
+        "median": 1.0,
+        "std": 0.07717863560634469,
+        "min": 0.7425530102920128,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.9432835862652487,
+        "median": 1.0,
+        "std": 0.07405908145734853,
+        "min": 0.8221932670435024,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -134,31 +183,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.38291595942999984,
-      "epsilon_decay": 0.995,
+      "learning_rate": 0.5039468076366348,
+      "gamma": 1.0,
+      "epsilon_decay": 1.0,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.25,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.1009577476210099,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 4,
-    "best_fitness": 85.0,
-    "mean_fitness": 77.1,
-    "min_fitness": 70.0,
-    "best_candidate_id": "g4_elite0",
+    "best_fitness": 73.0,
+    "mean_fitness": 64.9,
+    "min_fitness": 55.0,
+    "best_candidate_id": "g4_c7",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.07431101813783315,
-        "median": 1e-06,
-        "std": 0.11603815876777367,
+        "mean": 0.251271496049398,
+        "median": 0.17939481794869772,
+        "std": 0.1892362515689649,
         "min": 1e-06,
-        "max": 0.38291595942999984
+        "max": 0.5039468076366348
+      },
+      "gamma": {
+        "mean": 0.9485106020584025,
+        "median": 1.0,
+        "std": 0.10297879588319488,
+        "min": 0.7425530102920128,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.9571168918509857,
+        "median": 1.0,
+        "std": 0.07085314259433308,
+        "min": 0.8221932670435024,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -169,31 +232,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.38291595942999984,
-      "epsilon_decay": 0.995,
+      "learning_rate": 0.5039468076366348,
+      "gamma": 1.0,
+      "epsilon_decay": 1.0,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.25,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.12102279309431123,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 5,
-    "best_fitness": 89.0,
-    "mean_fitness": 80.0,
-    "min_fitness": 73.0,
-    "best_candidate_id": "g5_c4",
+    "best_fitness": 69.0,
+    "mean_fitness": 65.3,
+    "min_fitness": 60.0,
+    "best_candidate_id": "g5_c3",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.17717933190188873,
-        "median": 0.1200627406494439,
-        "std": 0.17360976205308962,
+        "mean": 0.42504663486935435,
+        "median": 0.5039468076366348,
+        "std": 0.2492812523322414,
         "min": 1e-06,
-        "max": 0.38291595942999984
+        "max": 0.9038223687929717
+      },
+      "gamma": {
+        "mean": 0.8666546879056668,
+        "median": 0.9233590583937763,
+        "std": 0.14520606002054856,
+        "min": 0.5921697313930769,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.9379693426883984,
+        "median": 1.0,
+        "std": 0.09566248009883022,
+        "min": 0.7039353909947779,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -204,31 +281,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.1200627406494439,
-      "epsilon_decay": 0.995,
+      "learning_rate": 0.028747514647896488,
+      "gamma": 0.7425530102920128,
+      "epsilon_decay": 0.8221932670435024,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.25,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.16338334724437392,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 6,
-    "best_fitness": 86.0,
-    "mean_fitness": 78.4,
-    "min_fitness": 71.0,
-    "best_candidate_id": "g6_c6",
+    "best_fitness": 73.0,
+    "mean_fitness": 63.2,
+    "min_fitness": 57.0,
+    "best_candidate_id": "g6_c4",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.20522198693876598,
-        "median": 0.13140527761024076,
-        "std": 0.15918371692368147,
+        "mean": 0.33111600369234884,
+        "median": 0.5039468076366348,
+        "std": 0.2558452752666173,
         "min": 1e-06,
-        "max": 0.41835495000112605
+        "max": 0.6330298963068575
+      },
+      "gamma": {
+        "mean": 0.7730345082867903,
+        "median": 0.7425530102920128,
+        "std": 0.24669678691468253,
+        "min": 0.1679633103067747,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.9393362185553359,
+        "median": 1.0,
+        "std": 0.07962761976420814,
+        "min": 0.8221932670435024,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -239,31 +330,45 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.38291595942999984,
-      "epsilon_decay": 0.995,
+      "learning_rate": 0.028747514647896488,
+      "gamma": 0.7425530102920128,
+      "epsilon_decay": 1.0,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.25,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.19405664593034636,
+    "adaptive_event": "disabled"
   },
   {
     "generation": 7,
-    "best_fitness": 84.0,
-    "mean_fitness": 77.4,
-    "min_fitness": 71.0,
-    "best_candidate_id": "g7_c4",
+    "best_fitness": 71.0,
+    "mean_fitness": 64.8,
+    "min_fitness": 56.0,
+    "best_candidate_id": "g7_c1",
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.3354052804442934,
-        "median": 0.38291595942999984,
-        "std": 0.15113304239574427,
-        "min": 0.04288169220621041,
-        "max": 0.5977487679498238
+        "mean": 0.3480081151999056,
+        "median": 0.5039468076366348,
+        "std": 0.22892231847691247,
+        "min": 1e-06,
+        "max": 0.576099366126402
+      },
+      "gamma": {
+        "mean": 0.8136266779109903,
+        "median": 0.8712765051460064,
+        "std": 0.24719163946986386,
+        "min": 0.1679633103067747,
+        "max": 1.0
       },
       "epsilon_decay": {
-        "mean": 0.995,
-        "median": 0.995,
-        "std": 0.0,
-        "min": 0.995,
-        "max": 0.995
+        "mean": 0.9669452610359798,
+        "median": 1.0,
+        "std": 0.0580454715582105,
+        "min": 0.8158878415140941,
+        "max": 1.0
       },
       "memory_size": {
         "mean": 2000,
@@ -274,9 +379,16 @@
       }
     },
     "best_chromosome": {
-      "learning_rate": 0.04288169220621041,
-      "epsilon_decay": 0.995,
+      "learning_rate": 0.2269703882742677,
+      "gamma": 1.0,
+      "epsilon_decay": 1.0,
       "memory_size": 2000
-    }
+    },
+    "mutation_rate_used": 0.25,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.17805321947584474,
+    "adaptive_event": "disabled"
   }
 ]

--- a/experiments/evolution_convergence/run_tournament_mut025/evolution_lineage.json
+++ b/experiments/evolution_convergence/run_tournament_mut025/evolution_lineage.json
@@ -2,1041 +2,1201 @@
   {
     "candidate_id": "g0_c0",
     "generation": 0,
-    "fitness": 84.0,
+    "fitness": 69.0,
     "learning_rate": 0.001,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 84
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g0_c1",
     "generation": 0,
-    "fitness": 88.0,
+    "fitness": 62.0,
     "learning_rate": 0.15942878976101,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 88
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g0_c2",
     "generation": 0,
-    "fitness": 83.0,
-    "learning_rate": 0.02610363003699699,
+    "fitness": 65.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 83
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g0_c3",
     "generation": 0,
-    "fitness": 84.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 84
-    }
-  },
-  {
-    "candidate_id": "g0_c4",
-    "generation": 0,
-    "fitness": 83.0,
-    "learning_rate": 1e-06,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 83
-    }
-  },
-  {
-    "candidate_id": "g0_c5",
-    "generation": 0,
-    "fitness": 77.0,
-    "learning_rate": 0.13903446179832052,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 77
-    }
-  },
-  {
-    "candidate_id": "g0_c6",
-    "generation": 0,
-    "fitness": 70.0,
-    "learning_rate": 0.02714925540397523,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 70
-    }
-  },
-  {
-    "candidate_id": "g0_c7",
-    "generation": 0,
-    "fitness": 82.0,
+    "fitness": 65.0,
     "learning_rate": 0.09255006818590938,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 82
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c4",
+    "generation": 0,
+    "fitness": 70.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c5",
+    "generation": 0,
+    "fitness": 54.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 54,
+      "raw_fitness": 54.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c6",
+    "generation": 0,
+    "fitness": 58.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c7",
+    "generation": 0,
+    "fitness": 59.0,
+    "learning_rate": 1e-06,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g0_c8",
     "generation": 0,
-    "fitness": 82.0,
-    "learning_rate": 0.2759141269457153,
+    "fitness": 70.0,
+    "learning_rate": 0.04184612773850849,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 82
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g0_c9",
     "generation": 0,
-    "fitness": 73.0,
+    "fitness": 63.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 73
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_elite0",
     "generation": 1,
-    "fitness": 73.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 66.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g0_c1",
-      "g0_c1"
+      "g0_c4",
+      "g0_c4"
     ],
     "metadata": {
-      "final_population": 73
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c1",
     "generation": 1,
-    "fitness": 88.0,
+    "fitness": 69.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g0_c1",
+      "g0_c4",
       "g0_c3"
     ],
     "metadata": {
-      "final_population": 88
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c2",
     "generation": 1,
-    "fitness": 81.0,
-    "learning_rate": 0.001,
+    "fitness": 62.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g0_c0",
+      "g0_c4",
       "g0_c1"
     ],
     "metadata": {
-      "final_population": 81
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c3",
     "generation": 1,
-    "fitness": 89.0,
+    "fitness": 70.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g0_c1",
-      "g0_c3"
+      "g0_c8",
+      "g0_c2"
     ],
     "metadata": {
-      "final_population": 89
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c4",
     "generation": 1,
-    "fitness": 72.0,
+    "fitness": 60.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g0_c4",
-      "g0_c1"
+      "g0_c4"
     ],
     "metadata": {
-      "final_population": 72
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c5",
     "generation": 1,
-    "fitness": 88.0,
-    "learning_rate": 1e-06,
+    "fitness": 59.0,
+    "learning_rate": 0.09255006818590938,
     "parent_ids": [
-      "g0_c1",
+      "g0_c0",
       "g0_c3"
     ],
     "metadata": {
-      "final_population": 88
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c6",
     "generation": 1,
-    "fitness": 81.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 64.0,
+    "learning_rate": 0.04184612773850849,
     "parent_ids": [
       "g0_c1",
       "g0_c8"
     ],
     "metadata": {
-      "final_population": 81
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c7",
     "generation": 1,
-    "fitness": 79.0,
-    "learning_rate": 0.02610363003699699,
+    "fitness": 61.0,
+    "learning_rate": 0.4931091356966321,
     "parent_ids": [
-      "g0_c2",
-      "g0_c4"
+      "g0_c8",
+      "g0_c8"
     ],
     "metadata": {
-      "final_population": 79
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c8",
     "generation": 1,
-    "fitness": 73.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 67.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g0_c1",
-      "g0_c1"
+      "g0_c0"
     ],
     "metadata": {
-      "final_population": 73
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c9",
     "generation": 1,
-    "fitness": 75.0,
-    "learning_rate": 1e-06,
+    "fitness": 65.0,
+    "learning_rate": 0.09255006818590938,
     "parent_ids": [
       "g0_c4",
       "g0_c3"
     ],
     "metadata": {
-      "final_population": 75
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_elite0",
     "generation": 2,
-    "fitness": 75.0,
+    "fitness": 76.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
       "g1_c3"
     ],
     "metadata": {
-      "final_population": 75
+      "final_population": 76,
+      "raw_fitness": 76.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c1",
     "generation": 2,
-    "fitness": 83.0,
+    "fitness": 70.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
       "g1_c3"
     ],
     "metadata": {
-      "final_population": 83
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c2",
     "generation": 2,
-    "fitness": 82.0,
-    "learning_rate": 0.02610363003699699,
+    "fitness": 63.0,
+    "learning_rate": 0.08764437573278186,
     "parent_ids": [
-      "g1_c7",
-      "g1_c5"
+      "g1_elite0",
+      "g1_elite0"
     ],
     "metadata": {
-      "final_population": 82
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c3",
     "generation": 2,
-    "fitness": 89.0,
+    "fitness": 65.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
-      "g1_c5"
+      "g1_c8"
     ],
     "metadata": {
-      "final_population": 89
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c4",
     "generation": 2,
-    "fitness": 79.0,
-    "learning_rate": 0.23850619476563123,
+    "fitness": 57.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c2",
-      "g1_c6"
+      "g1_c9"
     ],
     "metadata": {
-      "final_population": 79
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c5",
     "generation": 2,
-    "fitness": 83.0,
+    "fitness": 56.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
       "g1_c1"
     ],
     "metadata": {
-      "final_population": 83
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c6",
     "generation": 2,
-    "fitness": 85.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 66.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g1_c7",
-      "g1_c6"
+      "g1_c8",
+      "g1_c8"
     ],
     "metadata": {
-      "final_population": 85
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c7",
     "generation": 2,
-    "fitness": 75.0,
-    "learning_rate": 1e-06,
+    "fitness": 69.0,
+    "learning_rate": 0.17939481794869772,
     "parent_ids": [
-      "g1_c5",
+      "g1_elite0",
       "g1_c3"
     ],
     "metadata": {
-      "final_population": 75
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c8",
     "generation": 2,
-    "fitness": 78.0,
+    "fitness": 67.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
       "g1_c3"
     ],
     "metadata": {
-      "final_population": 78
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g2_c9",
     "generation": 2,
-    "fitness": 77.0,
+    "fitness": 60.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g1_c3",
-      "g1_c2"
+      "g1_elite0"
     ],
     "metadata": {
-      "final_population": 77
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_elite0",
     "generation": 3,
-    "fitness": 77.0,
+    "fitness": 59.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_c3",
-      "g2_c3"
+      "g2_elite0",
+      "g2_elite0"
     ],
     "metadata": {
-      "final_population": 77
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c1",
     "generation": 3,
-    "fitness": 83.0,
-    "learning_rate": 1e-06,
+    "fitness": 66.0,
+    "learning_rate": 0.17939481794869772,
     "parent_ids": [
       "g2_c2",
-      "g2_c3"
+      "g2_c7"
     ],
     "metadata": {
-      "final_population": 83
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c2",
     "generation": 3,
-    "fitness": 87.0,
+    "fitness": 62.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_c3",
-      "g2_c5"
+      "g2_c7",
+      "g2_c9"
     ],
     "metadata": {
-      "final_population": 87
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c3",
     "generation": 3,
-    "fitness": 82.0,
+    "fitness": 61.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g2_c1",
-      "g2_c3"
+      "g2_c7"
     ],
     "metadata": {
-      "final_population": 82
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c4",
     "generation": 3,
-    "fitness": 87.0,
-    "learning_rate": 0.1200627406494439,
+    "fitness": 56.0,
+    "learning_rate": 0.17939481794869772,
     "parent_ids": [
-      "g2_c4",
+      "g2_c7",
       "g2_c1"
     ],
     "metadata": {
-      "final_population": 87
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c5",
     "generation": 3,
-    "fitness": 84.0,
+    "fitness": 54.0,
     "learning_rate": 1e-06,
     "parent_ids": [
-      "g2_c6",
-      "g2_c3"
+      "g2_c1",
+      "g2_elite0"
     ],
     "metadata": {
-      "final_population": 84
+      "final_population": 54,
+      "raw_fitness": 54.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c6",
     "generation": 3,
-    "fitness": 92.0,
-    "learning_rate": 0.38291595942999984,
+    "fitness": 59.0,
+    "learning_rate": 0.17939481794869772,
     "parent_ids": [
-      "g2_c6",
-      "g2_c3"
+      "g2_c8",
+      "g2_c7"
     ],
     "metadata": {
-      "final_population": 92
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c7",
     "generation": 3,
-    "fitness": 81.0,
-    "learning_rate": 1e-06,
+    "fitness": 69.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
-      "g2_c6",
-      "g2_c3"
+      "g2_c1",
+      "g2_c7"
     ],
     "metadata": {
-      "final_population": 81
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c8",
     "generation": 3,
-    "fitness": 84.0,
-    "learning_rate": 0.15942878976101,
+    "fitness": 62.0,
+    "learning_rate": 0.10552005530494407,
     "parent_ids": [
-      "g2_c6",
-      "g2_c6"
+      "g2_c1",
+      "g2_c7"
     ],
     "metadata": {
-      "final_population": 84
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g3_c9",
     "generation": 3,
-    "fitness": 72.0,
+    "fitness": 65.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g2_c1",
-      "g2_c3"
+      "g2_c6"
     ],
     "metadata": {
-      "final_population": 72
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_elite0",
     "generation": 4,
-    "fitness": 85.0,
-    "learning_rate": 0.38291595942999984,
+    "fitness": 59.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
-      "g3_c6",
-      "g3_c6"
+      "g3_c7",
+      "g3_c7"
     ],
     "metadata": {
-      "final_population": 85
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c1",
     "generation": 4,
-    "fitness": 80.0,
-    "learning_rate": 1e-06,
+    "fitness": 55.0,
+    "learning_rate": 0.14825433230230892,
     "parent_ids": [
-      "g3_c2",
-      "g3_c5"
+      "g3_c1",
+      "g3_c1"
     ],
     "metadata": {
-      "final_population": 80
+      "final_population": 55,
+      "raw_fitness": 55.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c2",
     "generation": 4,
-    "fitness": 71.0,
-    "learning_rate": 1e-06,
+    "fitness": 67.0,
+    "learning_rate": 0.359561999431531,
     "parent_ids": [
-      "g3_c4",
-      "g3_c2"
+      "g3_c7",
+      "g3_c7"
     ],
     "metadata": {
-      "final_population": 71
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c3",
     "generation": 4,
-    "fitness": 76.0,
-    "learning_rate": 1e-06,
+    "fitness": 70.0,
+    "learning_rate": 0.10552005530494407,
     "parent_ids": [
-      "g3_c5",
-      "g3_c4"
+      "g3_c8",
+      "g3_c2"
     ],
     "metadata": {
-      "final_population": 76
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c4",
     "generation": 4,
-    "fitness": 77.0,
-    "learning_rate": 0.1200627406494439,
+    "fitness": 56.0,
+    "learning_rate": 0.17939481794869772,
     "parent_ids": [
-      "g3_c2",
-      "g3_c4"
+      "g3_c1",
+      "g3_c8"
     ],
     "metadata": {
-      "final_population": 77
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c5",
     "generation": 4,
-    "fitness": 79.0,
-    "learning_rate": 1e-06,
+    "fitness": 65.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
-      "g3_c4",
-      "g3_c2"
+      "g3_c7",
+      "g3_c7"
     ],
     "metadata": {
-      "final_population": 79
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c6",
     "generation": 4,
-    "fitness": 75.0,
-    "learning_rate": 1e-06,
+    "fitness": 70.0,
+    "learning_rate": 0.028747514647896488,
     "parent_ids": [
-      "g3_c8",
-      "g3_c4"
+      "g3_c1",
+      "g3_c1"
     ],
     "metadata": {
-      "final_population": 75
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c7",
     "generation": 4,
-    "fitness": 70.0,
-    "learning_rate": 1e-06,
+    "fitness": 73.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
-      "g3_c6",
-      "g3_c8"
+      "g3_c7",
+      "g3_c7"
     ],
     "metadata": {
-      "final_population": 70
+      "final_population": 73,
+      "raw_fitness": 73.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c8",
     "generation": 4,
-    "fitness": 81.0,
-    "learning_rate": 0.1200627406494439,
+    "fitness": 69.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g3_c6",
-      "g3_c4"
+      "g3_c7",
+      "g3_c3"
     ],
     "metadata": {
-      "final_population": 81
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g4_c9",
     "generation": 4,
-    "fitness": 77.0,
-    "learning_rate": 0.1200627406494439,
+    "fitness": 65.0,
+    "learning_rate": 0.17939481794869772,
     "parent_ids": [
-      "g3_c4",
+      "g3_c3",
       "g3_c1"
     ],
     "metadata": {
-      "final_population": 77
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_elite0",
     "generation": 5,
-    "fitness": 73.0,
-    "learning_rate": 0.38291595942999984,
+    "fitness": 68.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
-      "g4_elite0",
-      "g4_elite0"
+      "g4_c7",
+      "g4_c7"
     ],
     "metadata": {
-      "final_population": 73
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c1",
     "generation": 5,
-    "fitness": 75.0,
-    "learning_rate": 1e-06,
+    "fitness": 60.0,
+    "learning_rate": 0.2942146194328662,
     "parent_ids": [
-      "g4_c1",
-      "g4_elite0"
+      "g4_c3",
+      "g4_c6"
     ],
     "metadata": {
-      "final_population": 75
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c2",
     "generation": 5,
-    "fitness": 84.0,
-    "learning_rate": 1e-06,
+    "fitness": 66.0,
+    "learning_rate": 0.9038223687929717,
     "parent_ids": [
-      "g4_c5",
-      "g4_c9"
+      "g4_c7",
+      "g4_c3"
     ],
     "metadata": {
-      "final_population": 84
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c3",
     "generation": 5,
-    "fitness": 78.0,
-    "learning_rate": 1e-06,
+    "fitness": 69.0,
+    "learning_rate": 0.028747514647896488,
     "parent_ids": [
-      "g4_c8",
-      "g4_c5"
+      "g4_c6",
+      "g4_c6"
     ],
     "metadata": {
-      "final_population": 78
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c4",
     "generation": 5,
-    "fitness": 89.0,
-    "learning_rate": 0.1200627406494439,
+    "fitness": 68.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
-      "g4_c8",
-      "g4_c8"
+      "g4_c7",
+      "g4_c6"
     ],
     "metadata": {
-      "final_population": 89
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c5",
     "generation": 5,
-    "fitness": 78.0,
-    "learning_rate": 0.1200627406494439,
+    "fitness": 69.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
-      "g4_c4",
-      "g4_c9"
+      "g4_c7",
+      "g4_c2"
     ],
     "metadata": {
-      "final_population": 78
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c6",
     "generation": 5,
-    "fitness": 81.0,
-    "learning_rate": 0.38291595942999984,
+    "fitness": 61.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
-      "g4_c1",
-      "g4_elite0"
+      "g4_c7",
+      "g4_c6"
     ],
     "metadata": {
-      "final_population": 81
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c7",
     "generation": 5,
-    "fitness": 80.0,
-    "learning_rate": 0.38291595942999984,
+    "fitness": 64.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g4_elite0",
-      "g4_elite0"
+      "g4_c7",
+      "g4_c8"
     ],
     "metadata": {
-      "final_population": 80
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c8",
     "generation": 5,
-    "fitness": 78.0,
-    "learning_rate": 1e-06,
+    "fitness": 60.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
-      "g4_c1",
-      "g4_c9"
+      "g4_c3",
+      "g4_c7"
     ],
     "metadata": {
-      "final_population": 78
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g5_c9",
     "generation": 5,
-    "fitness": 84.0,
-    "learning_rate": 0.38291595942999984,
+    "fitness": 68.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
-      "g4_elite0",
+      "g4_c8",
       "g4_elite0"
     ],
     "metadata": {
-      "final_population": 84
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g6_elite0",
     "generation": 6,
-    "fitness": 72.0,
-    "learning_rate": 0.1200627406494439,
+    "fitness": 57.0,
+    "learning_rate": 0.028747514647896488,
     "parent_ids": [
-      "g5_c4",
-      "g5_c4"
+      "g5_c3",
+      "g5_c3"
     ],
     "metadata": {
-      "final_population": 72
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g6_c1",
     "generation": 6,
-    "fitness": 72.0,
-    "learning_rate": 0.1200627406494439,
+    "fitness": 57.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
-      "g5_c2",
-      "g5_c4"
+      "g5_c3",
+      "g5_c5"
     ],
     "metadata": {
-      "final_population": 72
+      "final_population": 57,
+      "raw_fitness": 57.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g6_c2",
     "generation": 6,
-    "fitness": 84.0,
-    "learning_rate": 0.38291595942999984,
+    "fitness": 65.0,
+    "learning_rate": 0.028747514647896488,
     "parent_ids": [
-      "g5_c6",
-      "g5_c2"
+      "g5_c3",
+      "g5_elite0"
     ],
     "metadata": {
-      "final_population": 84
+      "final_population": 65,
+      "raw_fitness": 65.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g6_c3",
     "generation": 6,
-    "fitness": 81.0,
-    "learning_rate": 0.10224174522660873,
+    "fitness": 58.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
       "g5_c4",
-      "g5_c2"
+      "g5_c5"
     ],
     "metadata": {
-      "final_population": 81
+      "final_population": 58,
+      "raw_fitness": 58.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g6_c4",
     "generation": 6,
-    "fitness": 83.0,
-    "learning_rate": 0.38291595942999984,
+    "fitness": 73.0,
+    "learning_rate": 0.028747514647896488,
     "parent_ids": [
-      "g5_c7",
-      "g5_c4"
+      "g5_c3",
+      "g5_c5"
     ],
     "metadata": {
-      "final_population": 83
+      "final_population": 73,
+      "raw_fitness": 73.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g6_c5",
     "generation": 6,
-    "fitness": 71.0,
+    "fitness": 63.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "g5_c2",
-      "g5_c6"
+      "g5_c7"
     ],
     "metadata": {
-      "final_population": 71
+      "final_population": 63,
+      "raw_fitness": 63.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g6_c6",
     "generation": 6,
-    "fitness": 86.0,
-    "learning_rate": 0.38291595942999984,
+    "fitness": 60.0,
+    "learning_rate": 0.6330298963068575,
     "parent_ids": [
       "g5_c4",
       "g5_c7"
     ],
     "metadata": {
-      "final_population": 86
+      "final_population": 60,
+      "raw_fitness": 60.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g6_c7",
     "generation": 6,
-    "fitness": 83.0,
-    "learning_rate": 0.41835495000112605,
+    "fitness": 68.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
-      "g5_c7",
-      "g5_c2"
+      "g5_c5",
+      "g5_c5"
     ],
     "metadata": {
-      "final_population": 83
+      "final_population": 68,
+      "raw_fitness": 68.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g6_c8",
     "generation": 6,
-    "fitness": 74.0,
-    "learning_rate": 0.14274781457103763,
+    "fitness": 69.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
       "g5_c2",
       "g5_c4"
     ],
     "metadata": {
-      "final_population": 74
+      "final_population": 69,
+      "raw_fitness": 69.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g6_c9",
     "generation": 6,
-    "fitness": 78.0,
-    "learning_rate": 1e-06,
+    "fitness": 62.0,
+    "learning_rate": 0.576099366126402,
     "parent_ids": [
       "g5_c9",
-      "g5_c2"
+      "g5_elite0"
     ],
     "metadata": {
-      "final_population": 78
+      "final_population": 62,
+      "raw_fitness": 62.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g7_elite0",
     "generation": 7,
-    "fitness": 79.0,
-    "learning_rate": 0.38291595942999984,
+    "fitness": 67.0,
+    "learning_rate": 0.028747514647896488,
     "parent_ids": [
-      "g6_c6",
-      "g6_c6"
+      "g6_c4",
+      "g6_c4"
     ],
     "metadata": {
-      "final_population": 79
+      "final_population": 67,
+      "raw_fitness": 67.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g7_c1",
     "generation": 7,
-    "fitness": 74.0,
-    "learning_rate": 0.38291595942999984,
+    "fitness": 71.0,
+    "learning_rate": 0.2269703882742677,
     "parent_ids": [
-      "g6_c6",
-      "g6_c3"
+      "g6_c5",
+      "g6_c5"
     ],
     "metadata": {
-      "final_population": 74
+      "final_population": 71,
+      "raw_fitness": 71.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g7_c2",
     "generation": 7,
-    "fitness": 74.0,
-    "learning_rate": 0.38291595942999984,
+    "fitness": 59.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
-      "g6_c6",
-      "g6_c9"
+      "g6_c5",
+      "g6_c8"
     ],
     "metadata": {
-      "final_population": 74
+      "final_population": 59,
+      "raw_fitness": 59.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g7_c3",
     "generation": 7,
-    "fitness": 79.0,
-    "learning_rate": 0.38291595942999984,
+    "fitness": 56.0,
+    "learning_rate": 0.05637628627754835,
     "parent_ids": [
-      "g6_c9",
-      "g6_c6"
+      "g6_c5",
+      "g6_c7"
     ],
     "metadata": {
-      "final_population": 79
+      "final_population": 56,
+      "raw_fitness": 56.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g7_c4",
     "generation": 7,
-    "fitness": 84.0,
-    "learning_rate": 0.04288169220621041,
+    "fitness": 61.0,
+    "learning_rate": 0.576099366126402,
     "parent_ids": [
-      "g6_c6",
+      "g6_c9",
       "g6_c2"
     ],
     "metadata": {
-      "final_population": 84
+      "final_population": 61,
+      "raw_fitness": 61.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g7_c5",
     "generation": 7,
-    "fitness": 79.0,
-    "learning_rate": 0.38291595942999984,
+    "fitness": 64.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
-      "g6_c2",
-      "g6_c6"
+      "g6_c8",
+      "g6_c2"
     ],
     "metadata": {
-      "final_population": 79
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g7_c6",
     "generation": 7,
-    "fitness": 76.0,
-    "learning_rate": 0.10224174522660873,
+    "fitness": 66.0,
+    "learning_rate": 1e-06,
     "parent_ids": [
-      "g6_c3",
+      "g6_c5",
       "g6_c7"
     ],
     "metadata": {
-      "final_population": 76
+      "final_population": 66,
+      "raw_fitness": 66.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g7_c7",
     "generation": 7,
-    "fitness": 71.0,
-    "learning_rate": 0.41167896364036644,
+    "fitness": 64.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
       "g6_c2",
-      "g6_c6"
+      "g6_c8"
     ],
     "metadata": {
-      "final_population": 71
+      "final_population": 64,
+      "raw_fitness": 64.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g7_c8",
     "generation": 7,
-    "fitness": 76.0,
-    "learning_rate": 0.5977487679498238,
+    "fitness": 70.0,
+    "learning_rate": 0.576099366126402,
     "parent_ids": [
       "g6_c7",
-      "g6_c6"
+      "g6_c9"
     ],
     "metadata": {
-      "final_population": 76
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g7_c9",
     "generation": 7,
-    "fitness": 82.0,
-    "learning_rate": 0.2849218382699254,
+    "fitness": 70.0,
+    "learning_rate": 0.5039468076366348,
     "parent_ids": [
-      "g6_c3",
-      "g6_c6"
+      "g6_c8",
+      "g6_c5"
     ],
     "metadata": {
-      "final_population": 82
+      "final_population": 70,
+      "raw_fitness": 70.0,
+      "boundary_penalty": 0.0
     }
   }
 ]

--- a/experiments/evolution_smoke/evolution_generation_summaries.json
+++ b/experiments/evolution_smoke/evolution_generation_summaries.json
@@ -5,26 +5,48 @@
     "mean_fitness": 6.0,
     "min_fitness": 6.0,
     "best_candidate_id": "g0_c0",
-    "best_chromosome": {
-      "learning_rate": 0.001,
-      "memory_size": 1000
-    },
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.001,
-        "median": 0.001,
-        "std": 0.0,
-        "min": 0.001,
-        "max": 0.001
+        "mean": 0.06324496448672984,
+        "median": 0.04677503409295469,
+        "std": 0.06705287464972312,
+        "min": 1e-06,
+        "max": 0.15942878976101
+      },
+      "gamma": {
+        "mean": 0.981275913785163,
+        "median": 0.9875518275703261,
+        "std": 0.02072113877802683,
+        "min": 0.95,
+        "max": 1.0
+      },
+      "epsilon_decay": {
+        "mean": 0.8722536710191502,
+        "median": 0.9011948778566765,
+        "std": 0.132335882752154,
+        "min": 0.6866249283632477,
+        "max": 1.0
       },
       "memory_size": {
-        "mean": 1000.0,
-        "median": 1000.0,
+        "mean": 2000,
+        "median": 2000.0,
         "std": 0.0,
-        "min": 1000,
-        "max": 1000
+        "min": 2000,
+        "max": 2000
       }
-    }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.001,
+      "gamma": 0.95,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    },
+    "mutation_rate_used": null,
+    "mutation_scale_used": null,
+    "mutation_rate_multiplier": null,
+    "mutation_scale_multiplier": null,
+    "diversity": 0.07336998774428188,
+    "adaptive_event": "initial_seeding"
   },
   {
     "generation": 1,
@@ -32,25 +54,47 @@
     "mean_fitness": 6.0,
     "min_fitness": 6.0,
     "best_candidate_id": "g1_elite0",
-    "best_chromosome": {
-      "learning_rate": 0.001,
-      "memory_size": 1000
-    },
     "gene_statistics": {
       "learning_rate": {
-        "mean": 0.001,
-        "median": 0.001,
-        "std": 0.0,
+        "mean": 0.08638223153320719,
+        "median": 0.09255006818590938,
+        "std": 0.05635159613637137,
         "min": 0.001,
-        "max": 0.001
+        "max": 0.15942878976101
+      },
+      "gamma": {
+        "mean": 0.9265723072955181,
+        "median": 0.975,
+        "std": 0.10040970519458406,
+        "min": 0.7562892291820724,
+        "max": 1.0
+      },
+      "epsilon_decay": {
+        "mean": 0.8408124641816239,
+        "median": 0.8408124641816239,
+        "std": 0.15418753581837613,
+        "min": 0.6866249283632477,
+        "max": 0.995
       },
       "memory_size": {
-        "mean": 1000.0,
-        "median": 1000.0,
+        "mean": 2000,
+        "median": 2000.0,
         "std": 0.0,
-        "min": 1000,
-        "max": 1000
+        "min": 2000,
+        "max": 2000
       }
-    }
+    },
+    "best_chromosome": {
+      "learning_rate": 0.001,
+      "gamma": 0.95,
+      "epsilon_decay": 0.995,
+      "memory_size": 2000
+    },
+    "mutation_rate_used": 0.25,
+    "mutation_scale_used": 0.2,
+    "mutation_rate_multiplier": 1.0,
+    "mutation_scale_multiplier": 1.0,
+    "diversity": 0.10364963116699469,
+    "adaptive_event": "disabled"
   }
 ]

--- a/experiments/evolution_smoke/evolution_lineage.json
+++ b/experiments/evolution_smoke/evolution_lineage.json
@@ -9,46 +9,54 @@
       "seed"
     ],
     "metadata": {
-      "final_population": 6
+      "final_population": 6,
+      "raw_fitness": 6.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g0_c1",
     "generation": 0,
     "fitness": 6.0,
-    "learning_rate": 1e-06,
+    "learning_rate": 0.15942878976101,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 6
+      "final_population": 6,
+      "raw_fitness": 6.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g0_c2",
     "generation": 0,
     "fitness": 6.0,
-    "learning_rate": 0.004224876496908031,
-    "parent_ids": [
-      "seed",
-      "seed"
-    ],
-    "metadata": {
-      "final_population": 6
-    }
-  },
-  {
-    "candidate_id": "g0_c3",
-    "generation": 0,
-    "fitness": 6.0,
     "learning_rate": 1e-06,
     "parent_ids": [
       "seed",
       "seed"
     ],
     "metadata": {
-      "final_population": 6
+      "final_population": 6,
+      "raw_fitness": 6.0,
+      "boundary_penalty": 0.0
+    }
+  },
+  {
+    "candidate_id": "g0_c3",
+    "generation": 0,
+    "fitness": 6.0,
+    "learning_rate": 0.09255006818590938,
+    "parent_ids": [
+      "seed",
+      "seed"
+    ],
+    "metadata": {
+      "final_population": 6,
+      "raw_fitness": 6.0,
+      "boundary_penalty": 0.0
     }
   },
   {
@@ -61,46 +69,54 @@
       "g0_c0"
     ],
     "metadata": {
-      "final_population": 6
+      "final_population": 6,
+      "raw_fitness": 6.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c1",
     "generation": 1,
     "fitness": 6.0,
-    "learning_rate": 1e-06,
+    "learning_rate": 0.15942878976101,
     "parent_ids": [
       "g0_c0",
       "g0_c1"
     ],
     "metadata": {
-      "final_population": 6
+      "final_population": 6,
+      "raw_fitness": 6.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c2",
     "generation": 1,
     "fitness": 6.0,
-    "learning_rate": 1e-06,
+    "learning_rate": 0.09255006818590938,
     "parent_ids": [
       "g0_c0",
       "g0_c3"
     ],
     "metadata": {
-      "final_population": 6
+      "final_population": 6,
+      "raw_fitness": 6.0,
+      "boundary_penalty": 0.0
     }
   },
   {
     "candidate_id": "g1_c3",
     "generation": 1,
     "fitness": 6.0,
-    "learning_rate": 1e-06,
+    "learning_rate": 0.09255006818590938,
     "parent_ids": [
       "g0_c3",
       "g0_c1"
     ],
     "metadata": {
-      "final_population": 6
+      "final_population": 6,
+      "raw_fitness": 6.0,
+      "boundary_penalty": 0.0
     }
   }
 ]

--- a/farm/core/hyperparameter_chromosome.py
+++ b/farm/core/hyperparameter_chromosome.py
@@ -357,8 +357,12 @@ class HyperparameterChromosome:
 # Default encoding policy by gene name.
 # learning_rate uses log-space 8-bit quantization so equal bucket changes map to
 # multiplicative LR changes, which is typically more meaningful than linear shifts.
+# epsilon_decay and gamma use linear 8-bit quantization; their ranges are bounded
+# and do not span multiple orders of magnitude in a way that requires log space.
 DEFAULT_GENE_ENCODINGS: Dict[str, GeneEncodingSpec] = {
     "learning_rate": GeneEncodingSpec(scale=GeneEncodingScale.LOG, bit_width=8),
+    "epsilon_decay": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "gamma": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
 }
 
 # Smallest positive IEEE-754 binary64; mirrors DecisionConfig allowing any (0, 1].
@@ -366,8 +370,9 @@ _EPSILON_DECAY_GENE_MIN = math.ldexp(1.0, -1074)
 
 
 # Default hyperparameter loci.
-# learning_rate is enabled for evolution now; others are placeholders that
-# document the extension path while remaining fixed in global config.
+# learning_rate, gamma, and epsilon_decay are enabled for evolution; memory_size
+# remains a fixed placeholder documenting the extension path while keeping integer
+# rounding concerns separate from the continuous-gene evolution phase.
 DEFAULT_HYPERPARAMETER_GENES: Tuple[HyperparameterGene, ...] = (
     HyperparameterGene(
         name="learning_rate",
@@ -379,13 +384,22 @@ DEFAULT_HYPERPARAMETER_GENES: Tuple[HyperparameterGene, ...] = (
         evolvable=True,
     ),
     HyperparameterGene(
+        name="gamma",
+        value_type=GeneValueType.REAL,
+        value=0.99,
+        min_value=0.0,
+        max_value=1.0,
+        default=0.99,
+        evolvable=True,
+    ),
+    HyperparameterGene(
         name="epsilon_decay",
         value_type=GeneValueType.REAL,
         value=0.995,
         min_value=_EPSILON_DECAY_GENE_MIN,
         max_value=1.0,
         default=0.995,
-        evolvable=False,
+        evolvable=True,
     ),
     HyperparameterGene(
         name="memory_size",

--- a/farm/runners/adaptive_mutation.py
+++ b/farm/runners/adaptive_mutation.py
@@ -71,7 +71,10 @@ class AdaptiveMutationConfig:
             the mean normalized gene diversity falls below
             ``diversity_threshold``.
         stall_window: Number of generations to look back for improvement.
-            Must be >= 1.
+            Must be >= 1. During startup, when fewer than
+            ``stall_window + 1`` observations exist, the controller uses the
+            available history so adaptation can begin without waiting for a
+            full window.
         improvement_threshold: Minimum absolute increase in best fitness over
             the window that counts as "improving".  Increases smaller than
             (or equal to) this value are treated as a stall.  Must be >= 0.

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -117,6 +117,7 @@ class EvolutionCandidateEvaluation:
     generation: int
     fitness: float
     learning_rate: float
+    chromosome_values: Dict[str, float]
     parent_ids: Tuple[str, str]
     metadata: Dict[str, Any]
 
@@ -318,6 +319,7 @@ class EvolutionExperiment:
                     generation=generation,
                     fitness=adjusted_fitness,
                     learning_rate=candidate.chromosome.get_value("learning_rate"),
+                    chromosome_values=self._serialize_chromosome_values(candidate.chromosome),
                     parent_ids=candidate.parent_ids,
                     metadata=metadata_with_lineage,
                 )
@@ -437,10 +439,7 @@ class EvolutionExperiment:
         resolved_gene_statistics = (
             gene_statistics if gene_statistics is not None else self._build_gene_statistics(generation_evals)
         )
-        best_chromosome = {
-            gene.name: gene.value
-            for gene in best.metadata["chromosome"].genes
-        }
+        best_chromosome = self._serialize_chromosome_values(best.metadata["chromosome"])
         produced = produced_with or _ProducedWith.initial()
         return EvolutionGenerationSummary(
             generation=generation,
@@ -500,6 +499,10 @@ class EvolutionExperiment:
                 "max": max(values),
             }
         return gene_statistics
+
+    def _serialize_chromosome_values(self, chromosome: HyperparameterChromosome) -> Dict[str, float]:
+        """Return a stable gene-name/value mapping for artifact serialization."""
+        return {gene.name: gene.value for gene in chromosome.genes}
 
     def _config_for_chromosome(self, chromosome: HyperparameterChromosome) -> SimulationConfig:
         config_copy = self.base_config.copy()
@@ -570,6 +573,7 @@ class EvolutionExperiment:
                 "generation": evaluation.generation,
                 "fitness": evaluation.fitness,
                 "learning_rate": evaluation.learning_rate,
+                "chromosome": evaluation.chromosome_values,
                 "parent_ids": list(evaluation.parent_ids),
                 "metadata": {
                     key: value

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -184,6 +184,10 @@ class TestEvolutionExperiment(unittest.TestCase):
             self.assertEqual(len(lineage), 8)
             self.assertEqual(lineage[0]["generation"], 0)
             self.assertEqual(lineage[-1]["generation"], 1)
+            self.assertIn("chromosome", lineage[0])
+            self.assertIn("learning_rate", lineage[0]["chromosome"])
+            self.assertIn("gamma", lineage[0]["chromosome"])
+            self.assertIn("epsilon_decay", lineage[0]["chromosome"])
             self.assertIn("gene_statistics", summaries[0])
             self.assertIn("learning_rate", summaries[0]["gene_statistics"])
             self.assertIn("gamma", summaries[0]["gene_statistics"])
@@ -378,6 +382,35 @@ class TestEvolutionExperimentAdaptiveMutation(unittest.TestCase):
         self.assertAlmostEqual(gen1.mutation_rate_multiplier, 1.0)
         self.assertGreater(gen2.mutation_rate_multiplier, gen1.mutation_rate_multiplier)
         self.assertAlmostEqual(gen2.mutation_rate_used, 0.2 * gen2.mutation_rate_multiplier)
+        self.assertIn("stalled", gen2.adaptive_event)
+
+    def test_adaptive_warmup_uses_partial_history_before_full_stall_window(self):
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=3,
+            population_size=3,
+            num_steps_per_candidate=1,
+            mutation_rate=0.2,
+            adaptive_mutation=AdaptiveMutationConfig(
+                enabled=True,
+                use_fitness_adaptation=True,
+                use_diversity_adaptation=False,
+                stall_window=5,
+                stall_multiplier=2.0,
+                improvement_threshold=1e-6,
+            ),
+            seed=123,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        # Flat fitness should trigger stall adaptation as soon as enough history
+        # exists to compare latest-vs-prior best (without waiting for a full
+        # stall_window+1 observations).
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, generation, member: (1.0, {"member": member})
+        )
+        _, gen1, gen2 = result.generation_summaries
+        self.assertAlmostEqual(gen1.mutation_rate_multiplier, 1.0)
+        self.assertGreater(gen2.mutation_rate_multiplier, 1.0)
         self.assertIn("stalled", gen2.adaptive_event)
 
     @patch("farm.runners.evolution_experiment.mutate_chromosome")

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -217,6 +217,10 @@ class TestEvolutionExperiment(unittest.TestCase):
     def test_boundary_penalty_adjusts_candidate_fitness(self):
         base_config = SimulationConfig()
         base_config.learning.learning_rate = 1e-6
+        # Move all other evolvable genes well inside bounds so only learning_rate
+        # (at its min boundary) incurs a penalty, keeping the expected values simple.
+        base_config.learning.gamma = 0.5
+        base_config.learning.epsilon_decay = 0.5
         config = EvolutionExperimentConfig(
             num_generations=1,
             population_size=3,

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -186,11 +186,15 @@ class TestEvolutionExperiment(unittest.TestCase):
             self.assertEqual(lineage[-1]["generation"], 1)
             self.assertIn("gene_statistics", summaries[0])
             self.assertIn("learning_rate", summaries[0]["gene_statistics"])
+            self.assertIn("gamma", summaries[0]["gene_statistics"])
+            self.assertIn("epsilon_decay", summaries[0]["gene_statistics"])
             self.assertIn("mean", summaries[0]["gene_statistics"]["learning_rate"])
             self.assertIn("median", summaries[0]["gene_statistics"]["learning_rate"])
             self.assertIn("std", summaries[0]["gene_statistics"]["learning_rate"])
             self.assertIn("best_chromosome", summaries[0])
             self.assertIn("learning_rate", summaries[0]["best_chromosome"])
+            self.assertIn("gamma", summaries[0]["best_chromosome"])
+            self.assertIn("epsilon_decay", summaries[0]["best_chromosome"])
 
     def test_repeated_run_on_same_instance_is_deterministic_with_seed(self):
         base_config = SimulationConfig()

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -71,8 +71,11 @@ def test_reproduce_mutates_learning_rate_and_passes_child_config():
     child_config = kwargs["config"]
     assert child_config is not parent.config
     assert child_config.decision.learning_rate == 0.012
-    # Placeholder genes remain fixed by default registry.
-    assert child_config.decision.epsilon_decay == 0.995
+    # epsilon_decay and gamma are now evolvable; gauss patched to 0.002 shifts both.
+    # span ≈ 1.0, mutation_scale (default) = 0.2 → sigma = 0.2 → delta = 0.002
+    assert child_config.decision.epsilon_decay == pytest.approx(0.997, abs=1e-9)
+    assert child_config.decision.gamma == pytest.approx(0.992, abs=1e-9)
+    # memory_size is fixed (evolvable=False) and stays at the parent value.
     assert child_config.decision.memory_size == 2000
     assert offspring.hyperparameter_chromosome.get_value("learning_rate") == 0.012
 

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -72,7 +72,8 @@ def test_reproduce_mutates_learning_rate_and_passes_child_config():
     assert child_config is not parent.config
     assert child_config.decision.learning_rate == 0.012
     # epsilon_decay and gamma are now evolvable; gauss patched to 0.002 shifts both.
-    # span ≈ 1.0, mutation_scale (default) = 0.2 → sigma = 0.2 → delta = 0.002
+    # gamma: span = 1.0, mutation_scale (default) = 0.2 → sigma = 0.2 → delta = 0.002
+    # epsilon_decay: span ≈ 1.0, mutation_scale = 0.2 → sigma ≈ 0.2 → delta = 0.002
     assert child_config.decision.epsilon_decay == pytest.approx(0.997, abs=1e-9)
     assert child_config.decision.gamma == pytest.approx(0.992, abs=1e-9)
     # memory_size is fixed (evolvable=False) and stays at the parent value.

--- a/tests/test_hyperparameter_chromosome.py
+++ b/tests/test_hyperparameter_chromosome.py
@@ -465,13 +465,14 @@ class TestAdditionalContinuousGenes(unittest.TestCase):
 
     def test_epsilon_decay_mutation_stays_in_bounds(self):
         chromosome = chromosome_from_values({"epsilon_decay": 0.5})
+        ed_min = chromosome.get_gene("epsilon_decay").min_value
         rng = random.Random(13)
         for _ in range(50):
             chromosome = mutate_chromosome(
                 chromosome, mutation_rate=1.0, mutation_scale=1.0, rng=rng
             )
             ed = chromosome.get_value("epsilon_decay")
-            self.assertGreater(ed, 0.0)
+            self.assertGreaterEqual(ed, ed_min)
             self.assertLessEqual(ed, 1.0)
 
     # --- crossover: all evolvable genes participate ---
@@ -491,6 +492,7 @@ class TestAdditionalContinuousGenes(unittest.TestCase):
     def test_crossover_then_mutation_keeps_all_evolvable_in_bounds(self):
         parent_a = chromosome_from_values({"learning_rate": 1e-6, "gamma": 0.0, "epsilon_decay": 0.9})
         parent_b = chromosome_from_values({"learning_rate": 1.0, "gamma": 1.0, "epsilon_decay": 1.0})
+        ed_min = parent_a.get_gene("epsilon_decay").min_value
         child = crossover_chromosomes(
             parent_a, parent_b, mode=CrossoverMode.BLEND, blend_alpha=0.5, rng=random.Random(9)
         )
@@ -499,7 +501,7 @@ class TestAdditionalContinuousGenes(unittest.TestCase):
         self.assertLessEqual(mutated.get_value("learning_rate"), 1.0)
         self.assertGreaterEqual(mutated.get_value("gamma"), 0.0)
         self.assertLessEqual(mutated.get_value("gamma"), 1.0)
-        self.assertGreater(mutated.get_value("epsilon_decay"), 0.0)
+        self.assertGreaterEqual(mutated.get_value("epsilon_decay"), ed_min)
         self.assertLessEqual(mutated.get_value("epsilon_decay"), 1.0)
 
     # --- config projection ---
@@ -531,6 +533,7 @@ class TestAdditionalContinuousGenes(unittest.TestCase):
         self.assertAlmostEqual(chromosome.get_value("memory_size"), 2000.0)
 
 
+class TestHyperparameterEncoding(unittest.TestCase):
     def test_learning_rate_quantized_encoding_uses_8bit_bounds(self):
         chromosome = default_hyperparameter_chromosome()
         learning_rate_gene = chromosome.get_gene("learning_rate")

--- a/tests/test_hyperparameter_chromosome.py
+++ b/tests/test_hyperparameter_chromosome.py
@@ -992,31 +992,15 @@ class TestComputeBoundaryPenalty(unittest.TestCase):
         self.assertEqual(compute_boundary_penalty(chromosome, cfg), 0.0)
 
     def test_full_penalty_at_max_boundary(self):
-        gene = HyperparameterGene(
-            name="learning_rate",
-            value_type=GeneValueType.REAL,
-            value=1.0,
-            min_value=1e-6,
-            max_value=1.0,
-            default=0.001,
-            evolvable=True,
-        )
-        chromosome = HyperparameterChromosome(genes=(gene,))
+        # Set all other evolvable genes to midpoints so only learning_rate (at max) incurs a penalty.
+        chromosome = chromosome_from_values({"learning_rate": 1.0, "gamma": 0.5, "epsilon_decay": 0.5})
         cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.05, near_boundary_threshold=0.1)
         penalty = compute_boundary_penalty(chromosome, cfg)
         self.assertAlmostEqual(penalty, 0.05)
 
     def test_full_penalty_at_min_boundary(self):
-        gene = HyperparameterGene(
-            name="learning_rate",
-            value_type=GeneValueType.REAL,
-            value=1e-6,
-            min_value=1e-6,
-            max_value=1.0,
-            default=0.001,
-            evolvable=True,
-        )
-        chromosome = HyperparameterChromosome(genes=(gene,))
+        # Set all other evolvable genes to midpoints so only learning_rate (at min) incurs a penalty.
+        chromosome = chromosome_from_values({"learning_rate": 1e-6, "gamma": 0.5, "epsilon_decay": 0.5})
         cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.05, near_boundary_threshold=0.1)
         penalty = compute_boundary_penalty(chromosome, cfg)
         self.assertAlmostEqual(penalty, 0.05)

--- a/tests/test_hyperparameter_chromosome.py
+++ b/tests/test_hyperparameter_chromosome.py
@@ -74,7 +74,8 @@ class TestHyperparameterChromosome(unittest.TestCase):
     def test_default_registry_marks_evolvable_vs_fixed(self):
         registry = hyperparameter_evolution_registry()
         self.assertTrue(registry["learning_rate"])
-        self.assertFalse(registry["epsilon_decay"])
+        self.assertTrue(registry["gamma"])
+        self.assertTrue(registry["epsilon_decay"])
         self.assertFalse(registry["memory_size"])
 
     def test_short_registry_alias_matches_evolution_registry(self):
@@ -143,7 +144,6 @@ class TestHyperparameterChromosome(unittest.TestCase):
         with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=0.05):
             mutated = mutate_chromosome(chromosome, mutation_rate=1.0, mutation_scale=0.1)
         self.assertNotEqual(mutated.get_value("learning_rate"), chromosome.get_value("learning_rate"))
-        self.assertEqual(mutated.get_value("epsilon_decay"), chromosome.get_value("epsilon_decay"))
         self.assertEqual(mutated.get_value("memory_size"), chromosome.get_value("memory_size"))
 
     def test_gaussian_mutation_clamps_to_gene_bounds(self):
@@ -292,7 +292,6 @@ class TestHyperparameterChromosome(unittest.TestCase):
                 mutation_scale=1.0,
                 mutation_mode=MutationMode.GAUSSIAN,
             )
-        self.assertEqual(mutated.get_value("epsilon_decay"), chromosome.get_value("epsilon_decay"))
         self.assertEqual(mutated.get_value("memory_size"), chromosome.get_value("memory_size"))
 
     def test_apply_chromosome_to_learning_config(self):
@@ -318,7 +317,220 @@ class TestHyperparameterChromosome(unittest.TestCase):
         self.assertEqual(stub.learning_rate, 0.02)
 
 
-class TestHyperparameterEncoding(unittest.TestCase):
+class TestAdditionalContinuousGenes(unittest.TestCase):
+    """Tests for the two additional evolvable continuous genes: gamma and epsilon_decay."""
+
+    # --- gamma gene: bounds, defaults, serialization ---
+
+    def test_default_chromosome_contains_gamma(self):
+        chromosome = default_hyperparameter_chromosome()
+        self.assertAlmostEqual(chromosome.get_value("gamma"), 0.99)
+
+    def test_gamma_gene_bounds_valid(self):
+        chromosome = chromosome_from_values({"gamma": 0.0})
+        self.assertEqual(chromosome.get_value("gamma"), 0.0)
+        chromosome = chromosome_from_values({"gamma": 1.0})
+        self.assertEqual(chromosome.get_value("gamma"), 1.0)
+
+    def test_gamma_gene_rejects_out_of_range_value(self):
+        with self.assertRaises(ValueError):
+            chromosome_from_values({"gamma": 1.5})
+
+    def test_gamma_gene_rejects_below_min(self):
+        with self.assertRaises(ValueError):
+            chromosome_from_values({"gamma": -0.1})
+
+    # --- epsilon_decay gene: now evolvable ---
+
+    def test_epsilon_decay_is_evolvable(self):
+        chromosome = default_hyperparameter_chromosome()
+        self.assertIn("epsilon_decay", chromosome.evolvable_gene_names())
+
+    def test_gamma_is_evolvable(self):
+        chromosome = default_hyperparameter_chromosome()
+        self.assertIn("gamma", chromosome.evolvable_gene_names())
+
+    def test_memory_size_is_still_fixed(self):
+        chromosome = default_hyperparameter_chromosome()
+        self.assertIn("memory_size", chromosome.fixed_gene_names())
+        self.assertNotIn("memory_size", chromosome.evolvable_gene_names())
+
+    # --- serialization round-trips for new genes ---
+
+    def test_gamma_serialization_round_trip(self):
+        original = chromosome_from_values({"gamma": 0.75})
+        restored = HyperparameterChromosome.from_dict(original.to_dict())
+        self.assertAlmostEqual(restored.get_value("gamma"), 0.75, places=15)
+
+    def test_all_genes_serialization_round_trip(self):
+        original = chromosome_from_values({
+            "learning_rate": 0.005,
+            "gamma": 0.95,
+            "epsilon_decay": 0.99,
+            "memory_size": 5000.0,
+        })
+        restored = HyperparameterChromosome.from_dict(original.to_dict())
+        self.assertAlmostEqual(restored.get_value("learning_rate"), 0.005, places=15)
+        self.assertAlmostEqual(restored.get_value("gamma"), 0.95, places=15)
+        self.assertAlmostEqual(restored.get_value("epsilon_decay"), 0.99, places=15)
+        self.assertAlmostEqual(restored.get_value("memory_size"), 5000.0, places=15)
+
+    def test_all_genes_serialization_through_json(self):
+        original = chromosome_from_values({"learning_rate": 0.003, "gamma": 0.97, "epsilon_decay": 0.998})
+        as_json = json.dumps(original.to_dict(), sort_keys=True)
+        restored = HyperparameterChromosome.from_dict(json.loads(as_json))
+        self.assertAlmostEqual(restored.get_value("learning_rate"), 0.003, places=15)
+        self.assertAlmostEqual(restored.get_value("gamma"), 0.97, places=15)
+        self.assertAlmostEqual(restored.get_value("epsilon_decay"), 0.998, places=15)
+
+    # --- encode/decode for new genes ---
+
+    def test_gamma_encode_decode_round_trip(self):
+        chromosome = default_hyperparameter_chromosome()
+        gamma_gene = chromosome.get_gene("gamma")
+        assert gamma_gene is not None
+        for value in (0.0, 0.5, 0.9, 0.99, 1.0):
+            encoded = gamma_gene.encode(value)
+            decoded = gamma_gene.decode(encoded)
+            self.assertAlmostEqual(decoded, value, delta=0.01)
+
+    def test_gamma_encoding_uses_8bit_bounds(self):
+        chromosome = default_hyperparameter_chromosome()
+        gamma_gene = chromosome.get_gene("gamma")
+        assert gamma_gene is not None
+        self.assertEqual(gamma_gene.encode(gamma_gene.min_value), 0)
+        self.assertEqual(gamma_gene.encode(gamma_gene.max_value), 255)
+
+    def test_epsilon_decay_encode_decode_round_trip(self):
+        chromosome = default_hyperparameter_chromosome()
+        ed_gene = chromosome.get_gene("epsilon_decay")
+        assert ed_gene is not None
+        for value in (0.9, 0.95, 0.995, 1.0):
+            encoded = ed_gene.encode(value)
+            decoded = ed_gene.decode(encoded)
+            # Linear 8-bit encoding has quantization error ~1/255 of the range (~0.004)
+            self.assertAlmostEqual(decoded, value, delta=0.005)
+
+    def test_epsilon_decay_encoding_uses_8bit_bounds(self):
+        chromosome = default_hyperparameter_chromosome()
+        ed_gene = chromosome.get_gene("epsilon_decay")
+        assert ed_gene is not None
+        self.assertEqual(ed_gene.encode(ed_gene.min_value), 0)
+        self.assertEqual(ed_gene.encode(ed_gene.max_value), 255)
+
+    def test_multi_gene_chromosome_encode_decode_round_trip(self):
+        chromosome = chromosome_from_values({"learning_rate": 0.005, "gamma": 0.95, "epsilon_decay": 0.99})
+        encoded = encode_chromosome(chromosome)
+        decoded = decode_chromosome(encoded, template=chromosome)
+        self.assertAlmostEqual(decoded.get_value("learning_rate"), 0.005, delta=0.005 * 0.06)
+        self.assertAlmostEqual(decoded.get_value("gamma"), 0.95, delta=0.01)
+        self.assertAlmostEqual(decoded.get_value("epsilon_decay"), 0.99, delta=0.005)
+
+    def test_multi_gene_chromosome_vector_encode_decode_round_trip(self):
+        chromosome = chromosome_from_values({"learning_rate": 0.005, "gamma": 0.95, "epsilon_decay": 0.99})
+        vec = encode_chromosome_vector(chromosome)
+        # 3 evolvable genes → 3-element vector
+        self.assertEqual(len(vec), 3)
+        decoded = decode_chromosome_vector(vec, template=chromosome)
+        self.assertAlmostEqual(decoded.get_value("learning_rate"), 0.005, delta=0.005 * 0.06)
+        self.assertAlmostEqual(decoded.get_value("gamma"), 0.95, delta=0.01)
+        self.assertAlmostEqual(decoded.get_value("epsilon_decay"), 0.99, delta=0.005)
+
+    # --- mutation: all evolvable genes change, fixed unchanged ---
+
+    def test_multi_gene_mutation_changes_all_evolvable_genes(self):
+        chromosome = chromosome_from_values({
+            "learning_rate": 0.5,
+            "gamma": 0.5,
+            "epsilon_decay": 0.5,
+        })
+        rng = random.Random(42)
+        mutated = mutate_chromosome(chromosome, mutation_rate=1.0, mutation_scale=0.1, rng=rng)
+        # All three evolvable genes should move; memory_size stays fixed.
+        self.assertNotEqual(mutated.get_value("learning_rate"), 0.5)
+        self.assertNotEqual(mutated.get_value("gamma"), 0.5)
+        self.assertNotEqual(mutated.get_value("epsilon_decay"), 0.5)
+        self.assertEqual(mutated.get_value("memory_size"), chromosome.get_value("memory_size"))
+
+    def test_gamma_mutation_stays_in_bounds(self):
+        chromosome = chromosome_from_values({"gamma": 0.99})
+        rng = random.Random(7)
+        for _ in range(50):
+            chromosome = mutate_chromosome(
+                chromosome, mutation_rate=1.0, mutation_scale=1.0, rng=rng
+            )
+            g = chromosome.get_value("gamma")
+            self.assertGreaterEqual(g, 0.0)
+            self.assertLessEqual(g, 1.0)
+
+    def test_epsilon_decay_mutation_stays_in_bounds(self):
+        chromosome = chromosome_from_values({"epsilon_decay": 0.5})
+        rng = random.Random(13)
+        for _ in range(50):
+            chromosome = mutate_chromosome(
+                chromosome, mutation_rate=1.0, mutation_scale=1.0, rng=rng
+            )
+            ed = chromosome.get_value("epsilon_decay")
+            self.assertGreater(ed, 0.0)
+            self.assertLessEqual(ed, 1.0)
+
+    # --- crossover: all evolvable genes participate ---
+
+    def test_crossover_mixes_all_evolvable_genes(self):
+        parent_a = chromosome_from_values({"learning_rate": 0.01, "gamma": 0.8, "epsilon_decay": 0.9})
+        parent_b = chromosome_from_values({"learning_rate": 0.5, "gamma": 0.99, "epsilon_decay": 0.999})
+        child = crossover_chromosomes(
+            parent_a, parent_b, mode=CrossoverMode.UNIFORM, uniform_parent_b_probability=0.5,
+            rng=random.Random(3),
+        )
+        # Each evolvable gene should come from one of the two parents.
+        self.assertIn(child.get_value("learning_rate"), (0.01, 0.5))
+        self.assertIn(child.get_value("gamma"), (0.8, 0.99))
+        self.assertIn(child.get_value("epsilon_decay"), (0.9, 0.999))
+
+    def test_crossover_then_mutation_keeps_all_evolvable_in_bounds(self):
+        parent_a = chromosome_from_values({"learning_rate": 1e-6, "gamma": 0.0, "epsilon_decay": 0.9})
+        parent_b = chromosome_from_values({"learning_rate": 1.0, "gamma": 1.0, "epsilon_decay": 1.0})
+        child = crossover_chromosomes(
+            parent_a, parent_b, mode=CrossoverMode.BLEND, blend_alpha=0.5, rng=random.Random(9)
+        )
+        mutated = mutate_chromosome(child, mutation_rate=1.0, mutation_scale=1.0, rng=random.Random(17))
+        self.assertGreaterEqual(mutated.get_value("learning_rate"), 1e-6)
+        self.assertLessEqual(mutated.get_value("learning_rate"), 1.0)
+        self.assertGreaterEqual(mutated.get_value("gamma"), 0.0)
+        self.assertLessEqual(mutated.get_value("gamma"), 1.0)
+        self.assertGreater(mutated.get_value("epsilon_decay"), 0.0)
+        self.assertLessEqual(mutated.get_value("epsilon_decay"), 1.0)
+
+    # --- config projection ---
+
+    def test_apply_chromosome_projects_gamma_to_decision_config(self):
+        decision = DecisionConfig(learning_rate=0.001, gamma=0.99)
+        chromosome = chromosome_from_values({"learning_rate": 0.005, "gamma": 0.95})
+        updated = apply_chromosome_to_learning_config(decision, chromosome)
+        self.assertAlmostEqual(updated.learning_rate, 0.005)
+        self.assertAlmostEqual(updated.gamma, 0.95)
+
+    def test_apply_chromosome_projects_epsilon_decay_to_decision_config(self):
+        decision = DecisionConfig(epsilon_decay=0.995)
+        chromosome = chromosome_from_values({"epsilon_decay": 0.98})
+        updated = apply_chromosome_to_learning_config(decision, chromosome)
+        self.assertAlmostEqual(updated.epsilon_decay, 0.98)
+
+    def test_chromosome_from_learning_config_picks_up_gamma(self):
+        decision = DecisionConfig(gamma=0.95)
+        chromosome = chromosome_from_learning_config(decision)
+        self.assertAlmostEqual(chromosome.get_value("gamma"), 0.95)
+
+    def test_chromosome_from_learning_config_picks_up_all_new_evolvable_genes(self):
+        decision = DecisionConfig(learning_rate=0.005, gamma=0.97, epsilon_decay=0.992, memory_size=2000)
+        chromosome = chromosome_from_learning_config(decision)
+        self.assertAlmostEqual(chromosome.get_value("learning_rate"), 0.005)
+        self.assertAlmostEqual(chromosome.get_value("gamma"), 0.97)
+        self.assertAlmostEqual(chromosome.get_value("epsilon_decay"), 0.992)
+        self.assertAlmostEqual(chromosome.get_value("memory_size"), 2000.0)
+
+
     def test_learning_rate_quantized_encoding_uses_8bit_bounds(self):
         chromosome = default_hyperparameter_chromosome()
         learning_rate_gene = chromosome.get_gene("learning_rate")
@@ -777,19 +989,37 @@ class TestComputeBoundaryPenalty(unittest.TestCase):
         self.assertEqual(compute_boundary_penalty(chromosome, cfg), 0.0)
 
     def test_full_penalty_at_max_boundary(self):
-        chromosome = chromosome_from_values({"learning_rate": 1.0})
+        gene = HyperparameterGene(
+            name="learning_rate",
+            value_type=GeneValueType.REAL,
+            value=1.0,
+            min_value=1e-6,
+            max_value=1.0,
+            default=0.001,
+            evolvable=True,
+        )
+        chromosome = HyperparameterChromosome(genes=(gene,))
         cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.05, near_boundary_threshold=0.1)
         penalty = compute_boundary_penalty(chromosome, cfg)
         self.assertAlmostEqual(penalty, 0.05)
 
     def test_full_penalty_at_min_boundary(self):
-        chromosome = chromosome_from_values({"learning_rate": 1e-6})
+        gene = HyperparameterGene(
+            name="learning_rate",
+            value_type=GeneValueType.REAL,
+            value=1e-6,
+            min_value=1e-6,
+            max_value=1.0,
+            default=0.001,
+            evolvable=True,
+        )
+        chromosome = HyperparameterChromosome(genes=(gene,))
         cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.05, near_boundary_threshold=0.1)
         penalty = compute_boundary_penalty(chromosome, cfg)
         self.assertAlmostEqual(penalty, 0.05)
 
     def test_zero_penalty_well_inside_bounds(self):
-        chromosome = chromosome_from_values({"learning_rate": 0.5})
+        chromosome = chromosome_from_values({"learning_rate": 0.5, "gamma": 0.5, "epsilon_decay": 0.5})
         cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.1, near_boundary_threshold=0.05)
         penalty = compute_boundary_penalty(chromosome, cfg)
         self.assertEqual(penalty, 0.0)
@@ -812,13 +1042,16 @@ class TestComputeBoundaryPenalty(unittest.TestCase):
 
     def test_no_penalty_for_fixed_genes(self):
         chromosome = default_hyperparameter_chromosome()
-        # epsilon_decay and memory_size are fixed (evolvable=False)
-        # Only learning_rate is evolvable; at its default of 0.001 it is very
-        # close to min (1e-6) on a linear scale → may receive a penalty.
-        # Override learning_rate to midpoint to guarantee zero penalty.
-        chromosome = chromosome.with_overrides({"learning_rate": 0.5})
+        # memory_size is the only fixed gene (evolvable=False).
+        # All evolvable genes (learning_rate, gamma, epsilon_decay) must be set
+        # well inside bounds to guarantee zero penalty.
+        chromosome = chromosome.with_overrides({
+            "learning_rate": 0.5,
+            "gamma": 0.5,
+            "epsilon_decay": 0.5,
+        })
         cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.1, near_boundary_threshold=0.05)
-        # Even though epsilon_decay is near its min, it is fixed → no penalty
+        # memory_size is fixed → no penalty even though its value is arbitrary
         penalty = compute_boundary_penalty(chromosome, cfg)
         self.assertEqual(penalty, 0.0)
 


### PR DESCRIPTION
This pull request extends the hyperparameter chromosome schema to support two additional continuously evolvable genes: `gamma` (discount factor) and `epsilon_decay` (exploration decay rate). Both are now evolvable with linear 8-bit quantization, and the codebase and tests are updated to reflect this. The groundwork for future support of integer and categorical genes is also documented. Extensive new and updated tests ensure correct encoding, mutation, crossover, and config projection for all evolvable genes.

**Chromosome schema and encoding updates:**
- Added `gamma` as an evolvable gene (range `[0.0, 1.0]`, default `0.99`, linear 8-bit encoding) and made `epsilon_decay` evolvable (range `(0, 1.0]`, default `0.995`, linear 8-bit encoding) in both `DEFAULT_HYPERPARAMETER_GENES` and `DEFAULT_GENE_ENCODINGS` in `farm/core/hyperparameter_chromosome.py`. [[1]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R360-R375) [[2]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R386-R402)
- Updated documentation to describe the new schema, encoding policies, and to clarify that `memory_size` remains fixed pending integer gene support. Added a roadmap for future discrete/integer gene support in `docs/design/hyperparameter_chromosome.md`. [[1]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L59-R69) [[2]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L375-R389)

**Serialization, mutation, and crossover:**
- Updated all encode/decode and mutation/crossover logic and tests to include `gamma` and `epsilon_decay` as evolvable, ensuring correct round-tripping, mutation, and crossover for all three continuous genes. [[1]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L257-R265) [[2]](diffhunk://#diff-9c7680134b11855929fe6dd4a3d862d1b80e80be48036a6186b545079899f572R320-R535) [[3]](diffhunk://#diff-9c7680134b11855929fe6dd4a3d862d1b80e80be48036a6186b545079899f572L780-R1009)

**Test suite improvements:**
- Added a dedicated test class for the new continuous genes, covering bounds, serialization, encoding, mutation, crossover, and config projection for `gamma` and `epsilon_decay` in `tests/test_hyperparameter_chromosome.py`.
- Updated existing tests and test fixtures to set all evolvable genes appropriately, ensuring that tests for boundary penalties and mutation only penalize or mutate the intended genes. [[1]](diffhunk://#diff-2e3ed6332444b9ae7417ca931cd484bb5c4a3e9dc9e16c74188bddbeb55d1deaR220-R223) [[2]](diffhunk://#diff-9c7680134b11855929fe6dd4a3d862d1b80e80be48036a6186b545079899f572L77-R78) [[3]](diffhunk://#diff-9c7680134b11855929fe6dd4a3d862d1b80e80be48036a6186b545079899f572L146) [[4]](diffhunk://#diff-9c7680134b11855929fe6dd4a3d862d1b80e80be48036a6186b545079899f572L295) [[5]](diffhunk://#diff-4b59fc907ff2fcd4bc8049d2392e0abb07d57e44aba581c1c2a74b7e76b94427L74-R79) [[6]](diffhunk://#diff-9c7680134b11855929fe6dd4a3d862d1b80e80be48036a6186b545079899f572L780-R1009)

**Documentation and roadmap:**
- Expanded design docs with a discrete-gene roadmap, describing planned support for integer, binary, and categorical genes, and clarifying current limitations and next steps.

These changes collectively enable richer hyperparameter evolution experiments and lay the foundation for future extensibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the set of evolved hyperparameters, changing mutation/crossover/encoding behavior and boundary-penalty calculations in evolution and reproduction flows; issues would primarily affect training dynamics and experiment determinism rather than system safety.
> 
> **Overview**
> **Promotes two additional learning hyperparameters into the evolution chromosome.** `gamma` is added as a new evolvable gene and `epsilon_decay` is switched from fixed to evolvable, both using default **linear 8-bit quantized encoding** alongside existing log-encoded `learning_rate`; `memory_size` stays fixed.
> 
> Updates docs and tests to reflect the expanded evolvable gene set, including encode/decode dict+vector round-trips, mutation/crossover coverage, reproduction wiring expectations, and boundary-penalty tests that now set non-target evolvable genes away from bounds to keep penalties deterministic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd44b5b97854707cae4044352fbf0462dfc7647f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->