### PR TITLE
Add stable_hyper_evo preset and explicit convergence criteria

### DIFF
--- a/docs/experiments/hyperparameter_evolution_convergence.md
+++ b/docs/experiments/hyperparameter_evolution_convergence.md
@@ -2,6 +2,22 @@
 
 This note documents how to capture and interpret learning-rate convergence from the hyperparameter chromosome evolution runner.
 
+## Quick start: stable preset
+
+The recommended way to run an experiment for the first time is via the `stable_hyper_evo` named preset. It encodes the configuration found to prevent lower-bound collapse and diversity collapse in the closure runs described below:
+
+```bash
+source venv/bin/activate
+python scripts/run_evolution_experiment.py \
+  --preset stable_hyper_evo \
+  --generations 8 \
+  --population-size 10 \
+  --steps-per-candidate 80 \
+  --output-dir experiments/evolution_smoke
+```
+
+The preset sets `--selection-method tournament`, `--boundary-mode reflect`, `--mutation-rate 0.20`, `--mutation-scale 0.15`, and enables adaptive mutation. Any flag you pass explicitly overrides the preset value.
+
 ## Methodology
 
 - Runner: `scripts/run_evolution_experiment.py`

--- a/farm/runners/__init__.py
+++ b/farm/runners/__init__.py
@@ -6,6 +6,8 @@ from farm.runners.adaptive_mutation import (
     compute_normalized_diversity,
 )
 from farm.runners.evolution_experiment import (
+    ConvergenceCriteria,
+    ConvergenceReason,
     EvolutionCandidateEvaluation,
     EvolutionExperiment,
     EvolutionExperimentConfig,
@@ -19,6 +21,8 @@ __all__ = [
     "AdaptiveMutationConfig",
     "AdaptiveMutationController",
     "compute_normalized_diversity",
+    "ConvergenceCriteria",
+    "ConvergenceReason",
     "EvolutionCandidateEvaluation",
     "EvolutionExperiment",
     "EvolutionExperimentConfig",

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -50,6 +50,74 @@ class EvolutionSelectionMethod(str, Enum):
     ROULETTE = "roulette"
 
 
+class ConvergenceReason(str, Enum):
+    """Reason a run was declared converged or its budget was exhausted.
+
+    ``FITNESS_PLATEAU``
+        The best fitness did not improve by more than the configured threshold
+        over the trailing fitness window.
+
+    ``DIVERSITY_COLLAPSE``
+        The mean normalized gene diversity stayed below the configured
+        threshold for the required number of consecutive generations.
+
+    ``BUDGET_EXHAUSTED``
+        The run completed all configured generations without any convergence
+        criterion being satisfied.  Returned only when
+        :attr:`ConvergenceCriteria.enabled` is ``True`` and neither fitness
+        plateau nor diversity collapse was detected.
+    """
+
+    FITNESS_PLATEAU = "fitness_plateau"
+    DIVERSITY_COLLAPSE = "diversity_collapse"
+    BUDGET_EXHAUSTED = "budget_exhausted"
+
+
+@dataclass(frozen=True)
+class ConvergenceCriteria:
+    """Configurable convergence stopping criteria for evolution experiments.
+
+    When ``enabled`` is ``False`` (default), convergence checking is skipped
+    entirely and the run always uses the full generation budget, preserving
+    existing behavior.  When ``True``:
+
+    - **Fitness plateau**: declares convergence when the best fitness fails
+      to improve by more than ``fitness_threshold`` absolute units over the
+      trailing ``fitness_window`` generations.
+    - **Diversity collapse**: declares convergence when the mean normalized
+      gene diversity remains below ``diversity_threshold`` for
+      ``diversity_window`` consecutive generations.
+
+    Checks are suppressed until at least ``min_generations`` full generations
+    have been evaluated.
+
+    When ``early_stop`` is ``True`` (default), the run halts as soon as a
+    criterion is met.  When ``False``, the run continues for all configured
+    generations but the result is still annotated with the first convergence
+    event detected.
+    """
+
+    enabled: bool = False
+    fitness_window: int = 5
+    fitness_threshold: float = 1e-4
+    diversity_window: int = 3
+    diversity_threshold: float = 0.01
+    min_generations: int = 1
+    early_stop: bool = True
+
+    def __post_init__(self) -> None:
+        if self.fitness_window < 1:
+            raise ValueError("fitness_window must be at least 1.")
+        if self.fitness_threshold < 0.0:
+            raise ValueError("fitness_threshold must be non-negative.")
+        if self.diversity_window < 1:
+            raise ValueError("diversity_window must be at least 1.")
+        if self.diversity_threshold < 0.0:
+            raise ValueError("diversity_threshold must be non-negative.")
+        if self.min_generations < 0:
+            raise ValueError("min_generations must be non-negative.")
+
+
 @dataclass(frozen=True)
 class EvolutionExperimentConfig:
     """Configuration for generation-based hyperparameter evolution."""
@@ -70,6 +138,7 @@ class EvolutionExperimentConfig:
     elitism_count: int = 1
     fitness_metric: EvolutionFitnessMetric = EvolutionFitnessMetric.FINAL_POPULATION
     adaptive_mutation: AdaptiveMutationConfig = field(default_factory=AdaptiveMutationConfig)
+    convergence_criteria: ConvergenceCriteria = field(default_factory=ConvergenceCriteria)
     seed: Optional[int] = None
     output_dir: Optional[str] = None
 
@@ -153,11 +222,29 @@ class EvolutionGenerationSummary:
 
 @dataclass
 class EvolutionExperimentResult:
-    """Container with generation summaries and per-candidate lineage."""
+    """Container with generation summaries and per-candidate lineage.
+
+    ``converged`` is ``True`` when a convergence criterion (fitness plateau or
+    diversity collapse) was satisfied.  It remains ``False`` when convergence
+    checking is disabled or when the run exhausted its generation budget
+    without triggering a criterion.
+
+    ``convergence_reason`` holds a :class:`ConvergenceReason` value (as a
+    string) when convergence checking is enabled.  It is ``"budget_exhausted"``
+    when all generations completed without a criterion being met, and ``None``
+    when convergence checking is disabled.
+
+    ``generation_of_convergence`` is the 0-based generation index at which the
+    criterion was first satisfied.  When the budget is exhausted it is set to
+    the index of the last completed generation.  ``None`` when disabled.
+    """
 
     generation_summaries: List[EvolutionGenerationSummary]
     evaluations: List[EvolutionCandidateEvaluation]
     best_candidate: EvolutionCandidateEvaluation
+    converged: bool = False
+    convergence_reason: Optional[str] = None
+    generation_of_convergence: Optional[int] = None
 
 
 FitnessEvaluator = Callable[
@@ -213,6 +300,13 @@ class EvolutionExperiment:
         # `_initialize_population`, not by the adaptive controller.
         produced_with: _ProducedWith = _ProducedWith.initial()
 
+        # Convergence tracking: histories are used by _check_convergence.
+        best_fitness_history: List[float] = []
+        diversity_history: List[Optional[float]] = []
+        converged = False
+        convergence_reason: Optional[str] = None
+        generation_of_convergence: Optional[int] = None
+
         for generation in range(self.config.num_generations):
             generation_evals = self._evaluate_generation(generation, population, evaluator)
             evaluations.extend(generation_evals)
@@ -241,6 +335,24 @@ class EvolutionExperiment:
                 adaptive_event=produced_with.event,
             )
 
+            # Update convergence histories and check criteria.
+            best_fitness_history.append(best_fitness)
+            diversity_history.append(diversity)
+            if not converged:
+                reason = self._check_convergence(generation, best_fitness_history, diversity_history)
+                if reason is not None:
+                    converged = True
+                    convergence_reason = reason.value
+                    generation_of_convergence = generation
+                    logger.info(
+                        "evolution_converged",
+                        generation=generation,
+                        reason=reason.value,
+                        early_stop=self.config.convergence_criteria.early_stop,
+                    )
+                    if self.config.convergence_criteria.early_stop:
+                        break
+
             controller.observe(best_fitness=best_fitness, diversity=diversity)
             next_rate = controller.effective_rate(self.config.mutation_rate)
             next_scale = controller.effective_scale(self.config.mutation_scale)
@@ -262,11 +374,20 @@ class EvolutionExperiment:
                 event=controller.last_event,
             )
 
+        # When convergence checking is enabled but no criterion was met during
+        # the run, annotate the result as budget-exhausted.
+        if self.config.convergence_criteria.enabled and not converged and generation_summaries:
+            convergence_reason = ConvergenceReason.BUDGET_EXHAUSTED.value
+            generation_of_convergence = len(generation_summaries) - 1
+
         best_candidate = max(evaluations, key=lambda item: item.fitness)
         result = EvolutionExperimentResult(
             generation_summaries=generation_summaries,
             evaluations=evaluations,
             best_candidate=best_candidate,
+            converged=converged,
+            convergence_reason=convergence_reason,
+            generation_of_convergence=generation_of_convergence,
         )
         self._persist_results(result)
         return result
@@ -476,6 +597,43 @@ class EvolutionExperiment:
             return None
         return compute_normalized_diversity(gene_statistics, evolvable_names, gene_bounds)
 
+    def _check_convergence(
+        self,
+        generation: int,
+        best_fitness_history: List[float],
+        diversity_history: List[Optional[float]],
+    ) -> Optional[ConvergenceReason]:
+        """Return a :class:`ConvergenceReason` if convergence is detected.
+
+        Returns ``None`` when convergence checking is disabled, when fewer
+        than ``min_generations`` have completed, or when no criterion is
+        satisfied.  The caller is responsible for appending to both history
+        lists *before* calling this method so that the current generation is
+        included in the check.
+        """
+        criteria = self.config.convergence_criteria
+        if not criteria.enabled:
+            return None
+        if generation < criteria.min_generations:
+            return None
+
+        # Fitness plateau: current best has not improved over the trailing window.
+        if len(best_fitness_history) >= criteria.fitness_window + 1:
+            window = best_fitness_history[-(criteria.fitness_window + 1):]
+            improvement = window[-1] - max(window[:-1])
+            if improvement <= criteria.fitness_threshold:
+                return ConvergenceReason.FITNESS_PLATEAU
+
+        # Diversity collapse: enough consecutive non-None diversity readings
+        # are all below the threshold.
+        recent_non_none = [d for d in diversity_history[-criteria.diversity_window:] if d is not None]
+        if len(recent_non_none) >= criteria.diversity_window and all(
+            d <= criteria.diversity_threshold for d in recent_non_none
+        ):
+            return ConvergenceReason.DIVERSITY_COLLAPSE
+
+        return None
+
     def _build_gene_statistics(
         self,
         generation_evals: List[EvolutionCandidateEvaluation],
@@ -562,6 +720,7 @@ class EvolutionExperiment:
         os.makedirs(self.config.output_dir, exist_ok=True)
         summaries_path = os.path.join(self.config.output_dir, "evolution_generation_summaries.json")
         lineage_path = os.path.join(self.config.output_dir, "evolution_lineage.json")
+        metadata_path = os.path.join(self.config.output_dir, "evolution_metadata.json")
 
         with open(summaries_path, "w", encoding="utf-8") as summaries_file:
             json.dump([asdict(summary) for summary in result.generation_summaries], summaries_file, indent=2)
@@ -586,10 +745,22 @@ class EvolutionExperiment:
         with open(lineage_path, "w", encoding="utf-8") as lineage_file:
             json.dump(serialized_evaluations, lineage_file, indent=2)
 
+        convergence_metadata: Dict[str, Any] = {
+            "converged": result.converged,
+            "convergence_reason": result.convergence_reason,
+            "generation_of_convergence": result.generation_of_convergence,
+            "num_generations_completed": len(result.generation_summaries),
+        }
+        with open(metadata_path, "w", encoding="utf-8") as metadata_file:
+            json.dump(convergence_metadata, metadata_file, indent=2)
+
         logger.info(
             "evolution_experiment_persisted",
             output_dir=self.config.output_dir,
             summaries_path=summaries_path,
             lineage_path=lineage_path,
+            metadata_path=metadata_path,
             num_generations=self.config.num_generations,
+            converged=result.converged,
+            convergence_reason=result.convergence_reason,
         )

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -606,15 +606,15 @@ class EvolutionExperiment:
         """Return a :class:`ConvergenceReason` if convergence is detected.
 
         Returns ``None`` when convergence checking is disabled, when fewer
-        than ``min_generations`` have completed, or when no criterion is
-        satisfied.  The caller is responsible for appending to both history
-        lists *before* calling this method so that the current generation is
-        included in the check.
+        than ``min_generations`` completed generations are recorded in the
+        histories, or when no criterion is satisfied.  The caller is
+        responsible for appending to both history lists *before* calling this
+        method so that the current generation is included in the check.
         """
         criteria = self.config.convergence_criteria
         if not criteria.enabled:
             return None
-        if generation < criteria.min_generations:
+        if len(best_fitness_history) < criteria.min_generations:
             return None
 
         # Fitness plateau: current best has not improved over the trailing window.

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -617,10 +617,11 @@ class EvolutionExperiment:
         if len(best_fitness_history) < criteria.min_generations:
             return None
 
-        # Fitness plateau: current best has not improved over the trailing window.
+        # Fitness plateau: current best has not improved enough relative to
+        # the best fitness from `fitness_window` generations ago.
         if len(best_fitness_history) >= criteria.fitness_window + 1:
             window = best_fitness_history[-(criteria.fitness_window + 1):]
-            improvement = window[-1] - max(window[:-1])
+            improvement = window[-1] - window[0]
             if improvement <= criteria.fitness_threshold:
                 return ConvergenceReason.FITNESS_PLATEAU
 

--- a/scripts/run_evolution_experiment.py
+++ b/scripts/run_evolution_experiment.py
@@ -17,6 +17,7 @@ if _repo_root not in sys.path:
 from farm.config import SimulationConfig  # noqa: E402
 from farm.runners import (  # noqa: E402
     AdaptiveMutationConfig,
+    ConvergenceCriteria,
     EvolutionExperiment,
     EvolutionExperimentConfig,
     EvolutionFitnessMetric,
@@ -299,6 +300,64 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         help="Structured logging level.",
     )
+    # ------------------------------------------------------------------
+    # Convergence criteria
+    # ------------------------------------------------------------------
+    parser.add_argument(
+        "--convergence-enabled",
+        action="store_true",
+        help=(
+            "Enable convergence checking.  When set, the run will detect "
+            "fitness plateau and diversity collapse and optionally stop early."
+        ),
+    )
+    parser.add_argument(
+        "--convergence-fitness-window",
+        type=int,
+        default=5,
+        help=(
+            "Number of trailing generations over which best-fitness improvement "
+            "is measured for the plateau criterion."
+        ),
+    )
+    parser.add_argument(
+        "--convergence-fitness-threshold",
+        type=float,
+        default=1e-4,
+        help=(
+            "Minimum absolute improvement in best fitness over the window "
+            "required to avoid a plateau declaration."
+        ),
+    )
+    parser.add_argument(
+        "--convergence-diversity-window",
+        type=int,
+        default=3,
+        help=(
+            "Number of consecutive generations with diversity below the threshold "
+            "required to trigger a diversity-collapse declaration."
+        ),
+    )
+    parser.add_argument(
+        "--convergence-diversity-threshold",
+        type=float,
+        default=0.01,
+        help="Normalized diversity at or below which diversity-collapse is considered.",
+    )
+    parser.add_argument(
+        "--convergence-min-generations",
+        type=int,
+        default=1,
+        help="Minimum number of completed generations before convergence checks begin.",
+    )
+    parser.add_argument(
+        "--convergence-no-early-stop",
+        action="store_true",
+        help=(
+            "When --convergence-enabled is set, annotate the result with convergence "
+            "metadata but do not halt the run early."
+        ),
+    )
     return parser
 
 
@@ -384,6 +443,15 @@ def main() -> int:
                     args.adaptive_per_gene_scale, label="--adaptive-per-gene-scale"
                 ),
             ),
