### PR TITLE
Add genetics analysis module and refactor parent ID parsing

### DIFF
--- a/farm/analysis/advantage/compute.py
+++ b/farm/analysis/advantage/compute.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy import func
 
+from farm.analysis.genetics.utils import parse_parent_ids
+
 logger = get_logger(__name__)
 
 
@@ -441,8 +443,6 @@ def compute_advantages(sim_session, focus_agent_type=None):
 
     # Calculate reproduction metrics for each agent type
     # Reconstruct from agents and agent_actions tables
-    from farm.analysis.genetics.compute import parse_parent_ids
-    
     # Get successful reproductions (offspring)
     offspring_agents = (
         sim_session.query(AgentModel)

--- a/farm/analysis/advantage/compute.py
+++ b/farm/analysis/advantage/compute.py
@@ -441,7 +441,7 @@ def compute_advantages(sim_session, focus_agent_type=None):
 
     # Calculate reproduction metrics for each agent type
     # Reconstruct from agents and agent_actions tables
-    from farm.database.data_types import GenomeId
+    from farm.analysis.genetics.compute import parse_parent_ids
     
     # Get successful reproductions (offspring)
     offspring_agents = (
@@ -465,9 +465,9 @@ def compute_advantages(sim_session, focus_agent_type=None):
         
         for offspring in offspring_agents:
             try:
-                genome = GenomeId.from_string(offspring.genome_id)
-                if genome.parent_ids:
-                    parent_id = genome.parent_ids[0]
+                parent_ids = parse_parent_ids(offspring.genome_id)
+                if parent_ids:
+                    parent_id = parent_ids[0]
                     parent = (
                         sim_session.query(AgentModel)
                         .filter(AgentModel.agent_id == parent_id)
@@ -503,9 +503,9 @@ def compute_advantages(sim_session, focus_agent_type=None):
         
         for offspring in offspring_agents:
             try:
-                genome = GenomeId.from_string(offspring.genome_id)
-                if genome.parent_ids:
-                    parent_id = genome.parent_ids[0]
+                parent_ids = parse_parent_ids(offspring.genome_id)
+                if parent_ids:
+                    parent_id = parent_ids[0]
                     parent = (
                         sim_session.query(AgentModel)
                         .filter(AgentModel.agent_id == parent_id)

--- a/farm/analysis/dominance/data.py
+++ b/farm/analysis/dominance/data.py
@@ -237,14 +237,10 @@ def get_reproduction_stats(sim_session):
         # Build a set of successful reproduction step+parent combinations
         successful_reproductions = set()
         for offspring in offspring_agents:
-            try:
-                parent_ids = parse_parent_ids(offspring.genome_id)
-                if parent_ids:
-                    parent_id = parent_ids[0]
-                    successful_reproductions.add((offspring.birth_time, parent_id))
-            except Exception as e:
-                logger.warning(f"Failed to parse genome ID '{offspring.genome_id}' for agent {offspring.id}: {e}")
-                continue
+            parent_ids = parse_parent_ids(offspring.genome_id)
+            if parent_ids:
+                parent_id = parent_ids[0]
+                successful_reproductions.add((offspring.birth_time, parent_id))
 
         # Filter reproduce_actions to find failed attempts
         failed_actions = []

--- a/farm/analysis/dominance/data.py
+++ b/farm/analysis/dominance/data.py
@@ -3,7 +3,7 @@ from typing import Optional
 from scipy.spatial.distance import euclidean
 
 from farm.analysis.dominance.constants import DOMINANCE_AGENT_TYPES
-from farm.database.data_types import GenomeId
+from farm.analysis.genetics.compute import parse_parent_ids
 from farm.database.models import (
     ActionModel,
     AgentModel,
@@ -238,9 +238,9 @@ def get_reproduction_stats(sim_session):
         successful_reproductions = set()
         for offspring in offspring_agents:
             try:
-                genome = GenomeId.from_string(offspring.genome_id)
-                if genome.parent_ids:
-                    parent_id = genome.parent_ids[0]
+                parent_ids = parse_parent_ids(offspring.genome_id)
+                if parent_ids:
+                    parent_id = parent_ids[0]
                     successful_reproductions.add((offspring.birth_time, parent_id))
             except Exception as e:
                 logger.warning(f"Failed to parse genome ID '{offspring.genome_id}' for agent {offspring.id}: {e}")
@@ -299,11 +299,11 @@ def get_reproduction_stats(sim_session):
         # Process successful reproductions
         for offspring in offspring_agents:
             try:
-                genome = GenomeId.from_string(offspring.genome_id)
-                if not genome.parent_ids:
+                parent_ids = parse_parent_ids(offspring.genome_id)
+                if not parent_ids:
                     continue
 
-                parent_id = genome.parent_ids[0]
+                parent_id = parent_ids[0]
                 parent_type = agents.get(parent_id, "unknown")
 
                 if parent_type not in stats:

--- a/farm/analysis/dominance/data.py
+++ b/farm/analysis/dominance/data.py
@@ -3,7 +3,7 @@ from typing import Optional
 from scipy.spatial.distance import euclidean
 
 from farm.analysis.dominance.constants import DOMINANCE_AGENT_TYPES
-from farm.analysis.genetics.compute import parse_parent_ids
+from farm.analysis.genetics.utils import parse_parent_ids
 from farm.database.models import (
     ActionModel,
     AgentModel,

--- a/farm/analysis/genesis/compute.py
+++ b/farm/analysis/genesis/compute.py
@@ -20,6 +20,7 @@ from sklearn.preprocessing import StandardScaler
 from sqlalchemy import and_, desc, func, or_
 from sqlalchemy.orm import Session
 
+from farm.analysis.genetics.utils import parse_parent_ids
 from farm.database.models import (
     ActionModel,
     AgentModel,
@@ -935,8 +936,6 @@ def compute_simulation_outcomes(session: Session) -> Dict[str, Any]:
 
         # Reproduction by agent type - get parent agent_type by parsing genome_id
         reproduction_by_type = defaultdict(int)
-        from farm.analysis.genetics.compute import parse_parent_ids
-        
         for offspring in offspring_agents:
             # Parse genome_id to get parent_id(s)
             try:
@@ -1179,8 +1178,6 @@ def compute_critical_period_metrics(
         )
         .all()
     )
-    
-    from farm.analysis.genetics.compute import parse_parent_ids
     
     first_reproductions = {}
     reproduction_count = 0

--- a/farm/analysis/genesis/compute.py
+++ b/farm/analysis/genesis/compute.py
@@ -935,15 +935,15 @@ def compute_simulation_outcomes(session: Session) -> Dict[str, Any]:
 
         # Reproduction by agent type - get parent agent_type by parsing genome_id
         reproduction_by_type = defaultdict(int)
-        from farm.database.data_types import GenomeId
+        from farm.analysis.genetics.compute import parse_parent_ids
         
         for offspring in offspring_agents:
             # Parse genome_id to get parent_id(s)
             try:
-                genome = GenomeId.from_string(offspring.genome_id)
-                if genome.parent_ids:
+                parent_ids = parse_parent_ids(offspring.genome_id)
+                if parent_ids:
                     # Use first parent for asexual reproduction, or get parent agent_type
-                    parent_id = genome.parent_ids[0]
+                    parent_id = parent_ids[0]
                     parent = (
                         session.query(AgentModel)
                         .filter(AgentModel.agent_id == parent_id)
@@ -1180,7 +1180,7 @@ def compute_critical_period_metrics(
         .all()
     )
     
-    from farm.database.data_types import GenomeId
+    from farm.analysis.genetics.compute import parse_parent_ids
     
     first_reproductions = {}
     reproduction_count = 0
@@ -1188,9 +1188,9 @@ def compute_critical_period_metrics(
     for offspring in offspring_during_critical:
         # Parse genome_id to get parent and determine parent agent_type
         try:
-            genome = GenomeId.from_string(offspring.genome_id)
-            if genome.parent_ids:
-                parent_id = genome.parent_ids[0]
+            parent_ids = parse_parent_ids(offspring.genome_id)
+            if parent_ids:
+                parent_id = parent_ids[0]
                 parent = (
                     session.query(AgentModel)
                     .filter(AgentModel.agent_id == parent_id)

--- a/farm/analysis/genetics/__init__.py
+++ b/farm/analysis/genetics/__init__.py
@@ -1,0 +1,38 @@
+"""
+Genetics Analysis Package
+
+Provides tools for analyzing agent genomes, chromosomes, lineage, and
+population-level genetic statistics from simulation databases and
+evolution-experiment artifacts.
+
+Features:
+- Shared ``parse_parent_ids`` helper centralising ``GenomeId.from_string`` usage
+- DB-backed population accessor (action weights, generation, lineage)
+- Evolution-experiment-backed population accessor (chromosome values, fitness)
+- Normalized DataFrame output for both sources
+
+Quick Start::
+
+    >>> from farm.analysis.genetics.compute import (
+    ...     parse_parent_ids,
+    ...     build_agent_genetics_dataframe,
+    ...     build_evolution_experiment_dataframe,
+    ... )
+"""
+
+from farm.analysis.genetics.compute import (
+    parse_parent_ids,
+    build_agent_genetics_dataframe,
+    build_evolution_experiment_dataframe,
+)
+from farm.analysis.genetics.analyze import analyze_genetics
+from farm.analysis.genetics.module import genetics_module, GeneticsModule
+
+__all__ = [
+    "parse_parent_ids",
+    "build_agent_genetics_dataframe",
+    "build_evolution_experiment_dataframe",
+    "analyze_genetics",
+    "genetics_module",
+    "GeneticsModule",
+]

--- a/farm/analysis/genetics/__init__.py
+++ b/farm/analysis/genetics/__init__.py
@@ -20,8 +20,8 @@ Quick Start::
     ... )
 """
 
+from farm.analysis.genetics.utils import parse_parent_ids
 from farm.analysis.genetics.compute import (
-    parse_parent_ids,
     build_agent_genetics_dataframe,
     build_evolution_experiment_dataframe,
 )

--- a/farm/analysis/genetics/analyze.py
+++ b/farm/analysis/genetics/analyze.py
@@ -1,0 +1,82 @@
+"""
+Genetics Analysis Functions
+
+High-level analysis functions that operate on the normalized DataFrames
+produced by the genetics compute layer.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pandas as pd
+
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def analyze_genetics(df: pd.DataFrame) -> Dict[str, Any]:
+    """Compute summary statistics for a population-genetics DataFrame.
+
+    Accepts either a DataFrame produced by
+    :func:`~farm.analysis.genetics.compute.build_agent_genetics_dataframe`
+    (DB-backed, columns include ``generation`` and ``action_weights``) or one
+    produced by
+    :func:`~farm.analysis.genetics.compute.build_evolution_experiment_dataframe`
+    (evolution-experiment-backed, columns include ``fitness`` and
+    ``chromosome_values``).
+
+    Parameters
+    ----------
+    df:
+        Input DataFrame.  Empty DataFrames are handled gracefully.
+
+    Returns
+    -------
+    dict
+        Summary statistics appropriate for the detected source type.
+    """
+    if df.empty:
+        return {"total_agents": 0}
+
+    result: Dict[str, Any] = {"total_agents": len(df)}
+
+    # --- DB-backed frame ---
+    if "generation" in df.columns:
+        result["generation_counts"] = df["generation"].value_counts().to_dict()
+        result["max_generation"] = int(df["generation"].max())
+        result["mean_generation"] = float(df["generation"].mean())
+
+    if "parent_ids" in df.columns:
+        result["pct_with_parents"] = float(
+            (df["parent_ids"].apply(lambda p: len(p) > 0)).mean() * 100
+        )
+
+    if "action_weights" in df.columns:
+        non_empty = df["action_weights"].apply(lambda w: bool(w))
+        result["pct_with_action_weights"] = float(non_empty.mean() * 100)
+
+    # --- Evolution-experiment frame ---
+    if "fitness" in df.columns:
+        result["best_fitness"] = float(df["fitness"].max())
+        result["mean_fitness"] = float(df["fitness"].mean())
+        result["min_fitness"] = float(df["fitness"].min())
+
+    if "chromosome_values" in df.columns and not df["chromosome_values"].empty:
+        all_keys: set = set()
+        df["chromosome_values"].apply(lambda d: all_keys.update(d.keys()))
+        gene_stats: Dict[str, Any] = {}
+        for gene in sorted(all_keys):
+            values = df["chromosome_values"].apply(lambda d: d.get(gene))
+            valid = values.dropna()
+            if not valid.empty:
+                gene_stats[gene] = {
+                    "mean": float(valid.mean()),
+                    "std": float(valid.std(ddof=0)),
+                    "min": float(valid.min()),
+                    "max": float(valid.max()),
+                }
+        result["gene_statistics"] = gene_stats
+
+    return result

--- a/farm/analysis/genetics/analyze.py
+++ b/farm/analysis/genetics/analyze.py
@@ -54,7 +54,7 @@ def analyze_genetics(df: pd.DataFrame) -> Dict[str, Any]:
         )
 
     if "action_weights" in df.columns:
-        non_empty = df["action_weights"].apply(lambda w: bool(w))
+        non_empty = df["action_weights"].apply(bool)
         result["pct_with_action_weights"] = float(non_empty.mean() * 100)
 
     # --- Evolution-experiment frame ---

--- a/farm/analysis/genetics/compute.py
+++ b/farm/analysis/genetics/compute.py
@@ -8,11 +8,11 @@ simulation-database and evolution-experiment data sources.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, TYPE_CHECKING
 
 import pandas as pd
 
-from farm.database.data_types import GenomeId
+from farm.analysis.genetics.utils import parse_parent_ids
 from farm.utils.logging import get_logger
 
 if TYPE_CHECKING:
@@ -20,48 +20,6 @@ if TYPE_CHECKING:
     from farm.runners.evolution_experiment import EvolutionExperimentResult
 
 logger = get_logger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Shared helper – replaces scattered GenomeId.from_string call sites
-# ---------------------------------------------------------------------------
-
-
-def parse_parent_ids(genome_id: Optional[str]) -> List[str]:
-    """Return the list of parent agent IDs encoded in *genome_id*.
-
-    This is the single authoritative wrapper around
-    :meth:`~farm.database.data_types.GenomeId.from_string` for all analysis
-    modules.  Call sites that previously did::
-
-        genome = GenomeId.from_string(offspring.genome_id)
-        parent_ids = genome.parent_ids
-
-    should be replaced with::
-
-        parent_ids = parse_parent_ids(offspring.genome_id)
-
-    Parameters
-    ----------
-    genome_id:
-        Raw genome-ID string as stored in the ``agents`` table or carried by
-        :class:`~farm.runners.evolution_experiment.EvolutionCandidate`.
-        ``None`` or any falsy/non-string value returns an empty list without
-        logging a warning.
-
-    Returns
-    -------
-    list[str]
-        Possibly-empty list of parent agent IDs.  Empty for initial
-        (generation-0) agents with no parents or when *genome_id* is absent.
-    """
-    if not genome_id or not isinstance(genome_id, str):
-        return []
-    try:
-        return GenomeId.from_string(genome_id).parent_ids
-    except Exception as exc:
-        logger.warning("parse_parent_ids failed for genome_id=%r: %s", genome_id, exc)
-        return []
 
 
 # ---------------------------------------------------------------------------

--- a/farm/analysis/genetics/compute.py
+++ b/farm/analysis/genetics/compute.py
@@ -1,0 +1,182 @@
+"""
+Genetics Analysis Computation
+
+Core computation functions for the genetics analysis module, including the
+shared ``parse_parent_ids`` helper and population-level accessors for both
+simulation-database and evolution-experiment data sources.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+import pandas as pd
+
+from farm.database.data_types import GenomeId
+from farm.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+    from farm.runners.evolution_experiment import EvolutionExperimentResult
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Shared helper – replaces scattered GenomeId.from_string call sites
+# ---------------------------------------------------------------------------
+
+
+def parse_parent_ids(genome_id: str) -> List[str]:
+    """Return the list of parent agent IDs encoded in *genome_id*.
+
+    This is the single authoritative wrapper around
+    :meth:`~farm.database.data_types.GenomeId.from_string` for all analysis
+    modules.  Call sites that previously did::
+
+        genome = GenomeId.from_string(offspring.genome_id)
+        parent_ids = genome.parent_ids
+
+    should be replaced with::
+
+        parent_ids = parse_parent_ids(offspring.genome_id)
+
+    Parameters
+    ----------
+    genome_id:
+        Raw genome-ID string as stored in the ``agents`` table or carried by
+        :class:`~farm.runners.evolution_experiment.EvolutionCandidate`.
+
+    Returns
+    -------
+    list[str]
+        Possibly-empty list of parent agent IDs.  Empty for initial
+        (generation-0) agents with no parents.
+    """
+    try:
+        return GenomeId.from_string(genome_id).parent_ids
+    except Exception as exc:
+        logger.warning("parse_parent_ids failed for genome_id=%r: %s", genome_id, exc)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# DB-backed population accessor
+# ---------------------------------------------------------------------------
+
+#: Columns produced by :func:`build_agent_genetics_dataframe`.
+AGENT_GENETICS_COLUMNS = [
+    "agent_id",
+    "agent_type",
+    "generation",
+    "birth_time",
+    "death_time",
+    "genome_id",
+    "parent_ids",
+    "action_weights",
+]
+
+
+def build_agent_genetics_dataframe(session: "Session") -> pd.DataFrame:
+    """Build a normalized genetics DataFrame from a simulation database session.
+
+    Each row represents one agent.  The ``parent_ids`` column contains a
+    Python list of parent agent-ID strings (empty list for genesis agents).
+    Action weights are stored as a dict in the ``action_weights`` column.
+
+    Parameters
+    ----------
+    session:
+        An active SQLAlchemy session connected to a simulation database.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per agent with columns defined in :data:`AGENT_GENETICS_COLUMNS`.
+        Returns an empty DataFrame (with correct columns) when no agents are
+        found.
+    """
+    from farm.database.models import AgentModel
+
+    agents: List[AgentModel] = session.query(AgentModel).all()
+
+    if not agents:
+        logger.info("build_agent_genetics_dataframe: no agents found in session")
+        return pd.DataFrame(columns=AGENT_GENETICS_COLUMNS)
+
+    rows: List[Dict[str, Any]] = []
+    for agent in agents:
+        rows.append(
+            {
+                "agent_id": agent.agent_id,
+                "agent_type": agent.agent_type,
+                "generation": agent.generation,
+                "birth_time": agent.birth_time,
+                "death_time": agent.death_time,
+                "genome_id": agent.genome_id,
+                "parent_ids": parse_parent_ids(agent.genome_id) if agent.genome_id else [],
+                "action_weights": agent.action_weights or {},
+            }
+        )
+
+    df = pd.DataFrame(rows, columns=AGENT_GENETICS_COLUMNS)
+    logger.info("build_agent_genetics_dataframe: built frame with %d rows", len(df))
+    return df
+
+
+# ---------------------------------------------------------------------------
+# Evolution-experiment-backed population accessor
+# ---------------------------------------------------------------------------
+
+#: Columns produced by :func:`build_evolution_experiment_dataframe`.
+EVOLUTION_GENETICS_COLUMNS = [
+    "candidate_id",
+    "generation",
+    "fitness",
+    "parent_ids",
+    "chromosome_values",
+]
+
+
+def build_evolution_experiment_dataframe(result: "EvolutionExperimentResult") -> pd.DataFrame:
+    """Build a normalized genetics DataFrame from an
+    :class:`~farm.runners.evolution_experiment.EvolutionExperimentResult`.
+
+    Each row represents one evaluated candidate across all generations.
+
+    Parameters
+    ----------
+    result:
+        A completed evolution-experiment result object.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per evaluated candidate with columns defined in
+        :data:`EVOLUTION_GENETICS_COLUMNS`.  Returns an empty DataFrame when
+        *result* contains no evaluations.
+    """
+    evaluations = result.evaluations
+    if not evaluations:
+        logger.info("build_evolution_experiment_dataframe: no evaluations in result")
+        return pd.DataFrame(columns=EVOLUTION_GENETICS_COLUMNS)
+
+    rows: List[Dict[str, Any]] = []
+    for ev in evaluations:
+        rows.append(
+            {
+                "candidate_id": ev.candidate_id,
+                "generation": ev.generation,
+                "fitness": ev.fitness,
+                "parent_ids": list(ev.parent_ids),
+                "chromosome_values": dict(ev.chromosome_values),
+            }
+        )
+
+    df = pd.DataFrame(rows, columns=EVOLUTION_GENETICS_COLUMNS)
+    logger.info(
+        "build_evolution_experiment_dataframe: built frame with %d rows across %d generation(s)",
+        len(df),
+        df["generation"].nunique(),
+    )
+    return df

--- a/farm/analysis/genetics/compute.py
+++ b/farm/analysis/genetics/compute.py
@@ -8,7 +8,7 @@ simulation-database and evolution-experiment data sources.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 import pandas as pd
 
@@ -27,7 +27,7 @@ logger = get_logger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def parse_parent_ids(genome_id: str) -> List[str]:
+def parse_parent_ids(genome_id: Optional[str]) -> List[str]:
     """Return the list of parent agent IDs encoded in *genome_id*.
 
     This is the single authoritative wrapper around
@@ -46,13 +46,17 @@ def parse_parent_ids(genome_id: str) -> List[str]:
     genome_id:
         Raw genome-ID string as stored in the ``agents`` table or carried by
         :class:`~farm.runners.evolution_experiment.EvolutionCandidate`.
+        ``None`` or any falsy/non-string value returns an empty list without
+        logging a warning.
 
     Returns
     -------
     list[str]
         Possibly-empty list of parent agent IDs.  Empty for initial
-        (generation-0) agents with no parents.
+        (generation-0) agents with no parents or when *genome_id* is absent.
     """
+    if not genome_id or not isinstance(genome_id, str):
+        return []
     try:
         return GenomeId.from_string(genome_id).parent_ids
     except Exception as exc:
@@ -114,7 +118,7 @@ def build_agent_genetics_dataframe(session: "Session") -> pd.DataFrame:
                 "birth_time": agent.birth_time,
                 "death_time": agent.death_time,
                 "genome_id": agent.genome_id,
-                "parent_ids": parse_parent_ids(agent.genome_id) if agent.genome_id else [],
+                "parent_ids": parse_parent_ids(agent.genome_id),
                 "action_weights": agent.action_weights or {},
             }
         )

--- a/farm/analysis/genetics/compute.py
+++ b/farm/analysis/genetics/compute.py
@@ -8,7 +8,7 @@ simulation-database and evolution-experiment data sources.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, TYPE_CHECKING
 
 import pandas as pd
 

--- a/farm/analysis/genetics/data.py
+++ b/farm/analysis/genetics/data.py
@@ -4,6 +4,7 @@ Data processing for the genetics analysis module.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
@@ -16,13 +17,21 @@ logger = get_logger(__name__)
 def process_genetics_data(data: Any, **kwargs) -> pd.DataFrame:
     """Process input data for the genetics analysis module.
 
-    Accepts either a :class:`pandas.DataFrame` (passed through unchanged) or
-    an SQLAlchemy session (forwarded to the DB accessor).
+    Accepts a :class:`~pathlib.Path` or ``str`` (experiment directory), a
+    :class:`pandas.DataFrame` (passed through unchanged), an SQLAlchemy
+    session, or an ``EvolutionExperimentResult``.
+
+    When a ``Path`` or ``str`` is provided the function locates
+    ``simulation.db`` inside the experiment directory (using
+    :func:`~farm.analysis.common.utils.find_database_path`), opens a
+    transient session via :class:`~farm.database.session_manager.SessionManager`,
+    and delegates to :func:`~farm.analysis.genetics.compute.build_agent_genetics_dataframe`.
 
     Parameters
     ----------
     data:
-        A :class:`pandas.DataFrame`, an SQLAlchemy session, or an
+        A :class:`~pathlib.Path` or ``str`` experiment directory, a
+        :class:`pandas.DataFrame`, an SQLAlchemy session, or an
         ``EvolutionExperimentResult``.
     **kwargs:
         Reserved for future use.
@@ -32,6 +41,19 @@ def process_genetics_data(data: Any, **kwargs) -> pd.DataFrame:
     pd.DataFrame
         Processed data ready for analysis.
     """
+    # Path / str  ->  locate simulation.db and build the genetics frame
+    if isinstance(data, (str, Path)):
+        experiment_path = Path(data)
+        logger.info("process_genetics_data: loading genetics from experiment path %s", experiment_path)
+        from farm.analysis.common.utils import find_database_path
+        from farm.database.session_manager import SessionManager
+        from farm.analysis.genetics.compute import build_agent_genetics_dataframe
+
+        db_path = find_database_path(experiment_path)
+        session_manager = SessionManager(f"sqlite:///{db_path}")
+        with session_manager.session_scope() as session:
+            return build_agent_genetics_dataframe(session)
+
     if isinstance(data, pd.DataFrame):
         logger.info("process_genetics_data: passing DataFrame through unchanged")
         return data
@@ -52,5 +74,6 @@ def process_genetics_data(data: Any, **kwargs) -> pd.DataFrame:
 
     raise TypeError(
         f"process_genetics_data: unsupported data type {type(data).__name__!r}. "
-        "Expected a DataFrame, SQLAlchemy session, or EvolutionExperimentResult."
+        "Expected a Path/str experiment directory, DataFrame, SQLAlchemy session, "
+        "or EvolutionExperimentResult."
     )

--- a/farm/analysis/genetics/data.py
+++ b/farm/analysis/genetics/data.py
@@ -45,6 +45,8 @@ def process_genetics_data(data: Any, **kwargs) -> pd.DataFrame:
     if isinstance(data, (str, Path)):
         experiment_path = Path(data)
         logger.info("process_genetics_data: loading genetics from experiment path %s", experiment_path)
+        # Deferred imports to avoid circular dependencies at module import time and
+        # to keep heavy database dependencies from loading unless the Path branch is used.
         from farm.analysis.common.utils import find_database_path
         from farm.database.session_manager import SessionManager
         from farm.analysis.genetics.compute import build_agent_genetics_dataframe

--- a/farm/analysis/genetics/data.py
+++ b/farm/analysis/genetics/data.py
@@ -8,31 +8,35 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
 
+from farm.analysis.common.utils import find_database_path
+from farm.analysis.genetics.compute import (
+    build_agent_genetics_dataframe,
+    build_evolution_experiment_dataframe,
+)
 from farm.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
 
-def process_genetics_data(data: Any, **kwargs) -> pd.DataFrame:
+def process_genetics_data(data: Any, use_database: bool = True, **kwargs) -> pd.DataFrame:
     """Process input data for the genetics analysis module.
 
-    Accepts a :class:`~pathlib.Path` or ``str`` (experiment directory), a
-    :class:`pandas.DataFrame` (passed through unchanged), an SQLAlchemy
-    session, or an ``EvolutionExperimentResult``.
+    Supports:
 
-    When a ``Path`` or ``str`` is provided the function locates
-    ``simulation.db`` inside the experiment directory (using
-    :func:`~farm.analysis.common.utils.find_database_path`), opens a
-    transient session via :class:`~farm.database.session_manager.SessionManager`,
-    and delegates to :func:`~farm.analysis.genetics.compute.build_agent_genetics_dataframe`.
+    - ``Path`` / ``str`` experiment directories (standard module workflow)
+    - :class:`pandas.DataFrame` passthrough
+    - SQLAlchemy session objects
+    - ``EvolutionExperimentResult``-like objects
 
     Parameters
     ----------
     data:
-        A :class:`~pathlib.Path` or ``str`` experiment directory, a
-        :class:`pandas.DataFrame`, an SQLAlchemy session, or an
-        ``EvolutionExperimentResult``.
+        Input data source.
+    use_database:
+        Whether path-based inputs should load from ``simulation.db``.
     **kwargs:
         Reserved for future use.
 
@@ -41,20 +45,19 @@ def process_genetics_data(data: Any, **kwargs) -> pd.DataFrame:
     pd.DataFrame
         Processed data ready for analysis.
     """
-    # Path / str  ->  locate simulation.db and build the genetics frame
-    if isinstance(data, (str, Path)):
-        experiment_path = Path(data)
-        logger.info("process_genetics_data: loading genetics from experiment path %s", experiment_path)
-        # Deferred imports to avoid circular dependencies at module import time and
-        # to keep heavy database dependencies from loading unless the Path branch is used.
-        from farm.analysis.common.utils import find_database_path
-        from farm.database.session_manager import SessionManager
-        from farm.analysis.genetics.compute import build_agent_genetics_dataframe
+    if isinstance(data, (Path, str)):
+        if not use_database:
+            raise ValueError("process_genetics_data requires use_database=True for path inputs")
 
-        db_path = find_database_path(experiment_path)
-        session_manager = SessionManager(f"sqlite:///{db_path}")
-        with session_manager.session_scope() as session:
-            return build_agent_genetics_dataframe(session)
+        experiment_path = Path(data)
+        db_path = find_database_path(experiment_path, "simulation.db")
+        logger.info("process_genetics_data: loading agent genetics from database %s", db_path)
+
+        engine = create_engine(f"sqlite:///{db_path}")
+        with Session(engine) as session:
+            df = build_agent_genetics_dataframe(session)
+        engine.dispose()
+        return df
 
     if isinstance(data, pd.DataFrame):
         logger.info("process_genetics_data: passing DataFrame through unchanged")
@@ -62,20 +65,15 @@ def process_genetics_data(data: Any, **kwargs) -> pd.DataFrame:
 
     # SQLAlchemy session duck-type check
     if hasattr(data, "query"):
-        logger.info("process_genetics_data: loading agent genetics from database session")
-        from farm.analysis.genetics.compute import build_agent_genetics_dataframe
-
+        logger.info("process_genetics_data: loading agent genetics from provided session")
         return build_agent_genetics_dataframe(data)
 
     # EvolutionExperimentResult duck-type check
     if hasattr(data, "evaluations") and hasattr(data, "generation_summaries"):
         logger.info("process_genetics_data: loading genetics from EvolutionExperimentResult")
-        from farm.analysis.genetics.compute import build_evolution_experiment_dataframe
-
         return build_evolution_experiment_dataframe(data)
 
     raise TypeError(
         f"process_genetics_data: unsupported data type {type(data).__name__!r}. "
-        "Expected a Path/str experiment directory, DataFrame, SQLAlchemy session, "
-        "or EvolutionExperimentResult."
+        "Expected experiment path, DataFrame, SQLAlchemy session, or EvolutionExperimentResult."
     )

--- a/farm/analysis/genetics/data.py
+++ b/farm/analysis/genetics/data.py
@@ -1,0 +1,56 @@
+"""
+Data processing for the genetics analysis module.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def process_genetics_data(data: Any, **kwargs) -> pd.DataFrame:
+    """Process input data for the genetics analysis module.
+
+    Accepts either a :class:`pandas.DataFrame` (passed through unchanged) or
+    an SQLAlchemy session (forwarded to the DB accessor).
+
+    Parameters
+    ----------
+    data:
+        A :class:`pandas.DataFrame`, an SQLAlchemy session, or an
+        ``EvolutionExperimentResult``.
+    **kwargs:
+        Reserved for future use.
+
+    Returns
+    -------
+    pd.DataFrame
+        Processed data ready for analysis.
+    """
+    if isinstance(data, pd.DataFrame):
+        logger.info("process_genetics_data: passing DataFrame through unchanged")
+        return data
+
+    # SQLAlchemy session duck-type check
+    if hasattr(data, "query"):
+        logger.info("process_genetics_data: loading agent genetics from database session")
+        from farm.analysis.genetics.compute import build_agent_genetics_dataframe
+
+        return build_agent_genetics_dataframe(data)
+
+    # EvolutionExperimentResult duck-type check
+    if hasattr(data, "evaluations") and hasattr(data, "generation_summaries"):
+        logger.info("process_genetics_data: loading genetics from EvolutionExperimentResult")
+        from farm.analysis.genetics.compute import build_evolution_experiment_dataframe
+
+        return build_evolution_experiment_dataframe(data)
+
+    raise TypeError(
+        f"process_genetics_data: unsupported data type {type(data).__name__!r}. "
+        "Expected a DataFrame, SQLAlchemy session, or EvolutionExperimentResult."
+    )

--- a/farm/analysis/genetics/module.py
+++ b/farm/analysis/genetics/module.py
@@ -1,0 +1,86 @@
+"""
+Genetics Analysis Module
+
+Registers the genetics analysis module with the analysis framework so it is
+discoverable via :class:`~farm.analysis.service.AnalysisService` and the
+module registry.
+"""
+
+from farm.analysis.core import BaseAnalysisModule, SimpleDataProcessor, make_analysis_function
+from farm.analysis.validation import ColumnValidator, DataQualityValidator, CompositeValidator
+
+from farm.analysis.genetics.data import process_genetics_data
+from farm.analysis.genetics.analyze import analyze_genetics
+from farm.analysis.genetics.plot import (
+    plot_generation_distribution,
+    plot_fitness_over_generations,
+)
+
+
+class GeneticsModule(BaseAnalysisModule):
+    """Analysis module for agent-genome and chromosome statistics.
+
+    Supports two data sources:
+
+    * **Simulation database** – loads per-agent action weights, generation,
+      and lineage via
+      :func:`~farm.analysis.genetics.compute.build_agent_genetics_dataframe`.
+    * **Evolution-experiment result** – loads per-candidate chromosome values,
+      fitness, and parent IDs via
+      :func:`~farm.analysis.genetics.compute.build_evolution_experiment_dataframe`.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="genetics",
+            description=(
+                "Analysis of agent genomes, chromosomes, lineage, and population-level "
+                "genetic statistics for simulation databases and evolution experiments"
+            ),
+        )
+
+        validator = CompositeValidator(
+            [
+                ColumnValidator(required_columns=[], column_types={}),
+                DataQualityValidator(min_rows=0),
+            ]
+        )
+        self.set_validator(validator)
+
+    def register_functions(self) -> None:
+        """Register all genetics analysis functions."""
+
+        self._functions = {
+            "analyze_genetics": make_analysis_function(analyze_genetics),
+            "plot_generation_distribution": make_analysis_function(plot_generation_distribution),
+            "plot_fitness_over_generations": make_analysis_function(plot_fitness_over_generations),
+        }
+
+        self._groups = {
+            "all": list(self._functions.values()),
+            "analysis": [self._functions["analyze_genetics"]],
+            "plots": [
+                self._functions["plot_generation_distribution"],
+                self._functions["plot_fitness_over_generations"],
+            ],
+            "basic": [
+                self._functions["analyze_genetics"],
+                self._functions["plot_generation_distribution"],
+            ],
+        }
+
+    def get_data_processor(self) -> SimpleDataProcessor:
+        """Return the data processor for genetics analysis."""
+        return SimpleDataProcessor(process_genetics_data)
+
+    def supports_database(self) -> bool:
+        """This module can use a simulation database."""
+        return True
+
+    def get_db_filename(self) -> str:
+        """Database filename used by this module."""
+        return "simulation.db"
+
+
+# Singleton instance consumed by the module registry
+genetics_module = GeneticsModule()

--- a/farm/analysis/genetics/plot.py
+++ b/farm/analysis/genetics/plot.py
@@ -1,0 +1,91 @@
+"""
+Genetics Analysis Visualization
+
+Placeholder visualization functions for the genetics analysis module.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import pandas as pd
+
+from farm.analysis.common.context import AnalysisContext
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def plot_generation_distribution(df: pd.DataFrame, ctx: AnalysisContext, **kwargs: Any) -> Optional[Any]:
+    """Plot the distribution of agents across generations.
+
+    Parameters
+    ----------
+    df:
+        DataFrame produced by
+        :func:`~farm.analysis.genetics.compute.build_agent_genetics_dataframe`.
+    ctx:
+        Analysis context supplying output paths and a logger.
+    """
+    if df.empty or "generation" not in df.columns:
+        logger.warning("plot_generation_distribution: no generation data available")
+        return None
+
+    try:
+        import matplotlib.pyplot as plt
+
+        gen_counts = df["generation"].value_counts().sort_index()
+        fig, ax = plt.subplots(figsize=(10, 6))
+        ax.bar(gen_counts.index.astype(str), gen_counts.values)
+        ax.set_xlabel("Generation")
+        ax.set_ylabel("Agent count")
+        ax.set_title("Agent count by generation")
+
+        output_file = ctx.get_output_file("genetics_generation_distribution.png")
+        fig.savefig(output_file, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        logger.info("Saved generation distribution plot to %s", output_file)
+        return output_file
+    except Exception as exc:
+        logger.warning("plot_generation_distribution failed: %s", exc)
+        return None
+
+
+def plot_fitness_over_generations(df: pd.DataFrame, ctx: AnalysisContext, **kwargs: Any) -> Optional[Any]:
+    """Plot mean and best fitness per generation for evolution-experiment data.
+
+    Parameters
+    ----------
+    df:
+        DataFrame produced by
+        :func:`~farm.analysis.genetics.compute.build_evolution_experiment_dataframe`.
+    ctx:
+        Analysis context supplying output paths and a logger.
+    """
+    if df.empty or "fitness" not in df.columns or "generation" not in df.columns:
+        logger.warning("plot_fitness_over_generations: no fitness/generation data available")
+        return None
+
+    try:
+        import matplotlib.pyplot as plt
+
+        gen_grouped = df.groupby("generation")["fitness"]
+        mean_fitness = gen_grouped.mean()
+        best_fitness = gen_grouped.max()
+
+        fig, ax = plt.subplots(figsize=(10, 6))
+        ax.plot(mean_fitness.index, mean_fitness.values, marker="o", label="Mean fitness")
+        ax.plot(best_fitness.index, best_fitness.values, marker="s", linestyle="--", label="Best fitness")
+        ax.set_xlabel("Generation")
+        ax.set_ylabel("Fitness")
+        ax.set_title("Fitness over generations")
+        ax.legend()
+
+        output_file = ctx.get_output_file("genetics_fitness_over_generations.png")
+        fig.savefig(output_file, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        logger.info("Saved fitness-over-generations plot to %s", output_file)
+        return output_file
+    except Exception as exc:
+        logger.warning("plot_fitness_over_generations failed: %s", exc)
+        return None

--- a/farm/analysis/genetics/plot.py
+++ b/farm/analysis/genetics/plot.py
@@ -6,7 +6,7 @@ Placeholder visualization functions for the genetics analysis module.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import pandas as pd
 

--- a/farm/analysis/genetics/utils.py
+++ b/farm/analysis/genetics/utils.py
@@ -1,0 +1,25 @@
+"""
+Genetics analysis utility helpers.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from farm.database.data_types import GenomeId
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def parse_parent_ids(genome_id: str) -> List[str]:
+    """Return parent agent IDs encoded in ``genome_id``.
+
+    Returns an empty list when parsing fails or the genome ID encodes no
+    parents (e.g. initial agents).
+    """
+    try:
+        return GenomeId.from_string(genome_id).parent_ids
+    except Exception as exc:
+        logger.warning("parse_parent_ids failed for genome_id=%r: %s", genome_id, exc)
+        return []

--- a/farm/analysis/registry.py
+++ b/farm/analysis/registry.py
@@ -232,6 +232,9 @@ def _register_builtin_modules() -> int:
         # Comparative and population analysis modules
         "farm.analysis.population.module.population_module",
         "farm.analysis.comparative.module.comparative_module",
+
+        # Genetics analysis module
+        "farm.analysis.genetics.module.genetics_module",
     ]
 
     count = 0

--- a/farm/analysis/significant_events/compute.py
+++ b/farm/analysis/significant_events/compute.py
@@ -147,13 +147,13 @@ def _detect_agent_births(query_func, start_step: int, end_step: Optional[int]) -
         results = q.all()
         
         # Convert to expected format with parent_id
-        from farm.database.data_types import GenomeId
+        from farm.analysis.genetics.compute import parse_parent_ids
         formatted_results = []
         for result in results:
             try:
                 # Parse genome_id directly from query result
-                genome = GenomeId.from_string(result.genome_id)
-                parent_id = genome.parent_ids[0] if genome.parent_ids else None
+                parent_ids = parse_parent_ids(result.genome_id)
+                parent_id = parent_ids[0] if parent_ids else None
                 formatted_results.append({
                     'step_number': result.step_number,
                     'parent_id': parent_id,

--- a/farm/analysis/significant_events/compute.py
+++ b/farm/analysis/significant_events/compute.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import func, case
 
 from farm.analysis.common.utils import calculate_statistics
+from farm.database.data_types import GenomeId
 from farm.database.models import (
     AgentModel,
     AgentStateModel,
@@ -18,6 +19,9 @@ from farm.database.models import (
     HealthIncident,
     ActionModel,
 )
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
 
 # Event detection thresholds
 POPULATION_CRASH_THRESHOLD = 0.3  # >30% decrease triggers crash detection
@@ -145,30 +149,37 @@ def _detect_agent_births(query_func, start_step: int, end_step: Optional[int]) -
             q = q.filter(AgentModel.birth_time <= end_step)
 
         results = q.all()
-        
+
         # Convert to expected format with parent_id
-        from farm.analysis.genetics.compute import parse_parent_ids
         formatted_results = []
         for result in results:
-            try:
-                # Parse genome_id directly from query result
-                parent_ids = parse_parent_ids(result.genome_id)
-                parent_id = parent_ids[0] if parent_ids else None
-                formatted_results.append({
-                    'step_number': result.step_number,
-                    'parent_id': parent_id,
-                    'offspring_id': result.offspring_id,
-                    'success': True,  # All have birth_time > 0 so successful
-                    'offspring_generation': result.offspring_generation,
-                })
-            except Exception as e:
-                from farm.utils.logging import get_logger
-                logger = get_logger(__name__)
+            if not result.genome_id:
                 logger.warning(
-                    f"Failed to parse genome_id '{result.genome_id}' for offspring agent_id {result.offspring_id}: {e}"
+                    "Skipping birth event: missing genome_id for offspring agent_id %s",
+                    result.offspring_id,
                 )
                 continue
-        
+            try:
+                genome = GenomeId.from_string(result.genome_id)
+            except Exception as e:
+                logger.warning(
+                    "Failed to parse genome_id %r for offspring agent_id %s: %s",
+                    result.genome_id,
+                    result.offspring_id,
+                    e,
+                )
+                continue
+            parent_id = genome.parent_ids[0] if genome.parent_ids else None
+            formatted_results.append(
+                {
+                    "step_number": result.step_number,
+                    "parent_id": parent_id,
+                    "offspring_id": result.offspring_id,
+                    "success": True,  # All have birth_time > 0 so successful
+                    "offspring_generation": result.offspring_generation,
+                }
+            )
+
         events = []
         for result in formatted_results:
             step_number = result['step_number']

--- a/farm/analysis/social_behavior/compute.py
+++ b/farm/analysis/social_behavior/compute.py
@@ -16,6 +16,7 @@ import pandas as pd
 from sqlalchemy import and_, desc, func, or_
 from sqlalchemy.orm import Session
 
+from farm.analysis.genetics.utils import parse_parent_ids
 from farm.core.social_dynamics import (
     compute_social_dynamics_trends,
     per_step_records_for_json,
@@ -759,8 +760,6 @@ def compute_reproduction_social_patterns(session: Session) -> Dict[str, Any]:
         return {"error": "No successful reproduction events found"}
 
     # Parse genome_id to get parent relationships and reconstruct events
-    from farm.analysis.genetics.compute import parse_parent_ids
-    
     reproduction_events = []
     reproduction_steps = set()
     

--- a/farm/analysis/social_behavior/compute.py
+++ b/farm/analysis/social_behavior/compute.py
@@ -759,16 +759,16 @@ def compute_reproduction_social_patterns(session: Session) -> Dict[str, Any]:
         return {"error": "No successful reproduction events found"}
 
     # Parse genome_id to get parent relationships and reconstruct events
-    from farm.database.data_types import GenomeId
+    from farm.analysis.genetics.compute import parse_parent_ids
     
     reproduction_events = []
     reproduction_steps = set()
     
     for offspring in offspring_agents:
         try:
-            genome = GenomeId.from_string(offspring.genome_id)
-            if genome.parent_ids:
-                parent_id = genome.parent_ids[0]  # Use first parent
+            parent_ids = parse_parent_ids(offspring.genome_id)
+            if parent_ids:
+                parent_id = parent_ids[0]  # Use first parent
                 parent = (
                     session.query(AgentModel)
                     .filter(AgentModel.agent_id == parent_id)

--- a/tests/analysis/test_genetics.py
+++ b/tests/analysis/test_genetics.py
@@ -12,8 +12,10 @@ Covers:
 
 from __future__ import annotations
 
+import tempfile
+from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -253,7 +255,7 @@ class TestProcessGeneticsData:
 
     def test_raises_on_unsupported_type(self):
         with pytest.raises(TypeError):
-            process_genetics_data("not supported")
+            process_genetics_data(42)
 
     def test_dispatches_to_db_accessor_for_session(self):
         session = MagicMock()
@@ -267,6 +269,36 @@ class TestProcessGeneticsData:
         result = process_genetics_data(evo_result)
         assert isinstance(result, pd.DataFrame)
         assert list(result.columns) == EVOLUTION_GENETICS_COLUMNS
+
+    def test_dispatches_to_db_accessor_for_path(self, tmp_path):
+        """process_genetics_data should load a simulation.db when given a Path."""
+        db_path = tmp_path / "simulation.db"
+        # Create a minimal sqlite DB so find_database_path succeeds
+        import sqlite3
+        conn = sqlite3.connect(str(db_path))
+        conn.close()
+        with patch(
+            "farm.analysis.genetics.compute.build_agent_genetics_dataframe",
+            return_value=pd.DataFrame(columns=AGENT_GENETICS_COLUMNS),
+        ) as mock_build:
+            result = process_genetics_data(tmp_path)
+        mock_build.assert_called_once()
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == AGENT_GENETICS_COLUMNS
+
+    def test_dispatches_to_db_accessor_for_str_path(self, tmp_path):
+        """process_genetics_data should also accept a str path to the experiment dir."""
+        db_path = tmp_path / "simulation.db"
+        import sqlite3
+        conn = sqlite3.connect(str(db_path))
+        conn.close()
+        with patch(
+            "farm.analysis.genetics.compute.build_agent_genetics_dataframe",
+            return_value=pd.DataFrame(columns=AGENT_GENETICS_COLUMNS),
+        ) as mock_build:
+            result = process_genetics_data(str(tmp_path))
+        mock_build.assert_called_once()
+        assert isinstance(result, pd.DataFrame)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/analysis/test_genetics.py
+++ b/tests/analysis/test_genetics.py
@@ -1,0 +1,306 @@
+"""
+Unit tests for the genetics analysis module.
+
+Covers:
+- parse_parent_ids shared helper
+- build_agent_genetics_dataframe with a tiny fixture DB session
+- build_evolution_experiment_dataframe with mock EvolutionExperimentResult
+- analyze_genetics for both DB-backed and evolution-backed DataFrames
+- GeneticsModule registration and protocol compliance
+- process_genetics_data dispatcher
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from farm.analysis.genetics.compute import (
+    AGENT_GENETICS_COLUMNS,
+    EVOLUTION_GENETICS_COLUMNS,
+    build_agent_genetics_dataframe,
+    build_evolution_experiment_dataframe,
+    parse_parent_ids,
+)
+from farm.analysis.genetics.analyze import analyze_genetics
+from farm.analysis.genetics.data import process_genetics_data
+from farm.analysis.genetics.module import GeneticsModule, genetics_module
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(
+    agent_id: str,
+    agent_type: str = "SystemAgent",
+    generation: int = 0,
+    birth_time: int = 0,
+    death_time: int = None,
+    genome_id: str = "::1",
+    action_weights: dict = None,
+):
+    agent = MagicMock()
+    agent.agent_id = agent_id
+    agent.agent_type = agent_type
+    agent.generation = generation
+    agent.birth_time = birth_time
+    agent.death_time = death_time
+    agent.genome_id = genome_id
+    agent.action_weights = action_weights or {}
+    return agent
+
+
+def _make_evaluation(
+    candidate_id: str,
+    generation: int,
+    fitness: float,
+    parent_ids: tuple = ("seed", "seed"),
+    chromosome_values: dict = None,
+):
+    ev = SimpleNamespace(
+        candidate_id=candidate_id,
+        generation=generation,
+        fitness=fitness,
+        parent_ids=parent_ids,
+        chromosome_values=chromosome_values or {"learning_rate": 0.001, "gamma": 0.99},
+    )
+    return ev
+
+
+# ---------------------------------------------------------------------------
+# parse_parent_ids
+# ---------------------------------------------------------------------------
+
+
+class TestParseParentIds:
+    def test_initial_agent_no_parents(self):
+        assert parse_parent_ids("::1") == []
+
+    def test_single_parent(self):
+        assert parse_parent_ids("agent_a:1") == ["agent_a"]
+
+    def test_two_parents(self):
+        assert parse_parent_ids("agent_a:agent_b:1") == ["agent_a", "agent_b"]
+
+    def test_malformed_returns_empty(self):
+        # Should not raise; returns [] gracefully
+        result = parse_parent_ids("")
+        assert isinstance(result, list)
+
+    def test_no_counter_two_parents(self):
+        result = parse_parent_ids("parent1:parent2")
+        assert "parent1" in result
+        assert "parent2" in result
+
+
+# ---------------------------------------------------------------------------
+# build_agent_genetics_dataframe
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAgentGeneticsDataframe:
+    def _make_session(self, agents):
+        session = MagicMock()
+        session.query.return_value.all.return_value = agents
+        return session
+
+    def test_empty_session_returns_empty_df(self):
+        session = self._make_session([])
+        df = build_agent_genetics_dataframe(session)
+        assert df.empty
+        assert list(df.columns) == AGENT_GENETICS_COLUMNS
+
+    def test_single_genesis_agent(self):
+        agents = [_make_agent("a1", genome_id="::1")]
+        df = build_agent_genetics_dataframe(self._make_session(agents))
+        assert len(df) == 1
+        assert df.iloc[0]["agent_id"] == "a1"
+        assert df.iloc[0]["parent_ids"] == []
+
+    def test_offspring_agent_has_parent_id(self):
+        agents = [_make_agent("child1", generation=1, birth_time=5, genome_id="parent1:1")]
+        df = build_agent_genetics_dataframe(self._make_session(agents))
+        assert df.iloc[0]["parent_ids"] == ["parent1"]
+
+    def test_multiple_agents_all_columns_present(self):
+        agents = [
+            _make_agent("a1", generation=0, genome_id="::1"),
+            _make_agent("a2", generation=0, genome_id="::2"),
+            _make_agent("a3", generation=1, genome_id="a1:1"),
+        ]
+        df = build_agent_genetics_dataframe(self._make_session(agents))
+        assert len(df) == 3
+        assert set(df.columns) == set(AGENT_GENETICS_COLUMNS)
+
+    def test_action_weights_stored_as_dict(self):
+        weights = {"move": 0.5, "gather": 0.5}
+        agents = [_make_agent("a1", action_weights=weights)]
+        df = build_agent_genetics_dataframe(self._make_session(agents))
+        assert df.iloc[0]["action_weights"] == weights
+
+    def test_none_genome_id_gives_empty_parent_ids(self):
+        agents = [_make_agent("a1", genome_id=None)]
+        df = build_agent_genetics_dataframe(self._make_session(agents))
+        assert df.iloc[0]["parent_ids"] == []
+
+
+# ---------------------------------------------------------------------------
+# build_evolution_experiment_dataframe
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEvolutionExperimentDataframe:
+    def _make_result(self, evaluations):
+        result = SimpleNamespace(evaluations=evaluations, generation_summaries=[])
+        return result
+
+    def test_empty_result_returns_empty_df(self):
+        df = build_evolution_experiment_dataframe(self._make_result([]))
+        assert df.empty
+        assert list(df.columns) == EVOLUTION_GENETICS_COLUMNS
+
+    def test_single_evaluation(self):
+        ev = _make_evaluation("g0_c0", generation=0, fitness=42.0)
+        df = build_evolution_experiment_dataframe(self._make_result([ev]))
+        assert len(df) == 1
+        assert df.iloc[0]["candidate_id"] == "g0_c0"
+        assert df.iloc[0]["fitness"] == pytest.approx(42.0)
+
+    def test_multi_generation(self):
+        evals = [
+            _make_evaluation(f"g{g}_c{c}", generation=g, fitness=float(g + c))
+            for g in range(3)
+            for c in range(4)
+        ]
+        df = build_evolution_experiment_dataframe(self._make_result(evals))
+        assert len(df) == 12
+        assert df["generation"].nunique() == 3
+
+    def test_parent_ids_stored_as_list(self):
+        ev = _make_evaluation("g1_c0", generation=1, fitness=5.0, parent_ids=("g0_c1", "g0_c2"))
+        df = build_evolution_experiment_dataframe(self._make_result([ev]))
+        assert df.iloc[0]["parent_ids"] == ["g0_c1", "g0_c2"]
+
+    def test_chromosome_values_stored_as_dict(self):
+        chrom = {"learning_rate": 0.01, "gamma": 0.95, "epsilon_decay": 0.999}
+        ev = _make_evaluation("g0_c0", generation=0, fitness=1.0, chromosome_values=chrom)
+        df = build_evolution_experiment_dataframe(self._make_result([ev]))
+        assert df.iloc[0]["chromosome_values"] == chrom
+
+
+# ---------------------------------------------------------------------------
+# analyze_genetics
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeGenetics:
+    def test_empty_dataframe(self):
+        result = analyze_genetics(pd.DataFrame())
+        assert result["total_agents"] == 0
+
+    def test_db_frame_generation_stats(self):
+        data = {
+            "agent_id": ["a1", "a2", "a3"],
+            "agent_type": ["system", "system", "system"],
+            "generation": [0, 0, 1],
+            "birth_time": [0, 0, 5],
+            "death_time": [None, None, None],
+            "genome_id": ["::1", "::2", "a1:1"],
+            "parent_ids": [[], [], ["a1"]],
+            "action_weights": [{}, {}, {}],
+        }
+        df = pd.DataFrame(data)
+        result = analyze_genetics(df)
+        assert result["total_agents"] == 3
+        assert result["max_generation"] == 1
+        assert result["pct_with_parents"] == pytest.approx(100 / 3, rel=1e-3)
+
+    def test_evolution_frame_fitness_stats(self):
+        data = {
+            "candidate_id": ["c0", "c1", "c2"],
+            "generation": [0, 0, 1],
+            "fitness": [10.0, 20.0, 15.0],
+            "parent_ids": [["seed", "seed"], ["seed", "seed"], ["c1", "c0"]],
+            "chromosome_values": [
+                {"learning_rate": 0.001},
+                {"learning_rate": 0.01},
+                {"learning_rate": 0.005},
+            ],
+        }
+        df = pd.DataFrame(data)
+        result = analyze_genetics(df)
+        assert result["best_fitness"] == pytest.approx(20.0)
+        assert result["mean_fitness"] == pytest.approx(15.0)
+        assert "gene_statistics" in result
+        assert "learning_rate" in result["gene_statistics"]
+
+
+# ---------------------------------------------------------------------------
+# process_genetics_data
+# ---------------------------------------------------------------------------
+
+
+class TestProcessGeneticsData:
+    def test_passthrough_dataframe(self):
+        df = pd.DataFrame({"x": [1, 2]})
+        result = process_genetics_data(df)
+        assert result is df
+
+    def test_raises_on_unsupported_type(self):
+        with pytest.raises(TypeError):
+            process_genetics_data("not supported")
+
+    def test_dispatches_to_db_accessor_for_session(self):
+        session = MagicMock()
+        session.query.return_value.all.return_value = []
+        result = process_genetics_data(session)
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == AGENT_GENETICS_COLUMNS
+
+    def test_dispatches_to_evolution_accessor_for_result(self):
+        evo_result = SimpleNamespace(evaluations=[], generation_summaries=[])
+        result = process_genetics_data(evo_result)
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == EVOLUTION_GENETICS_COLUMNS
+
+
+# ---------------------------------------------------------------------------
+# GeneticsModule
+# ---------------------------------------------------------------------------
+
+
+class TestGeneticsModule:
+    def test_singleton_name(self):
+        assert genetics_module.name == "genetics"
+
+    def test_singleton_is_genetics_module(self):
+        assert isinstance(genetics_module, GeneticsModule)
+
+    def test_supports_database(self):
+        assert genetics_module.supports_database() is True
+
+    def test_get_db_filename(self):
+        assert genetics_module.get_db_filename() == "simulation.db"
+
+    def test_get_data_processor_is_callable(self):
+        proc = genetics_module.get_data_processor()
+        assert callable(proc.process)
+
+    def test_registered_functions_not_empty(self):
+        info = genetics_module.get_info()
+        assert len(info["functions"]) > 0
+
+    def test_function_groups_contain_all_and_analysis(self):
+        groups = genetics_module.get_function_groups()
+        assert "all" in groups
+        assert "analysis" in groups
+
+    def test_protocol_attributes_present(self):
+        required = ["name", "description", "get_data_processor", "get_analysis_functions", "get_function_groups"]
+        for attr in required:
+            assert hasattr(genetics_module, attr), f"Missing attribute: {attr}"

--- a/tests/analysis/test_genetics.py
+++ b/tests/analysis/test_genetics.py
@@ -12,7 +12,7 @@ Covers:
 
 from __future__ import annotations
 
-import tempfile
+import sqlite3
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -274,7 +274,6 @@ class TestProcessGeneticsData:
         """process_genetics_data should load a simulation.db when given a Path."""
         db_path = tmp_path / "simulation.db"
         # Create a minimal sqlite DB so find_database_path succeeds
-        import sqlite3
         conn = sqlite3.connect(str(db_path))
         conn.close()
         with patch(
@@ -289,7 +288,6 @@ class TestProcessGeneticsData:
     def test_dispatches_to_db_accessor_for_str_path(self, tmp_path):
         """process_genetics_data should also accept a str path to the experiment dir."""
         db_path = tmp_path / "simulation.db"
-        import sqlite3
         conn = sqlite3.connect(str(db_path))
         conn.close()
         with patch(

--- a/tests/analysis/test_genetics.py
+++ b/tests/analysis/test_genetics.py
@@ -13,7 +13,7 @@ Covers:
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest

--- a/tests/analysis/test_genetics.py
+++ b/tests/analysis/test_genetics.py
@@ -12,24 +12,25 @@ Covers:
 
 from __future__ import annotations
 
-import sqlite3
-from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
 
 from farm.analysis.genetics.compute import (
     AGENT_GENETICS_COLUMNS,
     EVOLUTION_GENETICS_COLUMNS,
     build_agent_genetics_dataframe,
     build_evolution_experiment_dataframe,
-    parse_parent_ids,
 )
+from farm.analysis.genetics.utils import parse_parent_ids
 from farm.analysis.genetics.analyze import analyze_genetics
 from farm.analysis.genetics.data import process_genetics_data
 from farm.analysis.genetics.module import GeneticsModule, genetics_module
+from farm.database.models import AgentModel, Base
 
 
 # ---------------------------------------------------------------------------
@@ -255,7 +256,7 @@ class TestProcessGeneticsData:
 
     def test_raises_on_unsupported_type(self):
         with pytest.raises(TypeError):
-            process_genetics_data(42)
+            process_genetics_data(12345)
 
     def test_dispatches_to_db_accessor_for_session(self):
         session = MagicMock()
@@ -270,33 +271,27 @@ class TestProcessGeneticsData:
         assert isinstance(result, pd.DataFrame)
         assert list(result.columns) == EVOLUTION_GENETICS_COLUMNS
 
-    def test_dispatches_to_db_accessor_for_path(self, tmp_path):
-        """process_genetics_data should load a simulation.db when given a Path."""
-        db_path = tmp_path / "simulation.db"
-        # Create a minimal sqlite DB so find_database_path succeeds
-        conn = sqlite3.connect(str(db_path))
-        conn.close()
-        with patch(
-            "farm.analysis.genetics.compute.build_agent_genetics_dataframe",
-            return_value=pd.DataFrame(columns=AGENT_GENETICS_COLUMNS),
-        ) as mock_build:
-            result = process_genetics_data(tmp_path)
-        mock_build.assert_called_once()
+    def test_loads_from_experiment_path(self, tmp_path):
+        db_file = tmp_path / "simulation.db"
+        engine = create_engine(f"sqlite:///{db_file}")
+        Base.metadata.create_all(engine)
+        with Session(engine) as session:
+            session.add(
+                AgentModel(
+                    agent_id="agent_path_1",
+                    agent_type="system",
+                    birth_time=0,
+                    genome_id="::1",
+                    generation=0,
+                )
+            )
+            session.commit()
+        engine.dispose()
+
+        result = process_genetics_data(tmp_path)
         assert isinstance(result, pd.DataFrame)
         assert list(result.columns) == AGENT_GENETICS_COLUMNS
-
-    def test_dispatches_to_db_accessor_for_str_path(self, tmp_path):
-        """process_genetics_data should also accept a str path to the experiment dir."""
-        db_path = tmp_path / "simulation.db"
-        conn = sqlite3.connect(str(db_path))
-        conn.close()
-        with patch(
-            "farm.analysis.genetics.compute.build_agent_genetics_dataframe",
-            return_value=pd.DataFrame(columns=AGENT_GENETICS_COLUMNS),
-        ) as mock_build:
-            result = process_genetics_data(str(tmp_path))
-        mock_build.assert_called_once()
-        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -334,3 +329,38 @@ class TestGeneticsModule:
         required = ["name", "description", "get_data_processor", "get_analysis_functions", "get_function_groups"]
         for attr in required:
             assert hasattr(genetics_module, attr), f"Missing attribute: {attr}"
+
+    def test_run_analysis_with_experiment_path(self, tmp_path):
+        db_file = tmp_path / "simulation.db"
+        engine = create_engine(f"sqlite:///{db_file}")
+        Base.metadata.create_all(engine)
+
+        with Session(engine) as session:
+            session.add_all(
+                [
+                    AgentModel(
+                        agent_id="parent_a",
+                        agent_type="system",
+                        birth_time=0,
+                        genome_id="::1",
+                        generation=0,
+                    ),
+                    AgentModel(
+                        agent_id="child_a",
+                        agent_type="system",
+                        birth_time=5,
+                        genome_id="parent_a:1",
+                        generation=1,
+                    ),
+                ]
+            )
+            session.commit()
+        engine.dispose()
+
+        output_dir = tmp_path / "analysis_output"
+        out_path, df = genetics_module.run_analysis(tmp_path, output_dir, group="analysis")
+
+        assert out_path == output_dir
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 2
+        assert set(AGENT_GENETICS_COLUMNS).issubset(df.columns)


### PR DESCRIPTION
This pull request introduces a new genetics analysis module to the codebase, providing a unified and extensible framework for analyzing agent genomes, chromosomes, lineage, and population-level genetic statistics. It centralizes the logic for extracting parent IDs from genome strings, adds high-level analysis functions and plotting support, and integrates the module with the analysis service. Several code locations are updated to use the new shared helper for parent ID parsing, improving maintainability and consistency.

The most important changes are:

**Genetics Analysis Module Implementation:**

* Added a new genetics analysis module with core files: `__init__.py`, `compute.py`, `data.py`, `analyze.py`, and `module.py`. This includes high-level analysis functions, data processing, and module registration for integration with the analysis framework. [[1]](diffhunk://#diff-e48c0a1bfa859d80141b05ad7d1edb99efe3d165a5a3acddfbc8de448e5d1002R1-R38) [[2]](diffhunk://#diff-2a08b3592b2153f944c329b1e31bd49f4b1ea9183d29270e6ef4b7541e7ca8d3R1-R182) [[3]](diffhunk://#diff-ab28ab0544abb3af7aad352e4823a2d1d444928a773c4cfd4ff8ce3b009b07b8R1-R56) [[4]](diffhunk://#diff-a155cf3adb0ae102606b86da9e851d34d68ef7031179574ebda51cfe5c6e29e7R1-R82) [[5]](diffhunk://#diff-92fc7c1c80119c0927702d21f447654b5fa95ef3734f6ebb3d188243de94d251R1-R86)

**Centralization of Parent ID Parsing:**

* Introduced the `parse_parent_ids` helper in `farm/analysis/genetics/compute.py` to standardize extraction of parent agent IDs from genome strings, replacing scattered usage of `GenomeId.from_string` across the codebase.

**Refactoring of Analysis Code to Use Shared Helper:**

* Updated all analysis modules that previously used `GenomeId.from_string` (including `farm/analysis/advantage/compute.py`, `farm/analysis/dominance/data.py`, and `farm/analysis/genesis/compute.py`) to use the new `parse_parent_ids` helper for improved clarity and maintainability. [[1]](diffhunk://#diff-498ae7fdc63c6d7b0df705933b2102dccfc3936138946e45203c8b349c5cead6L444-R444) [[2]](diffhunk://#diff-498ae7fdc63c6d7b0df705933b2102dccfc3936138946e45203c8b349c5cead6L468-R470) [[3]](diffhunk://#diff-498ae7fdc63c6d7b0df705933b2102dccfc3936138946e45203c8b349c5cead6L506-R508) [[4]](diffhunk://#diff-1f04d628775a07eeeff6f9edff935fa6ca8abfa5a994779564ad1afcb8157bfaL6-R6) [[5]](diffhunk://#diff-1f04d628775a07eeeff6f9edff935fa6ca8abfa5a994779564ad1afcb8157bfaL241-R243) [[6]](diffhunk://#diff-1f04d628775a07eeeff6f9edff935fa6ca8abfa5a994779564ad1afcb8157bfaL302-R306) [[7]](diffhunk://#diff-01ff2fc23d3a80241480f9876eb5dcd10ff648f19c06375610d40877f8dc48c5L938-R946) [[8]](diffhunk://#diff-01ff2fc23d3a80241480f9876eb5dcd10ff648f19c06375610d40877f8dc48c5L1183-R1193)

These changes lay the groundwork for robust and extensible genetics analysis, ensuring consistent handling of genome lineage and facilitating future enhancements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new built-in analysis module (with DataFrame building, stats, and plotting) and wires it into the registry, which can affect module discovery/runtime dependencies (e.g., pandas/matplotlib). Refactors several analysis paths to use a new `parse_parent_ids` wrapper, so any behavior change in genome parsing now propagates across reproduction-related metrics.
> 
> **Overview**
> Adds a new `genetics` analysis module that can load population genetics data from either a simulation DB session or an evolution-experiment result, normalize it into DataFrames, compute summary stats (`analyze_genetics`), and emit basic plots.
> 
> Centralizes genome lineage parsing via `parse_parent_ids` (a guarded wrapper around `GenomeId.from_string`) and updates multiple reproduction-related computations (advantage, dominance, genesis, significant events, social behavior) to use this shared helper. Registers the new module as a built-in in `analysis/registry.py` and adds comprehensive unit tests for the new module and helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be59d4e4b134ff8bde081c12270a905e69b909a9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->