### PR TITLE
Implement intrinsic evolution experiment runner and related features

### DIFF
--- a/docs/experiments/hyperparameter_evolution_convergence.md
+++ b/docs/experiments/hyperparameter_evolution_convergence.md
@@ -2,6 +2,8 @@
 
 This note documents how to capture and interpret learning-rate convergence from the hyperparameter chromosome evolution runner.
 
+> Looking for *intra-population* (in-situ) evolution where each agent carries its own chromosome and selection emerges from survival? See [Intrinsic Evolution Experiment](./intrinsic_evolution.md). The two runners are complementary.
+
 ## Quick start: stable preset
 
 The recommended way to run an experiment for the first time is via the `stable_hyper_evo` named preset. It encodes the configuration found to prevent lower-bound collapse and diversity collapse in the closure runs described below:

--- a/docs/experiments/intrinsic_evolution.md
+++ b/docs/experiments/intrinsic_evolution.md
@@ -1,0 +1,273 @@
+# Intrinsic Evolution Experiment
+
+The intrinsic evolution runner treats hyperparameter selection as an
+*emergent* property of a single simulation rather than as an outer-loop
+search over independent runs. Each agent carries its own
+`HyperparameterChromosome`; offspring inherit it, optionally crossed with a
+co-parent and mutated; selection happens implicitly because agents must
+survive and reproduce in the shared resource environment.
+
+This is a complement to, not a replacement for,
+[`EvolutionExperiment`](./hyperparameter_evolution_convergence.md). The two
+runners answer different questions:
+
+| Question | Use |
+| --- | --- |
+| "What learning rate works best?" (clean, controlled, replicated) | `EvolutionExperiment` |
+| "How does the LR distribution evolve under intra-population competition?" | `IntrinsicEvolutionExperiment` |
+
+## Architecture
+
+```
+IntrinsicEvolutionExperiment.run()
+        |
+        +-> seed_population_diversity(env, policy)
+        |
+        +-> run_simulation loop (single sim)
+        |       |
+        |       +-> AgentCore.reproduce()
+        |             |
+        |             +-> _select_coparent() (optional)
+        |             +-> crossover_chromosomes (optional)
+        |             +-> mutate_chromosome
+        |
+        +-> GeneTrajectoryLogger.snapshot(env)
+                |
+                +-> intrinsic_gene_trajectory.jsonl  (every step, aggregate)
+                +-> intrinsic_gene_snapshots.jsonl   (every N steps, full)
+```
+
+## When to use
+
+Reach for the intrinsic runner when you care about:
+
+- **Frequency-dependent dynamics.** The "best" learning rate may depend on
+  what other agents are doing. Outer-loop GAs evaluate each candidate in a
+  monoculture, so they can't see this.
+- **Non-stationarity.** Resource depletion or population shifts can change
+  the optimal hyperparameters mid-run; an in-situ GA tracks that.
+- **Cost.** One simulation instead of `generations x population_size`
+  separate simulations for a comparable amount of selection pressure.
+- **Biological realism.** The environment itself becomes the fitness
+  function rather than a human-chosen scalar.
+
+Stick with `EvolutionExperiment` when you need clean per-candidate
+counterfactuals, statistical replication across seeds, or production
+hyperparameter selection.
+
+## Behavior change vs. previous code
+
+Before this runner existed, `AgentCore.reproduce()` *always* mutated the
+parent's chromosome at a hardcoded rate of 0.1, which silently affected the
+outer-loop `EvolutionExperiment`'s fitness signal.
+
+The new contract is:
+
+- When `environment.intrinsic_evolution_policy` is `None` or disabled,
+  children inherit the parent's chromosome unchanged. This is the default
+  for `run_simulation`, `EvolutionExperiment`, and any other path that does
+  not explicitly opt in.
+- When the policy is attached and enabled (as the
+  `IntrinsicEvolutionExperiment` runner does), reproduction runs optional
+  crossover with a co-parent, then mutation, using the policy's knobs.
+
+This means the outer-loop GA is now strictly cleaner: each candidate
+simulation observes a homogeneous starting population governed by the
+candidate's chromosome, with no intra-sim drift contaminating the fitness
+signal.
+
+## Components
+
+| Module | Purpose |
+| --- | --- |
+| [`farm/runners/intrinsic_evolution_experiment.py`](../../farm/runners/intrinsic_evolution_experiment.py) | `IntrinsicEvolutionPolicy`, `IntrinsicEvolutionExperimentConfig`, `IntrinsicEvolutionResult`, `seed_population_diversity()`, `IntrinsicEvolutionExperiment` |
+| [`farm/runners/gene_trajectory_logger.py`](../../farm/runners/gene_trajectory_logger.py) | `GeneTrajectoryLogger`: writes per-step aggregates and periodic full snapshots |
+| [`farm/core/agent/core.py`](../../farm/core/agent/core.py) | `AgentCore._derive_child_chromosome` and `_select_coparent` (called from `reproduce`) |
+| [`farm/core/simulation.py`](../../farm/core/simulation.py) | `run_simulation(..., on_environment_ready, on_step_end)` callback hooks the runner uses |
+
+## Quick start
+
+```python
+from farm.config import SimulationConfig
+from farm.core.hyperparameter_chromosome import (
+    BoundaryMode,
+    CrossoverMode,
+    MutationMode,
+)
+from farm.runners.intrinsic_evolution_experiment import (
+    IntrinsicEvolutionExperiment,
+    IntrinsicEvolutionExperimentConfig,
+    IntrinsicEvolutionPolicy,
+)
+
+base_config = SimulationConfig.from_centralized_config(environment="development")
+
+policy = IntrinsicEvolutionPolicy(
+    enabled=True,
+    seed_initial_diversity=True,
+    seed_mutation_rate=1.0,
+    seed_mutation_scale=0.2,
+    mutation_rate=0.1,
+    mutation_scale=0.1,
+    mutation_mode=MutationMode.GAUSSIAN,
+    boundary_mode=BoundaryMode.CLAMP,
+    crossover_enabled=True,
+    crossover_mode=CrossoverMode.UNIFORM,
+    coparent_strategy="nearest_alive_same_type",
+    coparent_max_radius=10.0,
+)
+
+config = IntrinsicEvolutionExperimentConfig(
+    num_steps=2000,
+    snapshot_interval=100,
+    policy=policy,
+    output_dir="experiments/intrinsic_evolution_smoke",
+    seed=42,
+)
+
+result = IntrinsicEvolutionExperiment(base_config, config).run()
+print(f"Final population: {result.final_population}")
+print(f"Final mean LR: {result.final_gene_statistics['learning_rate']['mean']}")
+```
+
+## `IntrinsicEvolutionPolicy` reference
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `enabled` | `True` | Master switch. When `False`, reproduction inherits chromosomes unchanged. |
+| `seed_initial_diversity` | `True` | Mutate every initial agent's chromosome once before the loop starts so the starting population is not a monoculture. |
+| `seed_mutation_rate` | `1.0` | Per-gene mutation probability for the seed pass. |
+| `seed_mutation_scale` | `0.2` | Per-gene scale for the seed pass. Larger spreads the population further. |
+| `mutation_rate` | `0.1` | Per-gene mutation probability at each reproduction event. |
+| `mutation_scale` | `0.1` | Per-gene scale at each reproduction event. |
+| `mutation_mode` | `MutationMode.GAUSSIAN` | `gaussian` or `multiplicative`. See [`HyperparameterChromosome` docs](../design/hyperparameter_chromosome.md). |
+| `boundary_mode` | `BoundaryMode.CLAMP` | `clamp`, `reflect`, or `interior_biased`. Controls out-of-bounds handling after mutation. |
+| `interior_bias_fraction` | `1e-3` | Used only when `boundary_mode = interior_biased`. |
+| `crossover_enabled` | `False` | When `True`, pick a co-parent and run `crossover_chromosomes` before mutation. |
+| `crossover_mode` | `CrossoverMode.UNIFORM` | Crossover operator (`single_point`, `uniform`, `blend`, `multi_point`). |
+| `blend_alpha` | `0.5` | BLX-alpha extent for blend crossover. |
+| `num_crossover_points` | `2` | Pivot count for multi-point crossover. |
+| `coparent_strategy` | `"nearest_alive_same_type"` | Either `nearest_alive_same_type` or `random_alive_same_type`. Both filter to alive agents of the same `agent_type`. |
+| `coparent_max_radius` | `None` | Optional spatial cap on the co-parent search; `None` is unbounded. |
+| `seed` | `None` | Optional RNG seed. Falls back to `IntrinsicEvolutionExperimentConfig.seed`. |
+
+If no eligible co-parent exists when crossover is enabled, reproduction
+silently falls back to mutation-only inheritance. This is the only way
+crossover can become asexual at runtime; everything else is policy-driven.
+
+## `IntrinsicEvolutionExperimentConfig` reference
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `num_steps` | `2000` | Length of the simulation. |
+| `snapshot_interval` | `100` | Cadence of full per-agent chromosome snapshots. Per-step aggregates are always recorded. |
+| `policy` | `IntrinsicEvolutionPolicy()` | See above. |
+| `output_dir` | `None` | When set, the runner writes JSONL trajectory and metadata files here (and forwards `path=output_dir` to `run_simulation` for its own artifacts). |
+| `seed` | `None` | Top-level RNG seed propagated to `run_simulation` and the policy if the policy seed is unset. |
+
+## Output artifacts
+
+When `output_dir` is set, three new files are written alongside whatever
+`run_simulation` produces (config, database, etc.):
+
+### `intrinsic_gene_trajectory.jsonl`
+
+One record per step. Compact and safe to write at every step.
+
+```json
+{
+  "step": 0,
+  "n_alive": 30,
+  "n_with_chromosome": 30,
+  "gene_stats": {
+    "learning_rate": {
+      "mean": 0.012,
+      "median": 0.011,
+      "std": 0.004,
+      "min": 0.005,
+      "max": 0.022,
+      "at_min_count": 0.0,
+      "at_max_count": 0.0,
+      "boundary_fraction": 0.0
+    },
+    "gamma": { ... },
+    "epsilon_decay": { ... }
+  }
+}
+```
+
+The schema matches the per-generation gene statistics produced by
+`EvolutionExperiment`, so downstream tooling can consume both.
+
+### `intrinsic_gene_snapshots.jsonl`
+
+One record every `snapshot_interval` steps (always at step 0). Heavier;
+used for lineage / per-agent analysis.
+
+```json
+{
+  "step": 0,
+  "agents": [
+    {
+      "agent_id": "0",
+      "agent_type": "system",
+      "generation": 0,
+      "parent_ids": ["seed"],
+      "chromosome": { "learning_rate": 0.012, "gamma": 0.99, ... }
+    },
+    ...
+  ]
+}
+```
+
+### `intrinsic_evolution_metadata.json`
+
+A single object summarizing the run. Includes the resolved policy with
+enums serialized to plain strings so it round-trips cleanly:
+
+```json
+{
+  "num_steps_completed": 2000,
+  "num_steps_configured": 2000,
+  "snapshot_interval": 100,
+  "final_population": 47,
+  "final_gene_statistics": { ... },
+  "policy": {
+    "enabled": true,
+    "mutation_mode": "gaussian",
+    "boundary_mode": "clamp",
+    "crossover_mode": "uniform",
+    ...
+  },
+  "seed": 42
+}
+```
+
+## Caveats and known limitations
+
+- **Confounded fitness.** Survival and reproduction in a shared environment
+  are noisy. An agent might "win" because of position, lineage timing, or
+  social context rather than its hyperparameters. Replicate runs across
+  multiple seeds and look at distributions, not single trajectories.
+- **Population_size = 1 per genotype.** Each unique chromosome is initially
+  represented by a single agent. Statistical power is low until lineages
+  expand. Seed diversity is intentionally aggressive (`mutation_rate=1.0`
+  by default) to spread the initial population.
+- **No selection-pressure knob yet.** Reproduction cost is fixed by the
+  agent's `ReproductionConfig`; density-dependent costs and explicit
+  speciation are out of scope for v1.
+- **Crossover requires same `agent_type`.** Cross-type pollination is not
+  supported. Co-parent selection always filters to identical
+  `agent_type`.
+
+## Out of scope (for now)
+
+- Density-dependent reproduction cost / explicit selection-pressure knobs.
+- Lineage tree visualization. The snapshot file makes this a notebook job.
+- Speciation / niche detection.
+
+## Testing
+
+- [`tests/runners/test_intrinsic_evolution_experiment.py`](../../tests/runners/test_intrinsic_evolution_experiment.py): policy / config validation, `seed_population_diversity`, runner orchestration with mocked `run_simulation`, artifact persistence.
+- [`tests/core/agent/test_reproduce_chromosome_policy.py`](../../tests/core/agent/test_reproduce_chromosome_policy.py): no-policy passthrough, mutation path, co-parent selection (nearest, random, radius, type-filter, alive-filter), crossover end-to-end.
+- [`tests/test_agent_reproduction_hyperparameters.py`](../../tests/test_agent_reproduction_hyperparameters.py): updated to assert the new contract (no policy = inheritance unchanged).

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ Welcome to the documentation and development notes for AgentFarm.
 
 - [Documentation Index](README.md)
 - [Hyperparameter Evolution Convergence Notes](experiments/hyperparameter_evolution_convergence.md)