+            convergence_criteria=ConvergenceCriteria(
+                enabled=args.convergence_enabled,
+                fitness_window=args.convergence_fitness_window,
+                fitness_threshold=args.convergence_fitness_threshold,
+                diversity_window=args.convergence_diversity_window,
+                diversity_threshold=args.convergence_diversity_threshold,
+                min_generations=args.convergence_min_generations,
+                early_stop=not args.convergence_no_early_stop,
+            ),
             selection_method=EvolutionSelectionMethod(args.selection_method),
             tournament_size=args.tournament_size,
             elitism_count=args.elitism_count,
@@ -416,6 +484,13 @@ def main() -> int:
             "num_crossover_points": args.num_crossover_points,
             "elitism_count": args.elitism_count,
             "adaptive_mutation": args.adaptive_mutation,
+            "convergence_enabled": args.convergence_enabled,
+            "convergence_fitness_window": args.convergence_fitness_window,
+            "convergence_fitness_threshold": args.convergence_fitness_threshold,
+            "convergence_diversity_window": args.convergence_diversity_window,
+            "convergence_diversity_threshold": args.convergence_diversity_threshold,
+            "convergence_min_generations": args.convergence_min_generations,
+            "convergence_early_stop": not args.convergence_no_early_stop,
             "seed": args.seed,
             "output_dir": args.output_dir,
         }
