### PR TITLE
Add multi-seed cohort runner and enhance aggregate reporting

### DIFF
--- a/docs/experiments/multi_seed_cohort.md
+++ b/docs/experiments/multi_seed_cohort.md
@@ -23,7 +23,7 @@ python scripts/run_cohort_experiment.py \
   --output-dir experiments/cohort_smoke
 ```
 
-This runs 5 seeds (0, 1, 2, 3, 4) and writes three artifacts to
+This runs 5 seeds (0, 1, 2, 3, 4) and writes four artifact types to
 `experiments/cohort_smoke/`:
 
 | File | Contents |

--- a/docs/experiments/multi_seed_cohort.md
+++ b/docs/experiments/multi_seed_cohort.md
@@ -1,0 +1,285 @@
+# Multi-Seed Cohort Runner
+
+Single evolution runs are noisy.  A configuration that looks best in one run
+can appear significantly worse (or better) in another simply because of random
+seed variance.  The **cohort runner** eliminates this ambiguity by executing
+the same evolution configuration over *N* independent random seeds and
+aggregating the results into a single summary with mean, standard deviation,
+and convergence statistics.
+
+---
+
+## Quick start
+
+```bash
+source venv/bin/activate
+python scripts/run_cohort_experiment.py \
+  --preset stable_hyper_evo \
+  --generations 8 \
+  --population-size 10 \
+  --steps-per-candidate 80 \
+  --num-seeds 5 \
+  --base-seed 0 \
+  --output-dir experiments/cohort_smoke
+```
+
+This runs 5 seeds (0, 1, 2, 3, 4) and writes three artifacts to
+`experiments/cohort_smoke/`:
+
+| File | Contents |
+|------|----------|
+| `cohort_manifest.json` | Resolved configuration snapshot (written before the run) |
+| `cohort_aggregate.json` | Per-seed detail + aggregate statistics |
+| `cohort_aggregate.csv` | One row per seed (notebook-ready) |
+| `seed_<N>/` | Full per-seed evolution artifacts (same layout as `run_evolution_experiment.py`) |
+
+---
+
+## Command-line flags
+
+All evolution flags from `run_evolution_experiment.py` are available plus
+two cohort-specific flags:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--num-seeds` | `3` | Number of seeds to run |
+| `--base-seed` | `0` | Seeds are `[base_seed, …, base_seed+num_seeds-1]` |
+
+Every other flag (generations, population-size, preset, adaptive-mutation,
+convergence, etc.) applies identically to each seed run.
+
+---
+
+## Artifact schema
+
+### `cohort_aggregate.json`
+
+```json
+{
+  "config": { ... },
+  "num_seeds": 5,
+  "seeds": [0, 1, 2, 3, 4],
+
+  "best_fitness_mean": 7.8,
+  "best_fitness_std":  1.2,
+  "best_fitness_min":  6.0,
+  "best_fitness_max":  9.5,
+
+  "convergence_rate": 0.4,
+  "convergence_reason_counts": {
+    "fitness_plateau": 2
+  },
+  "mean_generation_of_convergence": 5.5,
+  "std_generation_of_convergence":  0.7,
+
+  "lower_bound_occupancy_mean": 0.125,
+  "lower_bound_occupancy_std":  0.05,
+
+  "mean_elapsed_seconds": 12.3,
+  "total_elapsed_seconds": 61.5,
+
+  "seed_results": [
+    {
+      "seed": 0,
+      "best_fitness": 8.0,
+      "num_generations_completed": 8,
+      "converged": true,
+      "convergence_reason": "fitness_plateau",
+      "generation_of_convergence": 6,
+      "elapsed_seconds": 11.9,
+      "lower_bound_occupancy": 0.125
+    }
+  ]
+}
+```
+
+**Field reference**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `config` | object | Serialised `EvolutionExperimentConfig` template (seed field is the template value before per-seed override) |
+| `num_seeds` | int | Total seeds executed |
+| `seeds` | list[int] | Seed values in execution order |
+| `best_fitness_mean` | float | Mean of per-seed best fitness values |
+| `best_fitness_std` | float | Population standard deviation of best fitness |
+| `best_fitness_min` | float | Minimum best fitness across seeds |
+| `best_fitness_max` | float | Maximum best fitness across seeds |
+| `convergence_rate` | float | Fraction (0–1) of seeds that satisfied a convergence criterion |
+| `convergence_reason_counts` | object | Mapping of `ConvergenceReason` value → count |
+| `mean_generation_of_convergence` | float\|null | Mean 0-based generation index at convergence (converged seeds only); `null` when no seed converged |
+| `std_generation_of_convergence` | float\|null | Standard deviation of the same; `null` when fewer than 2 seeds converged |
+| `lower_bound_occupancy_mean` | float\|null | Mean fraction of generations where the best chromosome's `learning_rate` was at its lower boundary |
+| `lower_bound_occupancy_std` | float\|null | Standard deviation of the same |
+| `mean_elapsed_seconds` | float | Average wall-clock seconds per seed |
+| `total_elapsed_seconds` | float | Total wall-clock seconds for the cohort |
+| `seed_results` | list | One entry per seed (see below) |
+
+**`seed_results` entry**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `seed` | int | Seed used for this run |
+| `best_fitness` | float | Best fitness observed across all generations |
+| `num_generations_completed` | int | Generations that ran (may be less than budget when `early_stop=True`) |
+| `converged` | bool | Whether a convergence criterion was satisfied |
+| `convergence_reason` | str\|null | `"fitness_plateau"`, `"diversity_collapse"`, `"budget_exhausted"`, or `null` |
+| `generation_of_convergence` | int\|null | 0-based generation of first convergence event |
+| `elapsed_seconds` | float | Wall-clock seconds for this seed |
+| `lower_bound_occupancy` | float\|null | Fraction of generations the best chromosome hit the `learning_rate` lower boundary |
+
+### `cohort_aggregate.csv`
+
+One row per seed with the same columns as the `seed_results` entries above.
+Load directly into pandas:
+
+```python
+import pandas as pd
+df = pd.read_csv("experiments/cohort_smoke/cohort_aggregate.csv")
+print(df[["seed", "best_fitness", "converged", "lower_bound_occupancy"]])
+```
+
+---
+
+## Notebook ingestion
+
+A minimal loading snippet for `notebooks/hyperparameter_evolution_results.ipynb`
+or any new notebook:
+
+```python
+import json, pandas as pd
+
+with open("experiments/cohort_smoke/cohort_aggregate.json") as f:
+    cohort = json.load(f)
+
+# Top-level aggregates
+print(f"best_fitness  mean={cohort['best_fitness_mean']:.3f} "
+      f"± {cohort['best_fitness_std']:.3f}  "
+      f"[{cohort['best_fitness_min']:.3f}, {cohort['best_fitness_max']:.3f}]")
+print(f"convergence_rate={cohort['convergence_rate']:.0%}")
+print(f"lower_bound_occupancy mean={cohort['lower_bound_occupancy_mean']}")
+
+# Per-seed DataFrame
+df = pd.DataFrame(cohort["seed_results"])
+df.plot(x="seed", y="best_fitness", marker="o", title="Best fitness per seed")
+```
+
+---
+
+## Interpreting results with statistical confidence
+
+### Using mean ± std for fitness comparisons
+
+When comparing two configurations A and B:
+
+- If `best_fitness_mean_A − best_fitness_std_A > best_fitness_mean_B + best_fitness_std_B`,
+  configuration A is reliably superior.
+- Overlapping 1-σ bands indicate that the apparent winner may invert on
+  different seeds.  Run more seeds (`--num-seeds 10+`) or use a paired
+  t-test on the `seed_results` values.
+
+### Convergence rate
+
+A high `convergence_rate` (> 0.7) combined with a low
+`std_generation_of_convergence` means the search reliably converges in a
+predictable number of generations.  A low rate suggests the configuration
+rarely escapes the search space within the generation budget — consider
+increasing `--generations` or adjusting mutation parameters.
+
+### Lower-bound occupancy
+
+`lower_bound_occupancy_mean` close to 1.0 indicates that winning candidates
+consistently collapse to the minimum `learning_rate` boundary.  This is
+a sign of **lower-bound collapse** — the optimizer is effectively not
+searching the learning-rate space.  Mitigations:
+
+- Switch to `--boundary-mode reflect` (part of the `stable_hyper_evo`
+  preset) to let gene values bounce off boundaries instead of sticking.
+- Enable `--boundary-penalty-enabled` to add a soft fitness penalty near
+  boundaries.
+- Widen the `learning_rate` gene's minimum bound in the chromosome config.
+
+### Comparing multiple configurations
+
+Run each configuration as a separate cohort and store results in separate
+`--output-dir` directories:
+
+```bash
+# Config A
+python scripts/run_cohort_experiment.py \
+  --preset stable_hyper_evo --num-seeds 10 --base-seed 0 \
+  --output-dir experiments/cohort_A
+
+# Config B
+python scripts/run_cohort_experiment.py \
+  --selection-method roulette --num-seeds 10 --base-seed 0 \
+  --output-dir experiments/cohort_B
+```
+
+Then load both `cohort_aggregate.json` files in a notebook and compare the
+`best_fitness_mean` / `best_fitness_std` side-by-side:
+
+```python
+import json, pandas as pd
+
+configs = {"A": "experiments/cohort_A", "B": "experiments/cohort_B"}
+rows = []
+for name, path in configs.items():
+    with open(f"{path}/cohort_aggregate.json") as f:
+        d = json.load(f)
+    rows.append({
+        "config": name,
+        "mean": d["best_fitness_mean"],
+        "std": d["best_fitness_std"],
+        "convergence_rate": d["convergence_rate"],
+        "lb_occupancy": d["lower_bound_occupancy_mean"],
+    })
+comparison = pd.DataFrame(rows)
+print(comparison)
+```
+
+---
+
+## Programmatic API
+
+The `CohortRunner` class is exported from `farm.runners` and can be used
+directly without the CLI:
+
+```python
+from farm.config import SimulationConfig
+from farm.runners import (
+    AdaptiveMutationConfig,
+    CohortRunner,
+    ConvergenceCriteria,
+    EvolutionExperimentConfig,
+    EvolutionFitnessMetric,
+    EvolutionSelectionMethod,
+)
+from farm.core.hyperparameter_chromosome import BoundaryMode
+
+base_config = SimulationConfig.from_centralized_config(environment="development")
+template = EvolutionExperimentConfig(
+    num_generations=8,
+    population_size=10,
+    num_steps_per_candidate=80,
+    selection_method=EvolutionSelectionMethod.TOURNAMENT,
+    boundary_mode=BoundaryMode.REFLECT,
+    adaptive_mutation=AdaptiveMutationConfig(enabled=True),
+    convergence_criteria=ConvergenceCriteria(enabled=True, early_stop=True),
+    seed=None,  # overridden per seed
+)
+
+runner = CohortRunner(
+    base_config=base_config,
+    experiment_config_template=template,
+    seeds=list(range(5)),          # seeds 0..4
+    output_dir="experiments/cohort_api",
+)
+aggregate = runner.run()
+
+print(f"fitness  {aggregate.best_fitness_mean:.3f} ± {aggregate.best_fitness_std:.3f}")
+print(f"converged {aggregate.convergence_rate:.0%} of seeds")
+```
+
+The `CohortAggregateResult` and `CohortSeedResult` dataclasses are also
+exported from `farm.runners` if you need to type-annotate your own analysis
+code.

--- a/farm/runners/__init__.py
+++ b/farm/runners/__init__.py
@@ -7,6 +7,11 @@ from farm.runners.adaptive_mutation import (
     AdaptiveMutationController,
     compute_normalized_diversity,
 )
