### PR TITLE
Implement conditional DB flush in simulation with flush_if_needed method

### DIFF
--- a/farm/core/interfaces.py
+++ b/farm/core/interfaces.py
@@ -365,7 +365,7 @@ class DataLoggerProtocol(Protocol):
 
     def flush_if_needed(self) -> None:
         """Flush buffered data when periodic flush criteria are met."""
-        ...
+        pass
 
 
 @runtime_checkable

--- a/farm/core/interfaces.py
+++ b/farm/core/interfaces.py
@@ -363,6 +363,10 @@ class DataLoggerProtocol(Protocol):
         """Flush all buffered data to the database."""
         ...
 
+    def flush_if_needed(self) -> None:
+        """Flush buffered data when periodic flush criteria are met."""
+        ...
+
 
 @runtime_checkable
 class RepositoryProtocol(Protocol[T]):

--- a/farm/core/simulation.py
+++ b/farm/core/simulation.py
@@ -510,7 +510,11 @@ def run_simulation(
             # calling flush_all_buffers() unconditionally here was redundant
             # and caused unnecessary transaction overhead.
             if environment.db is not None:
-                environment.db.logger.flush_if_needed()
+                data_logger = environment.db.logger
+                if hasattr(data_logger, "flush_if_needed"):
+                    data_logger.flush_if_needed()
+                else:
+                    data_logger.flush_all_buffers()
             
             # Update environment once per step
             environment.update()

--- a/farm/core/simulation.py
+++ b/farm/core/simulation.py
@@ -511,8 +511,9 @@ def run_simulation(
             # and caused unnecessary transaction overhead.
             if environment.db is not None:
                 data_logger = environment.db.logger
-                if hasattr(data_logger, "flush_if_needed"):
-                    data_logger.flush_if_needed()
+                flush = getattr(data_logger, "flush_if_needed", None)
+                if callable(flush):
+                    flush()
                 else:
                     data_logger.flush_all_buffers()
             

--- a/farm/core/simulation.py
+++ b/farm/core/simulation.py
@@ -504,10 +504,13 @@ def run_simulation(
                 for agent in batch:
                     agent.act()
 
-            # Ensure all database operations are flushed before environment update
-            # This prevents timing mismatches between metrics calculation and agent database logging
+            # Flush buffered DB writes on a time-based schedule rather than
+            # every step.  Buffer-size-based flushing is already handled
+            # inside log_agent_action / log_health_incident / log_step, so
+            # calling flush_all_buffers() unconditionally here was redundant
+            # and caused unnecessary transaction overhead.
             if environment.db is not None:
-                environment.db.logger.flush_all_buffers()
+                environment.db.logger._check_time_based_flush()
             
             # Update environment once per step
             environment.update()

--- a/farm/core/simulation.py
+++ b/farm/core/simulation.py
@@ -510,7 +510,7 @@ def run_simulation(
             # calling flush_all_buffers() unconditionally here was redundant
             # and caused unnecessary transaction overhead.
             if environment.db is not None:
-                environment.db.logger._check_time_based_flush()
+                environment.db.logger.flush_if_needed()
             
             # Update environment once per step
             environment.update()

--- a/farm/database/data_logging.py
+++ b/farm/database/data_logging.py
@@ -86,7 +86,6 @@ class DataLogger(DataLoggerProtocol):
         return bool(
             self._action_buffer
             or self._health_incident_buffer
-            or self._resource_buffer
             or self._step_buffer
         )
 
@@ -106,6 +105,8 @@ class DataLogger(DataLoggerProtocol):
         callers should use this method rather than calling
         ``flush_all_buffers()`` unconditionally.
         """
+        if not self.needs_flush:
+            return
         self._check_time_based_flush()
 
     def log_agent_action(
@@ -666,3 +667,17 @@ class ShardedDataLogger:
         for shard_id, databases in self.sharded_db.shards.items():
             for db_type, db in databases.items():
                 db.logger.flush_all_buffers()
+
+    def flush_if_needed(self):
+        """Flush shard buffers when their periodic flush criteria are met.
+
+        Falls back to ``flush_all_buffers`` for shard loggers that do not yet
+        implement ``flush_if_needed``.
+        """
+        for shard_id, databases in self.sharded_db.shards.items():
+            for db_type, db in databases.items():
+                shard_logger = db.logger
+                if hasattr(shard_logger, "flush_if_needed"):
+                    shard_logger.flush_if_needed()
+                else:
+                    shard_logger.flush_all_buffers()

--- a/farm/database/data_logging.py
+++ b/farm/database/data_logging.py
@@ -96,6 +96,17 @@ class DataLogger(DataLoggerProtocol):
             self.flush_all_buffers()
             self._last_commit_time = current_time
 
+    def flush_if_needed(self) -> None:
+        """Flush buffers only when the time-based commit interval has elapsed.
+
+        This is the preferred public entry point for periodic flush calls
+        (e.g., once per simulation step).  Buffer-size-based flushing is
+        already handled internally by each individual ``log_*`` method, so
+        callers should use this method rather than calling
+        ``flush_all_buffers()`` unconditionally.
+        """
+        self._check_time_based_flush()
+
     def log_agent_action(
         self,
         step_number: int,

--- a/farm/database/data_logging.py
+++ b/farm/database/data_logging.py
@@ -86,6 +86,7 @@ class DataLogger(DataLoggerProtocol):
         return bool(
             self._action_buffer
             or self._health_incident_buffer
+            or self._resource_buffer
             or self._step_buffer
         )
 
@@ -297,6 +298,10 @@ class DataLogger(DataLoggerProtocol):
                 if self._health_incident_buffer:
                     session.bulk_insert_mappings(HealthIncident, self._health_incident_buffer)
                     self._health_incident_buffer.clear()
+
+                if self._resource_buffer:
+                    session.bulk_insert_mappings(ResourceModel, self._resource_buffer)
+                    self._resource_buffer.clear()
 
                 if self._step_buffer:
                     session.bulk_insert_mappings(SimulationStepModel, self._step_buffer)

--- a/farm/database/data_logging.py
+++ b/farm/database/data_logging.py
@@ -682,7 +682,8 @@ class ShardedDataLogger:
         for shard_id, databases in self.sharded_db.shards.items():
             for db_type, db in databases.items():
                 shard_logger = db.logger
-                if hasattr(shard_logger, "flush_if_needed"):
-                    shard_logger.flush_if_needed()
+                flush_if_needed = getattr(shard_logger, "flush_if_needed", None)
+                if callable(flush_if_needed):
+                    flush_if_needed()
                 else:
                     shard_logger.flush_all_buffers()

--- a/farm/database/data_logging.py
+++ b/farm/database/data_logging.py
@@ -86,6 +86,7 @@ class DataLogger(DataLoggerProtocol):
         return bool(
             self._action_buffer
             or self._health_incident_buffer
+            or self._resource_buffer
             or self._step_buffer
         )
 

--- a/farm/database/data_logging.py
+++ b/farm/database/data_logging.py
@@ -80,6 +80,15 @@ class DataLogger(DataLoggerProtocol):
         self._resource_buffer = []
         self._step_buffer = []
 
+    @property
+    def needs_flush(self) -> bool:
+        """Return True if any buffer has pending data waiting to be written."""
+        return bool(
+            self._action_buffer
+            or self._health_incident_buffer
+            or self._step_buffer
+        )
+
     def _check_time_based_flush(self):
         """Check if we should flush based on time interval."""
         current_time = time.time()
@@ -253,7 +262,13 @@ class DataLogger(DataLoggerProtocol):
             raise
 
     def flush_all_buffers(self) -> None:
-        """Flush all data buffers to the database in a single transaction."""
+        """Flush all data buffers to the database in a single transaction.
+
+        Returns immediately without touching the database when all buffers
+        are empty, avoiding unnecessary transaction overhead.
+        """
+        if not self.needs_flush:
+            return
 
         def _flush(session):
             # Disable autoflush during bulk operations

--- a/tests/core/test_interfaces.py
+++ b/tests/core/test_interfaces.py
@@ -72,6 +72,7 @@ class _ConcreteDataLogger:
     def log_agent(self, agent_id, birth_time, agent_type, position, initial_resources, starting_health, **kwargs): pass
     def log_health_incident(self, step_number, agent_id, health_before, health_after, cause, details=None): pass
     def flush_all_buffers(self): pass
+    def flush_if_needed(self): pass
 
 
 class _ConcreteRepository:
@@ -126,7 +127,14 @@ class TestProtocolAttributes:
             assert hasattr(DatabaseProtocol, method)
 
     def test_data_logger_protocol_methods(self):
-        for method in ("log_agent_action", "log_step", "log_agent", "log_health_incident", "flush_all_buffers"):
+        for method in (
+            "log_agent_action",
+            "log_step",
+            "log_agent",
+            "log_health_incident",
+            "flush_all_buffers",
+            "flush_if_needed",
+        ):
             assert hasattr(DataLoggerProtocol, method)
 
     def test_repository_protocol_methods(self):
@@ -178,6 +186,7 @@ class TestConcreteImplementations:
         dl.log_agent("a1", 0, "system", (0, 0), 1.0, 100.0)
         dl.log_health_incident(0, "a1", 100.0, 90.0, "combat")
         dl.flush_all_buffers()
+        dl.flush_if_needed()
 
     def test_concrete_repository_callable(self):
         repo = _ConcreteRepository()

--- a/tests/database/test_data_logging.py
+++ b/tests/database/test_data_logging.py
@@ -178,6 +178,30 @@ class TestDataLoggerBuffering(unittest.TestCase):
         self.logger.flush_all_buffers()
         self.db._execute_in_transaction.assert_not_called()
 
+    def test_flush_if_needed_triggers_on_interval(self):
+        """flush_if_needed should flush when commit interval has elapsed."""
+        import time as _time
+        self.logger.log_agent_action(
+            step_number=0, agent_id="a1", action_type="move"
+        )
+        # Wind the clock back so the interval appears elapsed.
+        self.logger._last_commit_time -= self.logger._commit_interval + 1
+        self.mock_session.bulk_insert_mappings = Mock()
+        self.mock_session.commit = Mock()
+        self.logger.flush_if_needed()
+        self.assertFalse(self.logger.needs_flush)
+
+    def test_flush_if_needed_skips_before_interval(self):
+        """flush_if_needed should not flush before commit interval has elapsed."""
+        self.logger.log_agent_action(
+            step_number=0, agent_id="a1", action_type="move"
+        )
+        # Leave _last_commit_time at 'now' so interval has NOT elapsed.
+        self.logger._last_commit_time = float("inf")  # far future
+        self.logger.flush_if_needed()
+        # Buffer must still have the pending item.
+        self.assertTrue(self.logger.needs_flush)
+
     def test_auto_flush_on_buffer_full(self):
         """When buffer reaches buffer_size the actions should be flushed."""
         self.mock_session.bulk_insert_mappings = Mock()

--- a/tests/database/test_data_logging.py
+++ b/tests/database/test_data_logging.py
@@ -151,6 +151,33 @@ class TestDataLoggerBuffering(unittest.TestCase):
         self.assertEqual(len(self.logger._action_buffer), 0)
         self.assertEqual(len(self.logger._health_incident_buffer), 0)
 
+    def test_needs_flush_false_when_empty(self):
+        """needs_flush should be False when all buffers are empty."""
+        self.assertFalse(self.logger.needs_flush)
+
+    def test_needs_flush_true_after_action_buffered(self):
+        """needs_flush should be True once an action is buffered."""
+        self.logger.log_agent_action(
+            step_number=0, agent_id="a1", action_type="move"
+        )
+        self.assertTrue(self.logger.needs_flush)
+
+    def test_needs_flush_false_after_flush(self):
+        """needs_flush should return False after all buffers are flushed."""
+        self.logger.log_agent_action(
+            step_number=0, agent_id="a1", action_type="move"
+        )
+        self.mock_session.bulk_insert_mappings = Mock()
+        self.mock_session.commit = Mock()
+        self.logger.flush_all_buffers()
+        self.assertFalse(self.logger.needs_flush)
+
+    def test_flush_all_buffers_noop_when_empty(self):
+        """flush_all_buffers should not touch the DB when all buffers are empty."""
+        self.db._execute_in_transaction = Mock()
+        self.logger.flush_all_buffers()
+        self.db._execute_in_transaction.assert_not_called()
+
     def test_auto_flush_on_buffer_full(self):
         """When buffer reaches buffer_size the actions should be flushed."""
         self.mock_session.bulk_insert_mappings = Mock()

--- a/tests/database/test_data_logging.py
+++ b/tests/database/test_data_logging.py
@@ -201,6 +201,13 @@ class TestDataLoggerBuffering(unittest.TestCase):
         # Buffer must still have the pending item.
         self.assertTrue(self.logger.needs_flush)
 
+    def test_flush_if_needed_noop_when_no_pending_buffers(self):
+        """flush_if_needed should not touch DB when there is nothing to flush."""
+        self.db._execute_in_transaction = Mock()
+        self.logger._last_commit_time -= self.logger._commit_interval + 1
+        self.logger.flush_if_needed()
+        self.db._execute_in_transaction.assert_not_called()
+
     def test_auto_flush_on_buffer_full(self):
         """When buffer reaches buffer_size the actions should be flushed."""
         self.mock_session.bulk_insert_mappings = Mock()
@@ -341,6 +348,7 @@ class TestShardedDataLogger(unittest.TestCase):
         shard_logger.log_metrics = Mock()
         shard_logger.log_agent_action = Mock()
         shard_logger.flush_all_buffers = Mock()
+        shard_logger.flush_if_needed = Mock()
         db_shard = Mock()
         db_shard.logger = shard_logger
         return db_shard
@@ -411,6 +419,20 @@ class TestShardedDataLogger(unittest.TestCase):
         logger.flush_all_buffers()
         # With 2 shards × 4 shard types = 8 calls
         self.assertGreaterEqual(shard.logger.flush_all_buffers.call_count, 4)
+
+    def test_flush_if_needed_uses_shard_flush_if_needed_when_available(self):
+        sharded_db, shard = self._make_sharded_db()
+        logger = ShardedDataLogger(sharded_db, simulation_id="sim_001")
+        logger.flush_if_needed()
+        self.assertGreaterEqual(shard.logger.flush_if_needed.call_count, 1)
+        shard.logger.flush_all_buffers.assert_not_called()
+
+    def test_flush_if_needed_falls_back_to_flush_all_buffers(self):
+        sharded_db, shard = self._make_sharded_db()
+        del shard.logger.flush_if_needed
+        logger = ShardedDataLogger(sharded_db, simulation_id="sim_001")
+        logger.flush_if_needed()
+        self.assertGreaterEqual(shard.logger.flush_all_buffers.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/tests/database/test_data_logging.py
+++ b/tests/database/test_data_logging.py
@@ -180,7 +180,6 @@ class TestDataLoggerBuffering(unittest.TestCase):
 
     def test_flush_if_needed_triggers_on_interval(self):
         """flush_if_needed should flush when commit interval has elapsed."""
-        import time as _time
         self.logger.log_agent_action(
             step_number=0, agent_id="a1", action_type="move"
         )

--- a/tests/database/test_data_logging.py
+++ b/tests/database/test_data_logging.py
@@ -428,11 +428,26 @@ class TestShardedDataLogger(unittest.TestCase):
         shard.logger.flush_all_buffers.assert_not_called()
 
     def test_flush_if_needed_falls_back_to_flush_all_buffers(self):
-        sharded_db, shard = self._make_sharded_db()
-        del shard.logger.flush_if_needed
+        # Use spec_set so flush_if_needed is genuinely absent (Mock.__getattr__
+        # would otherwise manufacture it on demand, making hasattr always True).
+        sharded_db = Mock()
+        shard_logger_no_flush = Mock(spec_set=["flush_all_buffers", "log_agent_states",
+                                               "log_agent_actions", "log_agent_action",
+                                               "log_resource_states", "log_simulation_step"])
+        shard = Mock()
+        shard.logger = shard_logger_no_flush
+        sharded_db.shards = {
+            0: {
+                "agents": shard,
+                "resources": shard,
+                "metrics": shard,
+                "actions": shard,
+            }
+        }
+        sharded_db._get_shard_for_step = Mock(return_value=0)
         logger = ShardedDataLogger(sharded_db, simulation_id="sim_001")
         logger.flush_if_needed()
-        self.assertGreaterEqual(shard.logger.flush_all_buffers.call_count, 1)
+        self.assertGreaterEqual(shard_logger_no_flush.flush_all_buffers.call_count, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request refactors the data logging buffer flushing mechanism to reduce unnecessary database transactions and improve efficiency. It introduces a new `flush_if_needed` method for periodic, time-based flushing, ensures that flushes only occur when there is actually data to write, and updates both the implementation and tests accordingly. The changes also add a `needs_flush` property for buffer state checking and extend support for sharded logging.

**Buffer Flushing Improvements:**

* Added a `flush_if_needed` method to both `DataLogger` and `ShardedDataLogger`, which flushes buffers only when the time-based commit interval has elapsed and there is pending data, reducing unnecessary database writes. Falls back to `flush_all_buffers` for loggers that don't implement `flush_if_needed`. (`farm/database/data_logging.py` [[1]](diffhunk://#diff-284fcd23ae2e499e203ce3ab06b642dea7b98bdea7c3306f63f4e5659de68b90R83-R111) [[2]](diffhunk://#diff-284fcd23ae2e499e203ce3ab06b642dea7b98bdea7c3306f63f4e5659de68b90R670-R683) `farm/core/interfaces.py` [[3]](diffhunk://#diff-70fa3189a837030f64d11e0514599fcdb9501ce3c6d8d6d61ab44b1d85f94b20R366-R369)
* Introduced a `needs_flush` property to `DataLogger` to check if any buffers have pending data, and updated `flush_all_buffers` to return immediately if there is nothing to flush. (`farm/database/data_logging.py` [[1]](diffhunk://#diff-284fcd23ae2e499e203ce3ab06b642dea7b98bdea7c3306f63f4e5659de68b90R83-R111) [[2]](diffhunk://#diff-284fcd23ae2e499e203ce3ab06b642dea7b98bdea7c3306f63f4e5659de68b90L256-R284)

**Simulation Logic Update:**

* Modified the simulation step in `run_simulation` to call `flush_if_needed` instead of always calling `flush_all_buffers`, avoiding redundant flushes and unnecessary transaction overhead. (`farm/core/simulation.py` [farm/core/simulation.pyL507-R517](diffhunk://#diff-ff06a5cb09730a065f7613b2ba815c4602c7f5e7b7ce98b3a346e0c9fc3b0786L507-R517))

**Testing Enhancements:**

* Added comprehensive tests for the new `needs_flush` property and `flush_if_needed` method, including edge cases where no flush should occur, and for sharded logger behavior. (`tests/database/test_data_logging.py` [[1]](diffhunk://#diff-ed3e05ce9f1a36fa2705c8999706efeb73c172bea2cf9254fd7ea38735d862e6R154-R210) [[2]](diffhunk://#diff-ed3e05ce9f1a36fa2705c8999706efeb73c172bea2cf9254fd7ea38735d862e6R351) [[3]](diffhunk://#diff-ed3e05ce9f1a36fa2705c8999706efeb73c172bea2cf9254fd7ea38735d862e6R423-R436)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when buffered simulation logs are committed by skipping per-step flushes unless the time interval has elapsed, which could affect durability/visibility of recent logs if a run crashes before the next interval. Logic is straightforward and covered by unit tests, but touches core simulation DB write paths (including sharded logging).
> 
> **Overview**
> Reduces database transaction overhead by introducing **conditional, time-based flushing** for buffered simulation logs.
> 
> Adds `DataLogger.needs_flush` plus a new `flush_if_needed()` API (also surfaced on `DataLoggerProtocol`) and updates `flush_all_buffers()` to no-op when buffers are empty. The simulation loop now calls `flush_if_needed()` each step (with a fallback to `flush_all_buffers()` for older loggers), and `ShardedDataLogger` gains the same conditional flush behavior with per-shard fallback.
> 
> Extends unit tests to cover `needs_flush`, `flush_if_needed` interval behavior, empty-flush no-ops, and sharded fallback semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 930ffe35601b5d3932e6dac1cffaf004510461fd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->