@@ -452,6 +527,9 @@ def main() -> int:
                 last_summary.mutation_scale_multiplier if last_summary else None
             ),
             "final_adaptive_event": last_summary.adaptive_event if last_summary else None,
+            "converged": result.converged,
+            "convergence_reason": result.convergence_reason,
+            "generation_of_convergence": result.generation_of_convergence,
             "output_dir": args.output_dir,
         }
         print(json.dumps(summary, indent=2))

--- a/scripts/run_evolution_experiment.py
+++ b/scripts/run_evolution_experiment.py
@@ -311,10 +311,10 @@ def _parse_args() -> argparse.Namespace:
     """
     parser = _build_parser()
     # First pass: discover --preset without failing on unknown/remaining args.
-    prelim, _ = parser.parse_known_args()
-    if prelim.preset is not None:
+    preset_discovery_args, _ = parser.parse_known_args()
+    if preset_discovery_args.preset is not None:
         # preset is already validated by choices=, so this lookup always succeeds.
-        parser.set_defaults(**PRESETS[prelim.preset])
+        parser.set_defaults(**PRESETS[preset_discovery_args.preset])
     return parser.parse_args()
 
 
@@ -420,8 +420,8 @@ def main() -> int:
             "output_dir": args.output_dir,
         }
         manifest_path = os.path.join(args.output_dir, "run_manifest.json")
-        with open(manifest_path, "w") as _f:
-            json.dump(manifest, _f, indent=2)
+        with open(manifest_path, "w") as manifest_file:
+            json.dump(manifest, manifest_file, indent=2)
         logger.info("evolution_experiment_manifest_written", path=manifest_path)
 
         start = time.time()

--- a/scripts/run_evolution_experiment.py
+++ b/scripts/run_evolution_experiment.py
@@ -29,6 +29,44 @@ from farm.core.hyperparameter_chromosome import (  # noqa: E402
 )
 from farm.utils.logging import configure_logging, get_logger  # noqa: E402
 
+# ---------------------------------------------------------------------------
+# Named presets
+# ---------------------------------------------------------------------------
+# Each preset is a dict whose keys match argparse ``dest`` names.  When a
+# preset is selected via ``--preset``, its values become the argparse
+# *defaults* for those arguments, so any explicit CLI flag still wins.
+#
+# ``stable_hyper_evo`` rationale
+# --------------------------------
+# Follow-up analysis in ``notebooks/hyperparameter_evolution_results.ipynb``
+# and ``docs/experiments/hyperparameter_evolution_convergence.md`` revealed
+# two recurring failure modes with the bare defaults:
+#
+#   1. **Lower-bound collapse** – tournament selection with aggressive mutation
+#      pushes the winning learning rate to its minimum boundary and keeps it
+#      there.  Switching to ``boundary_mode=reflect`` lets genes bounce back
+#      off the wall instead of sticking.
+#
+#   2. **Diversity collapse** – without adaptive mutation the population
+#      converges prematurely.  Enabling adaptive mutation with both the
+#      fitness-stall and diversity-collapse rules keeps the search alive.
+#
+# The mutation magnitudes (rate 0.20, scale 0.15) come from the
+# ``run_tournament_mut020_g6`` closure run, which showed the best trade-off
+# between exploration and exploitation across the evaluated configs.
+
+PRESETS: dict[str, dict[str, object]] = {
+    "stable_hyper_evo": {
+        "selection_method": EvolutionSelectionMethod.TOURNAMENT.value,
+        "boundary_mode": BoundaryMode.REFLECT.value,
+        "mutation_rate": 0.20,
+        "mutation_scale": 0.15,
+        "adaptive_mutation": True,
+        "tournament_size": 3,
+        "elitism_count": 1,
+    },
+}
+
 
 def _parse_per_gene_multipliers(raw: str | None, *, label: str) -> dict[str, float]:
     """Parse a comma-separated ``gene=value`` string into a multiplier dict.
