### PR TITLE
Add interior-biased mutation mode and boundary occupancy metrics

### DIFF
--- a/docs/design/hyperparameter_chromosome.md
+++ b/docs/design/hyperparameter_chromosome.md
@@ -190,7 +190,7 @@ minimum boundary (a common symptom with `learning_rate` at `1e-6`).  Unlike
 `REFLECT`, it does not change values that are already interior, so it is
 safer when mutations rarely overshoot by large amounts.
 
-
+### Soft boundary penalties
 
 `compute_boundary_penalty(chromosome, config)` returns a non-negative float
 that should be **subtracted** from the raw fitness score.

--- a/docs/design/hyperparameter_chromosome.md
+++ b/docs/design/hyperparameter_chromosome.md
@@ -161,7 +161,36 @@ mutated = mutate_chromosome(chromosome, mutation_rate=0.1, boundary_mode="reflec
 **Recommended default**: `CLAMP` for stability in early experiments;
 `REFLECT` when you observe boundary collapse (genes sticking at min/max).
 
-### Soft boundary penalties
+### `BoundaryMode.INTERIOR_BIASED`
+
+Clamps the raw value first (like `CLAMP`), then nudges any value that lands
+*exactly* on a boundary inward by a small random amount:
+
+- overshoot above `max_value` → clamp to `max_value`, then subtract
+  `uniform(0, interior_bias_fraction × span)`
+- undershoot below `min_value` → clamp to `min_value`, then add
+  `uniform(0, interior_bias_fraction × span)`
+- values strictly between the bounds are **unchanged** (no nudge applied)
+
+The `interior_bias_fraction` parameter (default `1e-3`, 0.1 % of range)
+controls the nudge magnitude.  Set it larger to push genes further from
+walls, smaller (or `0.0`) to match `CLAMP` behavior exactly.
+
+```python
+mutated = mutate_chromosome(
+    chromosome,
+    mutation_rate=0.1,
+    boundary_mode="interior_biased",
+    interior_bias_fraction=1e-3,
+)
+```
+
+**When to use**: preferred over `CLAMP` when genes repeatedly stick at the
+minimum boundary (a common symptom with `learning_rate` at `1e-6`).  Unlike
+`REFLECT`, it does not change values that are already interior, so it is
+safer when mutations rarely overshoot by large amounts.
+
+
 
 `compute_boundary_penalty(chromosome, config)` returns a non-negative float
 that should be **subtracted** from the raw fitness score.
@@ -394,12 +423,97 @@ Until step 1 is validated in integration tests, `memory_size` stays fixed to avo
 
 - `evolution_generation_summaries.json`
   - per-generation fitness aggregates (`best_fitness`, `mean_fitness`, `min_fitness`)
-  - per-gene statistics (`mean`, `median`, `std`, `min`, `max`)
+  - per-gene statistics (`mean`, `median`, `std`, `min`, `max`, `at_min_count`,
+    `at_max_count`, `boundary_fraction`)
   - best candidate chromosome values for that generation
+  - **`boundary_occupancy`**: per-gene fraction of candidates sitting exactly on
+    `min_value` or `max_value` that generation; `0.0` = no boundary hugging,
+    `1.0` = entire population pinned to a wall
 - `evolution_lineage.json`
   - one row per evaluated candidate with lineage (`parent_ids`) and fitness metadata
 
 Use `scripts/plot_hyperparameter_evolution.py` to produce a convergence chart from the summaries JSON.
+
+### Boundary occupancy fields
+
+Each entry in `gene_statistics` now contains three occupancy fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `at_min_count` | `float` | Number of candidates with `value == min_value` |
+| `at_max_count` | `float` | Number of candidates with `value == max_value` |
+| `boundary_fraction` | `float` | `(at_min_count + at_max_count) / population_size` |
+
+The top-level `boundary_occupancy` dict in each generation summary provides
+quick access to `boundary_fraction` per gene without digging into nested stats:
+
+```json
+{
+  "generation": 2,
+  "boundary_occupancy": {
+    "learning_rate": 0.5,
+    "gamma": 0.0,
+    "epsilon_decay": 0.167
+  }
+}
+```
+
+A `boundary_occupancy` rising toward `1.0` for `learning_rate` over multiple
+generations is the primary signal of boundary collapse.
+
+## Anti-collapse settings guide
+
+Boundary collapse — where all candidates cluster at `learning_rate=1e-6` — is
+the most common failure mode in hyperparameter evolution.  The table below
+lists the recommended combination of settings for each scenario.
+
+| Scenario | Recommended settings |
+|---|---|
+| Default / exploratory | `boundary_mode=clamp` (default) |
+| `learning_rate` stuck at `1e-6` | `boundary_mode=reflect` |
+| Reflect overshoots too aggressively | `boundary_mode=interior_biased`, `interior_bias_fraction=1e-3` |
+| Soft discouragement near walls | `boundary_penalty_enabled=True`, `penalty_strength=0.01` |
+| Diversity collapse | `adaptive_mutation=True`, `adaptive_diversity_multiplier=1.5` |
+| Combined anti-collapse | `--preset stable_hyper_evo` |
+
+### Choosing `interior_biased` vs `reflect`
+
+- **`reflect`**: zero chance of landing exactly on the boundary after any
+  overshoot because the reflected value is always at least `ε` inside.  Best
+  when overshoots are large and you want guaranteed diversity away from walls.
+- **`interior_biased`**: only nudges values that *would* land exactly on a
+  boundary; values that land strictly inside the range are unchanged.  Lower
+  overhead, safer for small perturbations, easier to reason about.
+
+### Example: anti-collapse run
+
+```bash
+source venv/bin/activate
+
+# Interior-biased mode with boundary-occupancy reporting
+python scripts/run_evolution_experiment.py \
+  --generations 6 --population-size 8 --steps-per-candidate 40 \
+  --selection-method tournament --mutation-rate 0.20 --mutation-scale 0.2 \
+  --boundary-mode interior_biased --interior-bias-fraction 1e-3 \
+  --fitness-metric final_population --seed 42 \
+  --output-dir experiments/evolution/run_interior_biased_g6
+```
+
+After the run, inspect `boundary_occupancy` in
+`experiments/evolution/run_interior_biased_g6/evolution_generation_summaries.json`:
+
+```bash
+python -c "
+import json, sys
+data = json.load(open('experiments/evolution/run_interior_biased_g6/evolution_generation_summaries.json'))
+for s in data:
+    print(f\"gen {s['generation']}: lr_occupancy={s['boundary_occupancy'].get('learning_rate', 0):.2%}\")
+"
+```
+
+A healthy run shows `lr_occupancy` remaining well below `50 %` for most
+generations.  Values consistently at or above `80 %` indicate collapse; switch
+to `reflect` or lower `mutation_scale` and re-run.
 
 ## Crossover strategy comparison runs
 

--- a/farm/core/hyperparameter_chromosome.py
+++ b/farm/core/hyperparameter_chromosome.py
@@ -82,10 +82,18 @@ class BoundaryMode(str, Enum):
     - ``REFLECT``: bounce the mutated value back from the boundary.  If the raw
       value overshoots by *d*, the reflected result is *d* inside the boundary.
       This preserves the bounded invariant while avoiding absorbing edge states.
+    - ``INTERIOR_BIASED``: clamp first like ``CLAMP``, then nudge any value
+      landing *exactly* on a boundary inward by a small random amount drawn
+      uniformly from ``(0, interior_bias_fraction * span]``.  This prevents
+      repeated exact-boundary hits without changing behavior for values that
+      land strictly inside the range.  The ``interior_bias_fraction`` parameter
+      of :func:`mutate_chromosome` controls the nudge magnitude (default
+      ``1e-3``).
     """
 
     CLAMP = "clamp"
     REFLECT = "reflect"
+    INTERIOR_BIASED = "interior_biased"
 
 
 @dataclass(frozen=True)
@@ -593,7 +601,15 @@ def chromosome_from_learning_config(learning_config: Any) -> HyperparameterChrom
     return chromosome_from_values(overrides)
 
 
-def _apply_boundary(raw_value: float, min_value: float, max_value: float, mode: BoundaryMode) -> float:
+def _apply_boundary(
+    raw_value: float,
+    min_value: float,
+    max_value: float,
+    mode: BoundaryMode,
+    *,
+    rng: Optional[random.Random] = None,
+    interior_bias_fraction: float = 1e-3,
+) -> float:
     """Apply a boundary strategy to a raw (possibly out-of-range) gene value.
 
     Args:
@@ -601,12 +617,32 @@ def _apply_boundary(raw_value: float, min_value: float, max_value: float, mode: 
         min_value: Gene's lower bound (inclusive).
         max_value: Gene's upper bound (inclusive).
         mode: The :class:`BoundaryMode` strategy to apply.
+        rng: Optional :class:`random.Random` instance used by
+            ``INTERIOR_BIASED`` mode.  Falls back to the module-level
+            ``random`` singleton when ``None``.
+        interior_bias_fraction: Fraction of the gene span used as the upper
+            bound of the inward nudge in ``INTERIOR_BIASED`` mode.  Must be
+            non-negative.  Only used when ``mode`` is
+            :attr:`BoundaryMode.INTERIOR_BIASED`.
 
     Returns:
         A float guaranteed to lie within ``[min_value, max_value]``.
     """
     if mode is BoundaryMode.CLAMP:
         return max(min_value, min(max_value, raw_value))
+
+    if mode is BoundaryMode.INTERIOR_BIASED:
+        clamped = max(min_value, min(max_value, raw_value))
+        span = max_value - min_value
+        if span == 0.0 or interior_bias_fraction <= 0.0:
+            return clamped
+        resolved_rng = rng or random
+        nudge_max = interior_bias_fraction * span
+        if clamped == min_value:
+            return min_value + resolved_rng.uniform(0.0, nudge_max)
+        if clamped == max_value:
+            return max_value - resolved_rng.uniform(0.0, nudge_max)
+        return clamped
 
     # REFLECT: bounce the value back from each boundary.
     # The folded space has period = 2 * span; the first half maps straight,
@@ -631,6 +667,7 @@ def mutate_chromosome(
     mutation_scale: Optional[float] = None,
     mutation_mode: Optional[Union[MutationMode, str]] = None,
     boundary_mode: Union[BoundaryMode, str] = BoundaryMode.CLAMP,
+    interior_bias_fraction: float = 1e-3,
     per_gene_rate_multipliers: Optional[Mapping[str, float]] = None,
     per_gene_scale_multipliers: Optional[Mapping[str, float]] = None,
     rng: Optional[random.Random] = None,
@@ -650,7 +687,13 @@ def mutate_chromosome(
         boundary_mode: How to handle raw values that exceed gene bounds after
             mutation.  ``"clamp"`` (default) reproduces the original behavior;
             ``"reflect"`` bounces the value back off the boundary so edge states
-            are not absorbing.  See :class:`BoundaryMode`.
+            are not absorbing; ``"interior_biased"`` clamps first and then
+            nudges values sitting exactly on a boundary inward by a small
+            random amount.  See :class:`BoundaryMode`.
+        interior_bias_fraction: Fraction of the gene span used as the upper
+            bound of the inward nudge when ``boundary_mode`` is
+            ``"interior_biased"``.  Must be non-negative.  Default ``1e-3``
+            (0.1 % of gene range).  Ignored for other boundary modes.
         per_gene_rate_multipliers: Optional mapping of gene name to a
             non-negative multiplier applied to the resolved per-gene mutation
             probability.  After multiplication, the probability is clamped to
@@ -674,6 +717,8 @@ def mutate_chromosome(
         raise ValueError("mutation_rate must be between 0 and 1.")
     if mutation_scale is not None and mutation_scale < 0.0:
         raise ValueError("mutation_scale must be non-negative.")
+    if interior_bias_fraction < 0.0:
+        raise ValueError("interior_bias_fraction must be non-negative.")
     if per_gene_rate_multipliers:
         validate_non_negative_mapping("per_gene_rate_multipliers", per_gene_rate_multipliers)
     if per_gene_scale_multipliers:
@@ -705,7 +750,14 @@ def mutate_chromosome(
             delta = resolved_rng.uniform(-resolved_scale, resolved_scale)
             raw_value = gene.value * (1.0 + delta)
 
-        bounded_value = _apply_boundary(raw_value, gene.min_value, gene.max_value, resolved_boundary_mode)
+        bounded_value = _apply_boundary(
+            raw_value,
+            gene.min_value,
+            gene.max_value,
+            resolved_boundary_mode,
+            rng=resolved_rng,
+            interior_bias_fraction=interior_bias_fraction,
+        )
         updated_genes.append(gene.with_value(bounded_value))
 
     return HyperparameterChromosome(genes=tuple(updated_genes))

--- a/farm/core/hyperparameter_chromosome.py
+++ b/farm/core/hyperparameter_chromosome.py
@@ -84,10 +84,10 @@ class BoundaryMode(str, Enum):
       This preserves the bounded invariant while avoiding absorbing edge states.
     - ``INTERIOR_BIASED``: clamp first like ``CLAMP``, then nudge any value
       landing *exactly* on a boundary inward by a small random amount drawn
-      uniformly from ``(0, interior_bias_fraction * span]``.  This prevents
+      uniformly from ``[0, interior_bias_fraction * span]``.  This reduces
       repeated exact-boundary hits without changing behavior for values that
       land strictly inside the range.  The ``interior_bias_fraction`` parameter
-      of :func:`mutate_chromosome` controls the nudge magnitude (default
+      of :func:`mutate_chromosome` controls the maximum nudge magnitude (default
       ``1e-3``).
     """
 
@@ -717,8 +717,8 @@ def mutate_chromosome(
         raise ValueError("mutation_rate must be between 0 and 1.")
     if mutation_scale is not None and mutation_scale < 0.0:
         raise ValueError("mutation_scale must be non-negative.")
-    if interior_bias_fraction < 0.0:
-        raise ValueError("interior_bias_fraction must be non-negative.")
+    if not math.isfinite(interior_bias_fraction) or interior_bias_fraction < 0.0:
+        raise ValueError("interior_bias_fraction must be a non-negative finite number.")
     if per_gene_rate_multipliers:
         validate_non_negative_mapping("per_gene_rate_multipliers", per_gene_rate_multipliers)
     if per_gene_scale_multipliers:

--- a/farm/core/hyperparameter_chromosome.py
+++ b/farm/core/hyperparameter_chromosome.py
@@ -637,7 +637,7 @@ def _apply_boundary(
         if span == 0.0 or interior_bias_fraction <= 0.0:
             return clamped
         resolved_rng = rng or random
-        nudge_max = interior_bias_fraction * span
+        nudge_max = min(interior_bias_fraction * span, span)
         if clamped == min_value:
             return min_value + resolved_rng.uniform(0.0, nudge_max)
         if clamped == max_value:

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -129,6 +129,7 @@ class EvolutionExperimentConfig:
     mutation_scale: float = 0.2
     mutation_mode: MutationMode = MutationMode.GAUSSIAN
     boundary_mode: BoundaryMode = BoundaryMode.CLAMP
+    interior_bias_fraction: float = 1e-3
     boundary_penalty: BoundaryPenaltyConfig = field(default_factory=BoundaryPenaltyConfig)
     crossover_mode: CrossoverMode = CrossoverMode.UNIFORM
     blend_alpha: float = 0.5
@@ -153,6 +154,8 @@ class EvolutionExperimentConfig:
             raise ValueError("mutation_rate must be between 0 and 1.")
         if self.mutation_scale < 0.0:
             raise ValueError("mutation_scale must be non-negative.")
+        if self.interior_bias_fraction < 0.0:
+            raise ValueError("interior_bias_fraction must be non-negative.")
         # Validate enum coercion for string-friendly construction.
         BoundaryMode(self.boundary_mode)
         CrossoverMode(self.crossover_mode)
@@ -203,6 +206,12 @@ class EvolutionGenerationSummary:
     ``mutation_rate=1.0`` to spread seed candidates) rather than via the
     adaptive controller.  ``diversity`` is measured **on this generation**
     and therefore is recorded for every generation.
+
+    ``boundary_occupancy`` maps each evolvable gene name to the fraction of
+    candidates in this generation whose gene value sits exactly on either
+    ``min_value`` or ``max_value``.  A value of ``0.0`` means no candidate
+    is pinned to a boundary; ``1.0`` means all candidates are.  Empty dict
+    when no gene data is available.
     """
 
     generation: int
@@ -219,6 +228,7 @@ class EvolutionGenerationSummary:
     diversity: Optional[float] = None
     adaptive_event: str = "initial_seeding"
     best_fitness_delta: Optional[float] = None
+    boundary_occupancy: Dict[str, float] = field(default_factory=dict)
 
 
 @dataclass
@@ -339,6 +349,7 @@ class EvolutionExperiment:
                 diversity=diversity,
                 adaptive_event=produced_with.event,
                 best_fitness_delta=produced_with.fitness_delta,
+                boundary_occupancy=summary.boundary_occupancy,
             )
 
             # Update convergence histories and check criteria.
@@ -410,6 +421,7 @@ class EvolutionExperiment:
                     mutation_scale=self.config.mutation_scale,
                     mutation_mode=self.config.mutation_mode,
                     boundary_mode=self.config.boundary_mode,
+                    interior_bias_fraction=self.config.interior_bias_fraction,
                     rng=self._run_rng,
                 )
             population.append(
@@ -498,6 +510,7 @@ class EvolutionExperiment:
                 mutation_scale=resolved_scale,
                 mutation_mode=self.config.mutation_mode,
                 boundary_mode=self.config.boundary_mode,
+                interior_bias_fraction=self.config.interior_bias_fraction,
                 per_gene_rate_multipliers=per_gene_rate_multipliers,
                 per_gene_scale_multipliers=per_gene_scale_multipliers,
                 rng=self._run_rng,
@@ -569,6 +582,11 @@ class EvolutionExperiment:
         )
         best_chromosome = self._serialize_chromosome_values(best.metadata["chromosome"])
         produced = produced_with or _ProducedWith.initial()
+        boundary_occupancy = {
+            gene_name: stats["boundary_fraction"]
+            for gene_name, stats in resolved_gene_statistics.items()
+            if "boundary_fraction" in stats
+        }
         return EvolutionGenerationSummary(
             generation=generation,
             best_fitness=max(fitness_values),
@@ -584,6 +602,7 @@ class EvolutionExperiment:
             diversity=diversity,
             adaptive_event=produced.event,
             best_fitness_delta=produced.fitness_delta,
+            boundary_occupancy=boundary_occupancy,
         )
 
     def _compute_diversity(
@@ -651,19 +670,29 @@ class EvolutionExperiment:
             return {}
 
         gene_values: Dict[str, List[float]] = {}
+        gene_bounds: Dict[str, Tuple[float, float]] = {}
         for evaluation in generation_evals:
             chromosome = evaluation.metadata["chromosome"]
             for gene in chromosome.genes:
                 gene_values.setdefault(gene.name, []).append(gene.value)
+                if gene.name not in gene_bounds:
+                    gene_bounds[gene.name] = (gene.min_value, gene.max_value)
 
         gene_statistics: Dict[str, Dict[str, float]] = {}
         for gene_name, values in gene_values.items():
+            min_bound, max_bound = gene_bounds.get(gene_name, (float("-inf"), float("inf")))
+            n = len(values)
+            at_min_count = sum(1 for v in values if v == min_bound)
+            at_max_count = sum(1 for v in values if v == max_bound)
             gene_statistics[gene_name] = {
                 "mean": statistics.mean(values),
                 "median": statistics.median(values),
                 "std": statistics.pstdev(values) if len(values) > 1 else 0.0,
                 "min": min(values),
                 "max": max(values),
+                "at_min_count": float(at_min_count),
+                "at_max_count": float(at_max_count),
+                "boundary_fraction": float(at_min_count + at_max_count) / n,
             }
         return gene_statistics
 

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -674,6 +674,8 @@ class EvolutionExperiment:
         for evaluation in generation_evals:
             chromosome = evaluation.metadata["chromosome"]
             for gene in chromosome.genes:
+                if not gene.evolvable:
+                    continue
                 gene_values.setdefault(gene.name, []).append(gene.value)
                 if gene.name not in gene_bounds:
                     gene_bounds[gene.name] = (gene.min_value, gene.max_value)

--- a/scripts/run_evolution_experiment.py
+++ b/scripts/run_evolution_experiment.py
@@ -185,6 +185,16 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Boundary strategy after mutation overshoots gene bounds.",
     )
     parser.add_argument(
+        "--interior-bias-fraction",
+        type=float,
+        default=1e-3,
+        help=(
+            "When --boundary-mode=interior_biased, fraction of the gene span used as the "
+            "upper bound of the inward nudge applied to values landing exactly on a boundary. "
+            "Must be non-negative.  Default: 1e-3."
+        ),
+    )
+    parser.add_argument(
         "--boundary-penalty-enabled",
         action="store_true",
         help="Enable soft near-boundary fitness penalty.",
@@ -419,6 +429,7 @@ def main() -> int:
         fitness_metric=args.fitness_metric,
         selection_method=args.selection_method,
         boundary_mode=args.boundary_mode,
+        interior_bias_fraction=args.interior_bias_fraction,
         boundary_penalty_enabled=args.boundary_penalty_enabled,
         boundary_penalty_strength=args.boundary_penalty_strength,
         boundary_penalty_threshold=args.boundary_penalty_threshold,
@@ -442,6 +453,7 @@ def main() -> int:
             mutation_rate=args.mutation_rate,
             mutation_scale=args.mutation_scale,
             boundary_mode=BoundaryMode(args.boundary_mode),
+            interior_bias_fraction=args.interior_bias_fraction,
             boundary_penalty=BoundaryPenaltyConfig(
                 enabled=args.boundary_penalty_enabled,
                 penalty_strength=args.boundary_penalty_strength,
@@ -502,6 +514,7 @@ def main() -> int:
             "mutation_scale": args.mutation_scale,
             "tournament_size": args.tournament_size,
             "boundary_mode": args.boundary_mode,
+            "interior_bias_fraction": args.interior_bias_fraction,
             "boundary_penalty_enabled": args.boundary_penalty_enabled,
             "boundary_penalty_strength": args.boundary_penalty_strength,
             "boundary_penalty_threshold": args.boundary_penalty_threshold,

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -1300,6 +1300,8 @@ class TestBoundaryOccupancyMetrics(unittest.TestCase):
             self.assertIn("learning_rate", summary.boundary_occupancy)
             self.assertIn("gamma", summary.boundary_occupancy)
             self.assertIn("epsilon_decay", summary.boundary_occupancy)
+            # Non-evolvable genes should not appear.
+            self.assertNotIn("memory_size", summary.boundary_occupancy)
             # Values must be fractions in [0, 1].
             for gene_name, frac in summary.boundary_occupancy.items():
                 self.assertGreaterEqual(frac, 0.0, msg=f"{gene_name} fraction < 0")
@@ -1322,6 +1324,7 @@ class TestBoundaryOccupancyMetrics(unittest.TestCase):
             )
         )
         gen_stats = result.generation_summaries[0].gene_statistics
+        self.assertNotIn("memory_size", gen_stats)
         for gene_name, stats in gen_stats.items():
             self.assertIn("at_min_count", stats, msg=f"at_min_count missing for {gene_name}")
             self.assertIn("at_max_count", stats, msg=f"at_max_count missing for {gene_name}")

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -1274,5 +1274,218 @@ class TestAdaptiveMutationHardenedBehavior(unittest.TestCase):
         self.assertAlmostEqual(gen2.best_fitness_delta, 4.0)
 
 
+class TestBoundaryOccupancyMetrics(unittest.TestCase):
+    """Tests for per-generation boundary occupancy reporting."""
+
+    def test_boundary_occupancy_present_in_generation_summaries(self):
+        """boundary_occupancy is populated for every generation."""
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=2,
+            population_size=4,
+            num_steps_per_candidate=1,
+            seed=42,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, generation, member: (
+                float(member + generation),
+                {"member": member},
+            )
+        )
+        for summary in result.generation_summaries:
+            self.assertIsInstance(summary.boundary_occupancy, dict)
+            # All evolvable genes should appear.
+            self.assertIn("learning_rate", summary.boundary_occupancy)
+            self.assertIn("gamma", summary.boundary_occupancy)
+            self.assertIn("epsilon_decay", summary.boundary_occupancy)
+            # Values must be fractions in [0, 1].
+            for gene_name, frac in summary.boundary_occupancy.items():
+                self.assertGreaterEqual(frac, 0.0, msg=f"{gene_name} fraction < 0")
+                self.assertLessEqual(frac, 1.0, msg=f"{gene_name} fraction > 1")
+
+    def test_gene_statistics_include_boundary_counts(self):
+        """gene_statistics dict contains at_min_count, at_max_count, boundary_fraction."""
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=1,
+            population_size=4,
+            num_steps_per_candidate=1,
+            seed=7,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, generation, member: (
+                float(member),
+                {"member": member},
+            )
+        )
+        gen_stats = result.generation_summaries[0].gene_statistics
+        for gene_name, stats in gen_stats.items():
+            self.assertIn("at_min_count", stats, msg=f"at_min_count missing for {gene_name}")
+            self.assertIn("at_max_count", stats, msg=f"at_max_count missing for {gene_name}")
+            self.assertIn("boundary_fraction", stats, msg=f"boundary_fraction missing for {gene_name}")
+            self.assertGreaterEqual(stats["at_min_count"], 0.0)
+            self.assertGreaterEqual(stats["at_max_count"], 0.0)
+            self.assertGreaterEqual(stats["boundary_fraction"], 0.0)
+            self.assertLessEqual(stats["boundary_fraction"], 1.0)
+
+    def test_boundary_occupancy_persisted_to_summaries_json(self):
+        """boundary_occupancy appears in the serialized generation summaries JSON."""
+        base_config = SimulationConfig()
+        with tempfile.TemporaryDirectory() as output_dir:
+            config = EvolutionExperimentConfig(
+                num_generations=2,
+                population_size=3,
+                num_steps_per_candidate=1,
+                output_dir=output_dir,
+                seed=13,
+            )
+            experiment = EvolutionExperiment(base_config, config)
+            experiment.run(
+                fitness_evaluator=lambda candidate, cfg, generation, member: (
+                    float(member + generation),
+                    {"member": member},
+                )
+            )
+            with open(
+                f"{output_dir}/evolution_generation_summaries.json",
+                encoding="utf-8",
+            ) as summaries_file:
+                summaries = json.load(summaries_file)
+
+            for summary in summaries:
+                self.assertIn("boundary_occupancy", summary)
+                self.assertIsInstance(summary["boundary_occupancy"], dict)
+                self.assertIn("learning_rate", summary["boundary_occupancy"])
+
+    def test_all_at_boundary_gives_occupancy_one(self):
+        """When every candidate is pinned to min_value, boundary_fraction == 1.0."""
+        base_config = SimulationConfig()
+        # Force learning_rate to minimum across all candidates (mutation_scale=0
+        # with initial learning_rate at min).
+        base_config.learning.learning_rate = 1e-6
+        config = EvolutionExperimentConfig(
+            num_generations=1,
+            population_size=3,
+            num_steps_per_candidate=1,
+            mutation_scale=0.0,
+            seed=17,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        result = experiment.run(
+            fitness_evaluator=lambda candidate, cfg, generation, member: (1.0, {"member": member})
+        )
+        gen_stats = result.generation_summaries[0].gene_statistics
+        # learning_rate is at its minimum for all three candidates.
+        lr_stats = gen_stats["learning_rate"]
+        self.assertAlmostEqual(lr_stats["at_min_count"], 3.0)
+        self.assertAlmostEqual(lr_stats["boundary_fraction"], 1.0)
+        # boundary_occupancy should reflect this.
+        self.assertAlmostEqual(
+            result.generation_summaries[0].boundary_occupancy["learning_rate"], 1.0
+        )
+
+
+class TestInteriorBiasedModeIntegration(unittest.TestCase):
+    """Integration tests for INTERIOR_BIASED boundary mode in the evolution runner."""
+
+    def test_config_accepts_interior_biased_boundary_mode(self):
+        config = EvolutionExperimentConfig(
+            boundary_mode=BoundaryMode.INTERIOR_BIASED,
+            interior_bias_fraction=1e-3,
+        )
+        self.assertEqual(config.boundary_mode, BoundaryMode.INTERIOR_BIASED)
+        self.assertAlmostEqual(config.interior_bias_fraction, 1e-3)
+
+    def test_config_rejects_negative_interior_bias_fraction(self):
+        with self.assertRaises(ValueError):
+            EvolutionExperimentConfig(
+                boundary_mode=BoundaryMode.INTERIOR_BIASED,
+                interior_bias_fraction=-0.01,
+            )
+
+    @patch("farm.runners.evolution_experiment.mutate_chromosome")
+    def test_interior_bias_fraction_forwarded_to_mutation_calls(self, mutate_mock):
+        mutate_mock.side_effect = lambda chromosome, **kwargs: chromosome
+        base_config = SimulationConfig()
+        config = EvolutionExperimentConfig(
+            num_generations=2,
+            population_size=4,
+            num_steps_per_candidate=1,
+            boundary_mode=BoundaryMode.INTERIOR_BIASED,
+            interior_bias_fraction=5e-3,
+            seed=55,
+        )
+        experiment = EvolutionExperiment(base_config, config)
+        experiment.run(
+            fitness_evaluator=lambda candidate, cfg, generation, member: (
+                float(member + generation),
+                {"member": member},
+            )
+        )
+        self.assertTrue(mutate_mock.called)
+        for call in mutate_mock.call_args_list:
+            self.assertEqual(call.kwargs.get("boundary_mode"), BoundaryMode.INTERIOR_BIASED)
+            self.assertAlmostEqual(call.kwargs.get("interior_bias_fraction"), 5e-3)
+
+    def test_interior_biased_reduces_boundary_occupancy_vs_clamp(self):
+        """Population-level: INTERIOR_BIASED should produce lower boundary occupancy
+        than CLAMP when starting at the minimum boundary with heavy mutation."""
+        base_config_clamp = SimulationConfig()
+        base_config_clamp.learning.learning_rate = 1e-6
+
+        base_config_ib = SimulationConfig()
+        base_config_ib.learning.learning_rate = 1e-6
+
+        def make_config(mode):
+            return EvolutionExperimentConfig(
+                num_generations=3,
+                population_size=6,
+                num_steps_per_candidate=1,
+                mutation_rate=1.0,
+                mutation_scale=0.5,
+                boundary_mode=mode,
+                interior_bias_fraction=0.1,
+                seed=100,
+            )
+
+        exp_clamp = EvolutionExperiment(base_config_clamp, make_config(BoundaryMode.CLAMP))
+        result_clamp = exp_clamp.run(
+            fitness_evaluator=lambda candidate, cfg, gen, member: (1.0, {"member": member})
+        )
+
+        exp_ib = EvolutionExperiment(base_config_ib, make_config(BoundaryMode.INTERIOR_BIASED))
+        result_ib = exp_ib.run(
+            fitness_evaluator=lambda candidate, cfg, gen, member: (1.0, {"member": member})
+        )
+
+        # Gene values must remain within their declared per-gene bounds.
+        # The chromosome schema validation already enforces this, but we verify
+        # here that no out-of-range value slips through.
+        from farm.core.hyperparameter_chromosome import default_hyperparameter_chromosome
+        gene_bounds = {gene.name: (gene.min_value, gene.max_value) for gene in default_hyperparameter_chromosome().genes}
+        for summary in result_ib.generation_summaries:
+            for gene_name, stats in summary.gene_statistics.items():
+                if gene_name in gene_bounds:
+                    lo, hi = gene_bounds[gene_name]
+                    self.assertGreaterEqual(stats["min"], lo, msg=f"{gene_name} min below bound")
+                    self.assertLessEqual(stats["max"], hi, msg=f"{gene_name} max above bound")
+
+        # At least one generation should have lower lr boundary occupancy with
+        # INTERIOR_BIASED than with CLAMP (since INTERIOR_BIASED nudges away from walls).
+        clamp_occ = [s.boundary_occupancy.get("learning_rate", 0.0) for s in result_clamp.generation_summaries]
+        ib_occ = [s.boundary_occupancy.get("learning_rate", 0.0) for s in result_ib.generation_summaries]
+        # Mean boundary fraction should be ≤ clamp's across the run.
+        import statistics as _stats
+        mean_clamp = _stats.mean(clamp_occ)
+        mean_ib = _stats.mean(ib_occ)
+        self.assertLessEqual(
+            mean_ib,
+            mean_clamp,
+            msg=f"INTERIOR_BIASED mean occupancy {mean_ib:.3f} should be ≤ CLAMP {mean_clamp:.3f}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -1,6 +1,7 @@
 """Tests for multi-generation hyperparameter evolution runner."""
 
 import json
+import statistics
 import tempfile
 import unittest
 from dataclasses import fields
@@ -1477,9 +1478,8 @@ class TestInteriorBiasedModeIntegration(unittest.TestCase):
         clamp_occ = [s.boundary_occupancy.get("learning_rate", 0.0) for s in result_clamp.generation_summaries]
         ib_occ = [s.boundary_occupancy.get("learning_rate", 0.0) for s in result_ib.generation_summaries]
         # Mean boundary fraction should be ≤ clamp's across the run.
-        import statistics as _stats
-        mean_clamp = _stats.mean(clamp_occ)
-        mean_ib = _stats.mean(ib_occ)
+        mean_clamp = statistics.mean(clamp_occ)
+        mean_ib = statistics.mean(ib_occ)
         self.assertLessEqual(
             mean_ib,
             mean_clamp,

--- a/tests/test_hyperparameter_chromosome.py
+++ b/tests/test_hyperparameter_chromosome.py
@@ -1068,5 +1068,139 @@ class TestComputeBoundaryPenalty(unittest.TestCase):
         self.assertAlmostEqual(penalty, 0.20)
 
 
+class TestInteriorBiasedBoundaryMode(unittest.TestCase):
+    """Tests for the INTERIOR_BIASED boundary mode."""
+
+    def test_interior_biased_string_alias_accepted(self):
+        chromosome = chromosome_from_values({"learning_rate": 0.5})
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=0.0):
+            mutated = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=0.1,
+                boundary_mode="interior_biased",
+            )
+        lr = mutated.get_value("learning_rate")
+        self.assertGreaterEqual(lr, 1e-6)
+        self.assertLessEqual(lr, 1.0)
+
+    def test_interior_biased_does_not_produce_exact_max_on_large_overshoot(self):
+        """When clamped value would be at max, INTERIOR_BIASED nudges it inward."""
+        chromosome = chromosome_from_values({"learning_rate": 0.999})
+        rng = random.Random(1)
+        # Large gauss pushes value above max → clamp to 1.0 → nudge inward
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=5.0):
+            mutated = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=1.0,
+                boundary_mode=BoundaryMode.INTERIOR_BIASED,
+                interior_bias_fraction=1e-3,
+                rng=rng,
+            )
+        lr = mutated.get_value("learning_rate")
+        self.assertGreaterEqual(lr, 1e-6)
+        self.assertLess(lr, 1.0, msg="INTERIOR_BIASED should nudge value below max boundary")
+
+    def test_interior_biased_does_not_produce_exact_min_on_large_undershoot(self):
+        """When clamped value would be at min, INTERIOR_BIASED nudges it inward."""
+        chromosome = chromosome_from_values({"learning_rate": 0.001})
+        rng = random.Random(2)
+        # Large negative gauss pushes value below min → clamp to 1e-6 → nudge inward
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=-5.0):
+            mutated = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=1.0,
+                boundary_mode=BoundaryMode.INTERIOR_BIASED,
+                interior_bias_fraction=1e-3,
+                rng=rng,
+            )
+        lr = mutated.get_value("learning_rate")
+        self.assertGreater(lr, 1e-6, msg="INTERIOR_BIASED should nudge value above min boundary")
+        self.assertLessEqual(lr, 1.0)
+
+    def test_interior_biased_strictly_interior_value_is_unchanged(self):
+        """When the clamped value is strictly interior, no nudge is applied."""
+        chromosome = chromosome_from_values({"learning_rate": 0.5})
+        # gauss returns 0 → raw = 0.5 (no overshoot) → stays at 0.5
+        # Note: do not pass rng so the module-level random.gauss patch applies.
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=0.0):
+            mutated = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=0.1,
+                boundary_mode=BoundaryMode.INTERIOR_BIASED,
+                interior_bias_fraction=1e-3,
+            )
+        self.assertAlmostEqual(mutated.get_value("learning_rate"), 0.5)
+
+    def test_interior_biased_stays_in_bounds_for_many_mutations(self):
+        """No gene value escapes [min, max] under INTERIOR_BIASED over many steps."""
+        rng = random.Random(99)
+        chromosome = chromosome_from_values({"learning_rate": 1e-6})
+        for _ in range(300):
+            chromosome = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=3.0,
+                boundary_mode=BoundaryMode.INTERIOR_BIASED,
+                interior_bias_fraction=1e-3,
+                rng=rng,
+            )
+            lr = chromosome.get_value("learning_rate")
+            self.assertGreaterEqual(lr, 1e-6, msg=f"Fell below min: {lr}")
+            self.assertLessEqual(lr, 1.0, msg=f"Exceeded max: {lr}")
+
+    def test_interior_biased_zero_fraction_behaves_like_clamp(self):
+        """interior_bias_fraction=0.0 means no nudge; value at exact boundary is kept."""
+        chromosome = chromosome_from_values({"learning_rate": 0.999})
+        rng = random.Random(7)
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=5.0):
+            mutated = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=1.0,
+                boundary_mode=BoundaryMode.INTERIOR_BIASED,
+                interior_bias_fraction=0.0,
+                rng=rng,
+            )
+        self.assertEqual(mutated.get_value("learning_rate"), 1.0)
+
+    def test_interior_biased_rejects_negative_fraction(self):
+        chromosome = chromosome_from_values({"learning_rate": 0.5})
+        with self.assertRaises(ValueError):
+            mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=0.1,
+                boundary_mode=BoundaryMode.INTERIOR_BIASED,
+                interior_bias_fraction=-0.01,
+            )
+
+    def test_interior_biased_nudge_within_bias_fraction_span(self):
+        """The nudged value must be within interior_bias_fraction * span of the boundary."""
+        chromosome = chromosome_from_values({"learning_rate": 0.999})
+        bias_fraction = 0.01
+        # Patch gauss to force overshoot → clamped to max (1.0).
+        # Patch uniform to return a deterministic nudge of 0.005.
+        with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=5.0), \
+             patch("farm.core.hyperparameter_chromosome.random.uniform", return_value=0.005):
+            mutated = mutate_chromosome(
+                chromosome,
+                mutation_rate=1.0,
+                mutation_scale=1.0,
+                boundary_mode=BoundaryMode.INTERIOR_BIASED,
+                interior_bias_fraction=bias_fraction,
+            )
+        lr = mutated.get_value("learning_rate")
+        # nudge = 0.005 → result = 1.0 - 0.005 = 0.995
+        self.assertAlmostEqual(lr, 1.0 - 0.005)
+        self.assertLessEqual(lr, 1.0)
+        span = 1.0 - 1e-6  # gene span
+        # Value should be within bias_fraction * span of max
+        self.assertGreaterEqual(lr, 1.0 - bias_fraction * span)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hyperparameter_chromosome.py
+++ b/tests/test_hyperparameter_chromosome.py
@@ -1087,7 +1087,6 @@ class TestInteriorBiasedBoundaryMode(unittest.TestCase):
     def test_interior_biased_does_not_produce_exact_max_on_large_overshoot(self):
         """When clamped value would be at max, INTERIOR_BIASED nudges it inward."""
         chromosome = chromosome_from_values({"learning_rate": 0.999})
-        rng = random.Random(1)
         # Large gauss pushes value above max → clamp to 1.0 → nudge inward
         with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=5.0):
             mutated = mutate_chromosome(
@@ -1096,7 +1095,6 @@ class TestInteriorBiasedBoundaryMode(unittest.TestCase):
                 mutation_scale=1.0,
                 boundary_mode=BoundaryMode.INTERIOR_BIASED,
                 interior_bias_fraction=1e-3,
-                rng=rng,
             )
         lr = mutated.get_value("learning_rate")
         self.assertGreaterEqual(lr, 1e-6)
@@ -1105,7 +1103,6 @@ class TestInteriorBiasedBoundaryMode(unittest.TestCase):
     def test_interior_biased_does_not_produce_exact_min_on_large_undershoot(self):
         """When clamped value would be at min, INTERIOR_BIASED nudges it inward."""
         chromosome = chromosome_from_values({"learning_rate": 0.001})
-        rng = random.Random(2)
         # Large negative gauss pushes value below min → clamp to 1e-6 → nudge inward
         with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=-5.0):
             mutated = mutate_chromosome(
@@ -1114,7 +1111,6 @@ class TestInteriorBiasedBoundaryMode(unittest.TestCase):
                 mutation_scale=1.0,
                 boundary_mode=BoundaryMode.INTERIOR_BIASED,
                 interior_bias_fraction=1e-3,
-                rng=rng,
             )
         lr = mutated.get_value("learning_rate")
         self.assertGreater(lr, 1e-6, msg="INTERIOR_BIASED should nudge value above min boundary")
@@ -1155,7 +1151,6 @@ class TestInteriorBiasedBoundaryMode(unittest.TestCase):
     def test_interior_biased_zero_fraction_behaves_like_clamp(self):
         """interior_bias_fraction=0.0 means no nudge; value at exact boundary is kept."""
         chromosome = chromosome_from_values({"learning_rate": 0.999})
-        rng = random.Random(7)
         with patch("farm.core.hyperparameter_chromosome.random.gauss", return_value=5.0):
             mutated = mutate_chromosome(
                 chromosome,
@@ -1163,7 +1158,6 @@ class TestInteriorBiasedBoundaryMode(unittest.TestCase):
                 mutation_scale=1.0,
                 boundary_mode=BoundaryMode.INTERIOR_BIASED,
                 interior_bias_fraction=0.0,
-                rng=rng,
             )
         self.assertEqual(mutated.get_value("learning_rate"), 1.0)
 


### PR DESCRIPTION
This pull request introduces a new "interior-biased" boundary handling mode for hyperparameter mutation, along with improved monitoring and reporting of boundary occupancy to help diagnose and prevent boundary collapse (where genes get stuck at min/max values). The changes span the core mutation logic, experiment configuration, statistics reporting, and documentation, making it easier to detect and mitigate issues with genes sticking to boundaries during evolutionary hyperparameter optimization.

**Boundary handling and mutation improvements:**

* Added a new `INTERIOR_BIASED` mode to `BoundaryMode`, which clamps mutated gene values and then nudges any value exactly on a boundary slightly inward by a configurable fraction of the gene's range. This helps prevent genes from sticking to min/max values without affecting values that are already interior. The nudge magnitude is controlled by a new `interior_bias_fraction` parameter, exposed throughout the mutation pipeline and validated for non-negativity. (`farm/core/hyperparameter_chromosome.py`, `farm/runners/evolution_experiment.py`, `scripts/run_evolution_experiment.py`) [[1]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R85-R96) [[2]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8L596-R646) [[3]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R670) [[4]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8L653-R696) [[5]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8R720-R721) [[6]](diffhunk://#diff-3f3eb1e548e60b84adf81b9b4dc78106b32eeead51726db97fb627981fc32fe8L708-R760) [[7]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR132) [[8]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR157-R158) [[9]](diffhunk://#diff-4ae39f58357e6b3bcbd54224215df75118b339e902392d3250b3ff83ebf546caR187-R196) [[10]](diffhunk://#diff-4ae39f58357e6b3bcbd54224215df75118b339e902392d3250b3ff83ebf546caR432) [[11]](diffhunk://#diff-4ae39f58357e6b3bcbd54224215df75118b339e902392d3250b3ff83ebf546caR456)

**Boundary occupancy monitoring and reporting:**

* Enhanced per-generation statistics to include `at_min_count`, `at_max_count`, and `boundary_fraction` for each gene, and added a top-level `boundary_occupancy` summary to each generation's results. This allows easy tracking of how many candidates are pinned to boundaries, helping to spot and diagnose boundary collapse. (`farm/runners/evolution_experiment.py`, `docs/design/hyperparameter_chromosome.md`) [[1]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR209-R214) [[2]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR231) [[3]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR352) [[4]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR585-R589) [[5]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR605) [[6]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR673-R697) [[7]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L397-R517)

**Documentation updates:**

* Updated the design documentation to explain the new `INTERIOR_BIASED` mode, describe the new boundary occupancy statistics, provide guidance on anti-collapse settings, and include example usage and analysis workflows. (`docs/design/hyperparameter_chromosome.md`) [[1]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12R164-R192) [[2]](diffhunk://#diff-fe296b3dc7ab76013d77d0248afb871d70ceb341aeb7f031c0e7075b745c3f12L397-R517)

**Configuration and CLI support:**

* Added support for the `interior_bias_fraction` parameter in experiment configuration, validation, and command-line interface, allowing users to easily enable and tune the new boundary handling mode from the CLI. (`farm/runners/evolution_experiment.py`, `scripts/run_evolution_experiment.py`) [[1]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR132) [[2]](diffhunk://#diff-2d2f3de936fb1a1622fff46277d8efa0df60f21892a957056bfcd7c8b2895eadR157-R158) [[3]](diffhunk://#diff-4ae39f58357e6b3bcbd54224215df75118b339e902392d3250b3ff83ebf546caR187-R196) [[4]](diffhunk://#diff-4ae39f58357e6b3bcbd54224215df75118b339e902392d3250b3ff83ebf546caR432) [[5]](diffhunk://#diff-4ae39f58357e6b3bcbd54224215df75118b339e902392d3250b3ff83ebf546caR456)

These improvements make hyperparameter evolution more robust to boundary collapse and provide better diagnostics and controls for users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mutation boundary handling and generation-summary output schema, which can affect experiment behavior and downstream consumers of persisted JSON artifacts. Risk is mitigated by added validation, CLI wiring, and expanded unit/integration tests.
> 
> **Overview**
> Adds a new `BoundaryMode.INTERIOR_BIASED` mutation option that clamps then randomly nudges values off exact min/max boundaries (configurable via new `interior_bias_fraction`, validated as non-negative) and threads this through `mutate_chromosome`, `EvolutionExperimentConfig`, and the evolution CLI.
> 
> Extends evolution generation reporting with boundary-hugging metrics: per-gene `at_min_count`, `at_max_count`, and `boundary_fraction`, plus a top-level per-generation `boundary_occupancy` map persisted to `evolution_generation_summaries.json`; documentation is updated with usage guidance and anti-collapse recommendations, and tests cover both the new boundary mode and the new metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2641df23230ac57be0a57774027a3925c7c879e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->