### PR TITLE
Refactor resource regeneration to use vectorized NumPy RNG

### DIFF
--- a/farm/core/resource_manager.py
+++ b/farm/core/resource_manager.py
@@ -497,7 +497,9 @@ class ResourceManager:
         z = (z ^ (z >> np.uint64(30))) * np.uint64(0xBF58476D1CE4E5B9)
         z = (z ^ (z >> np.uint64(27))) * np.uint64(0x94D049BB133111EB)
         z = z ^ (z >> np.uint64(31))
-        return z.astype(np.float64) / float(2**64)
+        # Use the top 53 bits so conversion to float64 is exact and the result
+        # is guaranteed to stay within [0, 1).
+        return (z >> np.uint64(11)).astype(np.float64) * (2.0**-53)
 
     def _seeded_regen_mask(self, time_step: int, regen_rate: float) -> np.ndarray:
         """Return deterministic per-resource regeneration mask for seeded runs."""

--- a/farm/core/resource_manager.py
+++ b/farm/core/resource_manager.py
@@ -2,6 +2,7 @@ import math
 import os
 import random
 import tempfile
+import hashlib
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -489,6 +490,47 @@ class ResourceManager:
         self.next_resource_id += 1
         return resource
 
+    @staticmethod
+    def _splitmix64_to_unit(values: np.ndarray) -> np.ndarray:
+        """Map uint64 values to deterministic [0, 1) float values via SplitMix64."""
+        z = (values + np.uint64(0x9E3779B97F4A7C15)).astype(np.uint64, copy=False)
+        z = (z ^ (z >> np.uint64(30))) * np.uint64(0xBF58476D1CE4E5B9)
+        z = (z ^ (z >> np.uint64(27))) * np.uint64(0x94D049BB133111EB)
+        z = z ^ (z >> np.uint64(31))
+        return z.astype(np.float64) / float(2**64)
+
+    def _seeded_regen_mask(self, time_step: int, regen_rate: float) -> np.ndarray:
+        """Return deterministic per-resource regeneration mask for seeded runs."""
+        resource_count = len(self.resources)
+        if resource_count == 0:
+            return np.array([], dtype=bool)
+
+        base_seed = self.seed_value or 0
+
+        # Build a stable per-resource seed from resource identity and step, then
+        # transform it to a uniform [0, 1) value with vectorized uint64 mixing.
+        hashed_values = np.fromiter(
+            (
+                int.from_bytes(
+                    hashlib.blake2b(
+                        (
+                            f"{base_seed}|{time_step}|{resource.resource_id}|"
+                            f"{resource.position[0]:.12f}|{resource.position[1]:.12f}"
+                        ).encode("utf-8"),
+                        digest_size=8,
+                        person=b"regen-v1",
+                    ).digest(),
+                    "little",
+                    signed=False,
+                )
+                for resource in self.resources
+            ),
+            dtype=np.uint64,
+            count=resource_count,
+        )
+        random_values = self._splitmix64_to_unit(hashed_values)
+        return random_values < regen_rate
+
     def update_resources(self, time_step: int) -> Dict:
         """
         Update all resources for the current time step using the same logic as the original Environment.
@@ -535,11 +577,7 @@ class ResourceManager:
                 else 2
             )
 
-            # Use a single per-step vectorized NumPy generator for deterministic seeded path.
-            # This avoids O(N) random.Random object allocations (one per resource per tick).
-            per_step_seed = (self.seed_value + time_step) & 0xFFFFFFFFFFFFFFFF
-            step_rng = np.random.Generator(np.random.SFC64(per_step_seed))
-            rng_mask = step_rng.random(len(self.resources)) < regen_rate
+            rng_mask = self._seeded_regen_mask(time_step=time_step, regen_rate=regen_rate)
 
             for resource, should_regen in zip(self.resources, rng_mask):
                 if should_regen and (
@@ -604,14 +642,18 @@ class ResourceManager:
 
     def _update_resources_deterministic(self, time_step: int, stats: Dict):
         """Update resources using deterministic regeneration logic."""
-        regen_rate = self.config.resource_regen_rate if self.config else 0.1
-        regen_amount = self.config.resource_regen_amount if self.config else 2
+        regen_rate = (
+            getattr(getattr(self.config, "resources", None), "resource_regen_rate", 0.1)
+            if self.config
+            else 0.1
+        )
+        regen_amount = (
+            getattr(getattr(self.config, "resources", None), "resource_regen_amount", 2)
+            if self.config
+            else 2
+        )
 
-        # Use a single per-step vectorized NumPy generator for deterministic seeded path.
-        # This avoids O(N) random.Random object allocations (one per resource per tick).
-        per_step_seed = ((self.seed_value or 0) + time_step) & 0xFFFFFFFFFFFFFFFF
-        step_rng = np.random.Generator(np.random.SFC64(per_step_seed))
-        rng_mask = step_rng.random(len(self.resources)) < regen_rate
+        rng_mask = self._seeded_regen_mask(time_step=time_step, regen_rate=regen_rate)
 
         for resource, should_regen in zip(self.resources, rng_mask):
             if should_regen and resource.amount < resource.max_amount:

--- a/farm/core/resource_manager.py
+++ b/farm/core/resource_manager.py
@@ -513,51 +513,38 @@ class ResourceManager:
         }
 
         if self.seed_value is not None:
-            # Create deterministic RNG based on seed and current time (same as original)
-            rng = random.Random(self.seed_value + time_step)
-
-            # Deterministically decide which resources regenerate (same as original)
-            for resource in self.resources:
-                # Use resource ID and position as additional entropy sources (same as original)
-                decision_seed = hash(
-                    (
-                        resource.resource_id,
-                        resource.position[0],
-                        resource.position[1],
-                        time_step,
-                    )
+            regen_rate = (
+                getattr(
+                    getattr(self.config, "resources", None),
+                    "resource_regen_rate",
+                    0.1,
                 )
-                # Mix with simulation seed (same as original)
-                combined_seed = (self.seed_value * 100000) + decision_seed
-                # Create a deterministic random generator for this resource (same as original)
-                resource_rng = random.Random(combined_seed)
-
-                # Check if this resource should regenerate (same as original)
-                regen_rate = (
-                    getattr(
-                        getattr(self.config, "resources", None),
-                        "resource_regen_rate",
-                        0.1,
-                    )
-                    if self.config
-                    else 0.1
+                if self.config
+                else 0.1
+            )
+            max_resource = (
+                self.config.resources.max_resource_amount if self.config else None
+            )
+            regen_amount = (
+                getattr(
+                    getattr(self.config, "resources", None),
+                    "resource_regen_amount",
+                    2,
                 )
-                max_resource = (
-                    self.config.resources.max_resource_amount if self.config else None
-                )
+                if self.config
+                else 2
+            )
 
-                if resource_rng.random() < regen_rate and (
+            # Use a single per-step vectorized NumPy generator for deterministic seeded path.
+            # This avoids O(N) random.Random object allocations (one per resource per tick).
+            per_step_seed = (self.seed_value + time_step) & 0xFFFFFFFFFFFFFFFF
+            step_rng = np.random.Generator(np.random.SFC64(per_step_seed))
+            rng_mask = step_rng.random(len(self.resources)) < regen_rate
+
+            for resource, should_regen in zip(self.resources, rng_mask):
+                if should_regen and (
                     max_resource is None or resource.amount < max_resource
                 ):
-                    regen_amount = (
-                        getattr(
-                            getattr(self.config, "resources", None),
-                            "resource_regen_amount",
-                            2,
-                        )
-                        if self.config
-                        else 2
-                    )
                     old_amount = resource.amount
                     resource.amount = min(
                         resource.amount + regen_amount,
@@ -617,31 +604,17 @@ class ResourceManager:
 
     def _update_resources_deterministic(self, time_step: int, stats: Dict):
         """Update resources using deterministic regeneration logic."""
-        for resource in self.resources:
-            # Create deterministic decision seed
-            decision_seed = hash(
-                (
-                    resource.resource_id,
-                    resource.position[0],
-                    resource.position[1],
-                    time_step,
-                )
-            )
+        regen_rate = self.config.resource_regen_rate if self.config else 0.1
+        regen_amount = self.config.resource_regen_amount if self.config else 2
 
-            # Mix with simulation seed
-            combined_seed = ((self.seed_value or 0) * 100000) + decision_seed
-            resource_rng = random.Random(combined_seed)
+        # Use a single per-step vectorized NumPy generator for deterministic seeded path.
+        # This avoids O(N) random.Random object allocations (one per resource per tick).
+        per_step_seed = ((self.seed_value or 0) + time_step) & 0xFFFFFFFFFFFFFFFF
+        step_rng = np.random.Generator(np.random.SFC64(per_step_seed))
+        rng_mask = step_rng.random(len(self.resources)) < regen_rate
 
-            # Check if resource should regenerate
-            regen_rate = self.config.resource_regen_rate if self.config else 0.1
-
-            if (
-                resource_rng.random() < regen_rate
-                and resource.amount < resource.max_amount
-            ):
-
-                regen_amount = self.config.resource_regen_amount if self.config else 2
-
+        for resource, should_regen in zip(self.resources, rng_mask):
+            if should_regen and resource.amount < resource.max_amount:
                 old_amount = resource.amount
                 resource.regenerate(regen_amount)
                 regenerated = resource.amount - old_amount

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -228,15 +228,21 @@ class TestResourceManager(unittest.TestCase):
             # Set each resource to a known starting amount so the comparison is meaningful
             for i, resource in enumerate(resource_manager.resources):
                 resource.amount = amount_overrides[i]
-            return resource_manager.update_resources(time_step=time_step)
+            stats = resource_manager.update_resources(time_step=time_step)
+            amounts_by_id = {
+                resource.resource_id: resource.amount
+                for resource in resource_manager.resources
+            }
+            return stats, amounts_by_id
 
         starting_amounts = [5, 3, 8, 2, 7]
 
-        stats1 = _run(seed=99, time_step=10, amount_overrides=starting_amounts)
-        stats2 = _run(seed=99, time_step=10, amount_overrides=starting_amounts)
+        stats1, amounts1 = _run(seed=99, time_step=10, amount_overrides=starting_amounts)
+        stats2, amounts2 = _run(seed=99, time_step=10, amount_overrides=starting_amounts)
 
         self.assertEqual(stats1["regeneration_events"], stats2["regeneration_events"])
         self.assertEqual(stats1["resources_regenerated"], stats2["resources_regenerated"])
+        self.assertEqual(amounts1, amounts2)
 
     def test_update_resources_seeded_uses_vectorized_rng(self):
         """Seeded path must not allocate per-resource random.Random objects."""
@@ -264,12 +270,55 @@ class TestResourceManager(unittest.TestCase):
         with unittest.mock.patch.object(_random.Random, "__init__", counting_init):
             resource_manager.update_resources(time_step=5)
 
-        # The seeded path must NOT create one random.Random per resource
-        self.assertLess(
+        self.assertEqual(
             len(constructor_calls),
-            len(resource_manager.resources),
-            "Seeded path must use vectorized NumPy RNG, not per-resource random.Random",
+            0,
+            "Seeded update path should not instantiate random.Random",
         )
+
+    def test_update_resources_determinism_stable_under_resource_order_changes(self):
+        """Seeded regeneration decisions must be stable regardless of list order."""
+
+        distribution = {"type": "random", "amount": 8}
+
+        rm1 = ResourceManager(
+            width=self.width,
+            height=self.height,
+            config=self.config,
+            seed=123,
+            database_logger=self.mock_logger,
+            simulation_id="test_simulation",
+        )
+        rm2 = ResourceManager(
+            width=self.width,
+            height=self.height,
+            config=self.config,
+            seed=123,
+            database_logger=self.mock_logger,
+            simulation_id="test_simulation",
+        )
+
+        rm1.initialize_resources(distribution)
+        rm2.initialize_resources(distribution)
+
+        # Establish a known starting amount by resource identity.
+        known_amounts = {}
+        for idx, resource in enumerate(rm1.resources):
+            known_amounts[resource.resource_id] = 2 + (idx % 5)
+        for resource in rm1.resources:
+            resource.amount = known_amounts[resource.resource_id]
+        for resource in rm2.resources:
+            resource.amount = known_amounts[resource.resource_id]
+
+        # Reorder only rm2 resources to ensure order does not affect outcomes.
+        rm2.resources = list(reversed(rm2.resources))
+
+        rm1.update_resources(time_step=9)
+        rm2.update_resources(time_step=9)
+
+        post1 = {resource.resource_id: resource.amount for resource in rm1.resources}
+        post2 = {resource.resource_id: resource.amount for resource in rm2.resources}
+        self.assertEqual(post1, post2)
 
     def test_consume_resource(self):
         """Test resource consumption."""

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -211,6 +211,66 @@ class TestResourceManager(unittest.TestCase):
         self.assertGreaterEqual(stats["regeneration_events"], 0)
         self.assertGreaterEqual(stats["resources_regenerated"], 0)
 
+    def test_update_resources_determinism_reproducible(self):
+        """Same seed + step must always produce identical regeneration outcomes."""
+
+        def _run(seed, time_step, amount_overrides):
+            resource_manager = ResourceManager(
+                width=self.width,
+                height=self.height,
+                config=self.config,
+                seed=seed,
+                database_logger=self.mock_logger,
+                simulation_id="test_simulation",
+            )
+            distribution = {"type": "random", "amount": 5}
+            resource_manager.initialize_resources(distribution)
+            # Set each resource to a known starting amount so the comparison is meaningful
+            for i, resource in enumerate(resource_manager.resources):
+                resource.amount = amount_overrides[i]
+            return resource_manager.update_resources(time_step=time_step)
+
+        starting_amounts = [5, 3, 8, 2, 7]
+
+        stats1 = _run(seed=99, time_step=10, amount_overrides=starting_amounts)
+        stats2 = _run(seed=99, time_step=10, amount_overrides=starting_amounts)
+
+        self.assertEqual(stats1["regeneration_events"], stats2["regeneration_events"])
+        self.assertEqual(stats1["resources_regenerated"], stats2["resources_regenerated"])
+
+    def test_update_resources_seeded_uses_vectorized_rng(self):
+        """Seeded path must not allocate per-resource random.Random objects."""
+        import random as _random
+        import unittest.mock
+
+        resource_manager = ResourceManager(
+            width=self.width,
+            height=self.height,
+            config=self.config,
+            seed=7,
+            database_logger=self.mock_logger,
+            simulation_id="test_simulation",
+        )
+        distribution = {"type": "random", "amount": 20}
+        resource_manager.initialize_resources(distribution)
+
+        constructor_calls = []
+        original_init = _random.Random.__init__
+
+        def counting_init(self_inner, *args, **kwargs):
+            constructor_calls.append(args)
+            return original_init(self_inner, *args, **kwargs)
+
+        with unittest.mock.patch.object(_random.Random, "__init__", counting_init):
+            resource_manager.update_resources(time_step=5)
+
+        # The seeded path must NOT create one random.Random per resource
+        self.assertLess(
+            len(constructor_calls),
+            len(resource_manager.resources),
+            "Seeded path must use vectorized NumPy RNG, not per-resource random.Random",
+        )
+
     def test_consume_resource(self):
         """Test resource consumption."""
         # Create a resource


### PR DESCRIPTION
This pull request significantly refactors the deterministic and seeded resource regeneration logic in `ResourceManager` to use a new, vectorized approach for reproducible and order-independent random decisions. The changes remove per-resource `random.Random` instantiation in favor of a fast, hash-based method, improving reproducibility, efficiency, and testability. Several comprehensive tests are added to ensure the new logic is stable, reproducible, and order-agnostic.

**Deterministic and Seeded Resource Regeneration Refactor:**

* Replaces per-resource `random.Random` usage with a new `_seeded_regen_mask` method, which uses a hash (Blake2b) of resource identity, position, timestep, and seed, combined with a SplitMix64-inspired mixing function to generate deterministic, vectorized random values for regeneration decisions. This ensures reproducibility and stability regardless of resource list order. (`farm/core/resource_manager.py`) [[1]](diffhunk://#diff-ecf447bf8844cb6f8575dcfae7a4e620d7ed18eca43175463b3b683dd74d10a1R493-R533) [[2]](diffhunk://#diff-ecf447bf8844cb6f8575dcfae7a4e620d7ed18eca43175463b3b683dd74d10a1L516-L535) [[3]](diffhunk://#diff-ecf447bf8844cb6f8575dcfae7a4e620d7ed18eca43175463b3b683dd74d10a1L548-L551) [[4]](diffhunk://#diff-ecf447bf8844cb6f8575dcfae7a4e620d7ed18eca43175463b3b683dd74d10a1R579-R585) [[5]](diffhunk://#diff-ecf447bf8844cb6f8575dcfae7a4e620d7ed18eca43175463b3b683dd74d10a1L620-R659)
* Removes the old logic for mixing seeds and creating per-resource random generators, simplifying and unifying the regeneration decision process. (`farm/core/resource_manager.py`) [[1]](diffhunk://#diff-ecf447bf8844cb6f8575dcfae7a4e620d7ed18eca43175463b3b683dd74d10a1L516-L535) [[2]](diffhunk://#diff-ecf447bf8844cb6f8575dcfae7a4e620d7ed18eca43175463b3b683dd74d10a1L548-L551) [[3]](diffhunk://#diff-ecf447bf8844cb6f8575dcfae7a4e620d7ed18eca43175463b3b683dd74d10a1L620-R659)

**Testing and Validation Enhancements:**

* Adds tests to verify that regeneration outcomes are reproducible for the same seed and timestep, that no per-resource `random.Random` objects are created in the seeded path, and that regeneration decisions are stable under changes in resource list order. (`tests/test_resource_manager.py`)

**Dependency and Import Updates:**

* Adds `hashlib` import to support Blake2b hashing for deterministic random value generation. (`farm/core/resource_manager.py`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core simulation regeneration behavior and determinism guarantees, which could alter outcomes or metrics across existing seeded runs. Added tests reduce regression risk but the RNG algorithm change may still affect expected baselines.
> 
> **Overview**
> **Seeded resource regeneration is refactored to be deterministic, vectorized, and order-independent.** The seeded update path now builds a per-resource regeneration mask via `blake2b` hashing (seed + timestep + resource identity/position) and SplitMix64-style mixing, eliminating per-resource `random.Random` instantiation.
> 
> Tests are expanded to assert reproducibility for the same seed/timestep, stability when resource list order changes, and that the seeded path does not allocate `random.Random` objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 156d807804fe2505a2519e7691c0cd2e3dd0623a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->