+- [Intrinsic Evolution Experiment](experiments/intrinsic_evolution.md)
 - [Devlog](devlog/)
 
 ## Latest Devlog

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -6,8 +6,10 @@ Most capabilities are provided by components, but it contains some agent-specifi
 logic for reward calculation, lifecycle management, and orchestration.
 """
 
+import math
+import random as _module_random
 from copy import deepcopy
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import torch
 
@@ -18,8 +20,10 @@ from farm.core.agent.config.component_configs import AgentComponentConfig
 from farm.core.agent.services import AgentServices
 from farm.core.device_utils import create_device_from_config
 from farm.core.hyperparameter_chromosome import (
+    HyperparameterChromosome,
     apply_chromosome_to_learning_config,
     chromosome_from_learning_config,
+    crossover_chromosomes,
     mutate_chromosome,
 )
 from farm.core.environment import _AgentList
@@ -31,7 +35,6 @@ if TYPE_CHECKING:
 
 
 logger = get_logger(__name__)
-DEFAULT_HYPERPARAMETER_MUTATION_RATE = 0.1
 
 
 class AgentCore:
@@ -679,6 +682,82 @@ class AgentCore:
         else:
             self.services.spatial_service = value
 
+    def _derive_child_chromosome(
+        self, parent_chromosome: HyperparameterChromosome
+    ) -> HyperparameterChromosome:
+        """Produce the child's chromosome from the parent's, honoring policy.
+
+        When the environment carries an enabled ``intrinsic_evolution_policy``,
+        the child is the result of (optional) crossover with a co-parent
+        followed by mutation.  When no policy is set or the policy is
+        disabled, the child inherits a deep copy of the parent's chromosome
+        unchanged.
+        """
+        policy = getattr(self.environment, "intrinsic_evolution_policy", None)
+        if policy is None or not getattr(policy, "enabled", False):
+            return deepcopy(parent_chromosome)
+
+        rng = getattr(self.environment, "intrinsic_evolution_rng", None)
+        base = parent_chromosome
+        if policy.crossover_enabled:
+            coparent = self._select_coparent(policy, rng)
+            if coparent is not None:
+                base = crossover_chromosomes(
+                    parent_chromosome,
+                    coparent.hyperparameter_chromosome,
+                    mode=policy.crossover_mode,
+                    blend_alpha=policy.blend_alpha,
+                    num_crossover_points=policy.num_crossover_points,
+                    rng=rng,
+                )
+
+        return mutate_chromosome(
+            base,
+            mutation_rate=policy.mutation_rate,
+            mutation_scale=policy.mutation_scale,
+            mutation_mode=policy.mutation_mode,
+            boundary_mode=policy.boundary_mode,
+            interior_bias_fraction=policy.interior_bias_fraction,
+            rng=rng,
+        )
+
+    def _select_coparent(self, policy, rng) -> Optional["AgentCore"]:
+        """Pick a co-parent for crossover according to the policy.
+
+        Filters to alive agents of the same ``agent_type`` (excluding self)
+        with a chromosome attribute, optionally constrained to
+        ``policy.coparent_max_radius`` Euclidean distance from self.
+        Returns ``None`` when no eligible candidate exists, in which case
+        reproduction falls back to asexual (mutation-only) inheritance.
+        """
+        if self.environment is None:
+            return None
+
+        candidates: List["AgentCore"] = []
+        for other in self.environment.alive_agent_objects:
+            if other is self:
+                continue
+            if other.agent_type != self.agent_type:
+                continue
+            if getattr(other, "hyperparameter_chromosome", None) is None:
+                continue
+            candidates.append(other)
+
+        if policy.coparent_max_radius is not None:
+            radius = policy.coparent_max_radius
+            candidates = [
+                a for a in candidates if math.dist(a.position, self.position) <= radius
+            ]
+
+        if not candidates:
+            return None
+
+        if policy.coparent_strategy == "nearest_alive_same_type":
+            return min(candidates, key=lambda a: math.dist(a.position, self.position))
+
+        chooser = rng if rng is not None else _module_random
+        return chooser.choice(candidates)
+
     def reproduce(self) -> bool:
         """
         Create offspring agent.
@@ -734,19 +813,17 @@ class AgentCore:
             # Generate new agent ID
             offspring_id = self.environment.get_next_agent_id()
 
-            # Build child config from a mutated hyperparameter chromosome (for evolvable loci).
-            # Prefer the stored chromosome so reproduction uses a single authoritative
-            # representation of inheritable hyperparameters. If it is missing, derive it
-            # from the current learning config and synchronize the instance state.
+            # Inherit the hyperparameter chromosome.  When the environment exposes
+            # an enabled `intrinsic_evolution_policy`, optionally cross with a
+            # co-parent and then mutate; otherwise the child inherits the parent
+            # chromosome unchanged so deterministic / outer-loop experiments
+            # observe a homogeneous population.
             parent_chromosome = getattr(self, "hyperparameter_chromosome", None)
             if parent_chromosome is None:
                 parent_chromosome = chromosome_from_learning_config(self.config.decision)
                 self.hyperparameter_chromosome = deepcopy(parent_chromosome)
 
-            child_chromosome = mutate_chromosome(
-                deepcopy(parent_chromosome),
-                mutation_rate=DEFAULT_HYPERPARAMETER_MUTATION_RATE,
-            )
+            child_chromosome = self._derive_child_chromosome(parent_chromosome)
             child_config = deepcopy(self.config)
             child_config.decision = apply_chromosome_to_learning_config(
                 child_config.decision,

--- a/farm/core/decision/decision.py
+++ b/farm/core/decision/decision.py
@@ -168,6 +168,23 @@ class DecisionModule:
             )
             self._initialize_fallback()
 
+    def reinitialize_algorithm(self, config: Any = None) -> None:
+        """Reinitialize the decision algorithm, optionally with a new config.
+
+        Use this when the agent's hyperparameter chromosome has been updated
+        (e.g., during population seeding) and the optimizer/algorithm must
+        reflect the new settings (learning rate, gamma, …).
+
+        Args:
+            config: Optional new :class:`DecisionConfig`.  When provided, the
+                module's ``config`` attribute is replaced before the algorithm
+                is reinitialized so all subsequent operations see the updated
+                parameters.
+        """
+        if config is not None:
+            self.config = config
+        self._initialize_algorithm()
+
     def _initialize_tianshou_ppo(self):
         """Initialize PPO using Tianshou."""
         if "ppo" not in _ALGORITHM_REGISTRY:

--- a/farm/core/hyperparameter_chromosome.py
+++ b/farm/core/hyperparameter_chromosome.py
@@ -13,9 +13,10 @@ from __future__ import annotations
 import copy
 import math
 import random
+import statistics
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
 
 
 def validate_non_negative_mapping(label: str, mapping: Mapping[str, float]) -> None:
