### PR TITLE
Harden adaptive mutation with damping and telemetry enhancements

### DIFF
--- a/farm/runners/__init__.py
+++ b/farm/runners/__init__.py
@@ -1,6 +1,8 @@
 """Runner exports."""
 
 from farm.runners.adaptive_mutation import (
+    DEFAULT_PER_GENE_RATE_MULTIPLIERS,
+    DEFAULT_PER_GENE_SCALE_MULTIPLIERS,
     AdaptiveMutationConfig,
     AdaptiveMutationController,
     compute_normalized_diversity,
@@ -18,6 +20,8 @@ from farm.runners.evolution_experiment import (
 )
 
 __all__ = [
+    "DEFAULT_PER_GENE_RATE_MULTIPLIERS",
+    "DEFAULT_PER_GENE_SCALE_MULTIPLIERS",
     "AdaptiveMutationConfig",
     "AdaptiveMutationController",
     "compute_normalized_diversity",

--- a/farm/runners/adaptive_mutation.py
+++ b/farm/runners/adaptive_mutation.py
@@ -36,6 +36,7 @@ Design notes:
 
 from __future__ import annotations
 
+import math
 import statistics
 from dataclasses import dataclass, field
 from types import MappingProxyType
@@ -194,8 +195,8 @@ class AdaptiveMutationConfig:
             raise ValueError("min_scale_multiplier must be positive.")
         if self.max_scale_multiplier < self.min_scale_multiplier:
             raise ValueError("max_scale_multiplier must be >= min_scale_multiplier.")
-        if self.max_step_multiplier < 1.0:
-            raise ValueError("max_step_multiplier must be >= 1.0.")
+        if not math.isfinite(self.max_step_multiplier) or self.max_step_multiplier < 1.0:
+            raise ValueError("max_step_multiplier must be a finite number >= 1.0.")
         validate_non_negative_mapping("per_gene_rate_multipliers", self.per_gene_rate_multipliers)
         validate_non_negative_mapping("per_gene_scale_multipliers", self.per_gene_scale_multipliers)
         # Re-bind to immutable views so the frozen dataclass is actually immutable.
@@ -392,7 +393,7 @@ class AdaptiveMutationController:
             return self._config.per_gene_rate_multipliers
         merged = dict(DEFAULT_PER_GENE_RATE_MULTIPLIERS)
         merged.update(self._config.per_gene_rate_multipliers)
-        return merged
+        return _freeze_mapping(merged)
 
     def per_gene_scale_multipliers(self) -> Mapping[str, float]:
         """Return the effective per-gene scale multipliers (empty if disabled).
@@ -408,4 +409,4 @@ class AdaptiveMutationController:
             return self._config.per_gene_scale_multipliers
         merged = dict(DEFAULT_PER_GENE_SCALE_MULTIPLIERS)
         merged.update(self._config.per_gene_scale_multipliers)
-        return merged
+        return _freeze_mapping(merged)

--- a/farm/runners/adaptive_mutation.py
+++ b/farm/runners/adaptive_mutation.py
@@ -49,6 +49,38 @@ def _freeze_mapping(mapping: Mapping[str, float]) -> Mapping[str, float]:
     return MappingProxyType(dict(mapping))
 
 
+# Built-in per-gene defaults tuned for the sensitivity of each evolvable locus.
+#
+# ``learning_rate`` uses log-space encoding but even so its effective value is
+# very sensitive to mutation scale near the lower bound.  Halving the scale
+# multiplier reduces chaotic jumps when exploration pressure is otherwise high.
+#
+# ``gamma`` and ``epsilon_decay`` are linear-encoded but both live near the
+# boundary at 1.0, making overshoots likely when the global scale is large.
+# A 0.75× scale softens those boundary hits without suppressing evolution.
+#
+# Users who call :meth:`AdaptiveMutationConfig.with_default_per_gene_multipliers`
+# or set ``use_default_per_gene_multipliers=True`` receive these mappings merged
+# with (but overridable by) their own per-gene configuration.
+DEFAULT_PER_GENE_SCALE_MULTIPLIERS: Mapping[str, float] = _freeze_mapping(
+    {
+        "learning_rate": 0.5,
+        "gamma": 0.75,
+        "epsilon_decay": 0.75,
+    }
+)
+
+# Rate defaults keep per-gene mutation probability unchanged; callers who want
+# to suppress certain loci entirely can override via per_gene_rate_multipliers.
+DEFAULT_PER_GENE_RATE_MULTIPLIERS: Mapping[str, float] = _freeze_mapping(
+    {
+        "learning_rate": 1.0,
+        "gamma": 1.0,
+        "epsilon_decay": 1.0,
+    }
+)
+
+
 @dataclass(frozen=True)
 class AdaptiveMutationConfig:
     """Configuration for adaptive mutation rate/scale schedules.
@@ -107,6 +139,21 @@ class AdaptiveMutationConfig:
             non-negative multiplier applied to that gene's mutation scale at
             mutation time.  Missing genes keep their resolved scale
             unchanged.
+        max_step_multiplier: Maximum factor by which the accumulated
+            rate/scale multiplier may change in a single generation.  The
+            raw factor derived from ``stall_multiplier`` or
+            ``improve_multiplier`` is clamped to
+            ``[1/max_step_multiplier, max_step_multiplier]`` before being
+            applied, so large step sizes in either direction are dampened.
+            Must be >= 1.0.  Set to a large value (e.g. ``1e9``) to
+            effectively disable damping.
+        use_default_per_gene_multipliers: When ``True`` and ``enabled`` is
+            ``True``, the built-in :data:`DEFAULT_PER_GENE_SCALE_MULTIPLIERS`
+            and :data:`DEFAULT_PER_GENE_RATE_MULTIPLIERS` constants are
+            applied as a baseline for ``learning_rate``, ``gamma``, and
+            ``epsilon_decay``.  Any keys present in ``per_gene_rate_multipliers``
+            or ``per_gene_scale_multipliers`` take precedence over the
+            defaults.
     """
 
     enabled: bool = False
@@ -124,6 +171,8 @@ class AdaptiveMutationConfig:
     max_scale_multiplier: float = 5.0
     per_gene_rate_multipliers: Mapping[str, float] = field(default_factory=dict)
     per_gene_scale_multipliers: Mapping[str, float] = field(default_factory=dict)
+    max_step_multiplier: float = 2.0
+    use_default_per_gene_multipliers: bool = False
 
     def __post_init__(self) -> None:
         if self.stall_window < 1:
@@ -146,6 +195,8 @@ class AdaptiveMutationConfig:
             raise ValueError("min_scale_multiplier must be positive.")
         if self.max_scale_multiplier < self.min_scale_multiplier:
             raise ValueError("max_scale_multiplier must be >= min_scale_multiplier.")
+        if self.max_step_multiplier < 1.0:
+            raise ValueError("max_step_multiplier must be >= 1.0.")
         validate_non_negative_mapping("per_gene_rate_multipliers", self.per_gene_rate_multipliers)
         validate_non_negative_mapping("per_gene_scale_multipliers", self.per_gene_scale_multipliers)
         # Re-bind to immutable views so the frozen dataclass is actually immutable.
@@ -220,6 +271,7 @@ class AdaptiveMutationController:
         self._scale_multiplier = 1.0
         self._last_diversity: Optional[float] = None
         self._last_event: str = "baseline"
+        self._last_fitness_delta: Optional[float] = None
 
     @property
     def config(self) -> AdaptiveMutationConfig:
@@ -238,6 +290,16 @@ class AdaptiveMutationController:
         return self._last_diversity
 
     @property
+    def last_fitness_delta(self) -> Optional[float]:
+        """Fitness improvement observed in the most recent :meth:`observe` call.
+
+        Positive means fitness improved; zero or negative means it stalled.
+        ``None`` when :meth:`observe` has not been called yet or when
+        ``use_fitness_adaptation`` is ``False``.
+        """
+        return self._last_fitness_delta
+
+    @property
     def last_event(self) -> str:
         """Human-readable tag describing the most recent adaptation action."""
         return self._last_event
@@ -253,6 +315,7 @@ class AdaptiveMutationController:
         """
         self._best_fitness_history.append(float(best_fitness))
         self._last_diversity = diversity
+        self._last_fitness_delta = None
         events: List[str] = []
 
         if not self._config.enabled:
@@ -264,14 +327,20 @@ class AdaptiveMutationController:
             prior_best = max(window[:-1])
             latest_best = window[-1]
             improvement = latest_best - prior_best
+            self._last_fitness_delta = improvement
             if improvement > self._config.improvement_threshold:
-                self._rate_multiplier *= self._config.improve_multiplier
-                self._scale_multiplier *= self._config.improve_multiplier
+                raw_factor = self._config.improve_multiplier
                 events.append("improving")
             else:
-                self._rate_multiplier *= self._config.stall_multiplier
-                self._scale_multiplier *= self._config.stall_multiplier
+                raw_factor = self._config.stall_multiplier
                 events.append("stalled")
+            # Dampen: clamp per-step factor to [1/max_step, max_step] so
+            # a single generation cannot swing the multiplier too far in
+            # either direction, reducing oscillation.
+            max_step = self._config.max_step_multiplier
+            bounded_factor = min(max_step, max(1.0 / max_step, raw_factor))
+            self._rate_multiplier *= bounded_factor
+            self._scale_multiplier *= bounded_factor
 
         if (
             self._config.use_diversity_adaptation
@@ -311,13 +380,33 @@ class AdaptiveMutationController:
         return max(0.0, base_scale * self._scale_multiplier)
 
     def per_gene_rate_multipliers(self) -> Mapping[str, float]:
-        """Return the configured per-gene rate multipliers (empty if disabled)."""
+        """Return the effective per-gene rate multipliers (empty if disabled).
+
+        When ``use_default_per_gene_multipliers`` is ``True``, the built-in
+        :data:`DEFAULT_PER_GENE_RATE_MULTIPLIERS` are used as a baseline.
+        Any keys present in the config's ``per_gene_rate_multipliers`` take
+        precedence over the defaults.
+        """
         if not self._config.enabled:
             return {}
-        return self._config.per_gene_rate_multipliers
+        if not self._config.use_default_per_gene_multipliers:
+            return self._config.per_gene_rate_multipliers
+        merged = dict(DEFAULT_PER_GENE_RATE_MULTIPLIERS)
+        merged.update(self._config.per_gene_rate_multipliers)
+        return merged
 
     def per_gene_scale_multipliers(self) -> Mapping[str, float]:
-        """Return the configured per-gene scale multipliers (empty if disabled)."""
+        """Return the effective per-gene scale multipliers (empty if disabled).
+
+        When ``use_default_per_gene_multipliers`` is ``True``, the built-in
+        :data:`DEFAULT_PER_GENE_SCALE_MULTIPLIERS` are used as a baseline.
+        Any keys present in the config's ``per_gene_scale_multipliers`` take
+        precedence over the defaults.
+        """
         if not self._config.enabled:
             return {}
-        return self._config.per_gene_scale_multipliers
+        if not self._config.use_default_per_gene_multipliers:
+            return self._config.per_gene_scale_multipliers
+        merged = dict(DEFAULT_PER_GENE_SCALE_MULTIPLIERS)
+        merged.update(self._config.per_gene_scale_multipliers)
+        return merged

--- a/farm/runners/adaptive_mutation.py
+++ b/farm/runners/adaptive_mutation.py
@@ -59,9 +59,8 @@ def _freeze_mapping(mapping: Mapping[str, float]) -> Mapping[str, float]:
 # boundary at 1.0, making overshoots likely when the global scale is large.
 # A 0.75× scale softens those boundary hits without suppressing evolution.
 #
-# Users who call :meth:`AdaptiveMutationConfig.with_default_per_gene_multipliers`
-# or set ``use_default_per_gene_multipliers=True`` receive these mappings merged
-# with (but overridable by) their own per-gene configuration.
+# Users who set ``use_default_per_gene_multipliers=True`` receive these mappings
+# merged with (but overridable by) their own per-gene configuration.
 DEFAULT_PER_GENE_SCALE_MULTIPLIERS: Mapping[str, float] = _freeze_mapping(
     {
         "learning_rate": 0.5,

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -258,7 +258,7 @@ FitnessEvaluator = Callable[
 class _ProducedWith:
     """Mutation parameters that produced a generation's population.
 
-    All four numeric fields are ``None`` for the initial population because
+    All five numeric fields are ``None`` for the initial population because
     seeding bypasses the adaptive controller.  ``event`` is a short tag
     matching :attr:`AdaptiveMutationController.last_event` from the
     observation that yielded these parameters.  ``fitness_delta`` is the

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -218,6 +218,7 @@ class EvolutionGenerationSummary:
     mutation_scale_multiplier: Optional[float] = None
     diversity: Optional[float] = None
     adaptive_event: str = "initial_seeding"
+    best_fitness_delta: Optional[float] = None
 
 
 @dataclass
@@ -260,7 +261,10 @@ class _ProducedWith:
     All four numeric fields are ``None`` for the initial population because
     seeding bypasses the adaptive controller.  ``event`` is a short tag
     matching :attr:`AdaptiveMutationController.last_event` from the
-    observation that yielded these parameters.
+    observation that yielded these parameters.  ``fitness_delta`` is the
+    fitness improvement (or lack thereof) that triggered the adaptation,
+    ``None`` for the initial population and when fitness adaptation is
+    disabled.
     """
 
     rate: Optional[float]
@@ -268,6 +272,7 @@ class _ProducedWith:
     rate_multiplier: Optional[float]
     scale_multiplier: Optional[float]
     event: str
+    fitness_delta: Optional[float] = None
 
     @classmethod
     def initial(cls) -> "_ProducedWith":
@@ -333,6 +338,7 @@ class EvolutionExperiment:
                 mutation_scale_multiplier=produced_with.scale_multiplier,
                 diversity=diversity,
                 adaptive_event=produced_with.event,
+                best_fitness_delta=produced_with.fitness_delta,
             )
 
             # Update convergence histories and check criteria.
@@ -372,6 +378,7 @@ class EvolutionExperiment:
                 rate_multiplier=controller.rate_multiplier,
                 scale_multiplier=controller.scale_multiplier,
                 event=controller.last_event,
+                fitness_delta=controller.last_fitness_delta,
             )
 
         # When convergence checking is enabled but no criterion was met during
@@ -576,6 +583,7 @@ class EvolutionExperiment:
             mutation_scale_multiplier=produced.scale_multiplier,
             diversity=diversity,
             adaptive_event=produced.event,
+            best_fitness_delta=produced.fitness_delta,
         )
 
     def _compute_diversity(

--- a/scripts/run_evolution_experiment.py
+++ b/scripts/run_evolution_experiment.py
@@ -274,6 +274,25 @@ def _build_parser() -> argparse.ArgumentParser:
         help="When --adaptive-mutation is set, skip the diversity-collapse adaptation rule.",
     )
     parser.add_argument(
+        "--adaptive-max-step-multiplier",
+        type=float,
+        default=2.0,
+        help=(
+            "Maximum factor by which the accumulated mutation multiplier may change in a "
+            "single generation.  Bounds per-step change to [1/max_step, max_step] so large "
+            "stall/improve factors are dampened.  Must be >= 1.0.  Default: 2.0."
+        ),
+    )
+    parser.add_argument(
+        "--adaptive-default-per-gene",
+        action="store_true",
+        help=(
+            "Apply built-in per-gene scale defaults tuned for sensitivity "
+            "(learning_rate=0.5×, gamma=0.75×, epsilon_decay=0.75× scale).  "
+            "User --adaptive-per-gene-scale values override these defaults."
+        ),
+    )
+    parser.add_argument(
         "--adaptive-per-gene-rate",
         type=str,
         default=None,
@@ -441,6 +460,8 @@ def main() -> int:
                 improve_multiplier=args.adaptive_improve_multiplier,
                 diversity_threshold=args.adaptive_diversity_threshold,
                 diversity_multiplier=args.adaptive_diversity_multiplier,
+                max_step_multiplier=args.adaptive_max_step_multiplier,
+                use_default_per_gene_multipliers=args.adaptive_default_per_gene,
                 per_gene_rate_multipliers=_parse_per_gene_multipliers(
                     args.adaptive_per_gene_rate, label="--adaptive-per-gene-rate"
                 ),

--- a/tests/runners/test_adaptive_mutation.py
+++ b/tests/runners/test_adaptive_mutation.py
@@ -205,6 +205,9 @@ class TestAdaptiveMutationController(unittest.TestCase):
             stall_multiplier=10.0,
             max_rate_multiplier=2.0,
             max_scale_multiplier=2.0,
+            # Set max_step_multiplier large so the per-step bound does not
+            # absorb the full stall_multiplier before the global clamp fires.
+            max_step_multiplier=100.0,
         )
         controller = AdaptiveMutationController(config)
         controller.observe(best_fitness=0.0, diversity=None)
@@ -251,6 +254,209 @@ class TestAdaptiveMutationController(unittest.TestCase):
         self.assertEqual(
             controller_enabled.per_gene_scale_multipliers()["learning_rate"], 0.5
         )
+
+    # ------------------------------------------------------------------ #
+    # New tests: max_step_multiplier damping                              #
+    # ------------------------------------------------------------------ #
+
+    def test_rejects_max_step_multiplier_below_one(self):
+        with self.assertRaises(ValueError):
+            AdaptiveMutationConfig(max_step_multiplier=0.5)
+
+    def test_max_step_multiplier_bounds_stall_increase(self):
+        """A large stall_multiplier is capped per-step by max_step_multiplier."""
+        config = AdaptiveMutationConfig(
+            enabled=True,
+            use_fitness_adaptation=True,
+            use_diversity_adaptation=False,
+            stall_window=1,
+            stall_multiplier=10.0,
+            max_step_multiplier=1.5,
+            max_rate_multiplier=100.0,
+        )
+        controller = AdaptiveMutationController(config)
+        controller.observe(best_fitness=0.0, diversity=None)
+        controller.observe(best_fitness=0.0, diversity=None)
+        # Without damping: 1.0 * 10.0 = 10.0.  With max_step=1.5: 1.0 * 1.5 = 1.5.
+        self.assertAlmostEqual(controller.rate_multiplier, 1.5)
+        self.assertIn("stalled", controller.last_event)
+
+    def test_max_step_multiplier_bounds_improve_reduction(self):
+        """A very aggressive improve_multiplier is capped per-step by max_step_multiplier."""
+        config = AdaptiveMutationConfig(
+            enabled=True,
+            use_fitness_adaptation=True,
+            use_diversity_adaptation=False,
+            stall_window=1,
+            improve_multiplier=0.1,
+            max_step_multiplier=1.5,
+            min_rate_multiplier=0.001,
+        )
+        controller = AdaptiveMutationController(config)
+        controller.observe(best_fitness=1.0, diversity=None)
+        controller.observe(best_fitness=2.0, diversity=None)
+        # Without damping: 1.0 * 0.1 = 0.1.  With max_step=1.5: 1.0 / 1.5 ≈ 0.667.
+        self.assertAlmostEqual(controller.rate_multiplier, 1.0 / 1.5)
+        self.assertIn("improving", controller.last_event)
+
+    def test_default_max_step_multiplier_does_not_affect_typical_configs(self):
+        """With typical stall=1.5 / improve=0.8 the default max_step=2.0 has no effect."""
+        config = AdaptiveMutationConfig(
+            enabled=True,
+            use_fitness_adaptation=True,
+            use_diversity_adaptation=False,
+            stall_window=1,
+            stall_multiplier=1.5,
+            improve_multiplier=0.8,
+            # default max_step_multiplier=2.0
+        )
+        controller = AdaptiveMutationController(config)
+        controller.observe(best_fitness=1.0, diversity=None)
+        controller.observe(best_fitness=1.0, diversity=None)  # stall
+        self.assertAlmostEqual(controller.rate_multiplier, 1.5)
+        controller.observe(best_fitness=2.0, diversity=None)  # improve
+        self.assertAlmostEqual(controller.rate_multiplier, 1.5 * 0.8)
+
+    def test_damping_reduces_oscillation_over_alternating_stall_improve(self):
+        """Alternating stall/improve with damping keeps multiplier within tighter bounds."""
+        tight_step = AdaptiveMutationConfig(
+            enabled=True,
+            use_fitness_adaptation=True,
+            use_diversity_adaptation=False,
+            stall_window=1,
+            stall_multiplier=3.0,
+            improve_multiplier=0.3,
+            max_step_multiplier=1.3,
+            min_rate_multiplier=0.01,
+            max_rate_multiplier=100.0,
+        )
+        controller_tight = AdaptiveMutationController(tight_step)
+
+        no_step = AdaptiveMutationConfig(
+            enabled=True,
+            use_fitness_adaptation=True,
+            use_diversity_adaptation=False,
+            stall_window=1,
+            stall_multiplier=3.0,
+            improve_multiplier=0.3,
+            max_step_multiplier=1000.0,
+            min_rate_multiplier=0.01,
+            max_rate_multiplier=1000.0,
+        )
+        controller_nodamp = AdaptiveMutationController(no_step)
+
+        # Alternate: first gen sets history, then stall/improve alternate.
+        fitnesses = [1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 5.0, 5.0]
+        for fit in fitnesses:
+            controller_tight.observe(best_fitness=fit, diversity=None)
+            controller_nodamp.observe(best_fitness=fit, diversity=None)
+
+        # The damped controller should have a smaller multiplier range.
+        self.assertLess(controller_tight.rate_multiplier, controller_nodamp.rate_multiplier)
+
+    # ------------------------------------------------------------------ #
+    # New tests: last_fitness_delta telemetry                             #
+    # ------------------------------------------------------------------ #
+
+    def test_last_fitness_delta_is_none_before_any_observation(self):
+        controller = AdaptiveMutationController(AdaptiveMutationConfig(enabled=True))
+        self.assertIsNone(controller.last_fitness_delta)
+
+    def test_last_fitness_delta_is_none_after_first_observation(self):
+        controller = AdaptiveMutationController(
+            AdaptiveMutationConfig(enabled=True, use_fitness_adaptation=True)
+        )
+        controller.observe(best_fitness=1.0, diversity=None)
+        # Only one history point: no comparison possible.
+        self.assertIsNone(controller.last_fitness_delta)
+
+    def test_last_fitness_delta_positive_on_improvement(self):
+        controller = AdaptiveMutationController(
+            AdaptiveMutationConfig(enabled=True, stall_window=1)
+        )
+        controller.observe(best_fitness=1.0, diversity=None)
+        controller.observe(best_fitness=3.0, diversity=None)
+        self.assertIsNotNone(controller.last_fitness_delta)
+        self.assertAlmostEqual(controller.last_fitness_delta, 2.0)
+
+    def test_last_fitness_delta_zero_on_stall(self):
+        controller = AdaptiveMutationController(
+            AdaptiveMutationConfig(enabled=True, stall_window=1)
+        )
+        controller.observe(best_fitness=5.0, diversity=None)
+        controller.observe(best_fitness=5.0, diversity=None)
+        self.assertIsNotNone(controller.last_fitness_delta)
+        self.assertAlmostEqual(controller.last_fitness_delta, 0.0)
+
+    def test_last_fitness_delta_is_none_when_fitness_adaptation_disabled(self):
+        controller = AdaptiveMutationController(
+            AdaptiveMutationConfig(
+                enabled=True,
+                use_fitness_adaptation=False,
+                use_diversity_adaptation=False,
+            )
+        )
+        controller.observe(best_fitness=1.0, diversity=None)
+        controller.observe(best_fitness=2.0, diversity=None)
+        # No fitness adaptation → no delta computed.
+        self.assertIsNone(controller.last_fitness_delta)
+
+    # ------------------------------------------------------------------ #
+    # New tests: use_default_per_gene_multipliers                         #
+    # ------------------------------------------------------------------ #
+
+    def test_use_default_per_gene_multipliers_false_returns_empty_when_none_configured(self):
+        config = AdaptiveMutationConfig(enabled=True, use_default_per_gene_multipliers=False)
+        controller = AdaptiveMutationController(config)
+        self.assertEqual(controller.per_gene_scale_multipliers(), {})
+        self.assertEqual(controller.per_gene_rate_multipliers(), {})
+
+    def test_use_default_per_gene_multipliers_true_applies_learning_rate_default(self):
+        from farm.runners.adaptive_mutation import DEFAULT_PER_GENE_SCALE_MULTIPLIERS
+
+        config = AdaptiveMutationConfig(enabled=True, use_default_per_gene_multipliers=True)
+        controller = AdaptiveMutationController(config)
+        scale_mults = controller.per_gene_scale_multipliers()
+        self.assertIn("learning_rate", scale_mults)
+        self.assertAlmostEqual(
+            scale_mults["learning_rate"],
+            DEFAULT_PER_GENE_SCALE_MULTIPLIERS["learning_rate"],
+        )
+
+    def test_use_default_per_gene_multipliers_true_applies_gamma_and_epsilon_decay(self):
+        from farm.runners.adaptive_mutation import DEFAULT_PER_GENE_SCALE_MULTIPLIERS
+
+        config = AdaptiveMutationConfig(enabled=True, use_default_per_gene_multipliers=True)
+        controller = AdaptiveMutationController(config)
+        scale_mults = controller.per_gene_scale_multipliers()
+        for gene in ("gamma", "epsilon_decay"):
+            self.assertIn(gene, scale_mults)
+            self.assertAlmostEqual(
+                scale_mults[gene],
+                DEFAULT_PER_GENE_SCALE_MULTIPLIERS[gene],
+            )
+
+    def test_user_per_gene_multipliers_override_defaults(self):
+        """User-supplied per-gene values take precedence over built-in defaults."""
+        config = AdaptiveMutationConfig(
+            enabled=True,
+            use_default_per_gene_multipliers=True,
+            per_gene_scale_multipliers={"learning_rate": 0.1},
+        )
+        controller = AdaptiveMutationController(config)
+        # User override wins.
+        self.assertAlmostEqual(controller.per_gene_scale_multipliers()["learning_rate"], 0.1)
+        # Other genes still come from defaults.
+        self.assertIn("gamma", controller.per_gene_scale_multipliers())
+
+    def test_defaults_not_returned_when_controller_disabled(self):
+        """When enabled=False, no per-gene multipliers (including defaults) are returned."""
+        config = AdaptiveMutationConfig(
+            enabled=False, use_default_per_gene_multipliers=True
+        )
+        controller = AdaptiveMutationController(config)
+        self.assertEqual(controller.per_gene_scale_multipliers(), {})
+        self.assertEqual(controller.per_gene_rate_multipliers(), {})
 
 
 if __name__ == "__main__":

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -1016,5 +1016,263 @@ class TestConvergenceMetadataPersisted(unittest.TestCase):
             self.assertEqual(metadata["convergence_reason"], "budget_exhausted")
 
 
+class TestAdaptiveMutationHardenedBehavior(unittest.TestCase):
+    """Tests for the hardened adaptive mutation update rules (issue: Evolution v2)."""
+
+    # ------------------------------------------------------------------ #
+    # Damping / bounded change per generation                             #
+    # ------------------------------------------------------------------ #
+
+    @patch("farm.runners.evolution_experiment.mutate_chromosome")
+    def test_max_step_multiplier_limits_single_generation_change(self, mutate_mock):
+        """max_step_multiplier prevents a large stall_multiplier from fully applying."""
+        mutate_mock.side_effect = lambda chromosome, **kwargs: chromosome
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=3,
+            population_size=3,
+            num_steps_per_candidate=1,
+            mutation_rate=0.3,
+            mutation_scale=0.1,
+            adaptive_mutation=AdaptiveMutationConfig(
+                enabled=True,
+                use_fitness_adaptation=True,
+                use_diversity_adaptation=False,
+                stall_window=1,
+                stall_multiplier=5.0,
+                max_step_multiplier=1.4,
+                max_rate_multiplier=100.0,
+            ),
+            seed=77,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, generation, member: (1.0, {"member": member})
+        )
+        gen0, gen1, gen2 = result.generation_summaries
+        # Gen 1 was produced before any observe() had effect: multiplier still 1.0.
+        self.assertAlmostEqual(gen1.mutation_rate_multiplier, 1.0)
+        # Gen 2 was produced after one stall observation.
+        # Without damping: multiplier would be 5.0.
+        # With max_step=1.4: multiplier should be exactly 1.4.
+        self.assertIsNotNone(gen2.mutation_rate_multiplier)
+        self.assertAlmostEqual(gen2.mutation_rate_multiplier, 1.4, places=5)
+        self.assertIn("stalled", gen2.adaptive_event)
+
+    @patch("farm.runners.evolution_experiment.mutate_chromosome")
+    def test_stable_adaptation_over_8_generations(self, mutate_mock):
+        """Integration test: with damping, multiplier stays within bounds over >= 8 gens."""
+        mutate_mock.side_effect = lambda chromosome, **kwargs: chromosome
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=9,
+            population_size=3,
+            num_steps_per_candidate=1,
+            mutation_rate=0.25,
+            mutation_scale=0.15,
+            adaptive_mutation=AdaptiveMutationConfig(
+                enabled=True,
+                use_fitness_adaptation=True,
+                use_diversity_adaptation=False,
+                stall_window=2,
+                stall_multiplier=2.0,
+                improve_multiplier=0.7,
+                max_step_multiplier=1.5,
+                min_rate_multiplier=0.05,
+                max_rate_multiplier=10.0,
+            ),
+            seed=42,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        # Alternating fitness: improves on even generations, stalls on odd.
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, generation, member: (
+                float(generation if generation % 2 == 0 else generation - 1),
+                {"member": member},
+            )
+        )
+        self.assertEqual(len(result.generation_summaries), 9)
+
+        # All non-seed generations must have bounded multipliers.
+        for summary in result.generation_summaries[1:]:
+            self.assertIsNotNone(summary.mutation_rate_multiplier)
+            self.assertGreaterEqual(summary.mutation_rate_multiplier, 0.05)
+            self.assertLessEqual(summary.mutation_rate_multiplier, 10.0)
+
+        # The effective mutation rate must always stay in [0, 1].
+        for summary in result.generation_summaries[1:]:
+            self.assertIsNotNone(summary.mutation_rate_used)
+            self.assertGreaterEqual(summary.mutation_rate_used, 0.0)
+            self.assertLessEqual(summary.mutation_rate_used, 1.0)
+
+    # ------------------------------------------------------------------ #
+    # Per-gene defaults without manual CLI flags                          #
+    # ------------------------------------------------------------------ #
+
+    @patch("farm.runners.evolution_experiment.mutate_chromosome")
+    def test_use_default_per_gene_multipliers_forwarded_to_mutate(self, mutate_mock):
+        """use_default_per_gene_multipliers=True passes built-in defaults to mutate_chromosome."""
+        mutate_mock.side_effect = lambda chromosome, **kwargs: chromosome
+        from farm.runners.adaptive_mutation import DEFAULT_PER_GENE_SCALE_MULTIPLIERS
+
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=2,
+            population_size=3,
+            num_steps_per_candidate=1,
+            adaptive_mutation=AdaptiveMutationConfig(
+                enabled=True,
+                use_fitness_adaptation=False,
+                use_diversity_adaptation=False,
+                use_default_per_gene_multipliers=True,
+            ),
+            seed=11,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        experiment.run(
+            fitness_evaluator=lambda candidate, cfg, generation, member: (
+                float(member),
+                {"member": member},
+            )
+        )
+        self.assertTrue(mutate_mock.called)
+        child_calls = [
+            call for call in mutate_mock.call_args_list
+            if call.kwargs.get("per_gene_scale_multipliers") is not None
+        ]
+        self.assertGreater(len(child_calls), 0)
+        for call in child_calls:
+            scale_mults = call.kwargs.get("per_gene_scale_multipliers", {})
+            self.assertAlmostEqual(
+                scale_mults.get("learning_rate"),
+                DEFAULT_PER_GENE_SCALE_MULTIPLIERS["learning_rate"],
+            )
+
+    @patch("farm.runners.evolution_experiment.mutate_chromosome")
+    def test_user_per_gene_overrides_default_per_gene(self, mutate_mock):
+        """User per-gene values override built-in defaults when both are active."""
+        mutate_mock.side_effect = lambda chromosome, **kwargs: chromosome
+        base_config = SimulationConfig()
+        custom_lr_scale = 0.1  # different from the built-in 0.5
+        config = EvolutionExperimentConfig(
+            num_generations=2,
+            population_size=3,
+            num_steps_per_candidate=1,
+            adaptive_mutation=AdaptiveMutationConfig(
+                enabled=True,
+                use_fitness_adaptation=False,
+                use_diversity_adaptation=False,
+                use_default_per_gene_multipliers=True,
+                per_gene_scale_multipliers={"learning_rate": custom_lr_scale},
+            ),
+            seed=22,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        experiment.run(
+            fitness_evaluator=lambda candidate, cfg, generation, member: (
+                float(member),
+                {"member": member},
+            )
+        )
+        child_calls = [
+            call for call in mutate_mock.call_args_list
+            if call.kwargs.get("per_gene_scale_multipliers") is not None
+        ]
+        self.assertGreater(len(child_calls), 0)
+        for call in child_calls:
+            scale_mults = call.kwargs.get("per_gene_scale_multipliers", {})
+            # User value wins over built-in default.
+            self.assertAlmostEqual(scale_mults.get("learning_rate"), custom_lr_scale)
+
+    # ------------------------------------------------------------------ #
+    # best_fitness_delta telemetry in EvolutionGenerationSummary          #
+    # ------------------------------------------------------------------ #
+
+    def test_best_fitness_delta_is_none_for_initial_seeding(self):
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=1,
+            population_size=3,
+            num_steps_per_candidate=1,
+            seed=1,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, generation, member: (1.0, {"member": member})
+        )
+        self.assertIsNone(result.generation_summaries[0].best_fitness_delta)
+
+    def test_best_fitness_delta_persisted_to_json(self):
+        base_config = SimulationConfig()
+        with tempfile.TemporaryDirectory() as output_dir:
+            config = EvolutionExperimentConfig(
+                num_generations=3,
+                population_size=3,
+                num_steps_per_candidate=1,
+                mutation_rate=0.2,
+                adaptive_mutation=AdaptiveMutationConfig(
+                    enabled=True,
+                    use_fitness_adaptation=True,
+                    use_diversity_adaptation=False,
+                    stall_window=1,
+                    stall_multiplier=2.0,
+                ),
+                output_dir=output_dir,
+                seed=5,
+            )
+            experiment = EvolutionExperiment(base_config, config)
+            experiment.run(
+                fitness_evaluator=lambda candidate, cfg, generation, member: (
+                    float(generation),
+                    {"member": member},
+                )
+            )
+            import os as _os
+            with open(
+                _os.path.join(output_dir, "evolution_generation_summaries.json"),
+                encoding="utf-8",
+            ) as fp:
+                summaries = json.load(fp)
+            # Field must be present in all summary records.
+            for summary in summaries:
+                self.assertIn("best_fitness_delta", summary)
+            # Gen 0 is seeded: no delta.
+            self.assertIsNone(summaries[0]["best_fitness_delta"])
+            # Gen 1 was produced before any controller observation, so delta is None.
+            self.assertIsNone(summaries[1]["best_fitness_delta"])
+            # Gen 2 reflects the improvement observed from gen 1.
+            self.assertIsNotNone(summaries[2]["best_fitness_delta"])
+
+    def test_best_fitness_delta_correct_magnitude_on_improvement(self):
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=3,
+            population_size=3,
+            num_steps_per_candidate=1,
+            adaptive_mutation=AdaptiveMutationConfig(
+                enabled=True,
+                use_fitness_adaptation=True,
+                use_diversity_adaptation=False,
+                stall_window=1,
+            ),
+            seed=9,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        fitness_by_gen = {0: 1.0, 1: 5.0, 2: 8.0}
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, generation, member: (
+                fitness_by_gen[generation],
+                {"member": member},
+            )
+        )
+        gen0, gen1, gen2 = result.generation_summaries
+        # Gen 0 and gen 1 have no delta (initial seeding / first observation).
+        self.assertIsNone(gen0.best_fitness_delta)
+        self.assertIsNone(gen1.best_fitness_delta)
+        # Gen 2 reflects the gen-1 observation: 5.0 - 1.0 = 4.0.
+        self.assertIsNotNone(gen2.best_fitness_delta)
+        self.assertAlmostEqual(gen2.best_fitness_delta, 4.0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the adaptive mutation system, focusing on improved configuration flexibility, per-gene mutation control, and better tracking of adaptation events. The main changes include the addition of built-in per-gene mutation defaults, a new configuration option to dampen per-generation multiplier swings, and expanded tracking/reporting of fitness improvements that trigger adaptation. These changes are exposed through both code and CLI, and are accompanied by updates to data structures and validation logic.

**Adaptive mutation configuration and logic improvements:**

* Added built-in per-gene mutation scale and rate defaults (`DEFAULT_PER_GENE_SCALE_MULTIPLIERS`, `DEFAULT_PER_GENE_RATE_MULTIPLIERS`) for `learning_rate`, `gamma`, and `epsilon_decay`, with logic to merge user overrides when `use_default_per_gene_multipliers` is set. [[1]](diffhunk://#diff-6e3310fa39d1c45e10d8d15a6c60f05a7fb9cddd5c84c07e6f545f29a07ebc00R52-R82) [[2]](diffhunk://#diff-6e3310fa39d1c45e10d8d15a6c60f05a7fb9cddd5c84c07e6f545f29a07ebc00L314-R411) [[3]](diffhunk://#diff-c8139a827bd991793bde210cf38e1257269e4a1665fe89dcc4aa8823325337b4R4-R5) [[4]](diffhunk://#diff-c8139a827bd991793bde210cf38e1257269e4a1665fe89dcc4aa8823325337b4R23-R24)
* Introduced `max_step_multiplier` to cap the per-generation change in mutation multipliers, reducing oscillation and allowing for smoother adaptation. Includes validation for this new parameter. [[1]](diffhunk://#diff-6e3310fa39d1c45e10d8d15a6c60f05a7fb9cddd5c84c07e6f545f29a07ebc00R141-R155) [[2]](diffhunk://#diff-6e3310fa39d1c45e10d8d15a6c60f05a7fb9cddd5c84c07e6f545f29a07ebc00R173-R174) [[3]](diffhunk://#diff-6e3310fa39d1c45e10d8d15a6c60f05a7fb9cddd5c84c07e6f545f29a07ebc00R197-R198) [[4]](diffhunk://#diff-6e3310fa39d1c45e10d8d15a6c60f05a7fb9cddd5c84c07e6f545f29a07ebc00R329-R342)
* Added `use_default_per_gene_multipliers` to `AdaptiveMutationConfig`, enabling use of the built-in per-gene defaults as a baseline for mutation multipliers. [[1]](diffhunk://#diff-6e3310fa39d1c45e10d8d15a6c60f05a7fb9cddd5c84c07e6f545f29a07ebc00R141-R155) [[2]](diffhunk://#diff-6e3310fa39d1c45e10d8d15a6c60f05a7fb9cddd5c84c07e6f545f29a07ebc00R173-R174) [[3]](diffhunk://#diff-6e3310fa39d1c45e10d8d15a6c60f05a7fb9cddd5c84c07e6f545f29a07ebc00L314-R411)

**Tracking and reporting enhancements:**

* The `AdaptiveMutationController` now tracks the fitness improvement (`last_fitness_delta`) that triggered adaptation, making this available as a property and storing it in experiment summaries. [[1]](diffhunk://#diff-6e3310fa39d1c45e10d8d15a6c60f05a7fb9cddd5c84c07e6f545f29a07ebc00R273) [[2]](diffhunk://#diff-6e3310fa39d1c45e10d8d15a6c60f05a7fb9cddd5c84c07e6f545f29a07ebc00R291-R300) [[3]](diffhunk://#diff-6e3310fa39d1c45e10d8d15a6c60f05a7fb9cddd5c84c07e6f545f29a07ebc00R317) [[4]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR221) [[5]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadL263-R275) [[6]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR341) [[7]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR381) [[8]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR586)

**CLI and test updates:**

* Exposed `--adaptive-max-step-multiplier` and `--adaptive-default-per-gene` options in the experiment runner CLI, allowing users to configure these new features from the command line. [[1]](diffhunk://#diff-4ae39f58357e6b3bcbd54224215df75118b339e902392d3250b3ff83ebf546caR276-R294) [[2]](diffhunk://#diff-4ae39f58357e6b3bcbd54224215df75118b339e902392d3250b3ff83ebf546caR463-R464)
* Updated tests to account for the new `max_step_multiplier` parameter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes adaptive mutation behavior by damping per-generation multiplier updates and optionally applying built-in per-gene defaults, which can alter experiment outcomes. Also extends persisted/logged telemetry, which is low risk but touches experiment result schemas.
> 
> **Overview**
> **Hardens adaptive mutation updates** by adding `max_step_multiplier` to cap how much mutation rate/scale multipliers can change per generation, reducing oscillation from aggressive `stall_multiplier`/`improve_multiplier` swings.
> 
> **Adds optional built-in per-gene multipliers** (`DEFAULT_PER_GENE_*_MULTIPLIERS`) and a `use_default_per_gene_multipliers` flag to merge these defaults with user overrides, and exports the constants from `farm.runners`.
> 
> **Improves experiment telemetry** by tracking `last_fitness_delta` in `AdaptiveMutationController` and persisting/logging it as `best_fitness_delta` in `EvolutionGenerationSummary`; CLI flags are added to configure the new damping and default-per-gene behavior, with expanded unit/integration tests covering all new paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 836b9d5f9875f030348577bd4d78eb19626d2b6d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->