@@ -60,10 +98,30 @@ def _parse_per_gene_multipliers(raw: str | None, *, label: str) -> dict[str, flo
     return multipliers
 
 
-def _parse_args() -> argparse.Namespace:
+def _build_parser() -> argparse.ArgumentParser:
+    """Return a fully-configured argument parser (without actually parsing)."""
     parser = argparse.ArgumentParser(
-        description="Run multi-generation hyperparameter evolution experiments.",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description=(
+            "Run multi-generation hyperparameter evolution experiments.\n\n"
+            "Named presets (--preset) provide opinionated defaults that reflect current\n"
+            "best-performing configurations.  Any explicit CLI flag still overrides the\n"
+            "preset value.\n\n"
+            "Available presets:\n"
+            "  stable_hyper_evo  tournament selection + reflect boundary + adaptive\n"
+            "                    mutation (rate 0.20, scale 0.15).  Prevents lower-bound\n"
+            "                    collapse and diversity collapse seen with bare defaults."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--preset",
+        type=str,
+        default=None,
+        choices=list(PRESETS),
+        help=(
+            "Load a named configuration preset.  Preset values act as defaults; any "
+            "explicit CLI flag still takes priority.  Available: %(choices)s."
+        ),
     )
     parser.add_argument(
         "--environment",
@@ -241,6 +299,22 @@ def _parse_args() -> argparse.Namespace:
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         help="Structured logging level.",
     )
+    return parser
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse CLI arguments, applying any named preset as baseline defaults.
+
+    Two-pass approach: the first parse discovers ``--preset``; if set, the
+    preset values are installed as argparse defaults before the final parse so
+    that any explicit flag the user supplied still wins over the preset.
+    """
+    parser = _build_parser()
+    # First pass: discover --preset without failing on unknown/remaining args.
+    prelim, _ = parser.parse_known_args()
+    if prelim.preset is not None:
+        # preset is already validated by choices=, so this lookup always succeeds.
+        parser.set_defaults(**PRESETS[prelim.preset])
     return parser.parse_args()
 
 
@@ -253,6 +327,7 @@ def main() -> int:
 
     logger.info(
         "evolution_experiment_cli_start",
+        preset=args.preset,
         environment=args.environment,
         profile=args.profile,
         generations=args.generations,
@@ -316,6 +391,38 @@ def main() -> int:
             seed=args.seed,
             output_dir=args.output_dir,
         )
+
+        # Persist the resolved configuration before running so the manifest is
+        # available even if the experiment is interrupted.
+        manifest: dict[str, object] = {
+            "script": "scripts/run_evolution_experiment.py",
+            "preset": args.preset,
+            "environment": args.environment,
+            "profile": args.profile,
+            "generations": args.generations,
+            "population_size": args.population_size,
+            "steps_per_candidate": args.steps_per_candidate,
+            "fitness_metric": args.fitness_metric,
+            "selection_method": args.selection_method,
+            "mutation_rate": args.mutation_rate,
+            "mutation_scale": args.mutation_scale,
+            "tournament_size": args.tournament_size,
+            "boundary_mode": args.boundary_mode,
+            "boundary_penalty_enabled": args.boundary_penalty_enabled,
+            "boundary_penalty_strength": args.boundary_penalty_strength,
+            "boundary_penalty_threshold": args.boundary_penalty_threshold,
+            "crossover_mode": args.crossover_mode,
+            "blend_alpha": args.blend_alpha,
+            "num_crossover_points": args.num_crossover_points,
+            "elitism_count": args.elitism_count,
+            "adaptive_mutation": args.adaptive_mutation,
+            "seed": args.seed,
+            "output_dir": args.output_dir,
+        }
+        manifest_path = os.path.join(args.output_dir, "run_manifest.json")
+        with open(manifest_path, "w") as _f:
+            json.dump(manifest, _f, indent=2)
+        logger.info("evolution_experiment_manifest_written", path=manifest_path)
 
         start = time.time()
         result = EvolutionExperiment(base_config, experiment_config).run()

--- a/scripts/run_evolution_experiment.py
+++ b/scripts/run_evolution_experiment.py
@@ -99,6 +99,10 @@ def _parse_per_gene_multipliers(raw: str | None, *, label: str) -> dict[str, flo
     return multipliers
 
 
+class _HelpFormatter(argparse.RawDescriptionHelpFormatter, argparse.ArgumentDefaultsHelpFormatter):
+    """Formatter that preserves raw description layout and also shows defaults."""
+
+
 def _build_parser() -> argparse.ArgumentParser:
     """Return a fully-configured argument parser (without actually parsing)."""
     parser = argparse.ArgumentParser(
@@ -112,7 +116,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "                    mutation (rate 0.20, scale 0.15).  Prevents lower-bound\n"
             "                    collapse and diversity collapse seen with bare defaults."
         ),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=_HelpFormatter,
     )
     parser.add_argument(
         "--preset",
@@ -219,7 +223,8 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--elitism-count", type=int, default=1, help="Top candidates copied to next generation.")
     parser.add_argument(
         "--adaptive-mutation",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="Enable adaptive mutation rate/scale based on fitness progress and diversity.",
     )
     parser.add_argument(

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -569,5 +569,452 @@ class TestEvolutionExperimentAdaptiveMutation(unittest.TestCase):
             self.assertNotIn("diversity_collapse", summaries[1]["adaptive_event"])
 
 
+class TestConvergenceCriteria(unittest.TestCase):
+    def test_defaults_are_disabled(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+
+        criteria = ConvergenceCriteria()
+        self.assertFalse(criteria.enabled)
+
+    def test_rejects_zero_fitness_window(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+
+        with self.assertRaises(ValueError):
+            ConvergenceCriteria(fitness_window=0)
+
+    def test_rejects_negative_fitness_threshold(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+
+        with self.assertRaises(ValueError):
+            ConvergenceCriteria(fitness_threshold=-0.1)
+
+    def test_rejects_zero_diversity_window(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+
+        with self.assertRaises(ValueError):
+            ConvergenceCriteria(diversity_window=0)
+
+    def test_rejects_negative_diversity_threshold(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+
+        with self.assertRaises(ValueError):
+            ConvergenceCriteria(diversity_threshold=-0.1)
+
+    def test_rejects_negative_min_generations(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+
+        with self.assertRaises(ValueError):
+            ConvergenceCriteria(min_generations=-1)
+
+    def test_accepts_valid_config(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+
+        criteria = ConvergenceCriteria(
+            enabled=True,
+            fitness_window=3,
+            fitness_threshold=0.01,
+            diversity_window=2,
+            diversity_threshold=0.05,
+            min_generations=2,
+            early_stop=False,
+        )
+        self.assertTrue(criteria.enabled)
+        self.assertEqual(criteria.fitness_window, 3)
+        self.assertEqual(criteria.min_generations, 2)
+        self.assertFalse(criteria.early_stop)
+
+    def test_zero_threshold_is_accepted(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+
+        # threshold=0 means any improvement (strictly > 0) avoids plateau.
+        criteria = ConvergenceCriteria(fitness_threshold=0.0, diversity_threshold=0.0)
+        self.assertEqual(criteria.fitness_threshold, 0.0)
+
+
+class TestConvergenceDisabledRegressionMode(unittest.TestCase):
+    """Regression: with convergence disabled all generations always run."""
+
+    def test_disabled_convergence_runs_all_generations(self):
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=4,
+            population_size=3,
+            num_steps_per_candidate=1,
+            seed=99,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, gen, member: (1.0, {"member": member})
+        )
+        self.assertEqual(len(result.generation_summaries), 4)
+        self.assertFalse(result.converged)
+        self.assertIsNone(result.convergence_reason)
+        self.assertIsNone(result.generation_of_convergence)
+
+    def test_disabled_convergence_persists_no_metadata_fields(self):
+        base_config = SimulationConfig()
+        with tempfile.TemporaryDirectory() as output_dir:
+            config = EvolutionExperimentConfig(
+                num_generations=2,
+                population_size=3,
+                num_steps_per_candidate=1,
+                output_dir=output_dir,
+                seed=77,
+            )
+            experiment = EvolutionExperiment(base_config, config)
+            result = experiment.run(
+                fitness_evaluator=lambda candidate, cfg, gen, member: (1.0, {"member": member})
+            )
+            import os as _os
+            metadata_path = _os.path.join(output_dir, "evolution_metadata.json")
+            with open(metadata_path, encoding="utf-8") as mf:
+                metadata = json.load(mf)
+            self.assertFalse(metadata["converged"])
+            self.assertIsNone(metadata["convergence_reason"])
+            self.assertIsNone(metadata["generation_of_convergence"])
+            self.assertEqual(metadata["num_generations_completed"], 2)
+            # Regression: existing summaries file is still an array.
+            summaries_path = _os.path.join(output_dir, "evolution_generation_summaries.json")
+            with open(summaries_path, encoding="utf-8") as sf:
+                summaries = json.load(sf)
+            self.assertIsInstance(summaries, list)
+
+
+class TestConvergenceFitnessPlateau(unittest.TestCase):
+    def test_plateau_triggers_convergence_when_no_improvement(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=10,
+            population_size=3,
+            num_steps_per_candidate=1,
+            convergence_criteria=ConvergenceCriteria(
+                enabled=True,
+                fitness_window=2,
+                fitness_threshold=0.0,
+                min_generations=0,
+                early_stop=True,
+            ),
+            seed=1,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, gen, member: (5.0, {"member": member})
+        )
+        self.assertTrue(result.converged)
+        self.assertEqual(result.convergence_reason, "fitness_plateau")
+        # With window=2 and min_generations=0, plateau fires when we have >=3 entries
+        # with no improvement: generation 2 (0-indexed) at the earliest.
+        self.assertIsNotNone(result.generation_of_convergence)
+        self.assertLess(result.generation_of_convergence, 10)
+        # Early stop: fewer than all 10 generations should have run.
+        self.assertLess(len(result.generation_summaries), 10)
+
+    def test_plateau_not_triggered_while_fitness_improves(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=5,
+            population_size=3,
+            num_steps_per_candidate=1,
+            convergence_criteria=ConvergenceCriteria(
+                enabled=True,
+                fitness_window=2,
+                fitness_threshold=0.5,
+                min_generations=0,
+                early_stop=True,
+            ),
+            seed=2,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        # Fitness strictly increases by 2 each generation: well above threshold=0.5.
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, gen, member: (
+                float(gen * 2 + 1),
+                {"member": member},
+            )
+        )
+        self.assertFalse(result.converged)
+        self.assertEqual(result.convergence_reason, "budget_exhausted")
+        self.assertEqual(len(result.generation_summaries), 5)
+
+    def test_plateau_respects_min_generations(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=10,
+            population_size=3,
+            num_steps_per_candidate=1,
+            convergence_criteria=ConvergenceCriteria(
+                enabled=True,
+                fitness_window=1,
+                fitness_threshold=0.0,
+                min_generations=5,
+                early_stop=True,
+            ),
+            seed=3,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, gen, member: (1.0, {"member": member})
+        )
+        self.assertTrue(result.converged)
+        # Plateau cannot fire before generation 5 (min_generations=5).
+        self.assertGreaterEqual(result.generation_of_convergence, 5)
+
+
+class TestConvergenceDiversityCollapse(unittest.TestCase):
+    def test_diversity_collapse_triggers_convergence(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=10,
+            population_size=3,
+            num_steps_per_candidate=1,
+            convergence_criteria=ConvergenceCriteria(
+                enabled=True,
+                # Set an unreachably high fitness threshold so plateau never fires.
+                fitness_window=100,
+                fitness_threshold=1e9,
+                diversity_window=2,
+                diversity_threshold=1.0,  # always satisfied
+                min_generations=0,
+                early_stop=True,
+            ),
+            seed=4,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, gen, member: (
+                float(gen),
+                {"member": member},
+            )
+        )
+        self.assertTrue(result.converged)
+        self.assertEqual(result.convergence_reason, "diversity_collapse")
+        self.assertLess(len(result.generation_summaries), 10)
+
+    def test_diversity_collapse_skipped_when_diversity_is_none(self):
+        """Diversity collapse must not fire when _compute_diversity returns None."""
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+        from unittest.mock import patch
+
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=5,
+            population_size=3,
+            num_steps_per_candidate=1,
+            convergence_criteria=ConvergenceCriteria(
+                enabled=True,
+                fitness_window=100,
+                fitness_threshold=1e9,
+                diversity_window=2,
+                diversity_threshold=1.0,  # would always fire if diversity were not None
+                min_generations=0,
+                early_stop=True,
+            ),
+            seed=5,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        with patch.object(EvolutionExperiment, "_compute_diversity", return_value=None):
+            result = experiment.run(
+                fitness_evaluator=lambda candidate, cfg, gen, member: (1.0, {"member": member})
+            )
+        # Diversity is always None so collapse never triggers; budget exhausted instead.
+        self.assertFalse(result.converged)
+        self.assertEqual(result.convergence_reason, "budget_exhausted")
+
+
+class TestConvergenceEarlyStop(unittest.TestCase):
+    def test_early_stop_true_halts_run(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=20,
+            population_size=3,
+            num_steps_per_candidate=1,
+            convergence_criteria=ConvergenceCriteria(
+                enabled=True,
+                fitness_window=1,
+                fitness_threshold=0.0,
+                min_generations=0,
+                early_stop=True,
+            ),
+            seed=6,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, gen, member: (1.0, {"member": member})
+        )
+        self.assertTrue(result.converged)
+        # Run must have stopped before all 20 generations completed.
+        self.assertLess(len(result.generation_summaries), 20)
+
+    def test_early_stop_false_annotates_without_halting(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=6,
+            population_size=3,
+            num_steps_per_candidate=1,
+            convergence_criteria=ConvergenceCriteria(
+                enabled=True,
+                fitness_window=1,
+                fitness_threshold=0.0,
+                min_generations=0,
+                early_stop=False,  # annotate only, don't stop
+            ),
+            seed=7,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, gen, member: (1.0, {"member": member})
+        )
+        # Converged is True (criterion met) but all 6 generations ran.
+        self.assertTrue(result.converged)
+        self.assertEqual(result.convergence_reason, "fitness_plateau")
+        self.assertEqual(len(result.generation_summaries), 6)
+
+    def test_early_stop_records_first_convergence_generation(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=10,
+            population_size=3,
+            num_steps_per_candidate=1,
+            convergence_criteria=ConvergenceCriteria(
+                enabled=True,
+                fitness_window=2,
+                fitness_threshold=0.0,
+                min_generations=0,
+                early_stop=False,
+            ),
+            seed=8,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, gen, member: (1.0, {"member": member})
+        )
+        first_detection = result.generation_of_convergence
+        self.assertIsNotNone(first_detection)
+        # The detection generation must be within the completed window.
+        self.assertLess(first_detection, len(result.generation_summaries))
+
+
+class TestConvergenceBudgetExhausted(unittest.TestCase):
+    def test_budget_exhausted_annotated_when_no_criterion_met(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=3,
+            population_size=3,
+            num_steps_per_candidate=1,
+            convergence_criteria=ConvergenceCriteria(
+                enabled=True,
+                # Extremely high threshold so plateau never fires.
+                fitness_window=100,
+                fitness_threshold=1e9,
+                # Extremely low threshold so diversity collapse never fires.
+                diversity_window=100,
+                diversity_threshold=0.0,
+                min_generations=0,
+            ),
+            seed=9,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, gen, member: (
+                float(gen * 100),
+                {"member": member},
+            )
+        )
+        self.assertFalse(result.converged)
+        self.assertEqual(result.convergence_reason, "budget_exhausted")
+        self.assertEqual(result.generation_of_convergence, 2)  # last generation index
+        self.assertEqual(len(result.generation_summaries), 3)
+
+
+class TestConvergenceMetadataPersisted(unittest.TestCase):
+    def test_convergence_metadata_written_to_file(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+        import os as _os
+
+        base_config = SimulationConfig()
+        with tempfile.TemporaryDirectory() as output_dir:
+            config = EvolutionExperimentConfig(
+                num_generations=10,
+                population_size=3,
+                num_steps_per_candidate=1,
+                convergence_criteria=ConvergenceCriteria(
+                    enabled=True,
+                    fitness_window=1,
+                    fitness_threshold=0.0,
+                    min_generations=0,
+                    early_stop=True,
+                ),
+                output_dir=output_dir,
+                seed=10,
+            )
+            experiment = EvolutionExperiment(base_config, config)
+            result = experiment.run(
+                fitness_evaluator=lambda candidate, cfg, gen, member: (1.0, {"member": member})
+            )
+            metadata_path = _os.path.join(output_dir, "evolution_metadata.json")
+            self.assertTrue(_os.path.exists(metadata_path))
+            with open(metadata_path, encoding="utf-8") as mf:
+                metadata = json.load(mf)
+            self.assertIn("converged", metadata)
+            self.assertIn("convergence_reason", metadata)
+            self.assertIn("generation_of_convergence", metadata)
+            self.assertIn("num_generations_completed", metadata)
+            self.assertTrue(metadata["converged"])
+            self.assertEqual(metadata["convergence_reason"], result.convergence_reason)
+            self.assertEqual(metadata["generation_of_convergence"], result.generation_of_convergence)
+            self.assertEqual(metadata["num_generations_completed"], len(result.generation_summaries))
+
+    def test_convergence_reason_enum_values_are_strings_in_json(self):
+        from farm.runners.evolution_experiment import ConvergenceCriteria
+        import os as _os
+
+        base_config = SimulationConfig()
+        with tempfile.TemporaryDirectory() as output_dir:
+            config = EvolutionExperimentConfig(
+                num_generations=5,
+                population_size=3,
+                num_steps_per_candidate=1,
+                convergence_criteria=ConvergenceCriteria(
+                    enabled=True,
+                    fitness_window=100,
+                    fitness_threshold=1e9,
+                    diversity_window=100,
+                    diversity_threshold=0.0,
+                    min_generations=0,
+                ),
+                output_dir=output_dir,
+                seed=11,
+            )
+            experiment = EvolutionExperiment(base_config, config)
+            experiment.run(
+                fitness_evaluator=lambda candidate, cfg, gen, member: (
+                    float(gen),
+                    {"member": member},
+                )
+            )
+            metadata_path = _os.path.join(output_dir, "evolution_metadata.json")
+            with open(metadata_path, encoding="utf-8") as mf:
+                metadata = json.load(mf)
+            # convergence_reason must be a plain string, not a dict or enum repr.
+            self.assertIsInstance(metadata["convergence_reason"], str)
+            self.assertEqual(metadata["convergence_reason"], "budget_exhausted")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -662,7 +662,7 @@ class TestConvergenceDisabledRegressionMode(unittest.TestCase):
                 seed=77,
             )
             experiment = EvolutionExperiment(base_config, config)
-            result = experiment.run(
+            experiment.run(
                 fitness_evaluator=lambda candidate, cfg, gen, member: (1.0, {"member": member})
             )
             import os as _os

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -762,8 +762,8 @@ class TestConvergenceFitnessPlateau(unittest.TestCase):
             fitness_evaluator=lambda candidate, cfg, gen, member: (1.0, {"member": member})
         )
         self.assertTrue(result.converged)
-        # Plateau cannot fire before generation 5 (min_generations=5).
-        self.assertGreaterEqual(result.generation_of_convergence, 5)
+        # Plateau cannot fire until five generations are recorded (indices 0–4).
+        self.assertGreaterEqual(result.generation_of_convergence, 4)
 
 
 class TestConvergenceDiversityCollapse(unittest.TestCase):

--- a/tests/test_run_evolution_experiment_cli.py
+++ b/tests/test_run_evolution_experiment_cli.py
@@ -217,6 +217,9 @@ class TestRunManifest(unittest.TestCase):
                 fake_result.best_candidate.fitness = 1.0
                 fake_result.best_candidate.learning_rate = 0.001
                 fake_result.best_candidate.parent_ids = []
+                fake_result.converged = False
+                fake_result.convergence_reason = None
+                fake_result.generation_of_convergence = None
 
                 with patch.object(
                     run_evolution_experiment.EvolutionExperiment,
@@ -261,6 +264,9 @@ class TestRunManifest(unittest.TestCase):
                 fake_result.best_candidate.fitness = 1.0
                 fake_result.best_candidate.learning_rate = 0.001
                 fake_result.best_candidate.parent_ids = []
+                fake_result.converged = False
+                fake_result.convergence_reason = None
+                fake_result.generation_of_convergence = None
 
                 with patch.object(
                     run_evolution_experiment.EvolutionExperiment,

--- a/tests/test_run_evolution_experiment_cli.py
+++ b/tests/test_run_evolution_experiment_cli.py
@@ -1,8 +1,10 @@
 """Smoke tests for the run_evolution_experiment CLI helpers."""
 
 import importlib
+import json
 import os
 import sys
+import tempfile
 import unittest
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -105,6 +107,174 @@ class TestAdaptiveCliFlags(unittest.TestCase):
         self.assertEqual(args.crossover_mode, "multi_point")
         self.assertAlmostEqual(args.blend_alpha, 0.9)
         self.assertEqual(args.num_crossover_points, 4)
+
+
+class TestPresets(unittest.TestCase):
+    def test_stable_hyper_evo_preset_exists(self):
+        self.assertIn("stable_hyper_evo", run_evolution_experiment.PRESETS)
+
+    def test_stable_hyper_evo_preset_has_required_keys(self):
+        preset = run_evolution_experiment.PRESETS["stable_hyper_evo"]
+        self.assertIn("selection_method", preset)
+        self.assertIn("boundary_mode", preset)
+        self.assertIn("mutation_rate", preset)
+        self.assertIn("mutation_scale", preset)
+        self.assertIn("adaptive_mutation", preset)
+
+    def test_stable_hyper_evo_preset_selection_is_tournament(self):
+        preset = run_evolution_experiment.PRESETS["stable_hyper_evo"]
+        self.assertEqual(preset["selection_method"], "tournament")
+
+    def test_stable_hyper_evo_preset_boundary_mode_is_reflect(self):
+        preset = run_evolution_experiment.PRESETS["stable_hyper_evo"]
+        self.assertEqual(preset["boundary_mode"], "reflect")
+
+    def test_stable_hyper_evo_preset_enables_adaptive_mutation(self):
+        preset = run_evolution_experiment.PRESETS["stable_hyper_evo"]
+        self.assertTrue(preset["adaptive_mutation"])
+
+    def test_preset_values_applied_when_flag_given(self):
+        argv = sys.argv[:]
+        try:
+            sys.argv = [
+                "run_evolution_experiment.py",
+                "--preset", "stable_hyper_evo",
+                "--generations", "1",
+                "--population-size", "2",
+                "--steps-per-candidate", "1",
+            ]
+            args = run_evolution_experiment._parse_args()
+        finally:
+            sys.argv = argv
+        self.assertEqual(args.preset, "stable_hyper_evo")
+        self.assertEqual(args.selection_method, "tournament")
+        self.assertEqual(args.boundary_mode, "reflect")
+        self.assertAlmostEqual(args.mutation_rate, 0.20)
+        self.assertAlmostEqual(args.mutation_scale, 0.15)
+        self.assertTrue(args.adaptive_mutation)
+
+    def test_explicit_flag_overrides_preset_value(self):
+        argv = sys.argv[:]
+        try:
+            sys.argv = [
+                "run_evolution_experiment.py",
+                "--preset", "stable_hyper_evo",
+                "--generations", "1",
+                "--population-size", "2",
+                "--steps-per-candidate", "1",
+                "--mutation-rate", "0.5",
+                "--boundary-mode", "clamp",
+            ]
+            args = run_evolution_experiment._parse_args()
+        finally:
+            sys.argv = argv
+        # Preset defaults: mutation_rate=0.20, boundary_mode=reflect
+        # Explicit flags should win.
+        self.assertAlmostEqual(args.mutation_rate, 0.5)
+        self.assertEqual(args.boundary_mode, "clamp")
+        # Other preset values still applied.
+        self.assertEqual(args.selection_method, "tournament")
+        self.assertTrue(args.adaptive_mutation)
+
+    def test_no_preset_leaves_standard_defaults(self):
+        argv = sys.argv[:]
+        try:
+            sys.argv = [
+                "run_evolution_experiment.py",
+                "--generations", "1",
+                "--population-size", "2",
+                "--steps-per-candidate", "1",
+            ]
+            args = run_evolution_experiment._parse_args()
+        finally:
+            sys.argv = argv
+        self.assertIsNone(args.preset)
+        self.assertAlmostEqual(args.mutation_rate, 0.25)
+        self.assertEqual(args.boundary_mode, "clamp")
+        self.assertFalse(args.adaptive_mutation)
+
+
+class TestRunManifest(unittest.TestCase):
+    def test_manifest_written_to_output_dir(self):
+        """main() should persist run_manifest.json in output_dir before the run."""
+        from unittest.mock import patch, MagicMock
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            argv = sys.argv[:]
+            try:
+                sys.argv = [
+                    "run_evolution_experiment.py",
+                    "--preset", "stable_hyper_evo",
+                    "--generations", "1",
+                    "--population-size", "2",
+                    "--steps-per-candidate", "1",
+                    "--output-dir", output_dir,
+                ]
+                fake_result = MagicMock()
+                fake_result.generation_summaries = []
+                fake_result.evaluations = []
+                fake_result.best_candidate.candidate_id = "test-id"
+                fake_result.best_candidate.fitness = 1.0
+                fake_result.best_candidate.learning_rate = 0.001
+                fake_result.best_candidate.parent_ids = []
+
+                with patch.object(
+                    run_evolution_experiment.EvolutionExperiment,
+                    "run",
+                    return_value=fake_result,
+                ):
+                    run_evolution_experiment.main()
+            finally:
+                sys.argv = argv
+
+            manifest_path = os.path.join(output_dir, "run_manifest.json")
+            self.assertTrue(os.path.isfile(manifest_path))
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+
+            self.assertEqual(manifest["preset"], "stable_hyper_evo")
+            self.assertEqual(manifest["selection_method"], "tournament")
+            self.assertEqual(manifest["boundary_mode"], "reflect")
+            self.assertAlmostEqual(manifest["mutation_rate"], 0.20)
+            self.assertAlmostEqual(manifest["mutation_scale"], 0.15)
+            self.assertTrue(manifest["adaptive_mutation"])
+            self.assertEqual(manifest["script"], "scripts/run_evolution_experiment.py")
+
+    def test_manifest_preset_is_null_when_no_preset_given(self):
+        """run_manifest.json should include preset=null when no --preset flag is used."""
+        from unittest.mock import patch, MagicMock
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            argv = sys.argv[:]
+            try:
+                sys.argv = [
+                    "run_evolution_experiment.py",
+                    "--generations", "1",
+                    "--population-size", "2",
+                    "--steps-per-candidate", "1",
+                    "--output-dir", output_dir,
+                ]
+                fake_result = MagicMock()
+                fake_result.generation_summaries = []
+                fake_result.evaluations = []
+                fake_result.best_candidate.candidate_id = "test-id"
+                fake_result.best_candidate.fitness = 1.0
+                fake_result.best_candidate.learning_rate = 0.001
+                fake_result.best_candidate.parent_ids = []
+
+                with patch.object(
+                    run_evolution_experiment.EvolutionExperiment,
+                    "run",
+                    return_value=fake_result,
+                ):
+                    run_evolution_experiment.main()
+            finally:
+                sys.argv = argv
+
+            manifest_path = os.path.join(output_dir, "run_manifest.json")
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+            self.assertIsNone(manifest["preset"])
 
 
 if __name__ == "__main__":

--- a/tests/test_run_evolution_experiment_cli.py
+++ b/tests/test_run_evolution_experiment_cli.py
@@ -176,7 +176,7 @@ class TestPresets(unittest.TestCase):
         self.assertEqual(args.selection_method, "tournament")
         self.assertTrue(args.adaptive_mutation)
 
-    def test_no_preset_leaves_standard_defaults(self):
+    def test_no_preset_uses_original_defaults(self):
         argv = sys.argv[:]
         try:
             sys.argv = [


### PR DESCRIPTION
This pull request introduces configurable convergence criteria to the hyperparameter evolution experiment framework, allowing experiments to automatically detect when they have converged (via fitness plateau or diversity collapse) and optionally stop early. It also adds a named preset for stable experiment configuration and enhances result metadata and CLI usability.

Key changes include:

**Convergence Criteria and Early Stopping:**
- Added a `ConvergenceCriteria` dataclass and `ConvergenceReason` enum to configure and track convergence checks (fitness plateau, diversity collapse, or budget exhaustion) in `EvolutionExperimentConfig` and the experiment runner. This enables automatic early stopping or annotation of convergence events. [[1]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR53-R120) [[2]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR141) [[3]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadL156-R247) [[4]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR303-R309) [[5]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR338-R355) [[6]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR377-R390) [[7]](diffhunk://#diff-c8139a827bd991793bde210cf38e1257269e4a1665fe89dcc4aa8823325337b4R9-R10) [[8]](diffhunk://#diff-c8139a827bd991793bde210cf38e1257269e4a1665fe89dcc4aa8823325337b4R24-R25) [[9]](diffhunk://#diff-4ae39f58357e6b3bcbd54224215df75118b339e902392d3250b3ff83ebf546caR20)

**Experiment Metadata and Output:**
- Enhanced experiment output by persisting convergence metadata (converged, reason, generation of convergence, etc.) to a new `evolution_metadata.json` file, and logging this information. [[1]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR723) [[2]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR748-R765)

**CLI Improvements and Presets:**
- Added a `--preset` CLI flag and introduced the `stable_hyper_evo` preset, which sets recommended defaults to avoid common failure modes (lower-bound and diversity collapse). Presets are described in documentation and CLI help. [[1]](diffhunk://#diff-4ae39f58357e6b3bcbd54224215df75118b339e902392d3250b3ff83ebf546caR33-R70) [[2]](diffhunk://#diff-4ae39f58357e6b3bcbd54224215df75118b339e902392d3250b3ff83ebf546caL63-R125)
- Exposed all convergence-related parameters as CLI flags (e.g., `--convergence-enabled`, `--convergence-fitness-window`, etc.), and implemented a two-pass argument parsing strategy to allow presets to act as defaults that can be overridden by explicit flags. [[1]](diffhunk://#diff-4ae39f58357e6b3bcbd54224215df75118b339e902392d3250b3ff83ebf546caR303-R376) [[2]](diffhunk://#diff-4ae39f58357e6b3bcbd54224215df75118b339e902392d3250b3ff83ebf546caL63-R125) [[3]](diffhunk://#diff-4ae39f58357e6b3bcbd54224215df75118b339e902392d3250b3ff83ebf546caR389)

**Documentation:**
- Updated experiment documentation to recommend the new `stable_hyper_evo` preset for first-time runs and explain its rationale.

These changes make hyperparameter evolution experiments more robust, reproducible, and user-friendly by providing automatic convergence detection, better defaults, and richer output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the evolution runner’s control flow to optionally stop early and changes persisted artifacts by adding new metadata output, which could affect existing experiment automation/parsers.
> 
> **Overview**
> Adds opt-in convergence detection to `EvolutionExperiment` via new `ConvergenceCriteria`/`ConvergenceReason`, tracking fitness-plateau and diversity-collapse conditions, optionally stopping early, and annotating results (including `budget_exhausted`).
> 
> Extends persisted outputs with `evolution_metadata.json` (convergence status/reason/generation) and updates the CLI with `--preset stable_hyper_evo`, two-pass preset parsing, full convergence-related flags, and a pre-run `run_manifest.json` for reproducibility; docs and tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e93a0975e13667f3c2ab4342bf4b52b3106a730b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->