### PR TITLE
Add genotypic diversity metrics for analysis

### DIFF
--- a/farm/analysis/genetics/__init__.py
+++ b/farm/analysis/genetics/__init__.py
@@ -10,6 +10,7 @@ Features:
 - DB-backed population accessor (action weights, generation, lineage)
 - Evolution-experiment-backed population accessor (chromosome values, fitness)
 - Normalized DataFrame output for both sources
+- Genotypic diversity metrics: heterozygosity, Shannon entropy, per-locus stats
 
 Quick Start::
 
@@ -17,21 +18,43 @@ Quick Start::
     ...     parse_parent_ids,
     ...     build_agent_genetics_dataframe,
     ...     build_evolution_experiment_dataframe,
+    ...     compute_continuous_locus_diversity,
+    ...     compute_categorical_locus_diversity,
+    ...     compute_population_diversity,
+    ...     compute_evolution_diversity_timeseries,
     ... )
 """
 
 from farm.analysis.genetics.utils import parse_parent_ids
 from farm.analysis.genetics.compute import (
+    ContinuousLocusDiversity,
+    CategoricalLocusDiversity,
+    PopulationDiversitySummary,
     build_agent_genetics_dataframe,
     build_evolution_experiment_dataframe,
+    compute_continuous_locus_diversity,
+    compute_categorical_locus_diversity,
+    compute_population_diversity,
+    compute_evolution_diversity_timeseries,
 )
 from farm.analysis.genetics.analyze import analyze_genetics
 from farm.analysis.genetics.module import genetics_module, GeneticsModule
 
 __all__ = [
     "parse_parent_ids",
+    # DataFrame accessors
     "build_agent_genetics_dataframe",
     "build_evolution_experiment_dataframe",
+    # Diversity result types
+    "ContinuousLocusDiversity",
+    "CategoricalLocusDiversity",
+    "PopulationDiversitySummary",
+    # Diversity computation functions
+    "compute_continuous_locus_diversity",
+    "compute_categorical_locus_diversity",
+    "compute_population_diversity",
+    "compute_evolution_diversity_timeseries",
+    # High-level analysis
     "analyze_genetics",
     "genetics_module",
     "GeneticsModule",

--- a/farm/analysis/genetics/analyze.py
+++ b/farm/analysis/genetics/analyze.py
@@ -7,6 +7,7 @@ produced by the genetics compute layer.
 
 from __future__ import annotations
 
+import math
 from typing import Any, Dict
 
 import pandas as pd
@@ -64,18 +65,40 @@ def analyze_genetics(df: pd.DataFrame) -> Dict[str, Any]:
         result["min_fitness"] = float(df["fitness"].min())
 
     if "chromosome_values" in df.columns and not df["chromosome_values"].empty:
-        all_keys: set = set()
-        df["chromosome_values"].apply(lambda d: all_keys.update(d.keys()))
+        values_by_gene: Dict[str, list] = {}
+        skipped_rows = 0
+        skipped_values = 0
+        for row in df["chromosome_values"]:
+            if not isinstance(row, dict):
+                skipped_rows += 1
+                continue
+            for gene, raw_value in row.items():
+                try:
+                    numeric_value = float(raw_value)
+                except (TypeError, ValueError):
+                    skipped_values += 1
+                    continue
+                if not math.isfinite(numeric_value):
+                    skipped_values += 1
+                    continue
+                values_by_gene.setdefault(gene, []).append(numeric_value)
+
+        if skipped_rows or skipped_values:
+            logger.warning(
+                "analyze_genetics: skipped malformed chromosome data rows=%d values=%d",
+                skipped_rows,
+                skipped_values,
+            )
+
         gene_stats: Dict[str, Any] = {}
-        for gene in sorted(all_keys):
-            values = df["chromosome_values"].apply(lambda d: d.get(gene))
-            valid = values.dropna()
-            if not valid.empty:
+        for gene, values in sorted(values_by_gene.items()):
+            series = pd.Series(values, dtype=float)
+            if not series.empty:
                 gene_stats[gene] = {
-                    "mean": float(valid.mean()),
-                    "std": float(valid.std(ddof=0)),
-                    "min": float(valid.min()),
-                    "max": float(valid.max()),
+                    "mean": float(series.mean()),
+                    "std": float(series.std(ddof=0)),
+                    "min": float(series.min()),
+                    "max": float(series.max()),
                 }
         result["gene_statistics"] = gene_stats
 

--- a/farm/analysis/genetics/compute.py
+++ b/farm/analysis/genetics/compute.py
@@ -2,14 +2,18 @@
 Genetics Analysis Computation
 
 Core computation functions for the genetics analysis module, including the
-shared ``parse_parent_ids`` helper and population-level accessors for both
-simulation-database and evolution-experiment data sources.
+shared ``parse_parent_ids`` helper, population-level accessors for both
+simulation-database and evolution-experiment data sources, and genotypic
+diversity metrics (heterozygosity, Shannon entropy, per-locus stats).
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, TYPE_CHECKING
+import math
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, TYPE_CHECKING
 
+import numpy as np
 import pandas as pd
 
 from farm.analysis.genetics.utils import parse_parent_ids
@@ -20,6 +24,130 @@ if TYPE_CHECKING:
     from farm.runners.evolution_experiment import EvolutionExperimentResult
 
 logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Diversity metric result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ContinuousLocusDiversity:
+    """Diversity metrics for a single continuous locus (hyperparameter gene).
+
+    Computed from N individuals' values for one gene.
+
+    Attributes
+    ----------
+    locus_name:
+        Identifier for this locus/gene.
+    n_individuals:
+        Number of individuals contributing data.
+    mean:
+        Population mean: ``μ = (1/N) Σ xᵢ``.
+    std:
+        Population standard deviation (ddof=0): ``σ = sqrt((1/N) Σ (xᵢ-μ)²)``.
+    normalized_variance:
+        Variance normalized by squared range span:
+        ``V̂ = Var(x) / span²`` where ``span = max_bound - min_bound``.
+        ``nan`` when bounds are not provided or span is zero.
+    coefficient_of_variation:
+        Relative spread: ``CV = σ / |μ|``.
+        ``nan`` when mean is zero or ``n_individuals`` is 0.
+    range_occupancy:
+        Fraction of the allowed range actually used:
+        ``R = (max(x) - min(x)) / span``.
+        ``nan`` when bounds are not provided; ``0.0`` when span is zero.
+    shannon_entropy:
+        Histogram-based Shannon entropy:
+        ``H = -Σᵢ pᵢ ln(pᵢ)`` where ``pᵢ`` are bin-frequency probabilities.
+        ``None`` when entropy computation was not requested
+        (``compute_entropy=False``).
+    """
+
+    locus_name: str
+    n_individuals: int
+    mean: float
+    std: float
+    normalized_variance: float
+    coefficient_of_variation: float
+    range_occupancy: float
+    shannon_entropy: Optional[float]
+
+
+@dataclass(frozen=True)
+class CategoricalLocusDiversity:
+    """Diversity metrics for a categorical/weighted locus (action weights).
+
+    Uses the population-mean allele frequencies
+    ``p_i = mean_j(w_{ij})`` (renormalized to sum to 1) as inputs to all
+    formulas.
+
+    Attributes
+    ----------
+    locus_name:
+        Identifier for this locus (e.g. ``"action_weights"``).
+    n_individuals:
+        Number of individuals contributing data.
+    allele_frequencies:
+        Mapping from category (action) name to population-mean frequency.
+    shannon_entropy:
+        ``H = -Σᵢ pᵢ ln(pᵢ)`` (nats).
+        Zero for a monomorphic locus (single non-zero category).
+    simpson_index:
+        ``D = Σᵢ pᵢ²``.
+        One for a monomorphic locus; minimum of ``1/k`` for ``k`` uniform
+        categories.
+    expected_heterozygosity:
+        ``He = 1 - Σᵢ pᵢ²``.
+        Zero for a monomorphic locus; maximum of ``1 - 1/k`` for ``k``
+        equally-weighted categories.
+    """
+
+    locus_name: str
+    n_individuals: int
+    allele_frequencies: Dict[str, float]
+    shannon_entropy: float
+    simpson_index: float
+    expected_heterozygosity: float
+
+
+@dataclass(frozen=True)
+class PopulationDiversitySummary:
+    """Aggregated diversity summary across all loci for a population snapshot.
+
+    Attributes
+    ----------
+    n_individuals:
+        Number of individuals in the snapshot.
+    continuous_loci:
+        Per-locus diversity for each continuous (hyperparameter) gene,
+        keyed by gene name.
+    categorical_loci:
+        Per-locus diversity for each categorical (action-weight) group,
+        keyed by locus name.
+    mean_normalized_variance:
+        Mean ``normalized_variance`` across all continuous loci, excluding
+        ``nan`` values.  ``nan`` when no finite values are available.
+    mean_coefficient_of_variation:
+        Mean ``coefficient_of_variation`` across all continuous loci,
+        excluding ``nan`` values.  ``nan`` when none are available.
+    mean_shannon_entropy:
+        Mean Shannon entropy across *all* loci (continuous histogram entropy
+        when requested, plus all categorical loci).  ``nan`` when none are
+        available.
+    mean_heterozygosity:
+        Mean ``expected_heterozygosity`` across categorical loci.
+        ``nan`` when no categorical loci exist.
+    """
+
+    n_individuals: int
+    continuous_loci: Dict[str, ContinuousLocusDiversity] = field(default_factory=dict)
+    categorical_loci: Dict[str, CategoricalLocusDiversity] = field(default_factory=dict)
+    mean_normalized_variance: float = float("nan")
+    mean_coefficient_of_variation: float = float("nan")
+    mean_shannon_entropy: float = float("nan")
+    mean_heterozygosity: float = float("nan")
 
 
 # ---------------------------------------------------------------------------
@@ -142,3 +270,368 @@ def build_evolution_experiment_dataframe(result: "EvolutionExperimentResult") ->
         df["generation"].nunique(),
     )
     return df
+
+
+# ---------------------------------------------------------------------------
+# Diversity metric computation
+# ---------------------------------------------------------------------------
+
+
+def compute_continuous_locus_diversity(
+    values: Sequence[float],
+    locus_name: str,
+    bounds: Optional[Tuple[float, float]] = None,
+    entropy_bins: int = 10,
+    compute_entropy: bool = False,
+) -> ContinuousLocusDiversity:
+    """Compute diversity metrics for a single continuous locus.
+
+    Parameters
+    ----------
+    values:
+        Per-individual values for this locus.  Must be non-empty.
+    locus_name:
+        Name used in the returned :class:`ContinuousLocusDiversity` object.
+    bounds:
+        Optional ``(min_value, max_value)`` defining the full allowed range.
+        Required for :attr:`~ContinuousLocusDiversity.normalized_variance`
+        and :attr:`~ContinuousLocusDiversity.range_occupancy` to be finite.
+    entropy_bins:
+        Number of equal-width histogram bins used when computing optional
+        Shannon entropy.  Ignored when ``compute_entropy=False``.
+    compute_entropy:
+        When ``True``, compute the histogram-based Shannon entropy and
+        populate :attr:`~ContinuousLocusDiversity.shannon_entropy`.
+
+    Returns
+    -------
+    ContinuousLocusDiversity
+
+    Raises
+    ------
+    ValueError
+        When ``values`` is empty.
+
+    Notes
+    -----
+    * Population variance (``ddof=0``) is used throughout.
+    * Histogram bins span ``[bounds[0], bounds[1]]`` when bounds are given,
+      otherwise span the observed data range.
+    * Zero-count bins are excluded from entropy (convention: ``0 ln 0 = 0``).
+    """
+    arr = np.asarray(values, dtype=float)
+    if len(arr) == 0:
+        raise ValueError(
+            f"compute_continuous_locus_diversity: no values for locus {locus_name!r}"
+        )
+
+    n = int(len(arr))
+    mean_val = float(np.mean(arr))
+    std_val = float(np.std(arr, ddof=0))
+    var_val = float(np.var(arr, ddof=0))
+
+    # Normalized variance: V̂ = Var(x) / span²
+    if bounds is not None:
+        span = bounds[1] - bounds[0]
+        normalized_variance = var_val / (span ** 2) if span > 0.0 else float("nan")
+    else:
+        normalized_variance = float("nan")
+
+    # Coefficient of variation: CV = σ / |μ|
+    if abs(mean_val) > 0.0:
+        coefficient_of_variation = std_val / abs(mean_val)
+    else:
+        coefficient_of_variation = float("nan")
+
+    # Range occupancy: R = (max(x) - min(x)) / span
+    observed_range = float(np.max(arr) - np.min(arr))
+    if bounds is not None:
+        span = bounds[1] - bounds[0]
+        range_occupancy = observed_range / span if span > 0.0 else 0.0
+    else:
+        range_occupancy = float("nan")
+
+    # Optional histogram-based Shannon entropy: H = -Σ pᵢ ln(pᵢ)
+    shannon_entropy: Optional[float] = None
+    if compute_entropy:
+        if bounds is not None:
+            bin_edges = np.linspace(bounds[0], bounds[1], entropy_bins + 1)
+            counts, _ = np.histogram(arr, bins=bin_edges)
+        else:
+            counts, _ = np.histogram(arr, bins=entropy_bins)
+        total = int(counts.sum())
+        if total > 0:
+            probs = counts[counts > 0] / total
+            shannon_entropy = float(-np.sum(probs * np.log(probs)))
+        else:
+            shannon_entropy = 0.0
+
+    return ContinuousLocusDiversity(
+        locus_name=locus_name,
+        n_individuals=n,
+        mean=mean_val,
+        std=std_val,
+        normalized_variance=normalized_variance,
+        coefficient_of_variation=coefficient_of_variation,
+        range_occupancy=range_occupancy,
+        shannon_entropy=shannon_entropy,
+    )
+
+
+def compute_categorical_locus_diversity(
+    weight_vectors: Sequence[Mapping[str, float]],
+    locus_name: str = "action_weights",
+) -> CategoricalLocusDiversity:
+    """Compute diversity metrics for a categorical/weighted locus.
+
+    Treats the population-mean action weights as allele frequencies and
+    applies standard population-genetics diversity formulas.
+
+    Parameters
+    ----------
+    weight_vectors:
+        Per-individual weight dicts ``{action_name: weight}``.
+        Must be non-empty; individuals with all-zero weights are included
+        (their zero contributions do not affect population-mean frequencies).
+    locus_name:
+        Name used in the returned :class:`CategoricalLocusDiversity` object.
+
+    Returns
+    -------
+    CategoricalLocusDiversity
+
+    Raises
+    ------
+    ValueError
+        When ``weight_vectors`` is empty.
+
+    Notes
+    -----
+    * Population-mean frequencies are renormalized to sum to 1 to guard
+      against floating-point rounding errors.
+    * When all mean weights are zero (degenerate input), a uniform
+      distribution over the observed categories is assumed.
+    * Zero-frequency categories contribute 0 to entropy (convention:
+      ``0 ln 0 = 0``).
+    """
+    if not weight_vectors:
+        raise ValueError(
+            f"compute_categorical_locus_diversity: no weight vectors for locus {locus_name!r}"
+        )
+
+    n = len(weight_vectors)
+
+    # Collect union of all action names
+    all_actions: List[str] = sorted(
+        {action for wv in weight_vectors for action in wv}
+    )
+
+    # Compute mean weight per action
+    mean_weights: Dict[str, float] = {
+        action: sum(float(wv.get(action, 0.0)) for wv in weight_vectors) / n
+        for action in all_actions
+    }
+
+    # Renormalize to guard against rounding
+    total_weight = sum(mean_weights.values())
+    if total_weight > 0.0:
+        allele_frequencies: Dict[str, float] = {
+            a: w / total_weight for a, w in mean_weights.items()
+        }
+    else:
+        # Degenerate: all zeros – fall back to uniform distribution
+        k = len(all_actions)
+        allele_frequencies = {a: 1.0 / k for a in all_actions} if k > 0 else {}
+
+    freqs = list(allele_frequencies.values())
+
+    # Shannon entropy: H = -Σᵢ pᵢ ln(pᵢ)
+    shannon_entropy = -sum(p * math.log(p) for p in freqs if p > 0.0)
+
+    # Simpson index: D = Σᵢ pᵢ²
+    simpson_index = sum(p ** 2 for p in freqs)
+
+    # Expected heterozygosity: He = 1 - Σᵢ pᵢ²
+    expected_heterozygosity = 1.0 - simpson_index
+
+    return CategoricalLocusDiversity(
+        locus_name=locus_name,
+        n_individuals=n,
+        allele_frequencies=allele_frequencies,
+        shannon_entropy=shannon_entropy,
+        simpson_index=simpson_index,
+        expected_heterozygosity=expected_heterozygosity,
+    )
+
+
+def compute_population_diversity(
+    df: pd.DataFrame,
+    gene_bounds: Optional[Mapping[str, Tuple[float, float]]] = None,
+    entropy_bins: int = 10,
+    compute_continuous_entropy: bool = False,
+) -> PopulationDiversitySummary:
+    """Compute genotypic diversity metrics across a population snapshot.
+
+    Accepts both DB-backed DataFrames (with an ``action_weights`` column
+    produced by :func:`build_agent_genetics_dataframe`) and
+    evolution-experiment DataFrames (with a ``chromosome_values`` column
+    produced by :func:`build_evolution_experiment_dataframe`).
+
+    Parameters
+    ----------
+    df:
+        Population snapshot DataFrame.  Recognised column sets:
+
+        - ``action_weights``: column of ``{action: weight}`` dicts →
+          categorical diversity via :func:`compute_categorical_locus_diversity`.
+        - ``chromosome_values``: column of ``{gene: value}`` dicts →
+          continuous diversity via :func:`compute_continuous_locus_diversity`.
+
+        Both columns can be present simultaneously.
+    gene_bounds:
+        Optional mapping from gene name to ``(min_value, max_value)`` used
+        to compute :attr:`~ContinuousLocusDiversity.normalized_variance` and
+        :attr:`~ContinuousLocusDiversity.range_occupancy`.
+    entropy_bins:
+        Number of histogram bins for optional continuous locus entropy.
+    compute_continuous_entropy:
+        When ``True``, compute histogram Shannon entropy for each continuous
+        locus and include it in :attr:`~PopulationDiversitySummary.mean_shannon_entropy`.
+
+    Returns
+    -------
+    PopulationDiversitySummary
+        Empty (zero individuals, all ``nan`` summaries) when *df* is empty.
+    """
+    n = len(df)
+
+    if n == 0:
+        return PopulationDiversitySummary(n_individuals=0)
+
+    bounds_map: Mapping[str, Tuple[float, float]] = gene_bounds or {}
+    continuous_loci: Dict[str, ContinuousLocusDiversity] = {}
+    categorical_loci: Dict[str, CategoricalLocusDiversity] = {}
+
+    # --- Continuous loci: chromosome_values column ---
+    if "chromosome_values" in df.columns:
+        all_genes: set = set()
+        for row in df["chromosome_values"]:
+            if isinstance(row, dict):
+                all_genes.update(row.keys())
+        for gene in sorted(all_genes):
+            values = [
+                float(row[gene])
+                for row in df["chromosome_values"]
+                if isinstance(row, dict) and gene in row
+            ]
+            if values:
+                locus = compute_continuous_locus_diversity(
+                    values,
+                    locus_name=gene,
+                    bounds=bounds_map.get(gene),
+                    entropy_bins=entropy_bins,
+                    compute_entropy=compute_continuous_entropy,
+                )
+                continuous_loci[gene] = locus
+
+    # --- Categorical loci: action_weights column ---
+    if "action_weights" in df.columns:
+        weight_vectors = [
+            row
+            for row in df["action_weights"]
+            if isinstance(row, dict) and len(row) > 0
+        ]
+        if weight_vectors:
+            cat_locus = compute_categorical_locus_diversity(
+                weight_vectors, locus_name="action_weights"
+            )
+            categorical_loci["action_weights"] = cat_locus
+
+    # --- Population-level summaries ---
+    norm_vars = [
+        locus.normalized_variance
+        for locus in continuous_loci.values()
+        if not math.isnan(locus.normalized_variance)
+    ]
+    mean_normalized_variance = float(np.mean(norm_vars)) if norm_vars else float("nan")
+
+    cvs = [
+        locus.coefficient_of_variation
+        for locus in continuous_loci.values()
+        if not math.isnan(locus.coefficient_of_variation)
+    ]
+    mean_coefficient_of_variation = float(np.mean(cvs)) if cvs else float("nan")
+
+    # Mean Shannon entropy aggregates continuous (when requested) + categorical
+    entropies: List[float] = []
+    for locus in continuous_loci.values():
+        if locus.shannon_entropy is not None:
+            entropies.append(locus.shannon_entropy)
+    for locus in categorical_loci.values():
+        entropies.append(locus.shannon_entropy)
+    mean_shannon_entropy = float(np.mean(entropies)) if entropies else float("nan")
+
+    hets = [locus.expected_heterozygosity for locus in categorical_loci.values()]
+    mean_heterozygosity = float(np.mean(hets)) if hets else float("nan")
+
+    return PopulationDiversitySummary(
+        n_individuals=n,
+        continuous_loci=continuous_loci,
+        categorical_loci=categorical_loci,
+        mean_normalized_variance=mean_normalized_variance,
+        mean_coefficient_of_variation=mean_coefficient_of_variation,
+        mean_shannon_entropy=mean_shannon_entropy,
+        mean_heterozygosity=mean_heterozygosity,
+    )
+
+
+def compute_evolution_diversity_timeseries(
+    result: "EvolutionExperimentResult",
+    gene_bounds: Optional[Mapping[str, Tuple[float, float]]] = None,
+    entropy_bins: int = 10,
+    compute_continuous_entropy: bool = False,
+) -> List[Dict[str, Any]]:
+    """Compute per-generation diversity metrics from an EvolutionExperimentResult.
+
+    Groups candidate evaluations by generation and applies
+    :func:`compute_population_diversity` to each group.
+
+    Parameters
+    ----------
+    result:
+        A completed :class:`~farm.runners.evolution_experiment.EvolutionExperimentResult`.
+    gene_bounds:
+        Optional mapping from gene name to ``(min_value, max_value)`` for
+        normalizing continuous diversity metrics.
+    entropy_bins:
+        Number of histogram bins for optional continuous locus entropy.
+    compute_continuous_entropy:
+        When ``True``, compute histogram entropy for continuous loci.
+
+    Returns
+    -------
+    list of dict
+        Each element is ``{"generation": int, "diversity": PopulationDiversitySummary}``,
+        sorted by generation in ascending order.
+        Returns an empty list when *result* contains no evaluations.
+    """
+    df = build_evolution_experiment_dataframe(result)
+    if df.empty:
+        return []
+
+    rows: List[Dict[str, Any]] = []
+    for gen, group in df.groupby("generation"):
+        summary = compute_population_diversity(
+            group.reset_index(drop=True),
+            gene_bounds=gene_bounds,
+            entropy_bins=entropy_bins,
+            compute_continuous_entropy=compute_continuous_entropy,
+        )
+        rows.append({"generation": int(gen), "diversity": summary})
+
+    rows.sort(key=lambda r: r["generation"])
+    logger.info(
+        "compute_evolution_diversity_timeseries: computed diversity for %d generation(s)",
+        len(rows),
+    )
+    return rows

--- a/farm/analysis/genetics/compute.py
+++ b/farm/analysis/genetics/compute.py
@@ -319,6 +319,17 @@ def compute_continuous_locus_diversity(
       otherwise span the observed data range.
     * Zero-count bins are excluded from entropy (convention: ``0 ln 0 = 0``).
     """