@@ -981,3 +982,51 @@ def apply_chromosome_to_learning_config(
     for key, value in updates.items():
         setattr(copied, key, value)
     return copied
+
+
+def compute_gene_statistics(
+    chromosomes: Iterable[HyperparameterChromosome],
+    *,
+    evolvable_only: bool = True,
+) -> Dict[str, Dict[str, float]]:
+    """Compute per-gene aggregate statistics across a collection of chromosomes.
+
+    For each gene name observed in the input, returns mean / median / pstdev /
+    min / max plus boundary occupancy counts and a fraction of values pinned
+    to either ``min_value`` or ``max_value``.  When ``evolvable_only`` is
+    ``True`` (the default), non-evolvable genes are skipped.
+
+    The output schema matches the per-generation gene statistics produced by
+    :class:`farm.runners.evolution_experiment.EvolutionExperiment` so the same
+    downstream tooling can consume both intra-simulation and outer-loop
+    artifacts.
+
+    Returns an empty dict when the input yields no qualifying genes.
+    """
+    gene_values: Dict[str, List[float]] = {}
+    gene_bounds: Dict[str, Tuple[float, float]] = {}
+    for chromosome in chromosomes:
+        for gene in chromosome.genes:
+            if evolvable_only and not gene.evolvable:
+                continue
+            gene_values.setdefault(gene.name, []).append(gene.value)
+            if gene.name not in gene_bounds:
+                gene_bounds[gene.name] = (gene.min_value, gene.max_value)
+
+    gene_statistics: Dict[str, Dict[str, float]] = {}
+    for gene_name, values in gene_values.items():
+        min_bound, max_bound = gene_bounds[gene_name]
+        n = len(values)
+        at_min_count = sum(1 for v in values if v == min_bound)
+        at_max_count = sum(1 for v in values if v == max_bound)
+        gene_statistics[gene_name] = {
+            "mean": statistics.mean(values),
+            "median": statistics.median(values),
+            "std": statistics.pstdev(values) if n > 1 else 0.0,
+            "min": min(values),
+            "max": max(values),
+            "at_min_count": float(at_min_count),
+            "at_max_count": float(at_max_count),
+            "boundary_fraction": float(at_min_count + at_max_count) / n,
+        }
+    return gene_statistics

--- a/farm/core/simulation.py
+++ b/farm/core/simulation.py
@@ -37,7 +37,7 @@ import os
 import random
 import time
 from datetime import datetime, timezone
-from typing import List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -275,6 +275,8 @@ def run_simulation(
     simulation_id: Optional[str] = None,
     identity: Optional[Identity] = None,
     disable_console_logging: bool = False,
+    on_environment_ready: Optional[Callable[[Environment], None]] = None,
+    on_step_end: Optional[Callable[[Environment, int], None]] = None,
 ) -> Environment:
     """
     Run the main simulation loop.
@@ -297,6 +299,15 @@ def run_simulation(
         Identity service instance for ID generation. If None, uses shared instance.
     disable_console_logging : bool, optional
         Whether to disable console logging during simulation (useful with tqdm), by default False
+    on_environment_ready : Optional[Callable[[Environment], None]], optional
+        Hook invoked after the environment and initial agents are created but
+        before the main loop begins.  Useful for attaching per-environment
+        policies (e.g., ``intrinsic_evolution_policy``) or seeding the
+        population.  Exceptions raised by the hook propagate.
+    on_step_end : Optional[Callable[[Environment, int], None]], optional
+        Hook invoked after ``environment.update()`` at the end of each step,
+        receiving the environment and the 0-based step index just completed.
+        Exceptions raised by the hook propagate.
 
     Returns
     -------
@@ -468,6 +479,11 @@ def run_simulation(
             environment.db.logger.flush_all_buffers()
             logger.info("initial_agents_committed_to_database")
 
+        # Allow callers to attach per-environment policy / state, seed
+        # population diversity, etc., after agents exist but before stepping.
+        if on_environment_ready is not None:
+            on_environment_ready(environment)
+
         # Main simulation loop
         # Disable tqdm progress bar in CI environments to avoid output interference
         disable_tqdm = (
@@ -525,6 +541,11 @@ def run_simulation(
             
             # Update environment once per step
             environment.update()
+
+            # Per-step hook (e.g., chromosome telemetry).  Runs after env update
+            # so consumers see the post-step state.
+            if on_step_end is not None:
+                on_step_end(environment, step)
 
             # Check for slow steps
             step_duration = time.time() - step_start_time

--- a/farm/core/simulation.py
+++ b/farm/core/simulation.py
@@ -474,15 +474,19 @@ def run_simulation(
             config.population.chaos_agents,
         )
 
-        # Ensure all initial agents are committed to database before simulation starts
+        # Allow callers to attach per-environment policy / state, seed
+        # population diversity, etc., after agents exist but before the
+        # initial DB flush.  Mutations made here (e.g., chromosome seeding)
+        # will therefore be captured by the flush below and keep in-memory
+        # state in sync with persisted records.
+        if on_environment_ready is not None:
+            on_environment_ready(environment)
+
+        # Ensure all initial agents (including any hook-induced mutations) are
+        # committed to database before simulation starts.
         if environment.db is not None:
             environment.db.logger.flush_all_buffers()
             logger.info("initial_agents_committed_to_database")
-
-        # Allow callers to attach per-environment policy / state, seed
-        # population diversity, etc., after agents exist but before stepping.
-        if on_environment_ready is not None:
-            on_environment_ready(environment)
 
         # Main simulation loop
         # Disable tqdm progress bar in CI environments to avoid output interference

--- a/farm/runners/evolution_experiment.py
+++ b/farm/runners/evolution_experiment.py
@@ -21,6 +21,7 @@ from farm.core.hyperparameter_chromosome import (
     apply_chromosome_to_learning_config,
     chromosome_from_learning_config,
     compute_boundary_penalty,
+    compute_gene_statistics,
     crossover_chromosomes,
     mutate_chromosome,
 )
@@ -668,35 +669,8 @@ class EvolutionExperiment:
     ) -> Dict[str, Dict[str, float]]:
         if not generation_evals:
             return {}
-
-        gene_values: Dict[str, List[float]] = {}
-        gene_bounds: Dict[str, Tuple[float, float]] = {}
-        for evaluation in generation_evals:
-            chromosome = evaluation.metadata["chromosome"]
-            for gene in chromosome.genes:
-                if not gene.evolvable:
-                    continue
-                gene_values.setdefault(gene.name, []).append(gene.value)
-                if gene.name not in gene_bounds:
-                    gene_bounds[gene.name] = (gene.min_value, gene.max_value)
-
-        gene_statistics: Dict[str, Dict[str, float]] = {}
-        for gene_name, values in gene_values.items():
-            min_bound, max_bound = gene_bounds.get(gene_name, (float("-inf"), float("inf")))
-            n = len(values)
-            at_min_count = sum(1 for v in values if v == min_bound)
-            at_max_count = sum(1 for v in values if v == max_bound)
-            gene_statistics[gene_name] = {
-                "mean": statistics.mean(values),
-                "median": statistics.median(values),
-                "std": statistics.pstdev(values) if len(values) > 1 else 0.0,
-                "min": min(values),
-                "max": max(values),
-                "at_min_count": float(at_min_count),
-                "at_max_count": float(at_max_count),
-                "boundary_fraction": float(at_min_count + at_max_count) / n,
-            }
-        return gene_statistics
+        chromosomes = [evaluation.metadata["chromosome"] for evaluation in generation_evals]
+        return compute_gene_statistics(chromosomes, evolvable_only=True)
 
     def _serialize_chromosome_values(self, chromosome: HyperparameterChromosome) -> Dict[str, float]:
         """Return a stable gene-name/value mapping for artifact serialization."""

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -107,6 +107,7 @@ class GeneTrajectoryLogger:
                     handle.flush()
                     handle.close()
                 except Exception:
+                    # Best-effort teardown: ignore flush/close failures to keep shutdown non-fatal.
                     pass
                 setattr(self, attr, None)
 

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -1,0 +1,123 @@
+"""Per-step chromosome telemetry for intrinsic-evolution simulations.
+
+Writes two append-only JSONL files alongside other run artifacts:
+
+- ``intrinsic_gene_trajectory.jsonl`` -- one record per step containing
+  aggregate per-gene statistics over alive agents.  Compact and cheap to
+  append every step.
+- ``intrinsic_gene_snapshots.jsonl`` -- one record every
+  ``snapshot_interval`` steps containing each alive agent's full chromosome
+  values.  Supports lineage analysis offline; bounded cost via the
+  configurable cadence.
+
+Both files are no-ops when ``output_dir`` is ``None``, allowing the logger to
+be used unconditionally inside the runner regardless of whether the user asked
+for persisted artifacts.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List, Optional, TextIO
+
+from farm.core.hyperparameter_chromosome import (
+    HyperparameterChromosome,
+    compute_gene_statistics,
+)
+
+
+class GeneTrajectoryLogger:
+    """Buffered JSONL logger for chromosome distributions and snapshots."""
+
+    TRAJECTORY_FILENAME = "intrinsic_gene_trajectory.jsonl"
+    SNAPSHOT_FILENAME = "intrinsic_gene_snapshots.jsonl"
+
+    def __init__(self, output_dir: Optional[str], snapshot_interval: int) -> None:
+        if snapshot_interval < 1:
+            raise ValueError("snapshot_interval must be at least 1.")
+        self._output_dir = output_dir
+        self._snapshot_interval = snapshot_interval
+        self._trajectory_handle: Optional[TextIO] = None
+        self._snapshot_handle: Optional[TextIO] = None
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
+            self._trajectory_handle = open(
+                os.path.join(output_dir, self.TRAJECTORY_FILENAME),
+                "w",
+                encoding="utf-8",
+            )
+            self._snapshot_handle = open(
+                os.path.join(output_dir, self.SNAPSHOT_FILENAME),
+                "w",
+                encoding="utf-8",
+            )
+
+    def snapshot(self, environment: Any, step: int) -> None:
+        """Record the chromosome distribution at ``step``.
+
+        Always appends a one-line aggregate record to the trajectory file.
+        Additionally appends a full per-agent snapshot when
+        ``step % snapshot_interval == 0`` (so step 0 is always captured).
+        """
+        if self._trajectory_handle is None:
+            return
+
+        alive_agents = list(environment.alive_agent_objects)
+        chromosomes: List[HyperparameterChromosome] = [
+            agent.hyperparameter_chromosome
+            for agent in alive_agents
+            if getattr(agent, "hyperparameter_chromosome", None) is not None
+        ]
+        gene_stats = compute_gene_statistics(chromosomes, evolvable_only=True)
+        trajectory_record: Dict[str, Any] = {
+            "step": step,
+            "n_alive": len(alive_agents),
+            "n_with_chromosome": len(chromosomes),
+            "gene_stats": gene_stats,
+        }
+        self._trajectory_handle.write(json.dumps(trajectory_record) + "\n")
+
+        if self._snapshot_handle is not None and step % self._snapshot_interval == 0:
+            agents_payload: List[Dict[str, Any]] = []
+            for agent in alive_agents:
+                chromosome = getattr(agent, "hyperparameter_chromosome", None)
+                if chromosome is None:
+                    continue
+                agents_payload.append(
+                    {
+                        "agent_id": getattr(agent, "agent_id", None),
+                        "agent_type": getattr(agent, "agent_type", None),
+                        "generation": getattr(agent, "generation", None),
+                        "parent_ids": _read_parent_ids(agent),
+                        "chromosome": {
+                            gene.name: gene.value for gene in chromosome.genes
+                        },
+                    }
+                )
+            snapshot_record = {"step": step, "agents": agents_payload}
+            self._snapshot_handle.write(json.dumps(snapshot_record) + "\n")
+
+    def close(self) -> None:
+        """Flush and close both file handles; safe to call multiple times."""
+        for attr in ("_trajectory_handle", "_snapshot_handle"):
+            handle = getattr(self, attr)
+            if handle is not None:
+                try:
+                    handle.flush()
+                    handle.close()
+                except Exception:
+                    pass
+                setattr(self, attr, None)
+
+
+def _read_parent_ids(agent: Any) -> List[str]:
+    """Best-effort extraction of an agent's parent_ids from its state manager."""
+    state = getattr(agent, "state", None)
+    if state is None:
+        return []
+    inner = getattr(state, "_state", None)
+    parent_ids = getattr(inner, "parent_ids", None) if inner is not None else None
+    if not parent_ids:
+        return []
+    return list(parent_ids)

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -16,7 +16,7 @@ import json
 import os
 import random
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional
 
 from farm.config import SimulationConfig
 from farm.core.hyperparameter_chromosome import (

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -238,7 +238,10 @@ class IntrinsicEvolutionExperiment:
             if getattr(agent, "hyperparameter_chromosome", None) is not None
         ]
         result = IntrinsicEvolutionResult(
-            num_steps_completed=int(environment.time),
+            num_steps_completed=min(
+                self.config.num_steps,
+                max(0, int(environment.time) - 1),
+            ),
             final_population=len(final_alive),
             final_gene_statistics=compute_gene_statistics(
                 final_chromosomes, evolvable_only=True

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -196,9 +196,7 @@ def seed_population_diversity(
         # seeded hyperparameters rather than the pre-seed defaults.
         behavior = getattr(agent, "behavior", None)
         if isinstance(behavior, LearningAgentBehavior):
-            dm = behavior.decision_module
-            dm.config = new_decision_config
-            dm._initialize_algorithm()  # noqa: SLF001
+            behavior.decision_module.reinitialize_algorithm(new_decision_config)
 
 
 class IntrinsicEvolutionExperiment:

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -109,10 +109,10 @@ class IntrinsicEvolutionPolicy:
             raise ValueError("num_crossover_points must be at least 1.")
         if self.coparent_max_radius is not None and self.coparent_max_radius < 0.0:
             raise ValueError("coparent_max_radius must be non-negative when set.")
-        # Coerce string-friendly enum values, raising if invalid.
-        MutationMode(self.mutation_mode)
-        BoundaryMode(self.boundary_mode)
-        CrossoverMode(self.crossover_mode)
+        # Coerce string-friendly enum values to enum instances, raising if invalid.
+        object.__setattr__(self, "mutation_mode", MutationMode(self.mutation_mode))
+        object.__setattr__(self, "boundary_mode", BoundaryMode(self.boundary_mode))
+        object.__setattr__(self, "crossover_mode", CrossoverMode(self.crossover_mode))
         if self.coparent_strategy not in ("nearest_alive_same_type", "random_alive_same_type"):
             raise ValueError(
                 "coparent_strategy must be 'nearest_alive_same_type' or 'random_alive_same_type'."
@@ -160,10 +160,17 @@ def seed_population_diversity(
     When ``policy.seed_initial_diversity`` is ``False`` this is a no-op.
     Both the agent's ``hyperparameter_chromosome`` attribute and its
     ``config.decision`` are updated so subsequent decision-module construction
-    sees the seeded values.
+    sees the seeded values.  If the agent already has a ``LearningAgentBehavior``
+    with a ``DecisionModule`` (i.e., the module was constructed before seeding),
+    the module's config is updated and its algorithm is reinitialized so that
+    optimizer hyper-parameters (LR, gamma, …) reflect the seeded chromosome.
     """
     if not policy.seed_initial_diversity:
         return
+
+    # Import here to avoid a top-level circular dependency.
+    from farm.core.agent.behaviors.learning import LearningAgentBehavior  # noqa: PLC0415
+
     for agent in list(environment.agent_objects):
         chromosome = getattr(agent, "hyperparameter_chromosome", None)
         if chromosome is None:
@@ -178,9 +185,20 @@ def seed_population_diversity(
             rng=rng,
         )
         agent.hyperparameter_chromosome = mutated
-        agent.config.decision = apply_chromosome_to_learning_config(
+        new_decision_config = apply_chromosome_to_learning_config(
             agent.config.decision, mutated
         )
+        agent.config.decision = new_decision_config
+
+        # If the agent's DecisionModule was already constructed (common when
+        # on_environment_ready fires after create_initial_agents), update its
+        # config and reinitialize the algorithm so the optimizer reflects the
+        # seeded hyperparameters rather than the pre-seed defaults.
+        behavior = getattr(agent, "behavior", None)
+        if isinstance(behavior, LearningAgentBehavior):
+            dm = behavior.decision_module
+            dm.config = new_decision_config
+            dm._initialize_algorithm()  # noqa: SLF001
 
 
 class IntrinsicEvolutionExperiment:

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -261,7 +261,7 @@ class IntrinsicEvolutionExperiment:
             _capture_current_state(environment, step=logical_step)
 
         try:
-            environment = run_simulation(
+            run_simulation(
                 num_steps=self.config.num_steps,
                 config=self.base_config,
                 path=self.config.output_dir,

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -16,7 +16,7 @@ import json
 import os
 import random
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from farm.config import SimulationConfig
 from farm.core.hyperparameter_chromosome import (
@@ -168,9 +168,6 @@ def seed_population_diversity(
     if not policy.seed_initial_diversity:
         return
 
-    # Import here to avoid a top-level circular dependency.
-    from farm.core.agent.behaviors.learning import LearningAgentBehavior  # noqa: PLC0415
-
     for agent in list(environment.agent_objects):
         chromosome = getattr(agent, "hyperparameter_chromosome", None)
         if chromosome is None:
@@ -190,13 +187,15 @@ def seed_population_diversity(
         )
         agent.config.decision = new_decision_config
 
-        # If the agent's DecisionModule was already constructed (common when
+        # If a decision module was already constructed (common when
         # on_environment_ready fires after create_initial_agents), update its
         # config and reinitialize the algorithm so the optimizer reflects the
         # seeded hyperparameters rather than the pre-seed defaults.
         behavior = getattr(agent, "behavior", None)
-        if isinstance(behavior, LearningAgentBehavior):
-            behavior.decision_module.reinitialize_algorithm(new_decision_config)
+        decision_module = getattr(behavior, "decision_module", None)
+        reinitialize = getattr(decision_module, "reinitialize_algorithm", None)
+        if callable(reinitialize):
+            reinitialize(new_decision_config)
 
 
 class IntrinsicEvolutionExperiment:
@@ -224,15 +223,42 @@ class IntrinsicEvolutionExperiment:
         )
 
         policy = self.config.policy
+        latest_step = 0
+        latest_population = 0
+        latest_gene_statistics: Dict[str, Dict[str, float]] = {}
+
+        def _capture_current_state(environment: Any, step: int) -> None:
+            """Capture the same state we emit to the trajectory logger.
+
+            The simulation loop performs a final post-loop environment update.
+            To keep metadata/result summaries aligned with persisted telemetry,
+            derive final result fields from the last callback-observed state.
+            """
+            nonlocal latest_step, latest_population, latest_gene_statistics
+            alive_agents = list(environment.alive_agent_objects)
+            chromosomes: List[HyperparameterChromosome] = [
+                agent.hyperparameter_chromosome
+                for agent in alive_agents
+                if getattr(agent, "hyperparameter_chromosome", None) is not None
+            ]
+            latest_step = step
+            latest_population = len(alive_agents)
+            latest_gene_statistics = compute_gene_statistics(
+                chromosomes,
+                evolvable_only=True,
+            )
 
         def _on_environment_ready(environment: Any) -> None:
             environment.intrinsic_evolution_policy = policy
             environment.intrinsic_evolution_rng = rng
             seed_population_diversity(environment, policy, rng)
             gene_logger.snapshot(environment, step=0)
+            _capture_current_state(environment, step=0)
 
         def _on_step_end(environment: Any, step: int) -> None:
-            gene_logger.snapshot(environment, step=step + 1)
+            logical_step = step + 1
+            gene_logger.snapshot(environment, step=logical_step)
+            _capture_current_state(environment, step=logical_step)
 
         try:
             environment = run_simulation(
@@ -247,21 +273,10 @@ class IntrinsicEvolutionExperiment:
         finally:
             gene_logger.close()
 
-        final_alive = environment.alive_agent_objects
-        final_chromosomes: List[HyperparameterChromosome] = [
-            agent.hyperparameter_chromosome
-            for agent in final_alive
-            if getattr(agent, "hyperparameter_chromosome", None) is not None
-        ]
         result = IntrinsicEvolutionResult(
-            num_steps_completed=min(
-                self.config.num_steps,
-                max(0, int(environment.time) - 1),
-            ),
-            final_population=len(final_alive),
-            final_gene_statistics=compute_gene_statistics(
-                final_chromosomes, evolvable_only=True
-            ),
+            num_steps_completed=min(self.config.num_steps, max(0, latest_step)),
+            final_population=latest_population,
+            final_gene_statistics=latest_gene_statistics,
         )
         self._persist(result)
         logger.info(

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -1,0 +1,282 @@
+"""Intrinsic evolution experiment runner.
+
+Runs a single long simulation in which each agent carries its own
+:class:`HyperparameterChromosome` and offspring inherit it (with optional
+crossover and configurable mutation).  Selection emerges from the resource
+environment itself: agents that survive and reproduce pass their
+hyperparameters on; lineages that fail die out.
+
+Compare with :mod:`farm.runners.evolution_experiment`, which runs an outer-loop
+GA *between* simulations.  Both runners are complementary, not substitutes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Literal, Optional
+
+from farm.config import SimulationConfig
+from farm.core.hyperparameter_chromosome import (
+    BoundaryMode,
+    CrossoverMode,
+    HyperparameterChromosome,
+    MutationMode,
+    apply_chromosome_to_learning_config,
+    compute_gene_statistics,
+    mutate_chromosome,
+)
+from farm.core.simulation import run_simulation
+from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+CoparentStrategy = Literal["nearest_alive_same_type", "random_alive_same_type"]
+
+
+@dataclass(frozen=True)
+class IntrinsicEvolutionPolicy:
+    """Policy controlling per-agent chromosome inheritance during a sim.
+
+    When attached to an :class:`Environment` (as ``intrinsic_evolution_policy``)
+    and ``enabled`` is ``True``, :meth:`AgentCore.reproduce` will derive each
+    child's chromosome by optionally crossing the parent with a co-parent and
+    then mutating the result according to these settings.  When the policy is
+    absent or disabled, children inherit the parent's chromosome unchanged.
+
+    Attributes:
+        enabled: Master switch for in-situ chromosome inheritance.
+        seed_initial_diversity: When ``True``, the runner mutates every
+            initial agent's chromosome once before the loop starts so the
+            starting population is not a monoculture.
+        seed_mutation_rate / seed_mutation_scale: Mutation knobs used **only**
+            for the initial diversity seed.  Defaults are intentionally larger
+            than per-reproduction values to spread the starting population.
+        mutation_rate / mutation_scale / mutation_mode: Per-reproduction
+            mutation parameters threaded through to
+            :func:`mutate_chromosome`.
+        boundary_mode / interior_bias_fraction: Boundary handling for mutated
+            values; matches semantics in :class:`BoundaryMode`.
+        crossover_enabled: When ``True``, reproduction picks a co-parent and
+            runs :func:`crossover_chromosomes` before mutation.
+        crossover_mode / blend_alpha / num_crossover_points: Crossover
+            operator settings (see :class:`CrossoverMode`).
+        coparent_strategy: How to pick the co-parent.  Both strategies filter
+            to alive agents of the same ``agent_type``; ``nearest`` is
+            deterministic-modulo-tiebreak and reflects spatial sociality,
+            ``random`` is uniform over the candidate pool.
+        coparent_max_radius: Optional spatial cap on the co-parent search;
+            ``None`` means unbounded.
+        seed: Optional seed for the policy's RNG; when ``None`` the runner
+            seeds from its own configured seed.
+    """
+
+    enabled: bool = True
+    seed_initial_diversity: bool = True
+    seed_mutation_rate: float = 1.0
+    seed_mutation_scale: float = 0.2
+    mutation_rate: float = 0.1
+    mutation_scale: float = 0.1
+    mutation_mode: MutationMode = MutationMode.GAUSSIAN
+    boundary_mode: BoundaryMode = BoundaryMode.CLAMP
+    interior_bias_fraction: float = 1e-3
+    crossover_enabled: bool = False
+    crossover_mode: CrossoverMode = CrossoverMode.UNIFORM
+    blend_alpha: float = 0.5
+    num_crossover_points: int = 2
+    coparent_strategy: CoparentStrategy = "nearest_alive_same_type"
+    coparent_max_radius: Optional[float] = None
+    seed: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.mutation_rate <= 1.0:
+            raise ValueError("mutation_rate must be between 0 and 1.")
+        if self.mutation_scale < 0.0:
+            raise ValueError("mutation_scale must be non-negative.")
+        if not 0.0 <= self.seed_mutation_rate <= 1.0:
+            raise ValueError("seed_mutation_rate must be between 0 and 1.")
+        if self.seed_mutation_scale < 0.0:
+            raise ValueError("seed_mutation_scale must be non-negative.")
+        if self.interior_bias_fraction < 0.0:
+            raise ValueError("interior_bias_fraction must be non-negative.")
+        if self.blend_alpha < 0.0:
+            raise ValueError("blend_alpha must be non-negative.")
+        if self.num_crossover_points < 1:
+            raise ValueError("num_crossover_points must be at least 1.")
+        if self.coparent_max_radius is not None and self.coparent_max_radius < 0.0:
+            raise ValueError("coparent_max_radius must be non-negative when set.")
+        # Coerce string-friendly enum values, raising if invalid.
+        MutationMode(self.mutation_mode)
+        BoundaryMode(self.boundary_mode)
+        CrossoverMode(self.crossover_mode)
+        if self.coparent_strategy not in ("nearest_alive_same_type", "random_alive_same_type"):
+            raise ValueError(
+                "coparent_strategy must be 'nearest_alive_same_type' or 'random_alive_same_type'."
+            )
+
+
+@dataclass(frozen=True)
+class IntrinsicEvolutionExperimentConfig:
+    """Top-level config for the intrinsic evolution runner."""
+
+    num_steps: int = 2000
+    snapshot_interval: int = 100
+    policy: IntrinsicEvolutionPolicy = field(default_factory=IntrinsicEvolutionPolicy)
+    output_dir: Optional[str] = None
+    seed: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.num_steps < 1:
+            raise ValueError("num_steps must be at least 1.")
+        if self.snapshot_interval < 1:
+            raise ValueError("snapshot_interval must be at least 1.")
+
+
+@dataclass
+class IntrinsicEvolutionResult:
+    """Summary of an intrinsic evolution run.
+
+    ``num_steps_completed`` may be smaller than ``config.num_steps`` if the
+    population went extinct early (mirroring ``run_simulation`` semantics).
+    ``final_gene_statistics`` is empty when the final population is empty.
+    """
+
+    num_steps_completed: int
+    final_population: int
+    final_gene_statistics: Dict[str, Dict[str, float]]
+
+
+def seed_population_diversity(
+    environment: Any,
+    policy: IntrinsicEvolutionPolicy,
+    rng: random.Random,
+) -> None:
+    """Mutate each initial agent's chromosome to spread the starting population.
+
+    When ``policy.seed_initial_diversity`` is ``False`` this is a no-op.
+    Both the agent's ``hyperparameter_chromosome`` attribute and its
+    ``config.decision`` are updated so subsequent decision-module construction
+    sees the seeded values.
+    """
+    if not policy.seed_initial_diversity:
+        return
+    for agent in list(environment.agent_objects):
+        chromosome = getattr(agent, "hyperparameter_chromosome", None)
+        if chromosome is None:
+            continue
+        mutated = mutate_chromosome(
+            chromosome,
+            mutation_rate=policy.seed_mutation_rate,
+            mutation_scale=policy.seed_mutation_scale,
+            mutation_mode=policy.mutation_mode,
+            boundary_mode=policy.boundary_mode,
+            interior_bias_fraction=policy.interior_bias_fraction,
+            rng=rng,
+        )
+        agent.hyperparameter_chromosome = mutated
+        agent.config.decision = apply_chromosome_to_learning_config(
+            agent.config.decision, mutated
+        )
+
+
+class IntrinsicEvolutionExperiment:
+    """Run a single simulation in which agents carry inheritable chromosomes."""
+
+    def __init__(
+        self,
+        base_config: SimulationConfig,
+        config: IntrinsicEvolutionExperimentConfig,
+    ) -> None:
+        self.base_config = base_config
+        self.config = config
+
+    def run(self) -> IntrinsicEvolutionResult:
+        """Execute the configured number of steps and persist artifacts."""
+        seed = self.config.seed if self.config.policy.seed is None else self.config.policy.seed
+        rng = random.Random(seed)
+
+        if self.config.output_dir:
+            os.makedirs(self.config.output_dir, exist_ok=True)
+
+        gene_logger = GeneTrajectoryLogger(
+            output_dir=self.config.output_dir,
+            snapshot_interval=self.config.snapshot_interval,
+        )
+
+        policy = self.config.policy
+
+        def _on_environment_ready(environment: Any) -> None:
+            environment.intrinsic_evolution_policy = policy
+            environment.intrinsic_evolution_rng = rng
+            seed_population_diversity(environment, policy, rng)
+            gene_logger.snapshot(environment, step=0)
+
+        def _on_step_end(environment: Any, step: int) -> None:
+            gene_logger.snapshot(environment, step=step + 1)
+
+        try:
+            environment = run_simulation(
+                num_steps=self.config.num_steps,
+                config=self.base_config,
+                path=self.config.output_dir,
+                save_config=False,
+                seed=self.config.seed,
+                on_environment_ready=_on_environment_ready,
+                on_step_end=_on_step_end,
+            )
+        finally:
+            gene_logger.close()
+
+        final_alive = environment.alive_agent_objects
+        final_chromosomes: List[HyperparameterChromosome] = [
+            agent.hyperparameter_chromosome
+            for agent in final_alive
+            if getattr(agent, "hyperparameter_chromosome", None) is not None
+        ]
+        result = IntrinsicEvolutionResult(
+            num_steps_completed=int(environment.time),
+            final_population=len(final_alive),
+            final_gene_statistics=compute_gene_statistics(
+                final_chromosomes, evolvable_only=True
+            ),
+        )
+        self._persist(result)
+        logger.info(
+            "intrinsic_evolution_completed",
+            output_dir=self.config.output_dir,
+            num_steps_completed=result.num_steps_completed,
+            final_population=result.final_population,
+        )
+        return result
+
+    def _persist(self, result: IntrinsicEvolutionResult) -> None:
+        if not self.config.output_dir:
+            return
+        metadata_path = os.path.join(
+            self.config.output_dir, "intrinsic_evolution_metadata.json"
+        )
+        payload: Dict[str, Any] = {
+            "num_steps_completed": result.num_steps_completed,
+            "num_steps_configured": self.config.num_steps,
+            "snapshot_interval": self.config.snapshot_interval,
+            "final_population": result.final_population,
+            "final_gene_statistics": result.final_gene_statistics,
+            "policy": _serialize_policy(self.config.policy),
+            "seed": self.config.seed,
+        }
+        with open(metadata_path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+
+
+def _serialize_policy(policy: IntrinsicEvolutionPolicy) -> Dict[str, Any]:
+    """Render policy as a JSON-friendly dict, coercing enums to their values."""
+    raw = asdict(policy)
+    for key in ("mutation_mode", "boundary_mode", "crossover_mode"):
+        value = raw.get(key)
+        if hasattr(value, "value"):
+            raw[key] = value.value
+    return raw

--- a/tests/core/agent/test_reproduce_chromosome_policy.py
+++ b/tests/core/agent/test_reproduce_chromosome_policy.py
@@ -1,0 +1,160 @@
+"""Tests for the intrinsic-evolution policy path in `AgentCore.reproduce`.
+
+Covers chromosome derivation logic in isolation (without spinning up a full
+simulation): the no-policy passthrough, the mutation path, and the optional
+crossover path with co-parent selection.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from types import SimpleNamespace
+from typing import List, Optional
+from unittest.mock import patch
+
+from farm.core.agent.config.component_configs import AgentComponentConfig
+from farm.core.agent.core import AgentCore
+from farm.core.decision.config import DecisionConfig
+from farm.core.hyperparameter_chromosome import (
+    CrossoverMode,
+    chromosome_from_learning_config,
+)
+from farm.runners.intrinsic_evolution_experiment import IntrinsicEvolutionPolicy
+
+
+def _make_agent(
+    *,
+    agent_id: str = "agent_1",
+    agent_type: str = "system",
+    learning_rate: float = 0.01,
+    position: tuple = (0.0, 0.0),
+    alive: bool = True,
+) -> AgentCore:
+    """Skeletal AgentCore stand-in carrying just what `_derive_child_chromosome` reads."""
+    agent = object.__new__(AgentCore)
+    agent.agent_id = agent_id
+    agent.agent_type = agent_type
+    agent.alive = alive
+    agent.environment = None
+    agent.state = SimpleNamespace(position=position)
+    config = AgentComponentConfig.default()
+    config.decision = DecisionConfig(learning_rate=learning_rate)
+    agent.config = config
+    agent.hyperparameter_chromosome = chromosome_from_learning_config(agent.config.decision)
+    return agent
+
+
+def _make_environment(agents: List[AgentCore], policy: Optional[IntrinsicEvolutionPolicy], rng):
+    """Minimal environment object exposing what reproduction reads from us."""
+    return SimpleNamespace(
+        alive_agent_objects=[a for a in agents if a.alive],
+        intrinsic_evolution_policy=policy,
+        intrinsic_evolution_rng=rng,
+    )
+
+
+def test_derive_child_no_policy_returns_deep_copy():
+    parent = _make_agent(learning_rate=0.05)
+    parent.environment = _make_environment([parent], policy=None, rng=None)
+    child = parent._derive_child_chromosome(parent.hyperparameter_chromosome)
+    assert child is not parent.hyperparameter_chromosome
+    assert child.get_value("learning_rate") == 0.05
+
+
+def test_derive_child_disabled_policy_returns_deep_copy():
+    parent = _make_agent(learning_rate=0.05)
+    policy = IntrinsicEvolutionPolicy(enabled=False)
+    parent.environment = _make_environment([parent], policy=policy, rng=random.Random(0))
+    child = parent._derive_child_chromosome(parent.hyperparameter_chromosome)
+    assert child.get_value("learning_rate") == 0.05
+
+
+def test_derive_child_with_policy_mutates():
+    parent = _make_agent(learning_rate=0.01)
+    policy = IntrinsicEvolutionPolicy(mutation_rate=1.0, mutation_scale=0.2)
+    parent.environment = _make_environment([parent], policy=policy, rng=None)
+
+    with patch("farm.core.hyperparameter_chromosome.random.random", return_value=0.0), patch(
+        "farm.core.hyperparameter_chromosome.random.gauss", return_value=0.002
+    ):
+        child = parent._derive_child_chromosome(parent.hyperparameter_chromosome)
+
+    assert child.get_value("learning_rate") != parent.hyperparameter_chromosome.get_value(
+        "learning_rate"
+    )
+
+
+def test_select_coparent_returns_none_when_alone():
+    parent = _make_agent()
+    policy = IntrinsicEvolutionPolicy(crossover_enabled=True)
+    parent.environment = _make_environment([parent], policy=policy, rng=random.Random(0))
+    assert parent._select_coparent(policy, random.Random(0)) is None
+
+
+def test_select_coparent_skips_dead_and_other_types():
+    parent = _make_agent(agent_id="p", position=(0.0, 0.0))
+    dead = _make_agent(agent_id="d", position=(1.0, 0.0), alive=False)
+    other_type = _make_agent(agent_id="o", agent_type="independent", position=(0.5, 0.0))
+    sibling = _make_agent(agent_id="s", position=(2.0, 0.0))
+    policy = IntrinsicEvolutionPolicy(crossover_enabled=True)
+    parent.environment = _make_environment(
+        [parent, dead, other_type, sibling], policy=policy, rng=random.Random(0)
+    )
+    chosen = parent._select_coparent(policy, random.Random(0))
+    assert chosen is sibling
+
+
+def test_select_coparent_respects_radius():
+    parent = _make_agent(agent_id="p", position=(0.0, 0.0))
+    near = _make_agent(agent_id="near", position=(1.0, 0.0))
+    far = _make_agent(agent_id="far", position=(10.0, 0.0))
+    policy = IntrinsicEvolutionPolicy(crossover_enabled=True, coparent_max_radius=5.0)
+    parent.environment = _make_environment([parent, near, far], policy=policy, rng=random.Random(0))
+    assert parent._select_coparent(policy, random.Random(0)) is near
+
+
+def test_select_coparent_nearest_strategy():
+    parent = _make_agent(agent_id="p", position=(0.0, 0.0))
+    closer = _make_agent(agent_id="closer", position=(1.0, 0.0))
+    farther = _make_agent(agent_id="farther", position=(5.0, 0.0))
+    policy = IntrinsicEvolutionPolicy(
+        crossover_enabled=True, coparent_strategy="nearest_alive_same_type"
+    )
+    parent.environment = _make_environment(
+        [parent, closer, farther], policy=policy, rng=random.Random(0)
+    )
+    assert parent._select_coparent(policy, random.Random(0)) is closer
+
+
+def test_select_coparent_random_strategy_uses_rng():
+    parent = _make_agent(agent_id="p", position=(0.0, 0.0))
+    options = [_make_agent(agent_id=f"o{i}", position=(float(i), 0.0)) for i in range(5)]
+    policy = IntrinsicEvolutionPolicy(
+        crossover_enabled=True, coparent_strategy="random_alive_same_type"
+    )
+    parent.environment = _make_environment([parent, *options], policy=policy, rng=random.Random(0))
+    rng = random.Random(123)
+    pick = parent._select_coparent(policy, rng)
+    assert pick in options
+
+
+def test_derive_child_with_crossover_uses_coparent():
+    """When crossover is enabled, the co-parent's chromosome is consulted."""
+    parent = _make_agent(agent_id="p", learning_rate=0.01, position=(0.0, 0.0))
+    coparent = _make_agent(agent_id="c", learning_rate=0.05, position=(1.0, 0.0))
+    policy = IntrinsicEvolutionPolicy(
+        crossover_enabled=True,
+        crossover_mode=CrossoverMode.UNIFORM,
+        mutation_rate=0.0,
+    )
+    parent.environment = _make_environment(
+        [parent, coparent], policy=policy, rng=random.Random(42)
+    )
+    rng_seed = random.Random(7)
+    parent.environment.intrinsic_evolution_rng = rng_seed
+    child = parent._derive_child_chromosome(parent.hyperparameter_chromosome)
+    lr = child.get_value("learning_rate")
+    assert math.isclose(lr, 0.01) or math.isclose(lr, 0.05), (
+        "uniform crossover should pick learning_rate from one of the two parents"
+    )

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -95,6 +95,24 @@ class TestIntrinsicEvolutionPolicy(unittest.TestCase):
         with self.assertRaises(ValueError):
             IntrinsicEvolutionPolicy(coparent_strategy="bogus")  # type: ignore[arg-type]
 
+    def test_string_enums_coerced_to_enum_instances(self):
+        """String values passed for enum fields must be normalized to enum instances."""
+        policy = IntrinsicEvolutionPolicy(
+            mutation_mode="gaussian",  # type: ignore[arg-type]
+            boundary_mode="clamp",  # type: ignore[arg-type]
+            crossover_mode="uniform",  # type: ignore[arg-type]
+        )
+        self.assertIsInstance(policy.mutation_mode, MutationMode)
+        self.assertIsInstance(policy.boundary_mode, BoundaryMode)
+        self.assertIsInstance(policy.crossover_mode, CrossoverMode)
+        self.assertEqual(policy.mutation_mode, MutationMode.GAUSSIAN)
+        self.assertEqual(policy.boundary_mode, BoundaryMode.CLAMP)
+        self.assertEqual(policy.crossover_mode, CrossoverMode.UNIFORM)
+
+    def test_invalid_string_enum_raises(self):
+        with self.assertRaises(ValueError):
+            IntrinsicEvolutionPolicy(mutation_mode="not_a_mode")  # type: ignore[arg-type]
+
 
 class TestIntrinsicEvolutionExperimentConfig(unittest.TestCase):
     def test_rejects_zero_steps(self):
@@ -131,6 +149,36 @@ class TestSeedPopulationDiversity(unittest.TestCase):
         # Decision config is updated alongside the chromosome.
         for agent, lr in zip(agents, new_lrs):
             self.assertEqual(agent.config.decision.learning_rate, lr)
+
+    def test_reinitializes_decision_module_when_behavior_present(self):
+        """DecisionModule config and algorithm are updated when already constructed."""
+        from unittest.mock import MagicMock
+
+        from farm.core.agent.behaviors.learning import LearningAgentBehavior
+
+        dm = MagicMock()
+        behavior = LearningAgentBehavior(dm)
+        config = SimpleNamespace(decision=SimpleNamespace(learning_rate=0.01))
+        chromosome = chromosome_from_learning_config(config.decision)
+        agent = SimpleNamespace(
+            agent_id="dm_agent",
+            agent_type="system",
+            alive=True,
+            config=config,
+            hyperparameter_chromosome=chromosome,
+            behavior=behavior,
+        )
+        env = _FakeEnvironment([agent])
+        policy = IntrinsicEvolutionPolicy(
+            seed_initial_diversity=True,
+            seed_mutation_rate=1.0,
+            seed_mutation_scale=0.5,
+        )
+        seed_population_diversity(env, policy, random.Random(42))
+
+        # DecisionModule config must be updated and algorithm reinitialized.
+        dm._initialize_algorithm.assert_called_once()
+        self.assertIs(dm.config, agent.config.decision)
 
 
 class TestRunnerOrchestration(unittest.TestCase):

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -1,0 +1,222 @@
+"""Tests for the intrinsic evolution runner.
+
+The runner drives a single simulation and patches `run_simulation` so we can
+exercise the orchestration (policy attachment, seed diversity, per-step
+logger snapshots, artifact persistence) without the cost of a full sim.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import tempfile
+import unittest
+from types import SimpleNamespace
+from typing import List
+from unittest.mock import patch
+
+from farm.config import SimulationConfig
+from farm.core.hyperparameter_chromosome import (
+    BoundaryMode,
+    CrossoverMode,
+    MutationMode,
+    chromosome_from_learning_config,
+)
+from farm.runners.intrinsic_evolution_experiment import (
+    IntrinsicEvolutionExperiment,
+    IntrinsicEvolutionExperimentConfig,
+    IntrinsicEvolutionPolicy,
+    seed_population_diversity,
+)
+
+
+def _make_fake_agent(learning_rate: float = 0.01):
+    """Lightweight agent stand-in carrying the attributes the runner reads."""
+    config = SimpleNamespace(decision=SimpleNamespace(learning_rate=learning_rate))
+    chromosome = chromosome_from_learning_config(config.decision)
+    state_inner = SimpleNamespace(parent_ids=["seed"])
+    return SimpleNamespace(
+        agent_id=f"a_{learning_rate}",
+        agent_type="system",
+        generation=0,
+        alive=True,
+        config=config,
+        hyperparameter_chromosome=chromosome,
+        state=SimpleNamespace(_state=state_inner),
+    )
+
+
+class _FakeEnvironment:
+    """Minimal environment compatible with the runner / logger contracts."""
+
+    def __init__(self, agents):
+        self._agents = list(agents)
+        self.time = 0
+        # Allow runner to attach policy / rng:
+        self.intrinsic_evolution_policy = None
+        self.intrinsic_evolution_rng = None
+
+    @property
+    def agents(self):
+        return [a.agent_id for a in self._agents if a.alive]
+
+    @property
+    def agent_objects(self):
+        return list(self._agents)
+
+    @property
+    def alive_agent_objects(self):
+        return [a for a in self._agents if a.alive]
+
+
+class TestIntrinsicEvolutionPolicy(unittest.TestCase):
+    def test_defaults_construct_cleanly(self):
+        policy = IntrinsicEvolutionPolicy()
+        self.assertTrue(policy.enabled)
+        self.assertEqual(policy.mutation_mode, MutationMode.GAUSSIAN)
+        self.assertEqual(policy.boundary_mode, BoundaryMode.CLAMP)
+        self.assertEqual(policy.crossover_mode, CrossoverMode.UNIFORM)
+        self.assertFalse(policy.crossover_enabled)
+
+    def test_rejects_invalid_mutation_rate(self):
+        with self.assertRaises(ValueError):
+            IntrinsicEvolutionPolicy(mutation_rate=1.5)
+
+    def test_rejects_negative_mutation_scale(self):
+        with self.assertRaises(ValueError):
+            IntrinsicEvolutionPolicy(mutation_scale=-0.1)
+
+    def test_rejects_negative_radius(self):
+        with self.assertRaises(ValueError):
+            IntrinsicEvolutionPolicy(coparent_max_radius=-1.0)
+
+    def test_rejects_unknown_coparent_strategy(self):
+        with self.assertRaises(ValueError):
+            IntrinsicEvolutionPolicy(coparent_strategy="bogus")  # type: ignore[arg-type]
+
+
+class TestIntrinsicEvolutionExperimentConfig(unittest.TestCase):
+    def test_rejects_zero_steps(self):
+        with self.assertRaises(ValueError):
+            IntrinsicEvolutionExperimentConfig(num_steps=0)
+
+    def test_rejects_zero_snapshot_interval(self):
+        with self.assertRaises(ValueError):
+            IntrinsicEvolutionExperimentConfig(snapshot_interval=0)
+
+
+class TestSeedPopulationDiversity(unittest.TestCase):
+    def test_no_op_when_disabled(self):
+        agents = [_make_fake_agent(0.01) for _ in range(3)]
+        env = _FakeEnvironment(agents)
+        original_lrs = [a.hyperparameter_chromosome.get_value("learning_rate") for a in agents]
+        policy = IntrinsicEvolutionPolicy(seed_initial_diversity=False)
+        seed_population_diversity(env, policy, random.Random(0))
+        new_lrs = [a.hyperparameter_chromosome.get_value("learning_rate") for a in agents]
+        self.assertEqual(original_lrs, new_lrs)
+
+    def test_seeds_each_agent_with_distinct_chromosome(self):
+        agents = [_make_fake_agent(0.01) for _ in range(5)]
+        env = _FakeEnvironment(agents)
+        policy = IntrinsicEvolutionPolicy(
+            seed_initial_diversity=True,
+            seed_mutation_rate=1.0,
+            seed_mutation_scale=0.3,
+        )
+        seed_population_diversity(env, policy, random.Random(0))
+        new_lrs = [a.hyperparameter_chromosome.get_value("learning_rate") for a in agents]
+        # With mutation_rate=1.0 and a non-zero scale, at least one value should differ.
+        self.assertTrue(any(lr != 0.01 for lr in new_lrs))
+        # Decision config is updated alongside the chromosome.
+        for agent, lr in zip(agents, new_lrs):
+            self.assertEqual(agent.config.decision.learning_rate, lr)
+
+
+class TestRunnerOrchestration(unittest.TestCase):
+    def _stub_run_simulation(self, num_agents: int = 4, num_steps: int = 3):
+        """Return a side-effect that mimics run_simulation's hook contract."""
+        agents = [_make_fake_agent(0.01) for _ in range(num_agents)]
+        env = _FakeEnvironment(agents)
+
+        def _side_effect(*args, **kwargs):
+            on_environment_ready = kwargs.get("on_environment_ready")
+            on_step_end = kwargs.get("on_step_end")
+            if on_environment_ready is not None:
+                on_environment_ready(env)
+            for step in range(num_steps):
+                env.time = step + 1
+                if on_step_end is not None:
+                    on_step_end(env, step)
+            return env
+
+        return _side_effect, env
+
+    def test_runner_attaches_policy_and_drives_loop(self):
+        side_effect, env = self._stub_run_simulation(num_agents=3, num_steps=4)
+        with patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation",
+            side_effect=side_effect,
+        ) as run_mock:
+            cfg = IntrinsicEvolutionExperimentConfig(num_steps=4, snapshot_interval=2, seed=7)
+            base_config = SimulationConfig()
+            result = IntrinsicEvolutionExperiment(base_config, cfg).run()
+
+        self.assertEqual(run_mock.call_count, 1)
+        # Policy is attached to the env exactly once during on_environment_ready.
+        self.assertIsInstance(env.intrinsic_evolution_policy, IntrinsicEvolutionPolicy)
+        self.assertIsInstance(env.intrinsic_evolution_rng, random.Random)
+        self.assertEqual(result.final_population, 3)
+        self.assertEqual(result.num_steps_completed, 4)
+        self.assertIn("learning_rate", result.final_gene_statistics)
+
+    def test_runner_persists_artifacts(self):
+        side_effect, _env = self._stub_run_simulation(num_agents=2, num_steps=5)
+        with tempfile.TemporaryDirectory() as output_dir, patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation",
+            side_effect=side_effect,
+        ):
+            cfg = IntrinsicEvolutionExperimentConfig(
+                num_steps=5,
+                snapshot_interval=2,
+                output_dir=output_dir,
+                seed=11,
+            )
+            base_config = SimulationConfig()
+            IntrinsicEvolutionExperiment(base_config, cfg).run()
+
+            traj_path = os.path.join(output_dir, "intrinsic_gene_trajectory.jsonl")
+            snap_path = os.path.join(output_dir, "intrinsic_gene_snapshots.jsonl")
+            meta_path = os.path.join(output_dir, "intrinsic_evolution_metadata.json")
+
+            self.assertTrue(os.path.exists(traj_path))
+            self.assertTrue(os.path.exists(snap_path))
+            self.assertTrue(os.path.exists(meta_path))
+
+            with open(traj_path, encoding="utf-8") as fh:
+                trajectory_lines = [json.loads(line) for line in fh if line.strip()]
+            with open(snap_path, encoding="utf-8") as fh:
+                snapshot_lines = [json.loads(line) for line in fh if line.strip()]
+            with open(meta_path, encoding="utf-8") as fh:
+                metadata = json.load(fh)
+
+            # Trajectory: one record per snapshot call (env_ready + 5 step_end = 6).
+            self.assertEqual(len(trajectory_lines), 6)
+            for record in trajectory_lines:
+                self.assertIn("step", record)
+                self.assertIn("gene_stats", record)
+                self.assertIn("learning_rate", record["gene_stats"])
+
+            # Snapshot interval = 2: steps 0, 2, 4 -> 3 snapshots.
+            self.assertEqual(len(snapshot_lines), 3)
+            self.assertEqual([rec["step"] for rec in snapshot_lines], [0, 2, 4])
+
+            self.assertEqual(metadata["num_steps_configured"], 5)
+            self.assertEqual(metadata["snapshot_interval"], 2)
+            self.assertIn("policy", metadata)
+            # Enums in the policy must serialize to plain string values.
+            self.assertEqual(metadata["policy"]["mutation_mode"], "gaussian")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -176,9 +176,8 @@ class TestSeedPopulationDiversity(unittest.TestCase):
         )
         seed_population_diversity(env, policy, random.Random(42))
 
-        # DecisionModule config must be updated and algorithm reinitialized.
-        dm._initialize_algorithm.assert_called_once()
-        self.assertIs(dm.config, agent.config.decision)
+        # DecisionModule must be reinitialized via the public reinitialize_algorithm method.
+        dm.reinitialize_algorithm.assert_called_once_with(agent.config.decision)
 
 
 class TestRunnerOrchestration(unittest.TestCase):

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -148,6 +148,8 @@ class TestRunnerOrchestration(unittest.TestCase):
                 env.time = step + 1
                 if on_step_end is not None:
                     on_step_end(env, step)
+            # Match run_simulation: one extra environment.update() after the loop.
+            env.time += 1
             return env
 
         return _side_effect, env

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -178,6 +178,32 @@ class TestSeedPopulationDiversity(unittest.TestCase):
         # DecisionModule must be reinitialized via the public reinitialize_algorithm method.
         dm.reinitialize_algorithm.assert_called_once_with(agent.config.decision)
 
+    def test_reinitializes_any_behavior_with_compatible_decision_module(self):
+        """Reinitialization is capability-based, not tied to one behavior class."""
+        from unittest.mock import MagicMock
+
+        dm = MagicMock()
+        behavior = SimpleNamespace(decision_module=dm)
+        config = SimpleNamespace(decision=SimpleNamespace(learning_rate=0.01))
+        chromosome = chromosome_from_learning_config(config.decision)
+        agent = SimpleNamespace(
+            agent_id="generic_behavior_agent",
+            agent_type="system",
+            alive=True,
+            config=config,
+            hyperparameter_chromosome=chromosome,
+            behavior=behavior,
+        )
+        env = _FakeEnvironment([agent])
+        policy = IntrinsicEvolutionPolicy(
+            seed_initial_diversity=True,
+            seed_mutation_rate=1.0,
+            seed_mutation_scale=0.5,
+        )
+        seed_population_diversity(env, policy, random.Random(42))
+
+        dm.reinitialize_algorithm.assert_called_once_with(agent.config.decision)
+
 
 class TestRunnerOrchestration(unittest.TestCase):
     def _stub_run_simulation(self, num_agents: int = 4, num_steps: int = 3):
@@ -264,6 +290,37 @@ class TestRunnerOrchestration(unittest.TestCase):
             self.assertIn("policy", metadata)
             # Enums in the policy must serialize to plain string values.
             self.assertEqual(metadata["policy"]["mutation_mode"], "gaussian")
+
+    def test_final_result_uses_last_hooked_state(self):
+        """Final metadata aligns with callback telemetry, not post-loop finalization."""
+        agents = [_make_fake_agent(0.01), _make_fake_agent(0.02)]
+        env = _FakeEnvironment(agents)
+
+        def _side_effect(*args, **kwargs):
+            on_environment_ready = kwargs.get("on_environment_ready")
+            on_step_end = kwargs.get("on_step_end")
+            if on_environment_ready is not None:
+                on_environment_ready(env)
+            # Run exactly one logical step and report it via hook.
+            env.time = 1
+            if on_step_end is not None:
+                on_step_end(env, 0)
+            # Simulate a post-loop finalization update that changes live state.
+            env._agents[1].alive = False
+            env.time = 2
+            return env
+
+        with patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation",
+            side_effect=_side_effect,
+        ):
+            cfg = IntrinsicEvolutionExperimentConfig(num_steps=1, snapshot_interval=1, seed=7)
+            base_config = SimulationConfig()
+            result = IntrinsicEvolutionExperiment(base_config, cfg).run()
+
+        # Last hooked state still had both agents alive.
+        self.assertEqual(result.final_population, 2)
+        self.assertEqual(result.num_steps_completed, 1)
 
 
 if __name__ == "__main__":

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -13,7 +13,6 @@ import random
 import tempfile
 import unittest
 from types import SimpleNamespace
-from typing import List
 from unittest.mock import patch
 
 from farm.config import SimulationConfig

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -8,10 +8,16 @@ from farm.core.agent.config.component_configs import AgentComponentConfig
 from farm.core.agent.core import AgentCore
 from farm.core.decision.config import DecisionConfig
 from farm.core.hyperparameter_chromosome import chromosome_from_learning_config
+from farm.runners.intrinsic_evolution_experiment import IntrinsicEvolutionPolicy
 
 
 def _build_parent_agent_for_reproduction() -> AgentCore:
-    """Create a minimal AgentCore instance with required reproduction attributes."""
+    """Create a minimal AgentCore instance with required reproduction attributes.
+
+    The mock environment defaults to ``intrinsic_evolution_policy=None`` so the
+    parent's chromosome is inherited unchanged unless a test explicitly opts
+    into the in-situ evolution policy.
+    """
     agent = object.__new__(AgentCore)
     agent.agent_id = "parent_1"
     agent.agent_type = "system"
@@ -19,6 +25,8 @@ def _build_parent_agent_for_reproduction() -> AgentCore:
     agent.services = Mock()
     agent.environment = Mock()
     agent.environment.get_next_agent_id.return_value = "child_1"
+    agent.environment.intrinsic_evolution_policy = None
+    agent.environment.intrinsic_evolution_rng = None
     agent.state = Mock()
     agent.state.position = (2.0, 3.0)
     agent.state._state = Mock()
@@ -47,8 +55,40 @@ def _build_parent_agent_for_reproduction() -> AgentCore:
     return agent
 
 
-def test_reproduce_mutates_learning_rate_and_passes_child_config():
+def test_reproduce_inherits_chromosome_unchanged_without_policy():
+    """Without an intrinsic evolution policy, child chromosome equals parent's exactly."""
     parent = _build_parent_agent_for_reproduction()
+    parent_lr = parent.hyperparameter_chromosome.get_value("learning_rate")
+
+    offspring = Mock()
+    offspring.state = Mock()
+    offspring.state._state = Mock()
+    offspring.state._state.model_copy.return_value = Mock()
+
+    with patch("farm.core.agent.factory.AgentFactory") as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is True
+    assert offspring.generation == 5
+    assert offspring.hyperparameter_chromosome.get_value("learning_rate") == parent_lr
+    kwargs = factory.create_learning_agent.call_args.kwargs
+    child_config = kwargs["config"]
+    assert child_config is not parent.config
+    # Pure inheritance: every gene matches.
+    assert child_config.decision.learning_rate == parent_lr
+
+
+def test_reproduce_with_policy_mutates_learning_rate_and_passes_child_config():
+    """When the policy is enabled, child genes are mutated using the policy's knobs."""
+    parent = _build_parent_agent_for_reproduction()
+    parent.environment.intrinsic_evolution_policy = IntrinsicEvolutionPolicy(
+        mutation_rate=1.0,
+        mutation_scale=0.2,
+    )
+    parent.environment.intrinsic_evolution_rng = None
+
     offspring = Mock()
     offspring.state = Mock()
     offspring.state._state = Mock()
@@ -70,22 +110,19 @@ def test_reproduce_mutates_learning_rate_and_passes_child_config():
     kwargs = factory.create_learning_agent.call_args.kwargs
     child_config = kwargs["config"]
     assert child_config is not parent.config
-    assert child_config.decision.learning_rate == 0.012
-    # epsilon_decay and gamma are now evolvable; gauss patched to 0.002 shifts both.
-    # gamma: span = 1.0, mutation_scale (default) = 0.2 → sigma = 0.2 → delta = 0.002
-    # epsilon_decay: span ≈ 1.0, mutation_scale = 0.2 → sigma ≈ 0.2 → delta = 0.002
+    assert child_config.decision.learning_rate == pytest.approx(0.012, abs=1e-9)
     assert child_config.decision.epsilon_decay == pytest.approx(0.997, abs=1e-9)
     assert child_config.decision.gamma == pytest.approx(0.992, abs=1e-9)
-    # memory_size is fixed (evolvable=False) and stays at the parent value.
     assert child_config.decision.memory_size == 2000
-    assert offspring.hyperparameter_chromosome.get_value("learning_rate") == 0.012
+    assert offspring.hyperparameter_chromosome.get_value("learning_rate") == pytest.approx(0.012, abs=1e-9)
 
 
 def test_reproduce_logs_exception_and_returns_false():
+    """Errors during chromosome derivation should refund and return False."""
     parent = _build_parent_agent_for_reproduction()
 
     with patch(
-        "farm.core.agent.core.mutate_chromosome",
+        "farm.core.agent.core.AgentCore._derive_child_chromosome",
         side_effect=RuntimeError("boom"),
     ), patch("farm.core.agent.core.logger.exception") as log_exception:
         success = AgentCore.reproduce(parent)


### PR DESCRIPTION
- Added `IntrinsicEvolutionExperiment` to facilitate in-situ evolution with per-agent hyperparameter chromosomes.
- Introduced `IntrinsicEvolutionPolicy` for managing chromosome inheritance, including crossover and mutation settings.
- Enhanced `AgentCore` to derive child chromosomes based on the intrinsic evolution policy, allowing for dynamic adaptation during simulations.
- Implemented `GeneTrajectoryLogger` for tracking chromosome statistics and snapshots throughout the simulation.
- Updated relevant documentation and tests to cover new functionalities and ensure robustness of the intrinsic evolution framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent reproduction semantics (no-policy now preserves chromosomes instead of always mutating) and adds new simulation-loop hooks, which can affect experiment outcomes and any code depending on prior implicit mutation behavior.
> 
> **Overview**
> Adds a new *in-situ* hyperparameter evolution path via `IntrinsicEvolutionExperiment`, which attaches an `IntrinsicEvolutionPolicy` to the environment to control per-offspring chromosome inheritance (optional co-parent crossover + mutation) and optionally seeds initial population diversity.
> 
> `AgentCore.reproduce()` is updated to honor this policy and, by default (no policy/disabled), **stop mutating chromosomes during reproduction** to keep outer-loop experiments deterministic/clean. `run_simulation()` gains `on_environment_ready` and `on_step_end` hooks to support per-run policy attachment and per-step logging.
> 
> Introduces `GeneTrajectoryLogger` plus a shared `compute_gene_statistics()` utility (now used by `EvolutionExperiment`) to emit intrinsic evolution JSONL trajectory/snapshot artifacts, and adds documentation + tests covering the new runner, policy validation, and updated reproduction contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 957050698580223cde83dd79880ab5fb2266e420. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->