+from farm.runners.cohort_runner import (
+    CohortAggregateResult,
+    CohortRunner,
+    CohortSeedResult,
+)
 from farm.runners.evolution_experiment import (
     ConvergenceCriteria,
     ConvergenceReason,
@@ -25,6 +30,9 @@ __all__ = [
     "AdaptiveMutationConfig",
     "AdaptiveMutationController",
     "compute_normalized_diversity",
+    "CohortAggregateResult",
+    "CohortRunner",
+    "CohortSeedResult",
     "ConvergenceCriteria",
     "ConvergenceReason",
     "EvolutionCandidateEvaluation",

--- a/farm/runners/cohort_runner.py
+++ b/farm/runners/cohort_runner.py
@@ -35,10 +35,14 @@ import csv
 import json
 import os
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional
 
 from farm.config import SimulationConfig
+from farm.core.hyperparameter_chromosome import (
+    chromosome_from_learning_config,
+    default_hyperparameter_chromosome,
+)
 from farm.runners.evolution_experiment import (
     EvolutionExperiment,
     EvolutionExperimentConfig,
@@ -156,16 +160,24 @@ class CohortAggregateResult:
     total_elapsed_seconds: float
 
 
-def _lower_bound_occupancy(result: EvolutionExperimentResult) -> Optional[float]:
+def _lower_bound_occupancy(
+    result: EvolutionExperimentResult,
+    *,
+    learning_rate_lower_bound: Optional[float],
+) -> Optional[float]:
     """Return fraction of generations where the best chromosome hit the lower boundary.
 
     A generation is considered to have *lower-bound occupancy* when the
     best candidate's ``learning_rate`` gene value is within 1 % of the
-    gene's minimum boundary.  The 1 % tolerance handles floating-point
-    noise after reflection/clamping.
+    configured lower boundary.  The 1 % tolerance handles floating-point
+    noise near the exact boundary value.
 
-    Returns ``None`` when no generation summaries are available.
+    Returns ``None`` when no generation summaries are available or when the
+    learning-rate lower boundary is unavailable.
     """
+    if learning_rate_lower_bound is None:
+        return None
+
     summaries = result.generation_summaries
     if not summaries:
         return None
@@ -178,16 +190,28 @@ def _lower_bound_occupancy(result: EvolutionExperimentResult) -> Optional[float]
         best_lr = summary.best_chromosome.get("learning_rate")
         if best_lr is None:
             continue
-        # Infer the lower bound from the gene statistics minimum across the
-        # population.  A chromosome value at (or within 1 %) of the population
-        # minimum is treated as boundary-hugging.
-        pop_min = lr_stats.get("min", best_lr)
-        # We use 0.001 as an absolute floor to handle cases where pop_min ~= 0.
-        threshold = max(abs(pop_min) * 0.01, 1e-9)
-        if abs(best_lr - pop_min) <= threshold:
+        # Use a small relative tolerance around the configured lower bound.
+        threshold = max(abs(learning_rate_lower_bound) * 0.01, 1e-9)
+        if abs(best_lr - learning_rate_lower_bound) <= threshold:
             count += 1
 
     return count / len(summaries)
+
+
+def _resolve_learning_rate_lower_bound(base_config: SimulationConfig) -> Optional[float]:
+    """Resolve configured learning-rate lower bound from simulation config."""
+    chromosome = default_hyperparameter_chromosome()
+    learning_config = getattr(base_config, "learning", None)
+    if learning_config is not None:
+        try:
+            chromosome = chromosome_from_learning_config(learning_config)
+        except (TypeError, ValueError):
+            # Fallback keeps test doubles and partial configs robust.
+            chromosome = default_hyperparameter_chromosome()
+    gene = chromosome.get_gene("learning_rate")
+    if gene is None:
+        return None
+    return gene.min_value
 
 
 def _safe_stdev(values: List[float]) -> Optional[float]:
@@ -252,6 +276,7 @@ class CohortRunner:
 
         cohort_start = time.time()
         seed_results: List[CohortSeedResult] = []
+        learning_rate_lower_bound = _resolve_learning_rate_lower_bound(self.base_config)
 
         for seed in self.seeds:
             seed_output_dir = (
@@ -266,7 +291,10 @@ class CohortRunner:
             result = EvolutionExperiment(self.base_config, seed_config).run()
             elapsed = time.time() - seed_start
 
-            occupancy = _lower_bound_occupancy(result)
+            occupancy = _lower_bound_occupancy(
+                result,
+                learning_rate_lower_bound=learning_rate_lower_bound,
+            )
             best_fitness = result.best_candidate.fitness
 
             seed_result = CohortSeedResult(

--- a/farm/runners/cohort_runner.py
+++ b/farm/runners/cohort_runner.py
@@ -32,6 +32,7 @@ Typical usage::
 from __future__ import annotations
 
 import csv
+import enum
 import json
 import os
 import time
@@ -484,16 +485,10 @@ def _serialize_experiment_config(config: EvolutionExperimentConfig) -> Dict[str,
     import dataclasses
 
     def _coerce(obj: Any) -> Any:
-        # Enum → its .value string
-        if hasattr(obj, "value") and isinstance(obj, type(obj)):
-            try:
-                # Only coerce actual Enum instances, not arbitrary objects with
-                # a `.value` attribute.
-                import enum
-                if isinstance(obj, enum.Enum):
-                    return obj.value
-            except ImportError:
-                pass
+        # Enum → its .value string (only for real Enum instances, not arbitrary
+        # objects that happen to expose a `.value` attribute).
+        if isinstance(obj, enum.Enum):
+            return obj.value
         if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
             return {f.name: _coerce(getattr(obj, f.name)) for f in dataclasses.fields(obj)}
         if hasattr(obj, "items"):

--- a/farm/runners/cohort_runner.py
+++ b/farm/runners/cohort_runner.py
@@ -1,0 +1,478 @@
+"""Multi-seed cohort runner for statistically-robust evolution experiments.
+
+Runs the same :class:`~farm.runners.EvolutionExperiment` configuration
+over *N* different random seeds and aggregates the per-seed results into a
+single :class:`CohortAggregateResult`.  This lets callers compare
+strategies with appropriate statistical confidence rather than relying on
+a single run.
+
+Typical usage::
+
+    from farm.config import SimulationConfig
+    from farm.runners import EvolutionExperimentConfig, EvolutionFitnessMetric
+    from farm.runners.cohort_runner import CohortRunner
+
+    base_config = SimulationConfig.from_centralized_config(environment="development")
+    template = EvolutionExperimentConfig(
+        num_generations=8,
+        population_size=10,
+        num_steps_per_candidate=80,
+        seed=None,  # overridden per seed by CohortRunner
+    )
+    runner = CohortRunner(
+        base_config=base_config,
+        experiment_config_template=template,
+        seeds=[1, 2, 3],
+        output_dir="experiments/cohort_run",
+    )
+    aggregate = runner.run()
+    print(aggregate.best_fitness_mean, aggregate.best_fitness_std)
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
+
+from farm.config import SimulationConfig
+from farm.runners.evolution_experiment import (
+    EvolutionExperiment,
+    EvolutionExperimentConfig,
+    EvolutionExperimentResult,
+)
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class CohortSeedResult:
+    """Per-seed result captured within a cohort run.
+
+    Attributes
+    ----------
+    seed:
+        The random seed used for this run.
+    best_fitness:
+        Best fitness value observed across all generations.
+    num_generations_completed:
+        Number of generations that ran (may be less than the budget when
+        ``early_stop`` is active).
+    converged:
+        ``True`` when a convergence criterion was satisfied.
+    convergence_reason:
+        String value from :class:`~farm.runners.ConvergenceReason`, or
+        ``None`` when convergence checking was disabled.
+    generation_of_convergence:
+        0-based generation index at which convergence was declared (or the
+        last generation when the budget was exhausted with checking enabled).
+        ``None`` when convergence checking was disabled.
+    elapsed_seconds:
+        Wall-clock seconds for this seed's run.
+    lower_bound_occupancy:
+        Fraction of generations in which the best chromosome's
+        ``learning_rate`` gene was at (or within 1 % of) its minimum
+        boundary.  ``None`` when no generation summaries were recorded.
+    """
+
+    seed: int
+    best_fitness: float
+    num_generations_completed: int
+    converged: bool
+    convergence_reason: Optional[str]
+    generation_of_convergence: Optional[int]
+    elapsed_seconds: float
+    lower_bound_occupancy: Optional[float]
+
+
+@dataclass
+class CohortAggregateResult:
+    """Aggregated statistics from a multi-seed cohort run.
+
+    Schema
+    ------
+    The following keys appear in both the JSON and CSV artifacts produced by
+    :meth:`CohortRunner._persist`:
+
+    ``num_seeds``
+        Total number of seeds executed.
+    ``seeds``
+        Ordered list of seed values used.
+    ``best_fitness_mean``, ``best_fitness_std``, ``best_fitness_min``, ``best_fitness_max``
+        Cross-seed statistics for the per-run best fitness.
+    ``convergence_rate``
+        Fraction (0–1) of seed runs that satisfied a convergence criterion.
+    ``convergence_reason_counts``
+        Mapping of convergence reason → count across seeds.
+    ``mean_generation_of_convergence``
+        Mean 0-based generation index at which convergence was first
+        declared (only across runs where ``converged`` is ``True``).
+        ``None`` when no run converged.
+    ``std_generation_of_convergence``
+        Standard deviation of the same (``None`` for 0 or 1 converged
+        runs).
+    ``lower_bound_occupancy_mean``, ``lower_bound_occupancy_std``
+        Cross-seed mean/std of per-seed lower-bound occupancy.  ``None``
+        when no seed produced generation summaries.
+    ``mean_elapsed_seconds``
+        Average wall-clock time per seed.
+    ``total_elapsed_seconds``
+        Total wall-clock time for the whole cohort.
+    ``seed_results``
+        Per-seed detail as a list of :class:`CohortSeedResult` mappings.
+    ``config``
+        Serialised :class:`~farm.runners.EvolutionExperimentConfig`
+        template (seed field reflects the template value, *not* individual
+        overrides).
+    """
+
+    config: Dict[str, Any]
+    num_seeds: int
+    seeds: List[int]
+    seed_results: List[CohortSeedResult]
+
+    # Cross-seed fitness statistics
+    best_fitness_mean: float
+    best_fitness_std: float
+    best_fitness_min: float
+    best_fitness_max: float
+
+    # Convergence statistics
+    convergence_rate: float
+    convergence_reason_counts: Dict[str, int]
+    mean_generation_of_convergence: Optional[float]
+    std_generation_of_convergence: Optional[float]
+
+    # Lower-bound occupancy
+    lower_bound_occupancy_mean: Optional[float]
+    lower_bound_occupancy_std: Optional[float]
+
+    # Timing
+    mean_elapsed_seconds: float
+    total_elapsed_seconds: float
+
+
+def _lower_bound_occupancy(result: EvolutionExperimentResult) -> Optional[float]:
+    """Return fraction of generations where the best chromosome hit the lower boundary.
+
+    A generation is considered to have *lower-bound occupancy* when the
+    best candidate's ``learning_rate`` gene value is within 1 % of the
+    gene's minimum boundary.  The 1 % tolerance handles floating-point
+    noise after reflection/clamping.
+
+    Returns ``None`` when no generation summaries are available.
+    """
+    summaries = result.generation_summaries
+    if not summaries:
+        return None
+
+    count = 0
+    for summary in summaries:
+        lr_stats = summary.gene_statistics.get("learning_rate")
+        if lr_stats is None:
+            continue
+        best_lr = summary.best_chromosome.get("learning_rate")
+        if best_lr is None:
+            continue
+        # Infer the lower bound from the gene statistics minimum across the
+        # population.  A chromosome value at (or within 1 %) of the population
+        # minimum is treated as boundary-hugging.
+        pop_min = lr_stats.get("min", best_lr)
+        # We use 0.001 as an absolute floor to handle cases where pop_min ~= 0.
+        threshold = max(abs(pop_min) * 0.01, 1e-9)
+        if abs(best_lr - pop_min) <= threshold:
+            count += 1
+
+    return count / len(summaries)
+
+
+def _safe_stdev(values: List[float]) -> Optional[float]:
+    """Return population standard deviation, or ``None`` for fewer than 2 values."""
+    if len(values) < 2:
+        return None
+    mean = sum(values) / len(values)
+    variance = sum((v - mean) ** 2 for v in values) / len(values)
+    return variance ** 0.5
+
+
+class CohortRunner:
+    """Run an :class:`~farm.runners.EvolutionExperiment` over multiple seeds.
+
+    Parameters
+    ----------
+    base_config:
+        Simulation configuration shared by all seed runs.
+    experiment_config_template:
+        Experiment configuration template.  The ``seed`` field is
+        overridden for each run; all other fields are shared.
+    seeds:
+        Explicit list of integer seeds to use.  Must be non-empty.
+    output_dir:
+        Root directory for artifacts.  A ``seed_<N>/`` sub-directory is
+        created for each run, and the aggregate artifacts are written to
+        the root.  When ``None`` no artifacts are persisted.
+    """
+
+    def __init__(
+        self,
+        base_config: SimulationConfig,
+        experiment_config_template: EvolutionExperimentConfig,
+        seeds: List[int],
+        output_dir: Optional[str] = None,
+    ) -> None:
+        if not seeds:
+            raise ValueError("seeds must be a non-empty list.")
+        self.base_config = base_config
+        self.experiment_config_template = experiment_config_template
+        self.seeds = list(seeds)
+        self.output_dir = output_dir
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def run(self) -> CohortAggregateResult:
+        """Execute one evolution run per seed and return aggregated results.
+
+        Each seed run writes its per-generation and lineage artifacts to
+        ``<output_dir>/seed_<N>/`` (when *output_dir* is set).  The
+        cohort-level JSON and CSV summaries are written to *output_dir*
+        after all seeds complete.
+        """
+        logger.info(
+            "cohort_run_start",
+            num_seeds=len(self.seeds),
+            seeds=self.seeds,
+            output_dir=self.output_dir,
+        )
+
+        cohort_start = time.time()
+        seed_results: List[CohortSeedResult] = []
+
+        for seed in self.seeds:
+            seed_output_dir = (
+                os.path.join(self.output_dir, f"seed_{seed}")
+                if self.output_dir
+                else None
+            )
+            seed_config = _replace_seed(self.experiment_config_template, seed, seed_output_dir)
+
+            logger.info("cohort_seed_start", seed=seed, output_dir=seed_output_dir)
+            seed_start = time.time()
+            result = EvolutionExperiment(self.base_config, seed_config).run()
+            elapsed = time.time() - seed_start
+
+            occupancy = _lower_bound_occupancy(result)
+            best_fitness = result.best_candidate.fitness
+
+            seed_result = CohortSeedResult(
+                seed=seed,
+                best_fitness=best_fitness,
+                num_generations_completed=len(result.generation_summaries),
+                converged=result.converged,
+                convergence_reason=result.convergence_reason,
+                generation_of_convergence=result.generation_of_convergence,
+                elapsed_seconds=round(elapsed, 3),
+                lower_bound_occupancy=occupancy,
+            )
+            seed_results.append(seed_result)
+            logger.info(
+                "cohort_seed_complete",
+                seed=seed,
+                best_fitness=best_fitness,
+                converged=result.converged,
+                convergence_reason=result.convergence_reason,
+                elapsed_seconds=seed_result.elapsed_seconds,
+            )
+
+        total_elapsed = time.time() - cohort_start
+        aggregate = self._aggregate(seed_results, total_elapsed)
+
+        if self.output_dir:
+            os.makedirs(self.output_dir, exist_ok=True)
+            self._persist(aggregate)
+
+        logger.info(
+            "cohort_run_complete",
+            num_seeds=len(self.seeds),
+            best_fitness_mean=aggregate.best_fitness_mean,
+            best_fitness_std=aggregate.best_fitness_std,
+            convergence_rate=aggregate.convergence_rate,
+            total_elapsed_seconds=round(total_elapsed, 3),
+        )
+        return aggregate
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _aggregate(
+        self,
+        seed_results: List[CohortSeedResult],
+        total_elapsed: float,
+    ) -> CohortAggregateResult:
+        fitnesses = [sr.best_fitness for sr in seed_results]
+        n = len(fitnesses)
+        mean_fitness = sum(fitnesses) / n
+        std_fitness = _safe_stdev(fitnesses) or 0.0
+
+        convergence_reason_counts: Dict[str, int] = {}
+        gen_of_convergence_values: List[float] = []
+        for sr in seed_results:
+            if sr.convergence_reason:
+                convergence_reason_counts[sr.convergence_reason] = (
+                    convergence_reason_counts.get(sr.convergence_reason, 0) + 1
+                )
+            if sr.converged and sr.generation_of_convergence is not None:
+                gen_of_convergence_values.append(float(sr.generation_of_convergence))
+
+        convergence_rate = sum(1 for sr in seed_results if sr.converged) / n
+
+        mean_gen_convergence: Optional[float] = None
+        std_gen_convergence: Optional[float] = None
+        if gen_of_convergence_values:
+            mean_gen_convergence = sum(gen_of_convergence_values) / len(gen_of_convergence_values)
+            std_gen_convergence = _safe_stdev(gen_of_convergence_values)
+
+        lb_occ_values = [sr.lower_bound_occupancy for sr in seed_results if sr.lower_bound_occupancy is not None]
+        lb_occ_mean: Optional[float] = (
+            sum(lb_occ_values) / len(lb_occ_values) if lb_occ_values else None
+        )
+        lb_occ_std: Optional[float] = _safe_stdev(lb_occ_values) if lb_occ_values else None
+
+        elapsed_values = [sr.elapsed_seconds for sr in seed_results]
+        mean_elapsed = sum(elapsed_values) / len(elapsed_values)
+
+        return CohortAggregateResult(
+            config=_serialize_experiment_config(self.experiment_config_template),
+            num_seeds=n,
+            seeds=list(self.seeds),
+            seed_results=seed_results,
+            best_fitness_mean=round(mean_fitness, 6),
+            best_fitness_std=round(std_fitness, 6),
+            best_fitness_min=round(min(fitnesses), 6),
+            best_fitness_max=round(max(fitnesses), 6),
+            convergence_rate=round(convergence_rate, 4),
+            convergence_reason_counts=convergence_reason_counts,
+            mean_generation_of_convergence=(
+                round(mean_gen_convergence, 3) if mean_gen_convergence is not None else None
+            ),
+            std_generation_of_convergence=(
+                round(std_gen_convergence, 3) if std_gen_convergence is not None else None
+            ),
+            lower_bound_occupancy_mean=(
+                round(lb_occ_mean, 4) if lb_occ_mean is not None else None
+            ),
+            lower_bound_occupancy_std=(
+                round(lb_occ_std, 4) if lb_occ_std is not None else None
+            ),
+            mean_elapsed_seconds=round(mean_elapsed, 3),
+            total_elapsed_seconds=round(total_elapsed, 3),
+        )
+
+    def _persist(self, aggregate: CohortAggregateResult) -> None:
+        """Write JSON and CSV aggregate artifacts to *output_dir*."""
+        assert self.output_dir is not None  # guarded by caller
+
+        json_path = os.path.join(self.output_dir, "cohort_aggregate.json")
+        csv_path = os.path.join(self.output_dir, "cohort_aggregate.csv")
+
+        # --- JSON artifact ---
+        payload: Dict[str, Any] = {
+            "config": aggregate.config,
+            "num_seeds": aggregate.num_seeds,
+            "seeds": aggregate.seeds,
+            "best_fitness_mean": aggregate.best_fitness_mean,
+            "best_fitness_std": aggregate.best_fitness_std,
+            "best_fitness_min": aggregate.best_fitness_min,
+            "best_fitness_max": aggregate.best_fitness_max,
+            "convergence_rate": aggregate.convergence_rate,
+            "convergence_reason_counts": aggregate.convergence_reason_counts,
+            "mean_generation_of_convergence": aggregate.mean_generation_of_convergence,
+            "std_generation_of_convergence": aggregate.std_generation_of_convergence,
+            "lower_bound_occupancy_mean": aggregate.lower_bound_occupancy_mean,
+            "lower_bound_occupancy_std": aggregate.lower_bound_occupancy_std,
+            "mean_elapsed_seconds": aggregate.mean_elapsed_seconds,
+            "total_elapsed_seconds": aggregate.total_elapsed_seconds,
+            "seed_results": [asdict(sr) for sr in aggregate.seed_results],
+        }
+        with open(json_path, "w", encoding="utf-8") as fp:
+            json.dump(payload, fp, indent=2)
+
+        # --- CSV artifact (one row per seed) ---
+        fieldnames = [
+            "seed",
+            "best_fitness",
+            "num_generations_completed",
+            "converged",
+            "convergence_reason",
+            "generation_of_convergence",
+            "elapsed_seconds",
+            "lower_bound_occupancy",
+        ]
+        with open(csv_path, "w", newline="", encoding="utf-8") as fp:
+            writer = csv.DictWriter(fp, fieldnames=fieldnames)
+            writer.writeheader()
+            for sr in aggregate.seed_results:
+                writer.writerow(asdict(sr))
+
+        logger.info(
+            "cohort_aggregate_persisted",
+            output_dir=self.output_dir,
+            json_path=json_path,
+            csv_path=csv_path,
+            num_seeds=aggregate.num_seeds,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _replace_seed(
+    template: EvolutionExperimentConfig,
+    seed: int,
+    output_dir: Optional[str],
+) -> EvolutionExperimentConfig:
+    """Return a copy of *template* with ``seed`` and ``output_dir`` replaced."""
+    # EvolutionExperimentConfig is a frozen dataclass; use keyword reconstruction.
+    import dataclasses
+
+    return dataclasses.replace(template, seed=seed, output_dir=output_dir)
+
+
+def _serialize_experiment_config(config: EvolutionExperimentConfig) -> Dict[str, Any]:
+    """Return a JSON-serialisable dict from an :class:`EvolutionExperimentConfig`.
+
+    Uses a recursive field walk instead of ``dataclasses.asdict`` to avoid
+    deep-copy failures on ``MappingProxyType`` members inside
+    :class:`~farm.runners.AdaptiveMutationConfig`.
+    """
+    import dataclasses
+
+    def _coerce(obj: Any) -> Any:
+        # Enum → its .value string
+        if hasattr(obj, "value") and isinstance(obj, type(obj)):
+            try:
+                # Only coerce actual Enum instances, not arbitrary objects with
+                # a `.value` attribute.
+                import enum
+                if isinstance(obj, enum.Enum):
+                    return obj.value
+            except ImportError:
+                pass
+        if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+            return {f.name: _coerce(getattr(obj, f.name)) for f in dataclasses.fields(obj)}
+        if hasattr(obj, "items"):
+            # dict-like (including MappingProxyType)
+            return {k: _coerce(v) for k, v in obj.items()}
+        if isinstance(obj, (list, tuple)):
+            return [_coerce(v) for v in obj]
+        return obj
+
+    return _coerce(config)

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository scripts package (shared CLI helpers live in sibling modules)."""

--- a/scripts/evolution_experiment_cli.py
+++ b/scripts/evolution_experiment_cli.py
@@ -1,0 +1,360 @@
+"""Shared argparse helpers for evolution experiment CLIs."""
+
+from __future__ import annotations
+
+import argparse
+
+# ---------------------------------------------------------------------------
+# Named presets
+# ---------------------------------------------------------------------------
+# Each preset is a dict whose keys match argparse ``dest`` names.  When a
+# preset is selected via ``--preset``, its values become the argparse
+# *defaults* for those arguments, so any explicit CLI flag still wins.
+#
+# ``stable_hyper_evo`` rationale
+# --------------------------------
+# Follow-up analysis in ``notebooks/hyperparameter_evolution_results.ipynb``
+# and ``docs/experiments/hyperparameter_evolution_convergence.md`` revealed
+# two recurring failure modes with the bare defaults:
+#
+#   1. **Lower-bound collapse** – tournament selection with aggressive mutation
+#      pushes the winning learning rate to its minimum boundary and keeps it
+#      there.  Switching to ``boundary_mode=reflect`` lets genes bounce back
+#      off the wall instead of sticking.
+#
+#   2. **Diversity collapse** – without adaptive mutation the population
+#      converges prematurely.  Enabling adaptive mutation with both the
+#      fitness-stall and diversity-collapse rules keeps the search alive.
+#
+# The mutation magnitudes (rate 0.20, scale 0.15) come from the
+# ``run_tournament_mut020_g6`` closure run, which showed the best trade-off
+# between exploration and exploitation across the evaluated configs.
+
+
+def get_presets(
+    *,
+    evolution_selection_method: type,
+    boundary_mode: type,
+) -> dict[str, dict[str, object]]:
+    """Return the evolution CLI preset table (requires runner/chromosome enums)."""
+    return {
+        "stable_hyper_evo": {
+            "selection_method": evolution_selection_method.TOURNAMENT.value,
+            "boundary_mode": boundary_mode.REFLECT.value,
+            "mutation_rate": 0.20,
+            "mutation_scale": 0.15,
+            "adaptive_mutation": True,
+            "tournament_size": 3,
+            "elitism_count": 1,
+        },
+    }
+
+
+def parse_per_gene_multipliers(raw: str | None, *, label: str) -> dict[str, float]:
+    """Parse a comma-separated ``gene=value`` string into a multiplier dict.
+
+    Returns an empty dict for ``None`` or empty input.  Raises ``ValueError``
+    on malformed entries; ``argparse`` will surface this as a CLI error.
+    """
+    if not raw:
+        return {}
+    multipliers: dict[str, float] = {}
+    for entry in raw.split(","):
+        token = entry.strip()
+        if not token:
+            continue
+        if "=" not in token:
+            raise ValueError(
+                f"{label} entry '{token}' must be of the form 'gene_name=value'."
+            )
+        name, _, value_str = token.partition("=")
+        name = name.strip()
+        if not name:
+            raise ValueError(f"{label} entry '{token}' has an empty gene name.")
+        try:
+            multipliers[name] = float(value_str)
+        except ValueError as exc:
+            raise ValueError(
+                f"{label} entry '{token}' has a non-numeric value."
+            ) from exc
+    return multipliers
+
+
+class EvolutionExperimentHelpFormatter(
+    argparse.RawDescriptionHelpFormatter,
+    argparse.ArgumentDefaultsHelpFormatter,
+):
+    """Formatter that preserves raw description layout and also shows defaults."""
+
+
+def add_evolution_training_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    presets: dict[str, dict[str, object]],
+    preset_help: str,
+    evolution_fitness_metric: type,
+    evolution_selection_method: type,
+    boundary_mode: type,
+    crossover_mode: type,
+    generations_help: str = "Number of generations to run.",
+    fitness_metric_help: str = "Built-in fitness metric used for parent selection.",
+) -> None:
+    """Add shared evolution hyperparameter / adaptive-mutation flags to *parser*."""
+    parser.add_argument(
+        "--preset",
+        type=str,
+        default=None,
+        choices=list(presets),
+        help=preset_help,
+    )
+    parser.add_argument(
+        "--environment",
+        type=str,
+        default="development",
+        choices=["development", "production", "testing"],
+        help="Centralized config environment.",
+    )
+    parser.add_argument(
+        "--profile",
+        type=str,
+        default=None,
+        choices=["benchmark", "simulation", "research"],
+        help="Optional centralized config profile.",
+    )
+    parser.add_argument("--generations", type=int, default=2, help=generations_help)
+    parser.add_argument("--population-size", type=int, default=4, help="Candidates per generation.")
+    parser.add_argument(
+        "--steps-per-candidate",
+        type=int,
+        default=20,
+        help="Simulation steps used to evaluate each candidate.",
+    )
+    parser.add_argument(
+        "--fitness-metric",
+        type=str,
+        default=evolution_fitness_metric.FINAL_POPULATION.value,
+        choices=[metric.value for metric in evolution_fitness_metric],
+        help=fitness_metric_help,
+    )
+    parser.add_argument(
+        "--selection-method",
+        type=str,
+        default=evolution_selection_method.TOURNAMENT.value,
+        choices=[method.value for method in evolution_selection_method],
+        help="Parent selection strategy.",
+    )
+    parser.add_argument("--mutation-rate", type=float, default=0.25, help="Mutation probability per gene.")
+    parser.add_argument(
+        "--mutation-scale",
+        type=float,
+        default=0.2,
+        help="Mutation magnitude for mutated genes.",
+    )
+    parser.add_argument(
+        "--tournament-size",
+        type=int,
+        default=3,
+        help="Tournament bracket size when tournament selection is used.",
+    )
+    parser.add_argument(
+        "--boundary-mode",
+        type=str,
+        default=boundary_mode.CLAMP.value,
+        choices=[mode.value for mode in boundary_mode],
+        help="Boundary strategy after mutation overshoots gene bounds.",
+    )
+    parser.add_argument(
+        "--interior-bias-fraction",
+        type=float,
+        default=1e-3,
+        help=(
+            "When --boundary-mode=interior_biased, fraction of the gene span used as the "
+            "upper bound of the inward nudge applied to values landing exactly on a boundary. "
+            "Must be non-negative.  Default: 1e-3."
+        ),
+    )
+    parser.add_argument(
+        "--boundary-penalty-enabled",
+        action="store_true",
+        help="Enable soft near-boundary fitness penalty.",
+    )
+    parser.add_argument(
+        "--boundary-penalty-strength",
+        type=float,
+        default=0.01,
+        help="Max per-gene penalty at exact boundary when penalty is enabled.",
+    )
+    parser.add_argument(
+        "--boundary-penalty-threshold",
+        type=float,
+        default=0.05,
+        help="Near-boundary zone width as fraction of gene range (0, 0.5].",
+    )
+    parser.add_argument(
+        "--crossover-mode",
+        type=str,
+        default=crossover_mode.UNIFORM.value,
+        choices=[mode.value for mode in crossover_mode],
+        help="Crossover operator used to create offspring chromosomes.",
+    )
+    parser.add_argument(
+        "--blend-alpha",
+        type=float,
+        default=0.5,
+        help="BLX-alpha extent used when --crossover-mode=blend.",
+    )
+    parser.add_argument(
+        "--num-crossover-points",
+        type=int,
+        default=2,
+        help="Pivot count used when --crossover-mode=multi_point.",
+    )
+    parser.add_argument("--elitism-count", type=int, default=1, help="Top candidates copied to next generation.")
+    parser.add_argument(
+        "--adaptive-mutation",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Enable adaptive mutation rate/scale based on fitness progress and diversity.",
+    )
+    parser.add_argument(
+        "--adaptive-stall-window",
+        type=int,
+        default=3,
+        help="Generations to look back when detecting a fitness stall.",
+    )
+    parser.add_argument(
+        "--adaptive-improve-threshold",
+        type=float,
+        default=1e-6,
+        help="Minimum best-fitness improvement over the window that counts as progress.",
+    )
+    parser.add_argument(
+        "--adaptive-stall-multiplier",
+        type=float,
+        default=1.5,
+        help="Multiplier applied to mutation rate/scale when the search stalls.",
+    )
+    parser.add_argument(
+        "--adaptive-improve-multiplier",
+        type=float,
+        default=0.8,
+        help="Multiplier applied to mutation rate/scale when fitness is improving.",
+    )
+    parser.add_argument(
+        "--adaptive-diversity-threshold",
+        type=float,
+        default=0.05,
+        help="Normalized diversity at or below which mutation is boosted.",
+    )
+    parser.add_argument(
+        "--adaptive-diversity-multiplier",
+        type=float,
+        default=1.5,
+        help="Multiplier applied to mutation rate/scale when diversity collapses.",
+    )
+    parser.add_argument(
+        "--adaptive-disable-fitness",
+        action="store_true",
+        help="When --adaptive-mutation is set, skip the fitness-progress adaptation rule.",
+    )
+    parser.add_argument(
+        "--adaptive-disable-diversity",
+        action="store_true",
+        help="When --adaptive-mutation is set, skip the diversity-collapse adaptation rule.",
+    )
+    parser.add_argument(
+        "--adaptive-max-step-multiplier",
+        type=float,
+        default=2.0,
+        help=(
+            "Maximum factor by which the accumulated mutation multiplier may change in a "
+            "single generation.  Bounds per-step change to [1/max_step, max_step] so large "
+            "stall/improve factors are dampened.  Must be >= 1.0.  Default: 2.0."
+        ),
+    )
+    parser.add_argument(
+        "--adaptive-default-per-gene",
+        action="store_true",
+        help=(
+            "Apply built-in per-gene scale defaults tuned for sensitivity "
+            "(learning_rate=0.5×, gamma=0.75×, epsilon_decay=0.75× scale).  "
+            "User --adaptive-per-gene-scale values override these defaults."
+        ),
+    )
+    parser.add_argument(
+        "--adaptive-per-gene-rate",
+        type=str,
+        default=None,
+        help=(
+            "Comma-separated per-gene mutation-rate multipliers, e.g. "
+            "'learning_rate=0.5,gamma=2.0'.  Each value must be non-negative."
+        ),
+    )
+    parser.add_argument(
+        "--adaptive-per-gene-scale",
+        type=str,
+        default=None,
+        help=(
+            "Comma-separated per-gene mutation-scale multipliers, e.g. "
+            "'learning_rate=0.5,gamma=2.0'.  Each value must be non-negative."
+        ),
+    )
+
+
+def add_evolution_convergence_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add shared convergence-criteria flags used by evolution cohort CLIs."""
+    parser.add_argument(
+        "--convergence-enabled",
+        action="store_true",
+        help=(
+            "Enable convergence checking.  When set, the run will detect "
+            "fitness plateau and diversity collapse and optionally stop early."
+        ),
+    )
+    parser.add_argument(
+        "--convergence-fitness-window",
+        type=int,
+        default=5,
+        help=(
+            "Number of trailing generations over which best-fitness improvement "
+            "is measured for the plateau criterion."
+        ),
+    )
+    parser.add_argument(
+        "--convergence-fitness-threshold",
+        type=float,
+        default=1e-4,
+        help=(
+            "Minimum absolute improvement in best fitness over the window "
+            "required to avoid a plateau declaration."
+        ),
+    )
+    parser.add_argument(
+        "--convergence-diversity-window",
+        type=int,
+        default=3,
+        help=(
+            "Number of consecutive generations with diversity below the threshold "
+            "required to trigger a diversity-collapse declaration."
+        ),
+    )
+    parser.add_argument(
+        "--convergence-diversity-threshold",
+        type=float,
+        default=0.01,
+        help="Normalized diversity at or below which diversity-collapse is considered.",
+    )
+    parser.add_argument(
+        "--convergence-min-generations",
+        type=int,
+        default=1,
+        help="Minimum number of completed generations before convergence checks begin.",
+    )
+    parser.add_argument(
+        "--convergence-no-early-stop",
+        action="store_true",
+        help=(
+            "When --convergence-enabled is set, annotate the result with convergence "
+            "metadata but do not halt the run early."
+        ),
+    )

--- a/scripts/run_cohort_experiment.py
+++ b/scripts/run_cohort_experiment.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""CLI entrypoint for multi-seed cohort evolution experiments.
+
+Runs the same :class:`~farm.runners.EvolutionExperiment` configuration
+over *N* random seeds and writes aggregate JSON/CSV artifacts to
+``--output-dir``.  All evolution flags mirror :mod:`run_evolution_experiment`.
+
+Example::
+
+    source venv/bin/activate
+    python scripts/run_cohort_experiment.py \\
+      --preset stable_hyper_evo \\
+      --generations 8 \\
+      --population-size 10 \\
+      --steps-per-candidate 80 \\
+      --num-seeds 5 \\
+      --base-seed 0 \\
+      --output-dir experiments/cohort_smoke
+
+Artifacts written to ``--output-dir``:
+
+* ``cohort_manifest.json``   – resolved configuration snapshot (pre-run)
+* ``cohort_aggregate.json``  – per-seed and aggregate statistics
+* ``cohort_aggregate.csv``   – per-seed rows (notebook-ready)
+* ``seed_<N>/``              – per-seed evolution artifacts (same layout as
+                               :mod:`run_evolution_experiment`)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+# Allow running directly from repo root without installing the package
+_repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+from farm.config import SimulationConfig  # noqa: E402
+from farm.runners import (  # noqa: E402
+    AdaptiveMutationConfig,
+    CohortRunner,
+    ConvergenceCriteria,
+    EvolutionExperimentConfig,
+    EvolutionFitnessMetric,
+    EvolutionSelectionMethod,
+)
+from farm.runners.cohort_runner import _serialize_experiment_config  # noqa: E402
+from farm.core.hyperparameter_chromosome import (  # noqa: E402
+    BoundaryMode,
+    BoundaryPenaltyConfig,
+    CrossoverMode,
+)
+from farm.utils.logging import configure_logging, get_logger  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Named presets (mirror run_evolution_experiment.py)
+# ---------------------------------------------------------------------------
+PRESETS: dict[str, dict[str, object]] = {
+    "stable_hyper_evo": {
+        "selection_method": EvolutionSelectionMethod.TOURNAMENT.value,
+        "boundary_mode": BoundaryMode.REFLECT.value,
+        "mutation_rate": 0.20,
+        "mutation_scale": 0.15,
+        "adaptive_mutation": True,
+        "tournament_size": 3,
+        "elitism_count": 1,
+    },
+}
+
+
+def _parse_per_gene_multipliers(raw: str | None, *, label: str) -> dict[str, float]:
+    """Parse a comma-separated ``gene=value`` string into a multiplier dict."""
+    if not raw:
+        return {}
+    multipliers: dict[str, float] = {}
+    for entry in raw.split(","):
+        token = entry.strip()
+        if not token:
+            continue
+        if "=" not in token:
+            raise ValueError(
+                f"{label} entry '{token}' must be of the form 'gene_name=value'."
+            )
+        name, _, value_str = token.partition("=")
+        name = name.strip()
+        if not name:
+            raise ValueError(f"{label} entry '{token}' has an empty gene name.")
+        try:
+            multipliers[name] = float(value_str)
+        except ValueError as exc:
+            raise ValueError(
+                f"{label} entry '{token}' has a non-numeric value."
+            ) from exc
+    return multipliers
+
+
+class _HelpFormatter(argparse.RawDescriptionHelpFormatter, argparse.ArgumentDefaultsHelpFormatter):
+    """Formatter that preserves raw description layout and also shows defaults."""
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Return a fully-configured argument parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run multi-seed cohort hyperparameter evolution experiments.\n\n"
+            "Executes the same evolution config over N seeds and writes aggregate\n"
+            "JSON/CSV artifacts to --output-dir for confidence-aware comparison.\n\n"
+            "Available presets:\n"
+            "  stable_hyper_evo  tournament selection + reflect boundary + adaptive\n"
+            "                    mutation (rate 0.20, scale 0.15)."
+        ),
+        formatter_class=_HelpFormatter,
+    )
+    # ------------------------------------------------------------------
+    # Cohort-specific flags
+    # ------------------------------------------------------------------
+    parser.add_argument(
+        "--num-seeds",
+        type=int,
+        default=3,
+        help="Number of seeds to run in the cohort.",
+    )
+    parser.add_argument(
+        "--base-seed",
+        type=int,
+        default=0,
+        help=(
+            "Base seed value.  Seeds are derived as "
+            "[base_seed, base_seed+1, ..., base_seed+num_seeds-1]."
+        ),
+    )
+    # ------------------------------------------------------------------
+    # Shared preset / environment flags
+    # ------------------------------------------------------------------
+    parser.add_argument(
+        "--preset",
+        type=str,
+        default=None,
+        choices=list(PRESETS),
+        help="Load a named configuration preset.",
+    )
+    parser.add_argument(
+        "--environment",
+        type=str,
+        default="development",
+        choices=["development", "production", "testing"],
+        help="Centralized config environment.",
+    )
+    parser.add_argument(
+        "--profile",
+        type=str,
+        default=None,
+        choices=["benchmark", "simulation", "research"],
+        help="Optional centralized config profile.",
+    )
+    parser.add_argument("--generations", type=int, default=2, help="Number of generations per seed.")
+    parser.add_argument("--population-size", type=int, default=4, help="Candidates per generation.")
+    parser.add_argument(
+        "--steps-per-candidate",
+        type=int,
+        default=20,
+        help="Simulation steps used to evaluate each candidate.",
+    )
+    parser.add_argument(
+        "--fitness-metric",
+        type=str,
+        default=EvolutionFitnessMetric.FINAL_POPULATION.value,
+        choices=[metric.value for metric in EvolutionFitnessMetric],
+        help="Built-in fitness metric.",
+    )
+    parser.add_argument(
+        "--selection-method",
+        type=str,
+        default=EvolutionSelectionMethod.TOURNAMENT.value,
+        choices=[method.value for method in EvolutionSelectionMethod],
+        help="Parent selection strategy.",
+    )
+    parser.add_argument("--mutation-rate", type=float, default=0.25, help="Mutation probability per gene.")
+    parser.add_argument("--mutation-scale", type=float, default=0.2, help="Mutation magnitude for mutated genes.")
+    parser.add_argument("--tournament-size", type=int, default=3, help="Tournament bracket size.")
+    parser.add_argument(
+        "--boundary-mode",
+        type=str,
+        default=BoundaryMode.CLAMP.value,
+        choices=[mode.value for mode in BoundaryMode],
+        help="Boundary strategy after mutation overshoots gene bounds.",
+    )
+    parser.add_argument("--boundary-penalty-enabled", action="store_true", help="Enable soft near-boundary fitness penalty.")
+    parser.add_argument("--boundary-penalty-strength", type=float, default=0.01)
+    parser.add_argument("--boundary-penalty-threshold", type=float, default=0.05)
+    parser.add_argument(
+        "--crossover-mode",
+        type=str,
+        default=CrossoverMode.UNIFORM.value,
+        choices=[mode.value for mode in CrossoverMode],
+        help="Crossover operator.",
+    )
+    parser.add_argument("--blend-alpha", type=float, default=0.5)
+    parser.add_argument("--num-crossover-points", type=int, default=2)
+    parser.add_argument("--elitism-count", type=int, default=1)
+    parser.add_argument(
+        "--adaptive-mutation",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Enable adaptive mutation.",
+    )
+    parser.add_argument("--adaptive-stall-window", type=int, default=3)
+    parser.add_argument("--adaptive-improve-threshold", type=float, default=1e-6)
+    parser.add_argument("--adaptive-stall-multiplier", type=float, default=1.5)
+    parser.add_argument("--adaptive-improve-multiplier", type=float, default=0.8)
+    parser.add_argument("--adaptive-diversity-threshold", type=float, default=0.05)
+    parser.add_argument("--adaptive-diversity-multiplier", type=float, default=1.5)
+    parser.add_argument("--adaptive-disable-fitness", action="store_true")
+    parser.add_argument("--adaptive-disable-diversity", action="store_true")
+    parser.add_argument("--adaptive-max-step-multiplier", type=float, default=2.0)
+    parser.add_argument("--adaptive-default-per-gene", action="store_true")
+    parser.add_argument("--adaptive-per-gene-rate", type=str, default=None)
+    parser.add_argument("--adaptive-per-gene-scale", type=str, default=None)
+    # ------------------------------------------------------------------
+    # Convergence criteria
+    # ------------------------------------------------------------------
+    parser.add_argument("--convergence-enabled", action="store_true")
+    parser.add_argument("--convergence-fitness-window", type=int, default=5)
+    parser.add_argument("--convergence-fitness-threshold", type=float, default=1e-4)
+    parser.add_argument("--convergence-diversity-window", type=int, default=3)
+    parser.add_argument("--convergence-diversity-threshold", type=float, default=0.01)
+    parser.add_argument("--convergence-min-generations", type=int, default=1)
+    parser.add_argument("--convergence-no-early-stop", action="store_true")
+    # ------------------------------------------------------------------
+    # Output
+    # ------------------------------------------------------------------
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="experiments/cohort",
+        help="Root directory for cohort artifacts.",
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+    )
+    return parser
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse CLI arguments, applying any named preset as baseline defaults."""
+    parser = _build_parser()
+    preset_discovery_args, _ = parser.parse_known_args()
+    if preset_discovery_args.preset is not None:
+        parser.set_defaults(**PRESETS[preset_discovery_args.preset])
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    configure_logging(environment=args.environment, log_dir="logs", log_level=args.log_level, disable_console=False)
+    logger = get_logger(__name__)
+
+    seeds = list(range(args.base_seed, args.base_seed + args.num_seeds))
+
+    logger.info(
+        "cohort_experiment_cli_start",
+        preset=args.preset,
+        num_seeds=args.num_seeds,
+        base_seed=args.base_seed,
+        seeds=seeds,
+        environment=args.environment,
+        generations=args.generations,
+        population_size=args.population_size,
+        steps_per_candidate=args.steps_per_candidate,
+        output_dir=args.output_dir,
+    )
+
+    try:
+        base_config = SimulationConfig.from_centralized_config(
+            environment=args.environment,
+            profile=args.profile,
+        )
+
+        experiment_config_template = EvolutionExperimentConfig(
+            num_generations=args.generations,
+            population_size=args.population_size,
+            num_steps_per_candidate=args.steps_per_candidate,
+            mutation_rate=args.mutation_rate,
+            mutation_scale=args.mutation_scale,
+            boundary_mode=BoundaryMode(args.boundary_mode),
+            boundary_penalty=BoundaryPenaltyConfig(
+                enabled=args.boundary_penalty_enabled,
+                penalty_strength=args.boundary_penalty_strength,
+                near_boundary_threshold=args.boundary_penalty_threshold,
+            ),
+            crossover_mode=CrossoverMode(args.crossover_mode),
+            blend_alpha=args.blend_alpha,
+            num_crossover_points=args.num_crossover_points,
+            adaptive_mutation=AdaptiveMutationConfig(
+                enabled=args.adaptive_mutation,
+                use_fitness_adaptation=not args.adaptive_disable_fitness,
+                use_diversity_adaptation=not args.adaptive_disable_diversity,
+                stall_window=args.adaptive_stall_window,
+                improvement_threshold=args.adaptive_improve_threshold,
+                stall_multiplier=args.adaptive_stall_multiplier,
+                improve_multiplier=args.adaptive_improve_multiplier,
+                diversity_threshold=args.adaptive_diversity_threshold,
+                diversity_multiplier=args.adaptive_diversity_multiplier,
+                max_step_multiplier=args.adaptive_max_step_multiplier,
+                use_default_per_gene_multipliers=args.adaptive_default_per_gene,
+                per_gene_rate_multipliers=_parse_per_gene_multipliers(
+                    args.adaptive_per_gene_rate, label="--adaptive-per-gene-rate"
+                ),
+                per_gene_scale_multipliers=_parse_per_gene_multipliers(
+                    args.adaptive_per_gene_scale, label="--adaptive-per-gene-scale"
+                ),
+            ),
+            convergence_criteria=ConvergenceCriteria(
+                enabled=args.convergence_enabled,
+                fitness_window=args.convergence_fitness_window,
+                fitness_threshold=args.convergence_fitness_threshold,
+                diversity_window=args.convergence_diversity_window,
+                diversity_threshold=args.convergence_diversity_threshold,
+                min_generations=args.convergence_min_generations,
+                early_stop=not args.convergence_no_early_stop,
+            ),
+            selection_method=EvolutionSelectionMethod(args.selection_method),
+            tournament_size=args.tournament_size,
+            elitism_count=args.elitism_count,
+            fitness_metric=EvolutionFitnessMetric(args.fitness_metric),
+            # seed overridden per-run by CohortRunner
+            seed=None,
+            output_dir=None,
+        )
+
+        # Persist cohort manifest before running.
+        manifest: dict[str, object] = {
+            "script": "scripts/run_cohort_experiment.py",
+            "preset": args.preset,
+            "environment": args.environment,
+            "profile": args.profile,
+            "num_seeds": args.num_seeds,
+            "base_seed": args.base_seed,
+            "seeds": seeds,
+            "experiment_config": _serialize_experiment_config(experiment_config_template),
+        }
+        manifest_path = os.path.join(args.output_dir, "cohort_manifest.json")
+        with open(manifest_path, "w") as manifest_file:
+            json.dump(manifest, manifest_file, indent=2)
+        logger.info("cohort_manifest_written", path=manifest_path)
+
+        start = time.time()
+        runner = CohortRunner(
+            base_config=base_config,
+            experiment_config_template=experiment_config_template,
+            seeds=seeds,
+            output_dir=args.output_dir,
+        )
+        aggregate = runner.run()
+        elapsed = time.time() - start
+
+        summary = {
+            "num_seeds": aggregate.num_seeds,
+            "seeds": aggregate.seeds,
+            "best_fitness_mean": aggregate.best_fitness_mean,
+            "best_fitness_std": aggregate.best_fitness_std,
+            "best_fitness_min": aggregate.best_fitness_min,
+            "best_fitness_max": aggregate.best_fitness_max,
+            "convergence_rate": aggregate.convergence_rate,
+            "convergence_reason_counts": aggregate.convergence_reason_counts,
+            "mean_generation_of_convergence": aggregate.mean_generation_of_convergence,
+            "std_generation_of_convergence": aggregate.std_generation_of_convergence,
+            "lower_bound_occupancy_mean": aggregate.lower_bound_occupancy_mean,
+            "lower_bound_occupancy_std": aggregate.lower_bound_occupancy_std,
+            "mean_elapsed_seconds": aggregate.mean_elapsed_seconds,
+            "total_elapsed_seconds": round(elapsed, 3),
+            "output_dir": args.output_dir,
+        }
+        print(json.dumps(summary, indent=2))
+        return 0
+    except Exception as exc:  # pragma: no cover - CLI safety guard
+        logger.error(
+            "cohort_experiment_cli_failed",
+            error_type=type(exc).__name__,
+            error_message=str(exc),
+            exc_info=True,
+        )
+        print(f"Cohort experiment failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_cohort_experiment.py
+++ b/scripts/run_cohort_experiment.py
@@ -189,6 +189,15 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=[mode.value for mode in BoundaryMode],
         help="Boundary strategy after mutation overshoots gene bounds.",
     )
+    parser.add_argument(
+        "--interior-bias-fraction",
+        type=float,
+        default=1e-3,
+        help=(
+            "When --boundary-mode=interior_biased, fraction of the gene span used as the "
+            "upper bound of the inward nudge applied to values landing exactly on a boundary."
+        ),
+    )
     parser.add_argument("--boundary-penalty-enabled", action="store_true", help="Enable soft near-boundary fitness penalty.")
     parser.add_argument("--boundary-penalty-strength", type=float, default=0.01)
     parser.add_argument("--boundary-penalty-threshold", type=float, default=0.05)
@@ -276,6 +285,7 @@ def main() -> int:
         generations=args.generations,
         population_size=args.population_size,
         steps_per_candidate=args.steps_per_candidate,
+        interior_bias_fraction=args.interior_bias_fraction,
         output_dir=args.output_dir,
     )
 
@@ -292,6 +302,7 @@ def main() -> int:
             mutation_rate=args.mutation_rate,
             mutation_scale=args.mutation_scale,
             boundary_mode=BoundaryMode(args.boundary_mode),
+            interior_bias_fraction=args.interior_bias_fraction,
             boundary_penalty=BoundaryPenaltyConfig(
                 enabled=args.boundary_penalty_enabled,
                 penalty_strength=args.boundary_penalty_strength,
@@ -346,10 +357,11 @@ def main() -> int:
             "num_seeds": args.num_seeds,
             "base_seed": args.base_seed,
             "seeds": seeds,
+            "interior_bias_fraction": args.interior_bias_fraction,
             "experiment_config": _serialize_experiment_config(experiment_config_template),
         }
         manifest_path = os.path.join(args.output_dir, "cohort_manifest.json")
-        with open(manifest_path, "w") as manifest_file:
+        with open(manifest_path, "w", encoding="utf-8") as manifest_file:
             json.dump(manifest, manifest_file, indent=2)
         logger.info("cohort_manifest_written", path=manifest_path)
 

--- a/scripts/run_cohort_experiment.py
+++ b/scripts/run_cohort_experiment.py
@@ -56,50 +56,18 @@ from farm.core.hyperparameter_chromosome import (  # noqa: E402
 )
 from farm.utils.logging import configure_logging, get_logger  # noqa: E402
 
-# ---------------------------------------------------------------------------
-# Named presets (mirror run_evolution_experiment.py)
-# ---------------------------------------------------------------------------
-PRESETS: dict[str, dict[str, object]] = {
-    "stable_hyper_evo": {
-        "selection_method": EvolutionSelectionMethod.TOURNAMENT.value,
-        "boundary_mode": BoundaryMode.REFLECT.value,
-        "mutation_rate": 0.20,
-        "mutation_scale": 0.15,
-        "adaptive_mutation": True,
-        "tournament_size": 3,
-        "elitism_count": 1,
-    },
-}
+from scripts.evolution_experiment_cli import (  # noqa: E402
+    EvolutionExperimentHelpFormatter,
+    add_evolution_convergence_arguments,
+    add_evolution_training_arguments,
+    get_presets,
+    parse_per_gene_multipliers,
+)
 
-
-def _parse_per_gene_multipliers(raw: str | None, *, label: str) -> dict[str, float]:
-    """Parse a comma-separated ``gene=value`` string into a multiplier dict."""
-    if not raw:
-        return {}
-    multipliers: dict[str, float] = {}
-    for entry in raw.split(","):
-        token = entry.strip()
-        if not token:
-            continue
-        if "=" not in token:
-            raise ValueError(
-                f"{label} entry '{token}' must be of the form 'gene_name=value'."
-            )
-        name, _, value_str = token.partition("=")
-        name = name.strip()
-        if not name:
-            raise ValueError(f"{label} entry '{token}' has an empty gene name.")
-        try:
-            multipliers[name] = float(value_str)
-        except ValueError as exc:
-            raise ValueError(
-                f"{label} entry '{token}' has a non-numeric value."
-            ) from exc
-    return multipliers
-
-
-class _HelpFormatter(argparse.RawDescriptionHelpFormatter, argparse.ArgumentDefaultsHelpFormatter):
-    """Formatter that preserves raw description layout and also shows defaults."""
+PRESETS = get_presets(
+    evolution_selection_method=EvolutionSelectionMethod,
+    boundary_mode=BoundaryMode,
+)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -113,11 +81,8 @@ def _build_parser() -> argparse.ArgumentParser:
             "  stable_hyper_evo  tournament selection + reflect boundary + adaptive\n"
             "                    mutation (rate 0.20, scale 0.15)."
         ),
-        formatter_class=_HelpFormatter,
+        formatter_class=EvolutionExperimentHelpFormatter,
     )
-    # ------------------------------------------------------------------
-    # Cohort-specific flags
-    # ------------------------------------------------------------------
     parser.add_argument(
         "--num-seeds",
         type=int,
@@ -133,115 +98,18 @@ def _build_parser() -> argparse.ArgumentParser:
             "[base_seed, base_seed+1, ..., base_seed+num_seeds-1]."
         ),
     )
-    # ------------------------------------------------------------------
-    # Shared preset / environment flags
-    # ------------------------------------------------------------------
-    parser.add_argument(
-        "--preset",
-        type=str,
-        default=None,
-        choices=list(PRESETS),
-        help="Load a named configuration preset.",
+    add_evolution_training_arguments(
+        parser,
+        presets=PRESETS,
+        preset_help="Load a named configuration preset.",
+        evolution_fitness_metric=EvolutionFitnessMetric,
+        evolution_selection_method=EvolutionSelectionMethod,
+        boundary_mode=BoundaryMode,
+        crossover_mode=CrossoverMode,
+        generations_help="Number of generations per seed.",
+        fitness_metric_help="Built-in fitness metric.",
     )
-    parser.add_argument(
-        "--environment",
-        type=str,
-        default="development",
-        choices=["development", "production", "testing"],
-        help="Centralized config environment.",
-    )
-    parser.add_argument(
-        "--profile",
-        type=str,
-        default=None,
-        choices=["benchmark", "simulation", "research"],
-        help="Optional centralized config profile.",
-    )
-    parser.add_argument("--generations", type=int, default=2, help="Number of generations per seed.")
-    parser.add_argument("--population-size", type=int, default=4, help="Candidates per generation.")
-    parser.add_argument(
-        "--steps-per-candidate",
-        type=int,
-        default=20,
-        help="Simulation steps used to evaluate each candidate.",
-    )
-    parser.add_argument(
-        "--fitness-metric",
-        type=str,
-        default=EvolutionFitnessMetric.FINAL_POPULATION.value,
-        choices=[metric.value for metric in EvolutionFitnessMetric],
-        help="Built-in fitness metric.",
-    )
-    parser.add_argument(
-        "--selection-method",
-        type=str,
-        default=EvolutionSelectionMethod.TOURNAMENT.value,
-        choices=[method.value for method in EvolutionSelectionMethod],
-        help="Parent selection strategy.",
-    )
-    parser.add_argument("--mutation-rate", type=float, default=0.25, help="Mutation probability per gene.")
-    parser.add_argument("--mutation-scale", type=float, default=0.2, help="Mutation magnitude for mutated genes.")
-    parser.add_argument("--tournament-size", type=int, default=3, help="Tournament bracket size.")
-    parser.add_argument(
-        "--boundary-mode",
-        type=str,
-        default=BoundaryMode.CLAMP.value,
-        choices=[mode.value for mode in BoundaryMode],
-        help="Boundary strategy after mutation overshoots gene bounds.",
-    )
-    parser.add_argument(
-        "--interior-bias-fraction",
-        type=float,
-        default=1e-3,
-        help=(
-            "When --boundary-mode=interior_biased, fraction of the gene span used as the "
-            "upper bound of the inward nudge applied to values landing exactly on a boundary."
-        ),
-    )
-    parser.add_argument("--boundary-penalty-enabled", action="store_true", help="Enable soft near-boundary fitness penalty.")
-    parser.add_argument("--boundary-penalty-strength", type=float, default=0.01)
-    parser.add_argument("--boundary-penalty-threshold", type=float, default=0.05)
-    parser.add_argument(
-        "--crossover-mode",
-        type=str,
-        default=CrossoverMode.UNIFORM.value,
-        choices=[mode.value for mode in CrossoverMode],
-        help="Crossover operator.",
-    )
-    parser.add_argument("--blend-alpha", type=float, default=0.5)
-    parser.add_argument("--num-crossover-points", type=int, default=2)
-    parser.add_argument("--elitism-count", type=int, default=1)
-    parser.add_argument(
-        "--adaptive-mutation",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="Enable adaptive mutation.",
-    )
-    parser.add_argument("--adaptive-stall-window", type=int, default=3)
-    parser.add_argument("--adaptive-improve-threshold", type=float, default=1e-6)
-    parser.add_argument("--adaptive-stall-multiplier", type=float, default=1.5)
-    parser.add_argument("--adaptive-improve-multiplier", type=float, default=0.8)
-    parser.add_argument("--adaptive-diversity-threshold", type=float, default=0.05)
-    parser.add_argument("--adaptive-diversity-multiplier", type=float, default=1.5)
-    parser.add_argument("--adaptive-disable-fitness", action="store_true")
-    parser.add_argument("--adaptive-disable-diversity", action="store_true")
-    parser.add_argument("--adaptive-max-step-multiplier", type=float, default=2.0)
-    parser.add_argument("--adaptive-default-per-gene", action="store_true")
-    parser.add_argument("--adaptive-per-gene-rate", type=str, default=None)
-    parser.add_argument("--adaptive-per-gene-scale", type=str, default=None)
-    # ------------------------------------------------------------------
-    # Convergence criteria
-    # ------------------------------------------------------------------
-    parser.add_argument("--convergence-enabled", action="store_true")
-    parser.add_argument("--convergence-fitness-window", type=int, default=5)
-    parser.add_argument("--convergence-fitness-threshold", type=float, default=1e-4)
-    parser.add_argument("--convergence-diversity-window", type=int, default=3)
-    parser.add_argument("--convergence-diversity-threshold", type=float, default=0.01)
-    parser.add_argument("--convergence-min-generations", type=int, default=1)
-    parser.add_argument("--convergence-no-early-stop", action="store_true")
-    # ------------------------------------------------------------------
-    # Output
-    # ------------------------------------------------------------------
+    add_evolution_convergence_arguments(parser)
     parser.add_argument(
         "--output-dir",
         type=str,
@@ -323,10 +191,10 @@ def main() -> int:
                 diversity_multiplier=args.adaptive_diversity_multiplier,
                 max_step_multiplier=args.adaptive_max_step_multiplier,
                 use_default_per_gene_multipliers=args.adaptive_default_per_gene,
-                per_gene_rate_multipliers=_parse_per_gene_multipliers(
+                per_gene_rate_multipliers=parse_per_gene_multipliers(
                     args.adaptive_per_gene_rate, label="--adaptive-per-gene-rate"
                 ),
-                per_gene_scale_multipliers=_parse_per_gene_multipliers(
+                per_gene_scale_multipliers=parse_per_gene_multipliers(
                     args.adaptive_per_gene_scale, label="--adaptive-per-gene-scale"
                 ),
             ),

--- a/scripts/run_evolution_experiment.py
+++ b/scripts/run_evolution_experiment.py
@@ -44,6 +44,11 @@ PRESETS = get_presets(
 )
 
 
+def _parse_per_gene_multipliers(raw: str | None, *, label: str) -> dict[str, float]:
+    """Backward-compatible alias for tests/imports using the old helper name."""
+    return parse_per_gene_multipliers(raw, label=label)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     """Return a fully-configured argument parser (without actually parsing)."""
     parser = argparse.ArgumentParser(

--- a/scripts/run_evolution_experiment.py
+++ b/scripts/run_evolution_experiment.py
@@ -30,77 +30,18 @@ from farm.core.hyperparameter_chromosome import (  # noqa: E402
 )
 from farm.utils.logging import configure_logging, get_logger  # noqa: E402
 
-# ---------------------------------------------------------------------------
-# Named presets
-# ---------------------------------------------------------------------------
-# Each preset is a dict whose keys match argparse ``dest`` names.  When a
-# preset is selected via ``--preset``, its values become the argparse
-# *defaults* for those arguments, so any explicit CLI flag still wins.
-#
-# ``stable_hyper_evo`` rationale
-# --------------------------------
-# Follow-up analysis in ``notebooks/hyperparameter_evolution_results.ipynb``
-# and ``docs/experiments/hyperparameter_evolution_convergence.md`` revealed
-# two recurring failure modes with the bare defaults:
-#
-#   1. **Lower-bound collapse** – tournament selection with aggressive mutation
-#      pushes the winning learning rate to its minimum boundary and keeps it
-#      there.  Switching to ``boundary_mode=reflect`` lets genes bounce back
-#      off the wall instead of sticking.
-#
-#   2. **Diversity collapse** – without adaptive mutation the population
-#      converges prematurely.  Enabling adaptive mutation with both the
-#      fitness-stall and diversity-collapse rules keeps the search alive.
-#
-# The mutation magnitudes (rate 0.20, scale 0.15) come from the
-# ``run_tournament_mut020_g6`` closure run, which showed the best trade-off
-# between exploration and exploitation across the evaluated configs.
+from scripts.evolution_experiment_cli import (  # noqa: E402
+    EvolutionExperimentHelpFormatter,
+    add_evolution_convergence_arguments,
+    add_evolution_training_arguments,
+    get_presets,
+    parse_per_gene_multipliers,
+)
 
-PRESETS: dict[str, dict[str, object]] = {
-    "stable_hyper_evo": {
-        "selection_method": EvolutionSelectionMethod.TOURNAMENT.value,
-        "boundary_mode": BoundaryMode.REFLECT.value,
-        "mutation_rate": 0.20,
-        "mutation_scale": 0.15,
-        "adaptive_mutation": True,
-        "tournament_size": 3,
-        "elitism_count": 1,
-    },
-}
-
-
-def _parse_per_gene_multipliers(raw: str | None, *, label: str) -> dict[str, float]:
-    """Parse a comma-separated ``gene=value`` string into a multiplier dict.
-
-    Returns an empty dict for ``None`` or empty input.  Raises ``ValueError``
-    on malformed entries; ``argparse`` will surface this as a CLI error.
-    """
-    if not raw:
-        return {}
-    multipliers: dict[str, float] = {}
-    for entry in raw.split(","):
-        token = entry.strip()
-        if not token:
-            continue
-        if "=" not in token:
-            raise ValueError(
-                f"{label} entry '{token}' must be of the form 'gene_name=value'."
-            )
-        name, _, value_str = token.partition("=")
-        name = name.strip()
-        if not name:
-            raise ValueError(f"{label} entry '{token}' has an empty gene name.")
-        try:
-            multipliers[name] = float(value_str)
-        except ValueError as exc:
-            raise ValueError(
-                f"{label} entry '{token}' has a non-numeric value."
-            ) from exc
-    return multipliers
-
-
-class _HelpFormatter(argparse.RawDescriptionHelpFormatter, argparse.ArgumentDefaultsHelpFormatter):
-    """Formatter that preserves raw description layout and also shows defaults."""
+PRESETS = get_presets(
+    evolution_selection_method=EvolutionSelectionMethod,
+    boundary_mode=BoundaryMode,
+)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -116,210 +57,21 @@ def _build_parser() -> argparse.ArgumentParser:
             "                    mutation (rate 0.20, scale 0.15).  Prevents lower-bound\n"
             "                    collapse and diversity collapse seen with bare defaults."
         ),
-        formatter_class=_HelpFormatter,
+        formatter_class=EvolutionExperimentHelpFormatter,
     )
-    parser.add_argument(
-        "--preset",
-        type=str,
-        default=None,
-        choices=list(PRESETS),
-        help=(
+    add_evolution_training_arguments(
+        parser,
+        presets=PRESETS,
+        preset_help=(
             "Load a named configuration preset.  Preset values act as defaults; any "
             "explicit CLI flag still takes priority.  Available: %(choices)s."
         ),
+        evolution_fitness_metric=EvolutionFitnessMetric,
+        evolution_selection_method=EvolutionSelectionMethod,
+        boundary_mode=BoundaryMode,
+        crossover_mode=CrossoverMode,
     )
-    parser.add_argument(
-        "--environment",
-        type=str,
-        default="development",
-        choices=["development", "production", "testing"],
-        help="Centralized config environment.",
-    )
-    parser.add_argument(
-        "--profile",
-        type=str,
-        default=None,
-        choices=["benchmark", "simulation", "research"],
-        help="Optional centralized config profile.",
-    )
-    parser.add_argument("--generations", type=int, default=2, help="Number of generations to run.")
-    parser.add_argument("--population-size", type=int, default=4, help="Candidates per generation.")
-    parser.add_argument(
-        "--steps-per-candidate",
-        type=int,
-        default=20,
-        help="Simulation steps used to evaluate each candidate.",
-    )
-    parser.add_argument(
-        "--fitness-metric",
-        type=str,
-        default=EvolutionFitnessMetric.FINAL_POPULATION.value,
-        choices=[metric.value for metric in EvolutionFitnessMetric],
-        help="Built-in fitness metric used for parent selection.",
-    )
-    parser.add_argument(
-        "--selection-method",
-        type=str,
-        default=EvolutionSelectionMethod.TOURNAMENT.value,
-        choices=[method.value for method in EvolutionSelectionMethod],
-        help="Parent selection strategy.",
-    )
-    parser.add_argument("--mutation-rate", type=float, default=0.25, help="Mutation probability per gene.")
-    parser.add_argument(
-        "--mutation-scale",
-        type=float,
-        default=0.2,
-        help="Mutation magnitude for mutated genes.",
-    )
-    parser.add_argument(
-        "--tournament-size",
-        type=int,
-        default=3,
-        help="Tournament bracket size when tournament selection is used.",
-    )
-    parser.add_argument(
-        "--boundary-mode",
-        type=str,
-        default=BoundaryMode.CLAMP.value,
-        choices=[mode.value for mode in BoundaryMode],
-        help="Boundary strategy after mutation overshoots gene bounds.",
-    )
-    parser.add_argument(
-        "--interior-bias-fraction",
-        type=float,
-        default=1e-3,
-        help=(
-            "When --boundary-mode=interior_biased, fraction of the gene span used as the "
-            "upper bound of the inward nudge applied to values landing exactly on a boundary. "
-            "Must be non-negative.  Default: 1e-3."
-        ),
-    )
-    parser.add_argument(
-        "--boundary-penalty-enabled",
-        action="store_true",
-        help="Enable soft near-boundary fitness penalty.",
-    )
-    parser.add_argument(
-        "--boundary-penalty-strength",
-        type=float,
-        default=0.01,
-        help="Max per-gene penalty at exact boundary when penalty is enabled.",
-    )
-    parser.add_argument(
-        "--boundary-penalty-threshold",
-        type=float,
-        default=0.05,
-        help="Near-boundary zone width as fraction of gene range (0, 0.5].",
-    )
-    parser.add_argument(
-        "--crossover-mode",
-        type=str,
-        default=CrossoverMode.UNIFORM.value,
-        choices=[mode.value for mode in CrossoverMode],
-        help="Crossover operator used to create offspring chromosomes.",
-    )
-    parser.add_argument(
-        "--blend-alpha",
-        type=float,
-        default=0.5,
-        help="BLX-alpha extent used when --crossover-mode=blend.",
-    )
-    parser.add_argument(
-        "--num-crossover-points",
-        type=int,
-        default=2,
-        help="Pivot count used when --crossover-mode=multi_point.",
-    )
-    parser.add_argument("--elitism-count", type=int, default=1, help="Top candidates copied to next generation.")
-    parser.add_argument(
-        "--adaptive-mutation",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="Enable adaptive mutation rate/scale based on fitness progress and diversity.",
-    )
-    parser.add_argument(
-        "--adaptive-stall-window",
-        type=int,
-        default=3,
-        help="Generations to look back when detecting a fitness stall.",
-    )
-    parser.add_argument(
-        "--adaptive-improve-threshold",
-        type=float,
-        default=1e-6,
-        help="Minimum best-fitness improvement over the window that counts as progress.",
-    )
-    parser.add_argument(
-        "--adaptive-stall-multiplier",
-        type=float,
-        default=1.5,
-        help="Multiplier applied to mutation rate/scale when the search stalls.",
-    )
-    parser.add_argument(
-        "--adaptive-improve-multiplier",
-        type=float,
-        default=0.8,
-        help="Multiplier applied to mutation rate/scale when fitness is improving.",
-    )
-    parser.add_argument(
-        "--adaptive-diversity-threshold",
-        type=float,
-        default=0.05,
-        help="Normalized diversity at or below which mutation is boosted.",
-    )
-    parser.add_argument(
-        "--adaptive-diversity-multiplier",
-        type=float,
-        default=1.5,
-        help="Multiplier applied to mutation rate/scale when diversity collapses.",
-    )
-    parser.add_argument(
-        "--adaptive-disable-fitness",
-        action="store_true",
-        help="When --adaptive-mutation is set, skip the fitness-progress adaptation rule.",
-    )
-    parser.add_argument(
-        "--adaptive-disable-diversity",
-        action="store_true",
-        help="When --adaptive-mutation is set, skip the diversity-collapse adaptation rule.",
-    )
-    parser.add_argument(
-        "--adaptive-max-step-multiplier",
-        type=float,
-        default=2.0,
-        help=(
-            "Maximum factor by which the accumulated mutation multiplier may change in a "
-            "single generation.  Bounds per-step change to [1/max_step, max_step] so large "
-            "stall/improve factors are dampened.  Must be >= 1.0.  Default: 2.0."
-        ),
-    )
-    parser.add_argument(
-        "--adaptive-default-per-gene",
-        action="store_true",
-        help=(
-            "Apply built-in per-gene scale defaults tuned for sensitivity "
-            "(learning_rate=0.5×, gamma=0.75×, epsilon_decay=0.75× scale).  "
-            "User --adaptive-per-gene-scale values override these defaults."
-        ),
-    )
-    parser.add_argument(
-        "--adaptive-per-gene-rate",
-        type=str,
-        default=None,
-        help=(
-            "Comma-separated per-gene mutation-rate multipliers, e.g. "
-            "'learning_rate=0.5,gamma=2.0'.  Each value must be non-negative."
-        ),
-    )
-    parser.add_argument(
-        "--adaptive-per-gene-scale",
-        type=str,
-        default=None,
-        help=(
-            "Comma-separated per-gene mutation-scale multipliers, e.g. "
-            "'learning_rate=0.5,gamma=2.0'.  Each value must be non-negative."
-        ),
-    )
+    add_evolution_convergence_arguments(parser)
     parser.add_argument("--seed", type=int, default=42, help="Global deterministic seed.")
     parser.add_argument(
         "--output-dir",
@@ -333,64 +85,6 @@ def _build_parser() -> argparse.ArgumentParser:
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         help="Structured logging level.",
-    )
-    # ------------------------------------------------------------------
-    # Convergence criteria
-    # ------------------------------------------------------------------
-    parser.add_argument(
-        "--convergence-enabled",
-        action="store_true",
-        help=(
-            "Enable convergence checking.  When set, the run will detect "
-            "fitness plateau and diversity collapse and optionally stop early."
-        ),
-    )
-    parser.add_argument(
-        "--convergence-fitness-window",
-        type=int,
-        default=5,
-        help=(
-            "Number of trailing generations over which best-fitness improvement "
-            "is measured for the plateau criterion."
-        ),
-    )
-    parser.add_argument(
-        "--convergence-fitness-threshold",
-        type=float,
-        default=1e-4,
-        help=(
-            "Minimum absolute improvement in best fitness over the window "
-            "required to avoid a plateau declaration."
-        ),
-    )
-    parser.add_argument(
-        "--convergence-diversity-window",
-        type=int,
-        default=3,
-        help=(
-            "Number of consecutive generations with diversity below the threshold "
-            "required to trigger a diversity-collapse declaration."
-        ),
-    )
-    parser.add_argument(
-        "--convergence-diversity-threshold",
-        type=float,
-        default=0.01,
-        help="Normalized diversity at or below which diversity-collapse is considered.",
-    )
-    parser.add_argument(
-        "--convergence-min-generations",
-        type=int,
-        default=1,
-        help="Minimum number of completed generations before convergence checks begin.",
-    )
-    parser.add_argument(
-        "--convergence-no-early-stop",
-        action="store_true",
-        help=(
-            "When --convergence-enabled is set, annotate the result with convergence "
-            "metadata but do not halt the run early."
-        ),
     )
     return parser
 
@@ -474,10 +168,10 @@ def main() -> int:
                 diversity_multiplier=args.adaptive_diversity_multiplier,
                 max_step_multiplier=args.adaptive_max_step_multiplier,
                 use_default_per_gene_multipliers=args.adaptive_default_per_gene,
-                per_gene_rate_multipliers=_parse_per_gene_multipliers(
+                per_gene_rate_multipliers=parse_per_gene_multipliers(
                     args.adaptive_per_gene_rate, label="--adaptive-per-gene-rate"
                 ),
-                per_gene_scale_multipliers=_parse_per_gene_multipliers(
+                per_gene_scale_multipliers=parse_per_gene_multipliers(
                     args.adaptive_per_gene_scale, label="--adaptive-per-gene-scale"
                 ),
             ),

--- a/tests/test_cohort_runner.py
+++ b/tests/test_cohort_runner.py
@@ -153,7 +153,16 @@ class TestLowerBoundOccupancy(unittest.TestCase):
     def test_returns_none_for_empty_summaries(self):
         result = MagicMock()
         result.generation_summaries = []
-        self.assertIsNone(_lower_bound_occupancy(result))
+        self.assertIsNone(
+            _lower_bound_occupancy(result, learning_rate_lower_bound=1e-6)
+        )
+
+    def test_returns_none_when_lower_bound_missing(self):
+        result = MagicMock()
+        result.generation_summaries = [MagicMock()]
+        self.assertIsNone(
+            _lower_bound_occupancy(result, learning_rate_lower_bound=None)
+        )
 
     def test_returns_zero_when_no_lower_bound_hit(self):
         result = MagicMock()
@@ -162,7 +171,7 @@ class TestLowerBoundOccupancy(unittest.TestCase):
         summary.gene_statistics = {"learning_rate": {"min": 0.001}}
         summary.best_chromosome = {"learning_rate": 0.05}
         result.generation_summaries = [summary]
-        occ = _lower_bound_occupancy(result)
+        occ = _lower_bound_occupancy(result, learning_rate_lower_bound=1e-6)
         self.assertIsNotNone(occ)
         self.assertAlmostEqual(occ, 0.0)
 
@@ -171,22 +180,32 @@ class TestLowerBoundOccupancy(unittest.TestCase):
         summary = MagicMock()
         # best_lr equal to pop_min
         summary.gene_statistics = {"learning_rate": {"min": 0.001}}
-        summary.best_chromosome = {"learning_rate": 0.001}
+        summary.best_chromosome = {"learning_rate": 1e-6}
         result.generation_summaries = [summary, summary]
-        occ = _lower_bound_occupancy(result)
+        occ = _lower_bound_occupancy(result, learning_rate_lower_bound=1e-6)
         self.assertAlmostEqual(occ, 1.0)
 
     def test_partial_occupancy(self):
         result = MagicMock()
         s_hit = MagicMock()
         s_hit.gene_statistics = {"learning_rate": {"min": 0.001}}
-        s_hit.best_chromosome = {"learning_rate": 0.001}
+        s_hit.best_chromosome = {"learning_rate": 1e-6}
         s_miss = MagicMock()
         s_miss.gene_statistics = {"learning_rate": {"min": 0.001}}
         s_miss.best_chromosome = {"learning_rate": 0.05}
         result.generation_summaries = [s_hit, s_miss, s_miss, s_miss]
-        occ = _lower_bound_occupancy(result)
+        occ = _lower_bound_occupancy(result, learning_rate_lower_bound=1e-6)
         self.assertAlmostEqual(occ, 0.25)
+
+    def test_uses_configured_lower_bound_not_population_min(self):
+        result = MagicMock()
+        summary = MagicMock()
+        # Population minimum is not at the real boundary.
+        summary.gene_statistics = {"learning_rate": {"min": 0.01}}
+        summary.best_chromosome = {"learning_rate": 0.01}
+        result.generation_summaries = [summary]
+        occ = _lower_bound_occupancy(result, learning_rate_lower_bound=1e-6)
+        self.assertAlmostEqual(occ, 0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -250,10 +269,9 @@ class TestCohortRunnerRun(unittest.TestCase):
             seeds=seeds,
             output_dir=output_dir,
         )
-        with (
-            patch.object(EvolutionExperiment, "__init__", fake_experiment_init),
-            patch.object(EvolutionExperiment, "run", fake_run),
-        ):
+        with patch.object(
+            EvolutionExperiment, "__init__", fake_experiment_init
+        ), patch.object(EvolutionExperiment, "run", fake_run):
             return runner.run()
 
     def test_returns_cohort_aggregate_result(self):
@@ -590,6 +608,25 @@ class TestRunCohortExperimentCLI(unittest.TestCase):
         preset = run_cohort_experiment.PRESETS["stable_hyper_evo"]
         for key in ("selection_method", "boundary_mode", "mutation_rate", "mutation_scale", "adaptive_mutation"):
             self.assertIn(key, preset)
+
+    def test_parse_args_interior_bias_fraction_custom(self):
+        argv = sys.argv[:]
+        try:
+            sys.argv = [
+                "run_cohort_experiment.py",
+                "--generations",
+                "1",
+                "--population-size",
+                "2",
+                "--steps-per-candidate",
+                "1",
+                "--interior-bias-fraction",
+                "0.123",
+            ]
+            args = run_cohort_experiment._parse_args()
+        finally:
+            sys.argv = argv
+        self.assertAlmostEqual(args.interior_bias_fraction, 0.123)
 
 
 if __name__ == "__main__":

--- a/tests/test_cohort_runner.py
+++ b/tests/test_cohort_runner.py
@@ -446,6 +446,10 @@ class TestRunCohortExperimentCLI(unittest.TestCase):
             sys.argv = argv
         self.assertEqual(args.num_seeds, 5)
         self.assertEqual(args.base_seed, 10)
+        # Seeds are derived as [base_seed, base_seed+1, ..., base_seed+num_seeds-1]
+        expected_seeds = list(range(10, 15))
+        derived_seeds = list(range(args.base_seed, args.base_seed + args.num_seeds))
+        self.assertEqual(derived_seeds, expected_seeds)
 
     def test_preset_applied_to_cohort(self):
         argv = sys.argv[:]

--- a/tests/test_cohort_runner.py
+++ b/tests/test_cohort_runner.py
@@ -9,7 +9,6 @@ import os
 import sys
 import tempfile
 import unittest
-from dataclasses import replace
 from unittest.mock import MagicMock, patch
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cohort_runner.py
+++ b/tests/test_cohort_runner.py
@@ -1,0 +1,592 @@
+"""Tests for farm.runners.cohort_runner and the run_cohort_experiment CLI."""
+
+from __future__ import annotations
+
+import csv
+import importlib
+import json
+import os
+import sys
+import tempfile
+import unittest
+from dataclasses import replace
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Make scripts importable
+# ---------------------------------------------------------------------------
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_SCRIPT_PATH = os.path.join(_REPO_ROOT, "scripts")
+for _p in (_REPO_ROOT, _SCRIPT_PATH):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from farm.runners import (  # noqa: E402
+    CohortAggregateResult,
+    CohortRunner,
+    CohortSeedResult,
+    EvolutionExperiment,
+    EvolutionExperimentConfig,
+    EvolutionFitnessMetric,
+)
+from farm.runners.cohort_runner import (  # noqa: E402
+    _lower_bound_occupancy,
+    _replace_seed,
+    _safe_stdev,
+    _serialize_experiment_config,
+)
+
+run_cohort_experiment = importlib.import_module("run_cohort_experiment")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_fake_result(
+    best_fitness: float = 5.0,
+    num_generations: int = 2,
+    converged: bool = False,
+    convergence_reason: str | None = None,
+    generation_of_convergence: int | None = None,
+) -> MagicMock:
+    """Build a minimal fake EvolutionExperimentResult."""
+    result = MagicMock()
+    result.best_candidate.fitness = best_fitness
+    result.generation_summaries = [MagicMock() for _ in range(num_generations)]
+    for i, s in enumerate(result.generation_summaries):
+        s.gene_statistics = {"learning_rate": {"mean": 0.05, "min": 0.001, "max": 0.1}}
+        s.best_chromosome = {"learning_rate": 0.05}
+    result.converged = converged
+    result.convergence_reason = convergence_reason
+    result.generation_of_convergence = generation_of_convergence
+    result.evaluations = []
+    return result
+
+
+def _make_base_config() -> MagicMock:
+    return MagicMock()
+
+
+def _make_experiment_config(**kwargs) -> EvolutionExperimentConfig:
+    defaults = dict(
+        num_generations=1,
+        population_size=2,
+        num_steps_per_candidate=1,
+        seed=None,
+    )
+    defaults.update(kwargs)
+    return EvolutionExperimentConfig(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _safe_stdev
+# ---------------------------------------------------------------------------
+
+class TestSafeStdev(unittest.TestCase):
+    def test_returns_none_for_empty(self):
+        self.assertIsNone(_safe_stdev([]))
+
+    def test_returns_none_for_single(self):
+        self.assertIsNone(_safe_stdev([1.0]))
+
+    def test_returns_zero_for_equal_values(self):
+        self.assertAlmostEqual(_safe_stdev([3.0, 3.0, 3.0]), 0.0)
+
+    def test_known_population_stdev(self):
+        # population stdev of [2, 4, 4, 4, 5, 5, 7, 9] = 2.0
+        result = _safe_stdev([2, 4, 4, 4, 5, 5, 7, 9])
+        self.assertAlmostEqual(result, 2.0, places=5)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _replace_seed
+# ---------------------------------------------------------------------------
+
+class TestReplaceSeed(unittest.TestCase):
+    def test_seed_and_output_dir_replaced(self):
+        template = _make_experiment_config(seed=42)
+        updated = _replace_seed(template, seed=99, output_dir="/tmp/out")
+        self.assertEqual(updated.seed, 99)
+        self.assertEqual(updated.output_dir, "/tmp/out")
+
+    def test_other_fields_preserved(self):
+        template = _make_experiment_config(num_generations=5, seed=1)
+        updated = _replace_seed(template, seed=2, output_dir=None)
+        self.assertEqual(updated.num_generations, 5)
+
+    def test_output_dir_can_be_none(self):
+        template = _make_experiment_config(seed=1)
+        updated = _replace_seed(template, seed=7, output_dir=None)
+        self.assertIsNone(updated.output_dir)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _serialize_experiment_config
+# ---------------------------------------------------------------------------
+
+class TestSerializeExperimentConfig(unittest.TestCase):
+    def test_returns_dict(self):
+        cfg = _make_experiment_config()
+        result = _serialize_experiment_config(cfg)
+        self.assertIsInstance(result, dict)
+
+    def test_enum_values_are_strings(self):
+        cfg = _make_experiment_config()
+        result = _serialize_experiment_config(cfg)
+        # fitness_metric and selection_method should be strings, not Enum objects
+        self.assertIsInstance(result["fitness_metric"], str)
+        self.assertIsInstance(result["selection_method"], str)
+
+    def test_json_serialisable(self):
+        cfg = _make_experiment_config()
+        result = _serialize_experiment_config(cfg)
+        # Should not raise
+        json.dumps(result)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _lower_bound_occupancy
+# ---------------------------------------------------------------------------
+
+class TestLowerBoundOccupancy(unittest.TestCase):
+    def test_returns_none_for_empty_summaries(self):
+        result = MagicMock()
+        result.generation_summaries = []
+        self.assertIsNone(_lower_bound_occupancy(result))
+
+    def test_returns_zero_when_no_lower_bound_hit(self):
+        result = MagicMock()
+        summary = MagicMock()
+        # best_lr far above pop_min
+        summary.gene_statistics = {"learning_rate": {"min": 0.001}}
+        summary.best_chromosome = {"learning_rate": 0.05}
+        result.generation_summaries = [summary]
+        occ = _lower_bound_occupancy(result)
+        self.assertIsNotNone(occ)
+        self.assertAlmostEqual(occ, 0.0)
+
+    def test_returns_one_when_always_at_lower_bound(self):
+        result = MagicMock()
+        summary = MagicMock()
+        # best_lr equal to pop_min
+        summary.gene_statistics = {"learning_rate": {"min": 0.001}}
+        summary.best_chromosome = {"learning_rate": 0.001}
+        result.generation_summaries = [summary, summary]
+        occ = _lower_bound_occupancy(result)
+        self.assertAlmostEqual(occ, 1.0)
+
+    def test_partial_occupancy(self):
+        result = MagicMock()
+        s_hit = MagicMock()
+        s_hit.gene_statistics = {"learning_rate": {"min": 0.001}}
+        s_hit.best_chromosome = {"learning_rate": 0.001}
+        s_miss = MagicMock()
+        s_miss.gene_statistics = {"learning_rate": {"min": 0.001}}
+        s_miss.best_chromosome = {"learning_rate": 0.05}
+        result.generation_summaries = [s_hit, s_miss, s_miss, s_miss]
+        occ = _lower_bound_occupancy(result)
+        self.assertAlmostEqual(occ, 0.25)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: CohortRunner constructor
+# ---------------------------------------------------------------------------
+
+class TestCohortRunnerConstructor(unittest.TestCase):
+    def test_raises_for_empty_seeds(self):
+        with self.assertRaises(ValueError):
+            CohortRunner(
+                base_config=_make_base_config(),
+                experiment_config_template=_make_experiment_config(),
+                seeds=[],
+            )
+
+    def test_stores_seeds(self):
+        runner = CohortRunner(
+            base_config=_make_base_config(),
+            experiment_config_template=_make_experiment_config(),
+            seeds=[1, 2, 3],
+        )
+        self.assertEqual(runner.seeds, [1, 2, 3])
+
+    def test_output_dir_default_is_none(self):
+        runner = CohortRunner(
+            base_config=_make_base_config(),
+            experiment_config_template=_make_experiment_config(),
+            seeds=[1],
+        )
+        self.assertIsNone(runner.output_dir)
+
+
+# ---------------------------------------------------------------------------
+# Integration / smoke tests: CohortRunner.run
+# ---------------------------------------------------------------------------
+
+class TestCohortRunnerRun(unittest.TestCase):
+    def _run_with_fake_results(
+        self,
+        seeds,
+        fake_results=None,
+        output_dir=None,
+    ) -> CohortAggregateResult:
+        if fake_results is None:
+            fake_results = [_make_fake_result(best_fitness=float(5 + i)) for i in range(len(seeds))]
+
+        call_count = [0]
+
+        def fake_experiment_init(self_inner, base_config, config):
+            self_inner.base_config = base_config
+            self_inner.config = config
+
+        def fake_run(self_inner):
+            idx = call_count[0]
+            call_count[0] += 1
+            return fake_results[idx]
+
+        runner = CohortRunner(
+            base_config=_make_base_config(),
+            experiment_config_template=_make_experiment_config(),
+            seeds=seeds,
+            output_dir=output_dir,
+        )
+        with (
+            patch.object(EvolutionExperiment, "__init__", fake_experiment_init),
+            patch.object(EvolutionExperiment, "run", fake_run),
+        ):
+            return runner.run()
+
+    def test_returns_cohort_aggregate_result(self):
+        result = self._run_with_fake_results([1, 2, 3])
+        self.assertIsInstance(result, CohortAggregateResult)
+
+    def test_num_seeds_matches(self):
+        result = self._run_with_fake_results([10, 20, 30])
+        self.assertEqual(result.num_seeds, 3)
+
+    def test_seeds_preserved(self):
+        result = self._run_with_fake_results([7, 8, 9])
+        self.assertEqual(result.seeds, [7, 8, 9])
+
+    def test_seed_results_length(self):
+        result = self._run_with_fake_results([1, 2, 3])
+        self.assertEqual(len(result.seed_results), 3)
+
+    def test_best_fitness_mean_correct(self):
+        # fitnesses: 5, 6, 7 → mean 6.0
+        result = self._run_with_fake_results([1, 2, 3])
+        self.assertAlmostEqual(result.best_fitness_mean, 6.0, places=4)
+
+    def test_best_fitness_min_max(self):
+        result = self._run_with_fake_results([1, 2, 3])
+        self.assertAlmostEqual(result.best_fitness_min, 5.0, places=4)
+        self.assertAlmostEqual(result.best_fitness_max, 7.0, places=4)
+
+    def test_convergence_rate_none_converged(self):
+        result = self._run_with_fake_results([1, 2])
+        self.assertAlmostEqual(result.convergence_rate, 0.0)
+
+    def test_convergence_rate_all_converged(self):
+        fakes = [
+            _make_fake_result(
+                best_fitness=5.0,
+                converged=True,
+                convergence_reason="fitness_plateau",
+                generation_of_convergence=1,
+            )
+            for _ in range(3)
+        ]
+        result = self._run_with_fake_results([1, 2, 3], fake_results=fakes)
+        self.assertAlmostEqual(result.convergence_rate, 1.0)
+
+    def test_convergence_reason_counts(self):
+        fakes = [
+            _make_fake_result(converged=True, convergence_reason="fitness_plateau", generation_of_convergence=1),
+            _make_fake_result(converged=True, convergence_reason="diversity_collapse", generation_of_convergence=2),
+            _make_fake_result(converged=False),
+        ]
+        result = self._run_with_fake_results([1, 2, 3], fake_results=fakes)
+        self.assertEqual(result.convergence_reason_counts.get("fitness_plateau"), 1)
+        self.assertEqual(result.convergence_reason_counts.get("diversity_collapse"), 1)
+
+    def test_mean_generation_of_convergence(self):
+        fakes = [
+            _make_fake_result(converged=True, convergence_reason="fitness_plateau", generation_of_convergence=2),
+            _make_fake_result(converged=True, convergence_reason="fitness_plateau", generation_of_convergence=4),
+        ]
+        result = self._run_with_fake_results([1, 2], fake_results=fakes)
+        self.assertAlmostEqual(result.mean_generation_of_convergence, 3.0)
+
+    def test_mean_generation_of_convergence_none_when_no_convergence(self):
+        result = self._run_with_fake_results([1, 2])
+        self.assertIsNone(result.mean_generation_of_convergence)
+
+    def test_elapsed_seconds_positive(self):
+        result = self._run_with_fake_results([1])
+        self.assertGreaterEqual(result.total_elapsed_seconds, 0.0)
+        self.assertGreaterEqual(result.mean_elapsed_seconds, 0.0)
+
+    def test_artifacts_written_to_output_dir(self):
+        with tempfile.TemporaryDirectory() as output_dir:
+            self._run_with_fake_results([1, 2], output_dir=output_dir)
+            self.assertTrue(os.path.isfile(os.path.join(output_dir, "cohort_aggregate.json")))
+            self.assertTrue(os.path.isfile(os.path.join(output_dir, "cohort_aggregate.csv")))
+
+    def test_json_artifact_schema(self):
+        """cohort_aggregate.json must contain the documented top-level keys."""
+        with tempfile.TemporaryDirectory() as output_dir:
+            self._run_with_fake_results([1, 2], output_dir=output_dir)
+            json_path = os.path.join(output_dir, "cohort_aggregate.json")
+            with open(json_path) as f:
+                data = json.load(f)
+
+        required_keys = {
+            "num_seeds",
+            "seeds",
+            "best_fitness_mean",
+            "best_fitness_std",
+            "best_fitness_min",
+            "best_fitness_max",
+            "convergence_rate",
+            "convergence_reason_counts",
+            "mean_generation_of_convergence",
+            "std_generation_of_convergence",
+            "lower_bound_occupancy_mean",
+            "lower_bound_occupancy_std",
+            "mean_elapsed_seconds",
+            "total_elapsed_seconds",
+            "seed_results",
+            "config",
+        }
+        for key in required_keys:
+            self.assertIn(key, data, f"Missing key: {key}")
+
+    def test_csv_artifact_schema(self):
+        """cohort_aggregate.csv must contain one row per seed with required columns."""
+        with tempfile.TemporaryDirectory() as output_dir:
+            self._run_with_fake_results([1, 2, 3], output_dir=output_dir)
+            csv_path = os.path.join(output_dir, "cohort_aggregate.csv")
+            with open(csv_path, newline="") as f:
+                reader = csv.DictReader(f)
+                rows = list(reader)
+
+        self.assertEqual(len(rows), 3)
+        required_columns = {
+            "seed",
+            "best_fitness",
+            "num_generations_completed",
+            "converged",
+            "convergence_reason",
+            "generation_of_convergence",
+            "elapsed_seconds",
+            "lower_bound_occupancy",
+        }
+        for col in required_columns:
+            self.assertIn(col, rows[0], f"Missing CSV column: {col}")
+
+    def test_json_seed_results_count(self):
+        with tempfile.TemporaryDirectory() as output_dir:
+            self._run_with_fake_results([1, 2, 3], output_dir=output_dir)
+            json_path = os.path.join(output_dir, "cohort_aggregate.json")
+            with open(json_path) as f:
+                data = json.load(f)
+        self.assertEqual(len(data["seed_results"]), 3)
+
+    def test_no_output_dir_no_artifacts(self):
+        """When output_dir is None no files should be created."""
+        result = self._run_with_fake_results([1, 2])
+        self.assertIsInstance(result, CohortAggregateResult)
+
+    def test_seed_per_run_matches_seeds_list(self):
+        """Each CohortSeedResult should carry its seed value."""
+        result = self._run_with_fake_results([11, 22, 33])
+        self.assertEqual([sr.seed for sr in result.seed_results], [11, 22, 33])
+
+    def test_reproducibility_same_seeds(self):
+        """Two runs with identical seeds and mocked results must produce identical aggregates."""
+        seeds = [1, 2, 3]
+        r1 = self._run_with_fake_results(seeds)
+        r2 = self._run_with_fake_results(seeds)
+        self.assertAlmostEqual(r1.best_fitness_mean, r2.best_fitness_mean)
+        self.assertAlmostEqual(r1.best_fitness_std, r2.best_fitness_std)
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke tests: run_cohort_experiment
+# ---------------------------------------------------------------------------
+
+class TestRunCohortExperimentCLI(unittest.TestCase):
+    def test_parse_args_num_seeds_default(self):
+        argv = sys.argv[:]
+        try:
+            sys.argv = [
+                "run_cohort_experiment.py",
+                "--generations", "1",
+                "--population-size", "2",
+                "--steps-per-candidate", "1",
+            ]
+            args = run_cohort_experiment._parse_args()
+        finally:
+            sys.argv = argv
+        self.assertEqual(args.num_seeds, 3)
+
+    def test_parse_args_num_seeds_custom(self):
+        argv = sys.argv[:]
+        try:
+            sys.argv = [
+                "run_cohort_experiment.py",
+                "--generations", "1",
+                "--population-size", "2",
+                "--steps-per-candidate", "1",
+                "--num-seeds", "5",
+                "--base-seed", "10",
+            ]
+            args = run_cohort_experiment._parse_args()
+        finally:
+            sys.argv = argv
+        self.assertEqual(args.num_seeds, 5)
+        self.assertEqual(args.base_seed, 10)
+
+    def test_preset_applied_to_cohort(self):
+        argv = sys.argv[:]
+        try:
+            sys.argv = [
+                "run_cohort_experiment.py",
+                "--preset", "stable_hyper_evo",
+                "--generations", "1",
+                "--population-size", "2",
+                "--steps-per-candidate", "1",
+            ]
+            args = run_cohort_experiment._parse_args()
+        finally:
+            sys.argv = argv
+        self.assertEqual(args.preset, "stable_hyper_evo")
+        self.assertEqual(args.selection_method, "tournament")
+        self.assertEqual(args.boundary_mode, "reflect")
+        self.assertAlmostEqual(args.mutation_rate, 0.20)
+        self.assertTrue(args.adaptive_mutation)
+
+    def test_manifest_written_before_run(self):
+        """cohort_manifest.json should be written before the cohort runs."""
+        with tempfile.TemporaryDirectory() as output_dir:
+            argv = sys.argv[:]
+            try:
+                sys.argv = [
+                    "run_cohort_experiment.py",
+                    "--generations", "1",
+                    "--population-size", "2",
+                    "--steps-per-candidate", "1",
+                    "--num-seeds", "2",
+                    "--base-seed", "0",
+                    "--output-dir", output_dir,
+                ]
+                fake_aggregate = CohortAggregateResult(
+                    config={},
+                    num_seeds=2,
+                    seeds=[0, 1],
+                    seed_results=[
+                        CohortSeedResult(
+                            seed=i,
+                            best_fitness=5.0,
+                            num_generations_completed=1,
+                            converged=False,
+                            convergence_reason=None,
+                            generation_of_convergence=None,
+                            elapsed_seconds=0.1,
+                            lower_bound_occupancy=None,
+                        )
+                        for i in range(2)
+                    ],
+                    best_fitness_mean=5.0,
+                    best_fitness_std=0.0,
+                    best_fitness_min=5.0,
+                    best_fitness_max=5.0,
+                    convergence_rate=0.0,
+                    convergence_reason_counts={},
+                    mean_generation_of_convergence=None,
+                    std_generation_of_convergence=None,
+                    lower_bound_occupancy_mean=None,
+                    lower_bound_occupancy_std=None,
+                    mean_elapsed_seconds=0.1,
+                    total_elapsed_seconds=0.2,
+                )
+                with patch.object(run_cohort_experiment.CohortRunner, "run", return_value=fake_aggregate):
+                    run_cohort_experiment.main()
+            finally:
+                sys.argv = argv
+
+            manifest_path = os.path.join(output_dir, "cohort_manifest.json")
+            self.assertTrue(os.path.isfile(manifest_path))
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+
+        self.assertEqual(manifest["num_seeds"], 2)
+        self.assertEqual(manifest["base_seed"], 0)
+        self.assertEqual(manifest["seeds"], [0, 1])
+        self.assertEqual(manifest["script"], "scripts/run_cohort_experiment.py")
+        self.assertIsNone(manifest["preset"])
+
+    def test_manifest_includes_preset_when_given(self):
+        with tempfile.TemporaryDirectory() as output_dir:
+            argv = sys.argv[:]
+            try:
+                sys.argv = [
+                    "run_cohort_experiment.py",
+                    "--preset", "stable_hyper_evo",
+                    "--generations", "1",
+                    "--population-size", "2",
+                    "--steps-per-candidate", "1",
+                    "--output-dir", output_dir,
+                ]
+                fake_aggregate = CohortAggregateResult(
+                    config={},
+                    num_seeds=3,
+                    seeds=[0, 1, 2],
+                    seed_results=[
+                        CohortSeedResult(
+                            seed=i,
+                            best_fitness=5.0,
+                            num_generations_completed=1,
+                            converged=False,
+                            convergence_reason=None,
+                            generation_of_convergence=None,
+                            elapsed_seconds=0.1,
+                            lower_bound_occupancy=None,
+                        )
+                        for i in range(3)
+                    ],
+                    best_fitness_mean=5.0,
+                    best_fitness_std=0.0,
+                    best_fitness_min=5.0,
+                    best_fitness_max=5.0,
+                    convergence_rate=0.0,
+                    convergence_reason_counts={},
+                    mean_generation_of_convergence=None,
+                    std_generation_of_convergence=None,
+                    lower_bound_occupancy_mean=None,
+                    lower_bound_occupancy_std=None,
+                    mean_elapsed_seconds=0.1,
+                    total_elapsed_seconds=0.3,
+                )
+                with patch.object(run_cohort_experiment.CohortRunner, "run", return_value=fake_aggregate):
+                    run_cohort_experiment.main()
+            finally:
+                sys.argv = argv
+
+            manifest_path = os.path.join(output_dir, "cohort_manifest.json")
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+
+        self.assertEqual(manifest["preset"], "stable_hyper_evo")
+
+    def test_presets_dict_contains_stable_hyper_evo(self):
+        self.assertIn("stable_hyper_evo", run_cohort_experiment.PRESETS)
+
+    def test_presets_stable_hyper_evo_has_required_keys(self):
+        preset = run_cohort_experiment.PRESETS["stable_hyper_evo"]
+        for key in ("selection_method", "boundary_mode", "mutation_rate", "mutation_scale", "adaptive_mutation"):
+            self.assertIn(key, preset)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cohort_runner.py
+++ b/tests/test_cohort_runner.py
@@ -27,7 +27,6 @@ from farm.runners import (  # noqa: E402
     CohortSeedResult,
     EvolutionExperiment,
     EvolutionExperimentConfig,
-    EvolutionFitnessMetric,
 )
 from farm.runners.cohort_runner import (  # noqa: E402
     _lower_bound_occupancy,


### PR DESCRIPTION
This pull request introduces the **multi-seed cohort runner** feature, which enables running evolution experiments across multiple random seeds to produce statistically robust results. It adds comprehensive documentation, exposes new API classes, and updates the package exports for easier programmatic access.

**New multi-seed cohort runner:**

* Added `docs/experiments/multi_seed_cohort.md` with a full user guide for the new cohort runner, including usage instructions, CLI flags, artifact schema, result interpretation, and API usage examples.

**API and exports:**

* Exposed `CohortRunner`, `CohortAggregateResult`, and `CohortSeedResult` in `farm.runners.__init__.py` for direct import and use in notebooks or other code. [[1]](diffhunk://#diff-c8139a827bd991793bde210cf38e1257269e4a1665fe89dcc4aa8823325337b4R10-R14) [[2]](diffhunk://#diff-c8139a827bd991793bde210cf38e1257269e4a1665fe89dcc4aa8823325337b4R33-R35)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new execution path that runs many `EvolutionExperiment`s and writes new JSON/CSV artifacts; risk is mainly around correctness of aggregation/serialization and filesystem side effects rather than security-critical logic.
> 
> **Overview**
> Adds a new **multi-seed cohort execution mode** via `CohortRunner`, which runs the same `EvolutionExperimentConfig` across a list of seeds (optionally under `seed_<N>/` subdirs) and returns an aggregate result with cross-seed fitness stats, convergence aggregates, timing, and a *lower-bound learning-rate occupancy* diagnostic.
> 
> Introduces `scripts/run_cohort_experiment.py` to expose this via CLI (including presets, per-gene adaptive-mutation multiplier parsing, and pre-run `cohort_manifest.json`), persists cohort summaries to `cohort_aggregate.json` and `cohort_aggregate.csv`, exports the new dataclasses from `farm.runners`, and adds comprehensive docs plus a full unit/smoke test suite covering aggregation, artifact schemas, and CLI argument/preset behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5555a0a918404c69a50c2d4dd4974750a91f4a36. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->