+    if bounds is not None and bounds[0] >= bounds[1]:
+        raise ValueError(
+            f"compute_continuous_locus_diversity: bounds must satisfy bounds[0] < bounds[1], "
+            f"got {bounds!r} for locus {locus_name!r}"
+        )
+    if compute_entropy and entropy_bins < 1:
+        raise ValueError(
+            f"compute_continuous_locus_diversity: entropy_bins must be >= 1, "
+            f"got {entropy_bins!r} for locus {locus_name!r}"
+        )
+
     arr = np.asarray(values, dtype=float)
     if len(arr) == 0:
         raise ValueError(
@@ -426,6 +437,12 @@ def compute_categorical_locus_diversity(
         {action for wv in weight_vectors for action in wv}
     )
 
+    if not all_actions:
+        raise ValueError(
+            f"compute_categorical_locus_diversity: weight_vectors contain no categories "
+            f"for locus {locus_name!r} (all dicts are empty)"
+        )
+
     # Compute mean weight per action
     mean_weights: Dict[str, float] = {
         action: sum(float(wv.get(action, 0.0)) for wv in weight_vectors) / n
@@ -519,11 +536,17 @@ def compute_population_diversity(
             if isinstance(row, dict):
                 all_genes.update(row.keys())
         for gene in sorted(all_genes):
-            values = [
-                float(row[gene])
-                for row in df["chromosome_values"]
-                if isinstance(row, dict) and gene in row
-            ]
+            values: List[float] = []
+            for row in df["chromosome_values"]:
+                if not isinstance(row, dict) or gene not in row:
+                    continue
+                raw_value = row[gene]
+                try:
+                    numeric_value = float(raw_value)
+                except (TypeError, ValueError):
+                    continue
+                if math.isfinite(numeric_value):
+                    values.append(numeric_value)
             if values:
                 locus = compute_continuous_locus_diversity(
                     values,

--- a/farm/analysis/genetics/compute.py
+++ b/farm/analysis/genetics/compute.py
@@ -317,6 +317,9 @@ def compute_continuous_locus_diversity(
     * Population variance (``ddof=0``) is used throughout.
     * Histogram bins span ``[bounds[0], bounds[1]]`` when bounds are given,
       otherwise span the observed data range.
+    * When bounds are provided and entropy is requested, out-of-range values
+      are clipped to the nearest bound before histogramming so all individuals
+      contribute to entropy.
     * Zero-count bins are excluded from entropy (convention: ``0 ln 0 = 0``).
     """
     if bounds is not None and bounds[0] >= bounds[1]:
@@ -358,7 +361,7 @@ def compute_continuous_locus_diversity(
     observed_range = float(np.max(arr) - np.min(arr))
     if bounds is not None:
         span = bounds[1] - bounds[0]
-        range_occupancy = observed_range / span if span > 0.0 else 0.0
+        range_occupancy = min(observed_range / span, 1.0) if span > 0.0 else 0.0
     else:
         range_occupancy = float("nan")
 
@@ -366,8 +369,22 @@ def compute_continuous_locus_diversity(
     shannon_entropy: Optional[float] = None
     if compute_entropy:
         if bounds is not None:
+            lower, upper = bounds
+            below_bounds = int(np.sum(arr < lower))
+            above_bounds = int(np.sum(arr > upper))
+            if below_bounds or above_bounds:
+                logger.warning(
+                    "compute_continuous_locus_diversity: clipped %d value(s) for locus %r to fit bounds %r "
+                    "(below=%d, above=%d)",
+                    below_bounds + above_bounds,
+                    locus_name,
+                    bounds,
+                    below_bounds,
+                    above_bounds,
+                )
+            arr_for_entropy = np.clip(arr, lower, upper)
             bin_edges = np.linspace(bounds[0], bounds[1], entropy_bins + 1)
-            counts, _ = np.histogram(arr, bins=bin_edges)
+            counts, _ = np.histogram(arr_for_entropy, bins=bin_edges)
         else:
             counts, _ = np.histogram(arr, bins=entropy_bins)
         total = int(counts.sum())

--- a/farm/analysis/significant_events/compute.py
+++ b/farm/analysis/significant_events/compute.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import func, case
 
 from farm.analysis.common.utils import calculate_statistics
-from farm.database.data_types import GenomeId
+from farm.analysis.genetics.utils import parse_parent_ids
 from farm.database.models import (
     AgentModel,
     AgentStateModel,
@@ -159,17 +159,8 @@ def _detect_agent_births(query_func, start_step: int, end_step: Optional[int]) -
                     result.offspring_id,
                 )
                 continue
-            try:
-                genome = GenomeId.from_string(result.genome_id)
-            except Exception as e:
-                logger.warning(
-                    "Failed to parse genome_id %r for offspring agent_id %s: %s",
-                    result.genome_id,
-                    result.offspring_id,
-                    e,
-                )
-                continue
-            parent_id = genome.parent_ids[0] if genome.parent_ids else None
+            parent_ids = parse_parent_ids(result.genome_id)
+            parent_id = parent_ids[0] if parent_ids else None
             formatted_results.append(
                 {
                     "step_number": result.step_number,

--- a/tests/analysis/test_genetics.py
+++ b/tests/analysis/test_genetics.py
@@ -8,10 +8,13 @@ Covers:
 - analyze_genetics for both DB-backed and evolution-backed DataFrames
 - GeneticsModule registration and protocol compliance
 - process_genetics_data dispatcher
+- Diversity metrics: ContinuousLocusDiversity, CategoricalLocusDiversity,
+  PopulationDiversitySummary, and timeseries computation
 """
 
 from __future__ import annotations
 
+import math
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -25,6 +28,10 @@ from farm.analysis.genetics.compute import (
     EVOLUTION_GENETICS_COLUMNS,
     build_agent_genetics_dataframe,
     build_evolution_experiment_dataframe,
+    compute_categorical_locus_diversity,
+    compute_continuous_locus_diversity,
+    compute_evolution_diversity_timeseries,
+    compute_population_diversity,
 )
 from farm.analysis.genetics.utils import parse_parent_ids
 from farm.analysis.genetics.analyze import analyze_genetics
@@ -364,3 +371,345 @@ class TestGeneticsModule:
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 2
         assert set(AGENT_GENETICS_COLUMNS).issubset(df.columns)
+
+
+# ---------------------------------------------------------------------------
+# Diversity metrics
+# ---------------------------------------------------------------------------
+
+
+class TestContinuousLocusDiversity:
+    """Tests for compute_continuous_locus_diversity."""
+
+    # --- Degenerate cases ---
+
+    def test_single_individual_zero_variance(self):
+        result = compute_continuous_locus_diversity([0.1], "lr", bounds=(0.0, 1.0))
+        assert result.std == pytest.approx(0.0)
+        assert result.normalized_variance == pytest.approx(0.0)
+        assert result.coefficient_of_variation == pytest.approx(0.0)
+        assert result.range_occupancy == pytest.approx(0.0)
+
+    def test_identical_population_zero_diversity(self):
+        values = [0.1, 0.1, 0.1, 0.1]
+        result = compute_continuous_locus_diversity(values, "lr", bounds=(0.0, 1.0))
+        assert result.std == pytest.approx(0.0)
+        assert result.normalized_variance == pytest.approx(0.0)
+        assert result.range_occupancy == pytest.approx(0.0)
+
+    def test_empty_values_raises(self):
+        with pytest.raises(ValueError, match="no values"):
+            compute_continuous_locus_diversity([], "lr")
+
+    # --- Hand-computed fixture: values=[0.1, 0.2, 0.3], bounds=(0.0, 1.0) ---
+    # mean = 0.2
+    # var  = ((0.1-0.2)² + (0.2-0.2)² + (0.3-0.2)²) / 3 = 0.02/3
+    # std  = sqrt(0.02/3) ≈ 0.081650
+    # normalized_variance = 0.02/3 / 1.0² ≈ 0.006667
+    # CV   = sqrt(0.02/3) / 0.2 ≈ 0.40825
+    # range_occupancy = (0.3 - 0.1) / 1.0 = 0.2
+
+    def test_fixture_mean(self):
+        r = compute_continuous_locus_diversity([0.1, 0.2, 0.3], "lr", bounds=(0.0, 1.0))
+        assert r.mean == pytest.approx(0.2)
+
+    def test_fixture_std(self):
+        r = compute_continuous_locus_diversity([0.1, 0.2, 0.3], "lr", bounds=(0.0, 1.0))
+        assert r.std == pytest.approx((0.02 / 3) ** 0.5, rel=1e-6)
+
+    def test_fixture_normalized_variance(self):
+        r = compute_continuous_locus_diversity([0.1, 0.2, 0.3], "lr", bounds=(0.0, 1.0))
+        assert r.normalized_variance == pytest.approx(0.02 / 3, rel=1e-6)
+
+    def test_fixture_coefficient_of_variation(self):
+        r = compute_continuous_locus_diversity([0.1, 0.2, 0.3], "lr", bounds=(0.0, 1.0))
+        expected_cv = (0.02 / 3) ** 0.5 / 0.2
+        assert r.coefficient_of_variation == pytest.approx(expected_cv, rel=1e-6)
+
+    def test_fixture_range_occupancy(self):
+        r = compute_continuous_locus_diversity([0.1, 0.2, 0.3], "lr", bounds=(0.0, 1.0))
+        assert r.range_occupancy == pytest.approx(0.2)
+
+    def test_fixture_n_individuals(self):
+        r = compute_continuous_locus_diversity([0.1, 0.2, 0.3], "lr", bounds=(0.0, 1.0))
+        assert r.n_individuals == 3
+
+    # --- Without bounds: normalized_variance and range_occupancy are nan ---
+
+    def test_no_bounds_normalized_variance_nan(self):
+        r = compute_continuous_locus_diversity([0.1, 0.2, 0.3], "lr")
+        assert math.isnan(r.normalized_variance)
+
+    def test_no_bounds_range_occupancy_nan(self):
+        r = compute_continuous_locus_diversity([0.1, 0.2, 0.3], "lr")
+        assert math.isnan(r.range_occupancy)
+
+    # --- CV nan when mean == 0 ---
+
+    def test_zero_mean_cv_nan(self):
+        r = compute_continuous_locus_diversity([0.0, 0.0], "lr")
+        assert math.isnan(r.coefficient_of_variation)
+
+    # --- Entropy ---
+
+    def test_entropy_none_by_default(self):
+        r = compute_continuous_locus_diversity([0.1, 0.2, 0.3], "lr")
+        assert r.shannon_entropy is None
+
+    def test_entropy_non_negative_when_requested(self):
+        r = compute_continuous_locus_diversity(
+            [0.1, 0.2, 0.3, 0.4, 0.5],
+            "lr",
+            bounds=(0.0, 1.0),
+            compute_entropy=True,
+        )
+        assert r.shannon_entropy is not None
+        assert r.shannon_entropy >= 0.0
+
+    def test_entropy_identical_pop_zero_or_low(self):
+        """All values in one bin → entropy = 0 (single occupied bin)."""
+        r = compute_continuous_locus_diversity(
+            [0.5, 0.5, 0.5],
+            "lr",
+            bounds=(0.0, 1.0),
+            entropy_bins=5,
+            compute_entropy=True,
+        )
+        assert r.shannon_entropy is not None
+        assert r.shannon_entropy == pytest.approx(0.0)
+
+
+class TestCategoricalLocusDiversity:
+    """Tests for compute_categorical_locus_diversity."""
+
+    # --- Degenerate cases ---
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="no weight vectors"):
+            compute_categorical_locus_diversity([], "action_weights")
+
+    def test_single_individual_heterozygosity_is_pure(self):
+        """Single individual: diversity of the distribution is what it is;
+        if it uses one action exclusively, He == 0."""
+        r = compute_categorical_locus_diversity([{"move": 1.0}], "aw")
+        assert r.expected_heterozygosity == pytest.approx(0.0)
+        assert r.shannon_entropy == pytest.approx(0.0)
+        assert r.simpson_index == pytest.approx(1.0)
+
+    def test_identical_population_single_action(self):
+        """All agents use move=1.0 → monomorphic, diversity = 0."""
+        vecs = [{"move": 1.0}, {"move": 1.0}, {"move": 1.0}]
+        r = compute_categorical_locus_diversity(vecs, "aw")
+        assert r.expected_heterozygosity == pytest.approx(0.0)
+        assert r.shannon_entropy == pytest.approx(0.0)
+        assert r.simpson_index == pytest.approx(1.0)
+
+    # --- Hand-computed fixture: 2 equal actions (uniform → max entropy) ---
+    # weight_vectors = [{"move": 0.5, "gather": 0.5}] * N
+    # p_move = 0.5, p_gather = 0.5
+    # H     = -(0.5 ln 0.5 + 0.5 ln 0.5) = ln(2) ≈ 0.693147
+    # D     = 0.5² + 0.5² = 0.5
+    # He    = 1 - 0.5 = 0.5
+
+    def test_fixture_uniform_two_actions_entropy(self):
+        vecs = [{"move": 0.5, "gather": 0.5}] * 4
+        r = compute_categorical_locus_diversity(vecs, "aw")
+        assert r.shannon_entropy == pytest.approx(math.log(2), rel=1e-6)
+
+    def test_fixture_uniform_two_actions_heterozygosity(self):
+        vecs = [{"move": 0.5, "gather": 0.5}] * 4
+        r = compute_categorical_locus_diversity(vecs, "aw")
+        assert r.expected_heterozygosity == pytest.approx(0.5)
+
+    def test_fixture_uniform_two_actions_simpson(self):
+        vecs = [{"move": 0.5, "gather": 0.5}] * 4
+        r = compute_categorical_locus_diversity(vecs, "aw")
+        assert r.simpson_index == pytest.approx(0.5)
+
+    def test_fixture_uniform_two_actions_allele_freqs(self):
+        vecs = [{"move": 0.5, "gather": 0.5}] * 3
+        r = compute_categorical_locus_diversity(vecs, "aw")
+        assert r.allele_frequencies["move"] == pytest.approx(0.5)
+        assert r.allele_frequencies["gather"] == pytest.approx(0.5)
+
+    # --- Max entropy for k uniform categories ---
+
+    def test_uniform_k4_max_entropy(self):
+        """4 equally-weighted categories → H = ln(4)."""
+        vecs = [{"a": 0.25, "b": 0.25, "c": 0.25, "d": 0.25}] * 5
+        r = compute_categorical_locus_diversity(vecs, "aw")
+        assert r.shannon_entropy == pytest.approx(math.log(4), rel=1e-6)
+        assert r.expected_heterozygosity == pytest.approx(1 - 1 / 4)
+
+    # --- n_individuals ---
+
+    def test_n_individuals(self):
+        vecs = [{"move": 1.0}] * 7
+        r = compute_categorical_locus_diversity(vecs, "aw")
+        assert r.n_individuals == 7
+
+    # --- Mixed population reduces heterozygosity ---
+
+    def test_mixed_population_nonzero_heterozygosity(self):
+        vecs = [
+            {"move": 0.8, "gather": 0.2},
+            {"move": 0.2, "gather": 0.8},
+        ]
+        r = compute_categorical_locus_diversity(vecs, "aw")
+        # mean: p_move = 0.5, p_gather = 0.5 → He = 0.5
+        assert r.expected_heterozygosity == pytest.approx(0.5)
+
+
+class TestComputePopulationDiversity:
+    """Tests for compute_population_diversity."""
+
+    def test_empty_dataframe_returns_zero_individuals(self):
+        result = compute_population_diversity(pd.DataFrame())
+        assert result.n_individuals == 0
+
+    def test_continuous_loci_from_chromosome_values(self):
+        data = {
+            "chromosome_values": [
+                {"lr": 0.1, "gamma": 0.9},
+                {"lr": 0.2, "gamma": 0.95},
+                {"lr": 0.3, "gamma": 0.99},
+            ]
+        }
+        df = pd.DataFrame(data)
+        result = compute_population_diversity(df, gene_bounds={"lr": (0.0, 1.0), "gamma": (0.8, 1.0)})
+        assert "lr" in result.continuous_loci
+        assert "gamma" in result.continuous_loci
+        assert result.continuous_loci["lr"].n_individuals == 3
+
+    def test_categorical_loci_from_action_weights(self):
+        data = {
+            "action_weights": [
+                {"move": 0.5, "gather": 0.5},
+                {"move": 0.5, "gather": 0.5},
+            ]
+        }
+        df = pd.DataFrame(data)
+        result = compute_population_diversity(df)
+        assert "action_weights" in result.categorical_loci
+        assert result.categorical_loci["action_weights"].expected_heterozygosity == pytest.approx(0.5)
+
+    def test_identical_pop_continuous_zero_normalized_variance(self):
+        data = {"chromosome_values": [{"lr": 0.1}] * 5}
+        df = pd.DataFrame(data)
+        result = compute_population_diversity(df, gene_bounds={"lr": (0.0, 1.0)})
+        assert result.continuous_loci["lr"].normalized_variance == pytest.approx(0.0)
+
+    def test_mean_heterozygosity_matches_single_locus(self):
+        vecs = [{"move": 0.5, "gather": 0.5}] * 3
+        df = pd.DataFrame({"action_weights": vecs})
+        result = compute_population_diversity(df)
+        assert result.mean_heterozygosity == pytest.approx(0.5)
+
+    def test_skips_empty_action_weight_dicts(self):
+        """Rows with empty action weight dicts are filtered out."""
+        data = {
+            "action_weights": [
+                {},
+                {"move": 1.0},
+                {"move": 1.0},
+            ]
+        }
+        df = pd.DataFrame(data)
+        result = compute_population_diversity(df)
+        # Only 2 non-empty rows contributed to categorical locus
+        assert result.categorical_loci["action_weights"].n_individuals == 2
+
+    def test_mean_normalized_variance_nan_without_bounds(self):
+        data = {"chromosome_values": [{"lr": 0.1}, {"lr": 0.2}]}
+        df = pd.DataFrame(data)
+        result = compute_population_diversity(df)  # no gene_bounds
+        assert math.isnan(result.mean_normalized_variance)
+
+    def test_both_continuous_and_categorical(self):
+        data = {
+            "chromosome_values": [{"lr": 0.1}, {"lr": 0.2}],
+            "action_weights": [{"move": 0.5, "gather": 0.5}, {"move": 0.5, "gather": 0.5}],
+        }
+        df = pd.DataFrame(data)
+        result = compute_population_diversity(df, gene_bounds={"lr": (0.0, 1.0)})
+        assert "lr" in result.continuous_loci
+        assert "action_weights" in result.categorical_loci
+
+
+class TestComputeEvolutionDiversityTimeseries:
+    """Tests for compute_evolution_diversity_timeseries."""
+
+    def _make_result(self, evals):
+        return SimpleNamespace(evaluations=evals, generation_summaries=[])
+
+    def _make_eval(self, candidate_id, generation, fitness, chromosome_values):
+        return SimpleNamespace(
+            candidate_id=candidate_id,
+            generation=generation,
+            fitness=fitness,
+            parent_ids=("seed", "seed"),
+            chromosome_values=chromosome_values,
+        )
+
+    def test_empty_result_returns_empty_list(self):
+        result = self._make_result([])
+        ts = compute_evolution_diversity_timeseries(result)
+        assert ts == []
+
+    def test_returns_one_entry_per_generation(self):
+        evals = [
+            self._make_eval(f"g{g}_c{c}", g, float(g + c), {"lr": 0.1 + 0.05 * c})
+            for g in range(3)
+            for c in range(4)
+        ]
+        result = self._make_result(evals)
+        ts = compute_evolution_diversity_timeseries(result)
+        assert len(ts) == 3
+        assert [r["generation"] for r in ts] == [0, 1, 2]
+
+    def test_entries_sorted_by_generation(self):
+        evals = [
+            self._make_eval("g2_c0", 2, 1.0, {"lr": 0.1}),
+            self._make_eval("g0_c0", 0, 2.0, {"lr": 0.2}),
+            self._make_eval("g1_c0", 1, 3.0, {"lr": 0.3}),
+        ]
+        result = self._make_result(evals)
+        ts = compute_evolution_diversity_timeseries(result)
+        assert [r["generation"] for r in ts] == [0, 1, 2]
+
+    def test_diversity_values_are_population_diversity_summary(self):
+        from farm.analysis.genetics.compute import PopulationDiversitySummary
+
+        evals = [
+            self._make_eval(f"g0_c{c}", 0, float(c), {"lr": 0.1 * (c + 1)})
+            for c in range(3)
+        ]
+        result = self._make_result(evals)
+        ts = compute_evolution_diversity_timeseries(result)
+        assert isinstance(ts[0]["diversity"], PopulationDiversitySummary)
+
+    def test_identical_generation_zero_normalized_variance(self):
+        """All candidates in one generation with the same lr → variance == 0."""
+        evals = [
+            self._make_eval(f"g0_c{c}", 0, 1.0, {"lr": 0.1})
+            for c in range(4)
+        ]
+        result = self._make_result(evals)
+        ts = compute_evolution_diversity_timeseries(
+            result, gene_bounds={"lr": (0.0, 1.0)}
+        )
+        lr_div = ts[0]["diversity"].continuous_loci["lr"]
+        assert lr_div.normalized_variance == pytest.approx(0.0)
+
+    def test_with_gene_bounds(self):
+        evals = [
+            self._make_eval(f"g0_c{c}", 0, 1.0, {"lr": 0.1 * (c + 1)})
+            for c in range(3)
+        ]
+        result = self._make_result(evals)
+        ts = compute_evolution_diversity_timeseries(
+            result, gene_bounds={"lr": (0.0, 1.0)}
+        )
+        lr_div = ts[0]["diversity"].continuous_loci["lr"]
+        assert not math.isnan(lr_div.normalized_variance)
+        assert not math.isnan(lr_div.range_occupancy)

--- a/tests/analysis/test_genetics.py
+++ b/tests/analysis/test_genetics.py
@@ -401,6 +401,22 @@ class TestContinuousLocusDiversity:
         with pytest.raises(ValueError, match="no values"):
             compute_continuous_locus_diversity([], "lr")
 
+    def test_reversed_bounds_raises(self):
+        with pytest.raises(ValueError, match="bounds must satisfy bounds\\[0\\] < bounds\\[1\\]"):
+            compute_continuous_locus_diversity([0.1, 0.2], "lr", bounds=(1.0, 0.0))
+
+    def test_equal_bounds_raises(self):
+        with pytest.raises(ValueError, match="bounds must satisfy bounds\\[0\\] < bounds\\[1\\]"):
+            compute_continuous_locus_diversity([0.5, 0.5], "lr", bounds=(0.5, 0.5))
+
+    def test_invalid_entropy_bins_raises(self):
+        with pytest.raises(ValueError, match="entropy_bins must be >= 1"):
+            compute_continuous_locus_diversity([0.1, 0.2], "lr", entropy_bins=0, compute_entropy=True)
+
+    def test_negative_entropy_bins_raises(self):
+        with pytest.raises(ValueError, match="entropy_bins must be >= 1"):
+            compute_continuous_locus_diversity([0.1, 0.2], "lr", entropy_bins=-5, compute_entropy=True)
+
     # --- Hand-computed fixture: values=[0.1, 0.2, 0.3], bounds=(0.0, 1.0) ---
     # mean = 0.2
     # var  = ((0.1-0.2)² + (0.2-0.2)² + (0.3-0.2)²) / 3 = 0.02/3
@@ -487,6 +503,16 @@ class TestCategoricalLocusDiversity:
     def test_empty_raises(self):
         with pytest.raises(ValueError, match="no weight vectors"):
             compute_categorical_locus_diversity([], "action_weights")
+
+    def test_all_empty_dicts_raises(self):
+        """Weight vectors with no categories (all empty dicts) should raise."""
+        with pytest.raises(ValueError, match="no categories"):
+            compute_categorical_locus_diversity([{}, {}], "action_weights")
+
+    def test_single_empty_dict_raises(self):
+        """A single empty dict provides no categories."""
+        with pytest.raises(ValueError, match="no categories"):
+            compute_categorical_locus_diversity([{}], "action_weights")
 
     def test_single_individual_heterozygosity_is_pure(self):
         """Single individual: diversity of the distribution is what it is;
@@ -634,6 +660,36 @@ class TestComputePopulationDiversity:
         result = compute_population_diversity(df, gene_bounds={"lr": (0.0, 1.0)})
         assert "lr" in result.continuous_loci
         assert "action_weights" in result.categorical_loci
+
+    def test_non_numeric_chromosome_values_are_skipped(self):
+        """Rows with non-numeric or None gene values are silently skipped."""
+        data = {
+            "chromosome_values": [
+                {"lr": 0.1},
+                {"lr": None},
+                {"lr": "bad"},
+                {"lr": 0.3},
+            ]
+        }
+        df = pd.DataFrame(data)
+        result = compute_population_diversity(df)
+        # Only the two finite numeric rows are counted
+        assert result.continuous_loci["lr"].n_individuals == 2
+        assert result.continuous_loci["lr"].mean == pytest.approx(0.2)
+
+    def test_nan_chromosome_values_are_skipped(self):
+        """NaN gene values are filtered out and don't poison locus stats."""
+        data = {
+            "chromosome_values": [
+                {"lr": 0.1},
+                {"lr": float("nan")},
+                {"lr": 0.3},
+            ]
+        }
+        df = pd.DataFrame(data)
+        result = compute_population_diversity(df)
+        assert result.continuous_loci["lr"].n_individuals == 2
+        assert result.continuous_loci["lr"].mean == pytest.approx(0.2)
 
 
 class TestComputeEvolutionDiversityTimeseries:

--- a/tests/analysis/test_genetics.py
+++ b/tests/analysis/test_genetics.py
@@ -249,6 +249,23 @@ class TestAnalyzeGenetics:
         assert "gene_statistics" in result
         assert "learning_rate" in result["gene_statistics"]
 
+    def test_evolution_frame_skips_malformed_chromosome_values(self):
+        data = {
+            "candidate_id": ["c0", "c1", "c2", "c3"],
+            "generation": [0, 0, 1, 1],
+            "fitness": [10.0, 20.0, 15.0, 12.0],
+            "chromosome_values": [
+                {"learning_rate": 0.001},
+                {"learning_rate": "bad"},
+                None,
+                {"learning_rate": 0.005},
+            ],
+        }
+        df = pd.DataFrame(data)
+        result = analyze_genetics(df)
+        assert "gene_statistics" in result
+        assert result["gene_statistics"]["learning_rate"]["mean"] == pytest.approx(0.003)
+
 
 # ---------------------------------------------------------------------------
 # process_genetics_data
@@ -493,6 +510,26 @@ class TestContinuousLocusDiversity:
         )
         assert r.shannon_entropy is not None
         assert r.shannon_entropy == pytest.approx(0.0)
+
+    def test_entropy_with_out_of_bounds_values_is_still_finite(self):
+        r = compute_continuous_locus_diversity(
+            [-0.5, 0.1, 0.9, 1.5],
+            "lr",
+            bounds=(0.0, 1.0),
+            entropy_bins=5,
+            compute_entropy=True,
+        )
+        assert r.shannon_entropy is not None
+        assert r.shannon_entropy > 0.0
+        assert r.shannon_entropy < float("inf")
+
+    def test_range_occupancy_clamped_to_one_when_values_exceed_bounds(self):
+        r = compute_continuous_locus_diversity(
+            [-0.5, 1.5],
+            "lr",
+            bounds=(0.0, 1.0),
+        )
+        assert r.range_occupancy == pytest.approx(1.0)
 
 
 class TestCategoricalLocusDiversity:


### PR DESCRIPTION
This pull request adds comprehensive support for genotypic diversity metrics in the genetics analysis module. It introduces new functions and result types for measuring diversity in both continuous and categorical genetic loci, as well as population-level and timeseries diversity analyses. Extensive tests are included to validate the correctness and robustness of these new metrics.

**Genotypic diversity metrics and API additions:**

* Added new diversity computation functions (`compute_continuous_locus_diversity`, `compute_categorical_locus_diversity`, `compute_population_diversity`, `compute_evolution_diversity_timeseries`) and result types (`ContinuousLocusDiversity`, `CategoricalLocusDiversity`, `PopulationDiversitySummary`) to the `farm.analysis.genetics` public API. These support calculation of heterozygosity, Shannon entropy, per-locus statistics, and diversity over time.

**Testing and validation:**

* Introduced detailed tests for all new diversity metrics, covering edge cases, hand-computed fixtures, and population-level summaries. This includes tests for continuous loci, categorical loci, population diversity summaries, and timeseries diversity computation.
* Updated test imports to include the new diversity computation functions for use in the test suite.
* Expanded module-level test documentation to describe the new diversity metrics being tested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive analysis-only API changes plus extensive unit tests; main risk is correctness/interpretation of the new diversity formulas and their handling of edge cases (empty/degenerate inputs, missing bounds).
> 
> **Overview**
> Adds a new diversity-metrics layer to `farm.analysis.genetics`, including result dataclasses (`ContinuousLocusDiversity`, `CategoricalLocusDiversity`, `PopulationDiversitySummary`) and computation functions for per-locus, population-wide, and per-generation evolution timeseries diversity.
> 
> Exports the new APIs from `farm.analysis.genetics.__init__` and extends `tests/analysis/test_genetics.py` with detailed coverage for degenerate cases and hand-checked fixtures for variance/entropy/heterozygosity calculations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50debcc2f110f0102a14f64457497dff90a312a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->