### PR TITLE
Add phylogenetics analysis module with tree construction and visualization

### DIFF
--- a/farm/analysis/__init__.py
+++ b/farm/analysis/__init__.py
@@ -58,6 +58,7 @@ from farm.analysis import (
     dominance,
     genesis,
     learning,
+    phylogenetics,
     population,
     resources,
     significant_events,

--- a/farm/analysis/phylogenetics/__init__.py
+++ b/farm/analysis/phylogenetics/__init__.py
@@ -1,0 +1,62 @@
+"""Phylogenetics Analysis Package
+
+Provides tools for building, serialising, and visualising phylogenetic trees
+(and DAGs for dual-parent reproduction) from agent lineage data stored in a
+simulation database or in ``evolution_lineage.json`` artifacts.
+
+Features
+--------
+- In-memory tree/DAG builder with deterministic node ordering
+- Explicit handling of orphan nodes (missing parents) and dual-parent cases
+- JSON export (full tree/DAG) and Newick export (single-parent projection)
+- Summary statistics: depth, branching factor, lineage survival
+- Matplotlib visualisation integrated with the ``farm/charts/``-style API
+
+Quick Start::
+
+    >>> from farm.analysis.phylogenetics import (
+    ...     build_phylogenetic_tree,
+    ...     build_phylogenetic_tree_from_records,
+    ...     PhylogeneticTree,
+    ...     PhylogeneticNode,
+    ...     PhylogeneticTreeSummary,
+    ...     analyze_phylogenetics,
+    ...     plot_phylogenetic_tree,
+    ... )
+
+Two-parent (DAG) note
+---------------------
+When the simulation uses sexual reproduction each agent can have two parents,
+making the structure a DAG rather than a strict tree.  The ``is_dag`` flag on
+:class:`PhylogeneticTree` signals this.  Newick export uses a single-parent
+spanning-tree projection (first parent wins); the JSON export preserves the
+full DAG.
+"""
+
+from farm.analysis.phylogenetics.compute import (
+    PhylogeneticNode,
+    PhylogeneticTree,
+    PhylogeneticTreeSummary,
+    build_phylogenetic_tree,
+    build_phylogenetic_tree_from_records,
+)
+from farm.analysis.phylogenetics.analyze import analyze_phylogenetics
+from farm.analysis.phylogenetics.plot import plot_phylogenetic_tree
+from farm.analysis.phylogenetics.module import PhylogeneticsModule, phylogenetics_module
+
+__all__ = [
+    # Data structures
+    "PhylogeneticNode",
+    "PhylogeneticTree",
+    "PhylogeneticTreeSummary",
+    # Builder functions
+    "build_phylogenetic_tree",
+    "build_phylogenetic_tree_from_records",
+    # Analysis
+    "analyze_phylogenetics",
+    # Visualisation
+    "plot_phylogenetic_tree",
+    # Module
+    "PhylogeneticsModule",
+    "phylogenetics_module",
+]

--- a/farm/analysis/phylogenetics/analyze.py
+++ b/farm/analysis/phylogenetics/analyze.py
@@ -14,14 +14,15 @@ from farm.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-def analyze_phylogenetics(tree: PhylogeneticTree) -> Dict[str, Any]:
+def analyze_phylogenetics(df: PhylogeneticTree) -> Dict[str, Any]:
     """Return a flat summary-statistics dictionary for a phylogenetic tree/DAG.
 
     Parameters
     ----------
-    tree:
-        :class:`~farm.analysis.phylogenetics.compute.PhylogeneticTree` built
-        by one of the builder functions in the compute module.
+    df:
+        :class:`~farm.analysis.phylogenetics.compute.PhylogeneticTree` from
+        the module data processor (parameter name ``df`` for the analysis
+        framework wrapper).
 
     Returns
     -------
@@ -29,7 +30,7 @@ def analyze_phylogenetics(tree: PhylogeneticTree) -> Dict[str, Any]:
         Keys mirror :class:`~farm.analysis.phylogenetics.compute.PhylogeneticTreeSummary`
         fields, with additional ``"is_dag"`` and ``"roots"`` entries.
     """
-    if not tree.nodes:
+    if not df.nodes:
         return {
             "num_nodes": 0,
             "num_founders": 0,
@@ -44,7 +45,7 @@ def analyze_phylogenetics(tree: PhylogeneticTree) -> Dict[str, Any]:
             "roots": [],
         }
 
-    s = tree.summary()
+    s = df.summary()
     return {
         "num_nodes": s.num_nodes,
         "num_founders": s.num_founders,
@@ -56,5 +57,5 @@ def analyze_phylogenetics(tree: PhylogeneticTree) -> Dict[str, Any]:
         "num_surviving_lineages": s.num_surviving_lineages,
         "lineage_survival_rate": s.lineage_survival_rate,
         "num_lineages_at_final_step": s.num_lineages_at_final_step,
-        "roots": list(tree.roots),
+        "roots": list(df.roots),
     }

--- a/farm/analysis/phylogenetics/analyze.py
+++ b/farm/analysis/phylogenetics/analyze.py
@@ -1,0 +1,60 @@
+"""Phylogenetics analysis functions.
+
+High-level analysis functions that operate on
+:class:`~farm.analysis.phylogenetics.compute.PhylogeneticTree` objects.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from farm.analysis.phylogenetics.compute import PhylogeneticTree
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def analyze_phylogenetics(tree: PhylogeneticTree) -> Dict[str, Any]:
+    """Return a flat summary-statistics dictionary for a phylogenetic tree/DAG.
+
+    Parameters
+    ----------
+    tree:
+        :class:`~farm.analysis.phylogenetics.compute.PhylogeneticTree` built
+        by one of the builder functions in the compute module.
+
+    Returns
+    -------
+    dict
+        Keys mirror :class:`~farm.analysis.phylogenetics.compute.PhylogeneticTreeSummary`
+        fields, with additional ``"is_dag"`` and ``"roots"`` entries.
+    """
+    if not tree.nodes:
+        return {
+            "num_nodes": 0,
+            "num_founders": 0,
+            "num_orphans": 0,
+            "max_depth": 0,
+            "mean_depth": 0.0,
+            "mean_branching_factor": 0.0,
+            "is_dag": False,
+            "num_surviving_lineages": -1,
+            "lineage_survival_rate": 0.0,
+            "num_lineages_at_final_step": -1,
+            "roots": [],
+        }
+
+    s = tree.summary()
+    return {
+        "num_nodes": s.num_nodes,
+        "num_founders": s.num_founders,
+        "num_orphans": s.num_orphans,
+        "max_depth": s.max_depth,
+        "mean_depth": s.mean_depth,
+        "mean_branching_factor": s.mean_branching_factor,
+        "is_dag": s.is_dag,
+        "num_surviving_lineages": s.num_surviving_lineages,
+        "lineage_survival_rate": s.lineage_survival_rate,
+        "num_lineages_at_final_step": s.num_lineages_at_final_step,
+        "roots": list(tree.roots),
+    }

--- a/farm/analysis/phylogenetics/compute.py
+++ b/farm/analysis/phylogenetics/compute.py
@@ -544,6 +544,7 @@ def build_phylogenetic_tree_from_records(
     id_key: str = "candidate_id",
     parent_ids_key: str = "parent_ids",
     generation_key: str = "generation",
+    max_depth: Optional[int] = None,
 ) -> PhylogeneticTree:
     """Build a phylogenetic tree/DAG from evolution-lineage JSON records.
 
@@ -567,6 +568,9 @@ def build_phylogenetic_tree_from_records(
         Key for the parent ID list.  Defaults to ``"parent_ids"``.
     generation_key:
         Key for the generation number.  Defaults to ``"generation"``.
+    max_depth:
+        Maximum BFS depth to assign.  Nodes beyond this depth are marked as
+        pruned (``depth == -1``).  ``None`` means unlimited.
 
     Returns
     -------
@@ -651,4 +655,4 @@ def build_phylogenetic_tree_from_records(
             death_time=death_time,
         )
 
-    return _build_tree_from_nodes(node_map)
+    return _build_tree_from_nodes(node_map, max_depth=max_depth)

--- a/farm/analysis/phylogenetics/compute.py
+++ b/farm/analysis/phylogenetics/compute.py
@@ -1,0 +1,557 @@
+"""Phylogenetic tree construction and analysis from GenomeId lineage.
+
+Builds an in-memory tree (or DAG for two-parent reproduction) from agents in a
+simulation database or from ``evolution_lineage.json`` records.  Supports:
+
+* JSON export of the full tree/DAG structure.
+* Newick export (single-parent spanning-tree projection) for tree-shaped
+  structures; the DAG case is clearly documented below.
+* Summary statistics: depth, branching factor, lineage survival.
+* Deterministic node ordering and explicit handling of orphan and
+  dual-parent cases.
+
+Two-parent (DAG) note
+---------------------
+When agents reproduce with two parents the resulting structure is a DAG, not a
+strict tree, because each node can have two in-edges.  This module preserves the
+full DAG internally (``PhylogeneticTree.is_dag == True``) and offers a
+*single-parent spanning-tree projection* for formats that require a tree
+(e.g. Newick): the first element of each node's ``parent_ids`` list is
+selected as the canonical parent.  The second parent edge is **dropped** in
+the projection but is always available in ``PhylogeneticNode.parent_ids``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+
+from farm.analysis.genetics.utils import parse_parent_ids
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Core data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PhylogeneticNode:
+    """A single node in the phylogenetic tree/DAG.
+
+    Attributes
+    ----------
+    node_id:
+        Unique agent identifier.
+    parent_ids:
+        IDs of parent agents (empty for founders).  Two parents indicates
+        sexual/dual-parent reproduction; the resulting graph is a DAG.
+    children_ids:
+        IDs of child agents whose ``parent_ids`` include this node.
+        Populated by the builder; sorted for determinism.
+    depth:
+        BFS distance from the nearest root (founder) node.  ``-1`` for nodes
+        unreachable from any root (should not occur in well-formed data).
+    generation:
+        Agent generation number when available; ``-1`` when unknown.
+    birth_time:
+        Simulation step when the agent was born; ``-1`` when unknown.
+    death_time:
+        Simulation step when the agent died; ``None`` for still-alive agents.
+    is_root:
+        ``True`` when the node has no parents within the dataset (i.e. it is a
+        founder or an orphan whose parents are absent from the dataset).
+    is_orphan:
+        ``True`` when the node encodes parent IDs in its genome but none of
+        those parents appear in the dataset.
+    """
+
+    node_id: str
+    parent_ids: List[str]
+    children_ids: List[str] = field(default_factory=list)
+    depth: int = 0
+    generation: int = -1
+    birth_time: int = -1
+    death_time: Optional[int] = None
+    is_root: bool = False
+    is_orphan: bool = False
+
+
+@dataclass
+class PhylogeneticTreeSummary:
+    """Summary statistics for a phylogenetic tree/DAG.
+
+    Attributes
+    ----------
+    num_nodes:
+        Total number of nodes.
+    num_founders:
+        Number of root/founder nodes (no parents, or orphans).
+    num_orphans:
+        Nodes with encoded parent IDs that are absent from the dataset.
+    max_depth:
+        Maximum BFS depth from any root.
+    mean_depth:
+        Mean BFS depth over all nodes.
+    mean_branching_factor:
+        Mean number of children per internal node (nodes with at least one
+        child).  ``0.0`` for fully leaf-only graphs.
+    is_dag:
+        ``True`` when any node has two or more parents.
+    num_surviving_lineages:
+        Number of founder lineages with at least one node surviving to the
+        final observed simulation step.  ``-1`` if no timing data is available.
+    lineage_survival_rate:
+        ``num_surviving_lineages / num_founders``, or ``0.0`` when there are
+        no founders.
+    num_lineages_at_final_step:
+        Number of distinct founder lineages represented by agents alive at
+        the final simulation step.  ``-1`` if no timing data is available.
+    """
+
+    num_nodes: int
+    num_founders: int
+    num_orphans: int
+    max_depth: int
+    mean_depth: float
+    mean_branching_factor: float
+    is_dag: bool
+    num_surviving_lineages: int
+    lineage_survival_rate: float
+    num_lineages_at_final_step: int
+
+
+class PhylogeneticTree:
+    """In-memory phylogenetic tree/DAG built from agent lineage data.
+
+    When agents reproduce with two parents the structure becomes a DAG rather
+    than a strict tree.  This class preserves the full DAG internally but
+    offers convenience methods for tree-shaped projections (e.g. Newick
+    export) that reduce dual-parent nodes to a single-parent representation
+    by always choosing the *first* listed parent.
+
+    Parameters
+    ----------
+    nodes:
+        Mapping from ``node_id`` to :class:`PhylogeneticNode`.
+    roots:
+        Ordered list of root node IDs (founders), deterministically sorted.
+    is_dag:
+        ``True`` when the structure contains any node with two or more parents.
+    max_step:
+        Optional maximum simulation step; used for lineage survival statistics.
+    """
+
+    def __init__(
+        self,
+        nodes: Dict[str, PhylogeneticNode],
+        roots: List[str],
+        *,
+        is_dag: bool = False,
+        max_step: Optional[int] = None,
+    ) -> None:
+        self.nodes = nodes
+        self.roots = roots
+        self.is_dag = is_dag
+        self.max_step = max_step
+
+    # ------------------------------------------------------------------
+    # Summary statistics
+    # ------------------------------------------------------------------
+
+    def summary(self) -> PhylogeneticTreeSummary:
+        """Compute and return summary statistics for this tree/DAG."""
+        if not self.nodes:
+            return PhylogeneticTreeSummary(
+                num_nodes=0,
+                num_founders=len(self.roots),
+                num_orphans=0,
+                max_depth=0,
+                mean_depth=0.0,
+                mean_branching_factor=0.0,
+                is_dag=self.is_dag,
+                num_surviving_lineages=-1,
+                lineage_survival_rate=0.0,
+                num_lineages_at_final_step=-1,
+            )
+
+        depths = [node.depth for node in self.nodes.values() if node.depth >= 0]
+        max_depth = max(depths) if depths else 0
+        mean_depth = sum(depths) / len(depths) if depths else 0.0
+        num_orphans = sum(1 for n in self.nodes.values() if n.is_orphan)
+
+        internal = [n for n in self.nodes.values() if n.children_ids]
+        mean_branching_factor = (
+            sum(len(n.children_ids) for n in internal) / len(internal)
+            if internal
+            else 0.0
+        )
+
+        # Lineage survival (requires birth_time / death_time data)
+        has_timing = any(
+            n.birth_time >= 0 or n.death_time is not None
+            for n in self.nodes.values()
+        )
+        if has_timing and self.max_step is not None:
+            surviving_founders = self._compute_surviving_founders()
+            num_surviving = len(surviving_founders)
+            num_founders = len(self.roots)
+            survival_rate = num_surviving / num_founders if num_founders else 0.0
+            alive_at_final = {
+                n.node_id
+                for n in self.nodes.values()
+                if n.birth_time >= 0
+                and n.birth_time <= self.max_step
+                and (n.death_time is None or n.death_time >= self.max_step)
+            }
+            lineage_ids_at_final: Set[str] = set()
+            for nid in alive_at_final:
+                founder = self._get_founder(nid)
+                if founder:
+                    lineage_ids_at_final.add(founder)
+            num_at_final = len(lineage_ids_at_final)
+        else:
+            num_surviving = -1
+            survival_rate = 0.0
+            num_at_final = -1
+
+        return PhylogeneticTreeSummary(
+            num_nodes=len(self.nodes),
+            num_founders=len(self.roots),
+            num_orphans=num_orphans,
+            max_depth=max_depth,
+            mean_depth=mean_depth,
+            mean_branching_factor=mean_branching_factor,
+            is_dag=self.is_dag,
+            num_surviving_lineages=num_surviving,
+            lineage_survival_rate=survival_rate,
+            num_lineages_at_final_step=num_at_final,
+        )
+
+    def _compute_surviving_founders(self) -> Set[str]:
+        """Return the set of founders that have at least one surviving descendant."""
+        if self.max_step is None:
+            return set()
+        surviving: Set[str] = set()
+        for node in self.nodes.values():
+            alive = (
+                node.birth_time >= 0
+                and node.birth_time <= self.max_step
+                and (node.death_time is None or node.death_time >= self.max_step)
+            )
+            if alive:
+                founder = self._get_founder(node.node_id)
+                if founder:
+                    surviving.add(founder)
+        return surviving
+
+    def _get_founder(self, node_id: str) -> Optional[str]:
+        """Walk up to the root via single-parent projection and return its ID."""
+        visited: Set[str] = set()
+        current = node_id
+        while current in self.nodes:
+            if current in visited:
+                break  # cycle guard
+            visited.add(current)
+            node = self.nodes[current]
+            if node.is_root:
+                return current
+            parents_in_tree = [p for p in node.parent_ids if p in self.nodes]
+            if not parents_in_tree:
+                return current
+            current = parents_in_tree[0]  # single-parent projection
+        return None
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the full tree/DAG to a JSON-compatible dictionary.
+
+        The ``is_dag`` flag signals consumers whether the structure contains
+        dual-parent relationships.  Node order and ``children_ids`` lists are
+        sorted for determinism.
+        """
+        return {
+            "is_dag": self.is_dag,
+            "max_step": self.max_step,
+            "roots": self.roots,
+            "nodes": {
+                nid: {
+                    "node_id": node.node_id,
+                    "parent_ids": node.parent_ids,
+                    "children_ids": sorted(node.children_ids),
+                    "depth": node.depth,
+                    "generation": node.generation,
+                    "birth_time": node.birth_time,
+                    "death_time": node.death_time,
+                    "is_root": node.is_root,
+                    "is_orphan": node.is_orphan,
+                }
+                for nid, node in sorted(self.nodes.items())
+            },
+        }
+
+    def to_json(self, *, indent: int = 2) -> str:
+        """Return the tree/DAG serialized as a JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)
+
+    def to_newick(self) -> str:
+        """Export the tree as a Newick string using single-parent projection.
+
+        When the tree is a DAG (dual-parent reproduction) each node's second
+        parent edge is dropped; only the first parent is retained.  This
+        projects the DAG onto a spanning tree that is compatible with the
+        Newick format.
+
+        Orphan nodes (roots whose parents were absent from the dataset) are
+        included as top-level taxa within a synthetic root group.  When there
+        is a single real root, no wrapping is added.
+
+        Returns
+        -------
+        str
+            Newick string terminated with ``;``.
+        """
+        if not self.nodes:
+            return "();"
+
+        # Build spanning-tree child map: only the first parent edge is used
+        spanning_children: Dict[str, List[str]] = defaultdict(list)
+        for nid, node in sorted(self.nodes.items()):  # sorted for determinism
+            if not node.is_root and node.parent_ids:
+                first_parent = node.parent_ids[0]
+                if first_parent in self.nodes:
+                    spanning_children[first_parent].append(nid)
+
+        def _subtree(nid: str, visited: Set[str]) -> str:
+            if nid in visited:
+                return nid  # cycle guard
+            visited = visited | {nid}
+            kids = sorted(spanning_children.get(nid, []))
+            if not kids:
+                return nid
+            inner = ",".join(_subtree(k, visited) for k in kids)
+            return f"({inner}){nid}"
+
+        if len(self.roots) == 1:
+            result = _subtree(self.roots[0], set())
+        else:
+            parts = [_subtree(r, set()) for r in sorted(self.roots)]
+            result = "(" + ",".join(parts) + ")"
+
+        return result + ";"
+
+
+# ---------------------------------------------------------------------------
+# Builder helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_tree_from_nodes(
+    node_map: Dict[str, PhylogeneticNode],
+    *,
+    max_depth: Optional[int] = None,
+) -> PhylogeneticTree:
+    """Shared builder: wire parent→child edges, assign depths, detect DAG."""
+    # Pass 1: identify roots / orphans and wire children
+    for nid, node in sorted(node_map.items()):  # sorted for determinism
+        parents_in_tree = [p for p in node.parent_ids if p in node_map]
+        if not node.parent_ids:
+            node.is_root = True
+        elif not parents_in_tree:
+            node.is_root = True
+            node.is_orphan = True
+        else:
+            for pid in parents_in_tree:
+                if nid not in node_map[pid].children_ids:
+                    node_map[pid].children_ids.append(nid)
+
+    roots = sorted(nid for nid, n in node_map.items() if n.is_root)
+
+    # Pass 2: BFS from roots to assign depths
+    queue: deque[Tuple[str, int]] = deque()
+    for r in roots:
+        queue.append((r, 0))
+        node_map[r].depth = 0
+
+    visited: Set[str] = set(roots)
+    while queue:
+        nid, depth = queue.popleft()
+        node_map[nid].depth = depth
+        if max_depth is not None and depth >= max_depth:
+            continue
+        for child_id in sorted(node_map[nid].children_ids):
+            if child_id not in visited:
+                visited.add(child_id)
+                queue.append((child_id, depth + 1))
+
+    # Nodes not reachable from any root (data integrity issue)
+    for nid, node in node_map.items():
+        if nid not in visited:
+            node.depth = -1
+            logger.warning("phylogenetic_tree: unreachable node node_id=%s", nid)
+
+    # Sort children for determinism
+    for node in node_map.values():
+        node.children_ids.sort()
+
+    # max_step from timing data
+    max_step: Optional[int] = None
+    all_times: List[int] = (
+        [n.death_time for n in node_map.values() if n.death_time is not None]
+        + [n.birth_time for n in node_map.values() if n.birth_time >= 0]
+    )
+    if all_times:
+        max_step = max(all_times)
+
+    is_dag = any(len(n.parent_ids) > 1 for n in node_map.values())
+
+    return PhylogeneticTree(
+        nodes=node_map,
+        roots=roots,
+        is_dag=is_dag,
+        max_step=max_step,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public builder functions
+# ---------------------------------------------------------------------------
+
+
+def build_phylogenetic_tree(
+    agents: Sequence[Any],
+    *,
+    max_depth: Optional[int] = None,
+) -> PhylogeneticTree:
+    """Build a phylogenetic tree/DAG from a collection of agent objects.
+
+    Each agent must have at minimum an ``agent_id`` and a ``genome_id``
+    attribute.  The optional attributes ``generation``, ``birth_time``, and
+    ``death_time`` are used when present for richer summary statistics.
+
+    Orphan handling
+    ~~~~~~~~~~~~~~~
+    Agents whose ``parent_ids`` (decoded from ``genome_id``) contain IDs
+    absent from the dataset are treated as roots with ``is_orphan=True``.
+
+    Parameters
+    ----------
+    agents:
+        Iterable of agent-like objects.
+    max_depth:
+        Optional depth cap for BFS traversal.  Nodes beyond ``max_depth`` are
+        included in the tree but BFS stops there; useful for large simulations
+        where you only want the upper portion of the tree.
+
+    Returns
+    -------
+    PhylogeneticTree
+    """
+    node_map: Dict[str, PhylogeneticNode] = {}
+    for agent in agents:
+        agent_id = str(agent.agent_id)
+        genome_id = getattr(agent, "genome_id", None)
+        if genome_id is not None:
+            try:
+                parent_ids: List[str] = parse_parent_ids(str(genome_id))
+            except Exception:
+                parent_ids = []
+        else:
+            parent_ids = []
+
+        generation = getattr(agent, "generation", None)
+        birth_time = getattr(agent, "birth_time", None)
+        death_time = getattr(agent, "death_time", None)
+
+        node_map[agent_id] = PhylogeneticNode(
+            node_id=agent_id,
+            parent_ids=parent_ids,
+            generation=int(generation) if generation is not None else -1,
+            birth_time=int(birth_time) if birth_time is not None else -1,
+            death_time=int(death_time) if death_time is not None else None,
+        )
+
+    return _build_tree_from_nodes(node_map, max_depth=max_depth)
+
+
+def build_phylogenetic_tree_from_records(
+    records: Sequence[Dict[str, Any]],
+    *,
+    id_key: str = "candidate_id",
+    parent_ids_key: str = "parent_ids",
+    generation_key: str = "generation",
+) -> PhylogeneticTree:
+    """Build a phylogenetic tree/DAG from evolution-lineage JSON records.
+
+    Accepts the list produced by
+    :class:`~farm.runners.evolution_experiment.EvolutionExperiment` and
+    written to ``evolution_lineage.json``.
+
+    The function also accepts per-agent snapshot records from
+    ``intrinsic_gene_snapshots.jsonl`` when the records have an ``"agent_id"``
+    key; the ``id_key`` parameter can be adjusted accordingly.
+
+    Parameters
+    ----------
+    records:
+        List of dicts, each with at least ``candidate_id`` (or the value of
+        ``id_key``) and ``parent_ids`` (list of strings).
+    id_key:
+        Key for the node identifier.  Falls back to ``"agent_id"`` then
+        ``"node_id"`` when the primary key is absent.
+    parent_ids_key:
+        Key for the parent ID list.  Defaults to ``"parent_ids"``.
+    generation_key:
+        Key for the generation number.  Defaults to ``"generation"``.
+
+    Returns
+    -------
+    PhylogeneticTree
+    """
+    node_map: Dict[str, PhylogeneticNode] = {}
+
+    for record in records:
+        raw_id = (
+            record.get(id_key)
+            or record.get("agent_id")
+            or record.get("node_id")
+        )
+        if raw_id is None:
+            logger.warning(
+                "build_phylogenetic_tree_from_records: record missing id_key=%r; skipping",
+                id_key,
+            )
+            continue
+        node_id = str(raw_id)
+
+        raw_parents = record.get(parent_ids_key, [])
+        if isinstance(raw_parents, (list, tuple)):
+            parent_ids = [str(p) for p in raw_parents if p is not None]
+        else:
+            parent_ids = []
+
+        generation_raw = record.get(generation_key, None)
+        generation = int(generation_raw) if generation_raw is not None else -1
+
+        birth_time_raw = record.get("birth_time", None)
+        birth_time = int(birth_time_raw) if birth_time_raw is not None else -1
+
+        death_time_raw = record.get("death_time", None)
+        death_time = int(death_time_raw) if death_time_raw is not None else None
+
+        node_map[node_id] = PhylogeneticNode(
+            node_id=node_id,
+            parent_ids=parent_ids,
+            generation=generation,
+            birth_time=birth_time,
+            death_time=death_time,
+        )
+
+    return _build_tree_from_nodes(node_map)

--- a/farm/analysis/phylogenetics/compute.py
+++ b/farm/analysis/phylogenetics/compute.py
@@ -321,13 +321,13 @@ class PhylogeneticTree:
         if not self.nodes:
             return "();"
 
-        # Build spanning-tree child map: only the first parent edge is used
+        # Build spanning-tree child map: first parent *present in this tree*
         spanning_children: Dict[str, List[str]] = defaultdict(list)
         for nid, node in sorted(self.nodes.items()):  # sorted for determinism
             if not node.is_root and node.parent_ids:
-                first_parent = node.parent_ids[0]
-                if first_parent in self.nodes:
-                    spanning_children[first_parent].append(nid)
+                parents_in_tree = [p for p in node.parent_ids if p in self.nodes]
+                if parents_in_tree:
+                    spanning_children[parents_in_tree[0]].append(nid)
 
         def _subtree(nid: str, visited: Set[str]) -> str:
             if nid in visited:

--- a/farm/analysis/phylogenetics/compute.py
+++ b/farm/analysis/phylogenetics/compute.py
@@ -375,16 +375,37 @@ def _build_tree_from_nodes(
     roots = sorted(nid for nid, n in node_map.items() if n.is_root)
 
     # Pass 2: BFS from roots to assign depths
+    for node in node_map.values():
+        node.depth = -1
+
     queue: deque[Tuple[str, int]] = deque()
     for r in roots:
         queue.append((r, 0))
         node_map[r].depth = 0
 
     visited: Set[str] = set(roots)
+    pruned_reachable: Set[str] = set()
+
+    def _mark_pruned_descendants(start_node_id: str) -> None:
+        """Mark descendants skipped due to max_depth as intentionally pruned."""
+        stack = [start_node_id]
+        local_seen: Set[str] = set()
+        while stack:
+            current_id = stack.pop()
+            if current_id in local_seen or current_id in visited:
+                continue
+            local_seen.add(current_id)
+            pruned_reachable.add(current_id)
+            stack.extend(node_map[current_id].children_ids)
+
     while queue:
         nid, depth = queue.popleft()
         node_map[nid].depth = depth
         if max_depth is not None and depth >= max_depth:
+            # These descendants are reachable but deliberately pruned from depth
+            # assignment for upper-tree analysis views.
+            for child_id in node_map[nid].children_ids:
+                _mark_pruned_descendants(child_id)
             continue
         for child_id in sorted(node_map[nid].children_ids):
             if child_id not in visited:
@@ -393,8 +414,7 @@ def _build_tree_from_nodes(
 
     # Nodes not reachable from any root (data integrity issue)
     for nid, node in node_map.items():
-        if nid not in visited:
-            node.depth = -1
+        if nid not in visited and nid not in pruned_reachable:
             logger.warning("phylogenetic_tree: unreachable node node_id=%s", nid)
 
     # Sort children for determinism
@@ -454,6 +474,37 @@ def build_phylogenetic_tree(
     -------
     PhylogeneticTree
     """
+    def _coerce_int(value: Any, *, default: int, field_name: str, node_id: str) -> int:
+        if value is None:
+            return default
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            logger.warning(
+                "build_phylogenetic_tree: invalid %s=%r for node_id=%s; using default=%s",
+                field_name,
+                value,
+                node_id,
+                default,
+            )
+            return default
+
+    def _coerce_optional_int(
+        value: Any, *, field_name: str, node_id: str
+    ) -> Optional[int]:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            logger.warning(
+                "build_phylogenetic_tree: invalid %s=%r for node_id=%s; using None",
+                field_name,
+                value,
+                node_id,
+            )
+            return None
+
     node_map: Dict[str, PhylogeneticNode] = {}
     for agent in agents:
         agent_id = str(agent.agent_id)
@@ -473,9 +524,15 @@ def build_phylogenetic_tree(
         node_map[agent_id] = PhylogeneticNode(
             node_id=agent_id,
             parent_ids=parent_ids,
-            generation=int(generation) if generation is not None else -1,
-            birth_time=int(birth_time) if birth_time is not None else -1,
-            death_time=int(death_time) if death_time is not None else None,
+            generation=_coerce_int(
+                generation, default=-1, field_name="generation", node_id=agent_id
+            ),
+            birth_time=_coerce_int(
+                birth_time, default=-1, field_name="birth_time", node_id=agent_id
+            ),
+            death_time=_coerce_optional_int(
+                death_time, field_name="death_time", node_id=agent_id
+            ),
         )
 
     return _build_tree_from_nodes(node_map, max_depth=max_depth)
@@ -515,6 +572,37 @@ def build_phylogenetic_tree_from_records(
     -------
     PhylogeneticTree
     """
+    def _coerce_int(value: Any, *, default: int, field_name: str, node_id: str) -> int:
+        if value is None:
+            return default
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            logger.warning(
+                "build_phylogenetic_tree_from_records: invalid %s=%r for node_id=%s; using default=%s",
+                field_name,
+                value,
+                node_id,
+                default,
+            )
+            return default
+
+    def _coerce_optional_int(
+        value: Any, *, field_name: str, node_id: str
+    ) -> Optional[int]:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            logger.warning(
+                "build_phylogenetic_tree_from_records: invalid %s=%r for node_id=%s; using None",
+                field_name,
+                value,
+                node_id,
+            )
+            return None
+
     node_map: Dict[str, PhylogeneticNode] = {}
 
     for record in records:
@@ -537,14 +625,23 @@ def build_phylogenetic_tree_from_records(
         else:
             parent_ids = []
 
-        generation_raw = record.get(generation_key, None)
-        generation = int(generation_raw) if generation_raw is not None else -1
-
-        birth_time_raw = record.get("birth_time", None)
-        birth_time = int(birth_time_raw) if birth_time_raw is not None else -1
-
-        death_time_raw = record.get("death_time", None)
-        death_time = int(death_time_raw) if death_time_raw is not None else None
+        generation = _coerce_int(
+            record.get(generation_key, None),
+            default=-1,
+            field_name=generation_key,
+            node_id=node_id,
+        )
+        birth_time = _coerce_int(
+            record.get("birth_time", None),
+            default=-1,
+            field_name="birth_time",
+            node_id=node_id,
+        )
+        death_time = _coerce_optional_int(
+            record.get("death_time", None),
+            field_name="death_time",
+            node_id=node_id,
+        )
 
         node_map[node_id] = PhylogeneticNode(
             node_id=node_id,

--- a/farm/analysis/phylogenetics/data.py
+++ b/farm/analysis/phylogenetics/data.py
@@ -55,7 +55,7 @@ def process_phylogenetics_data(data: Any, **kwargs: Any) -> PhylogeneticTree:
     # SQLAlchemy session duck-typed check
     if hasattr(data, "query"):
         try:
-            from farm.database.models import AgentModel  # noqa: PLC0415
+            from farm.database.models import AgentModel  # noqa: PLC0415  # local import is intentional
 
             agents = data.query(AgentModel).all()
             return build_phylogenetic_tree(agents, **kwargs)

--- a/farm/analysis/phylogenetics/data.py
+++ b/farm/analysis/phylogenetics/data.py
@@ -8,8 +8,9 @@ raw simulation data into a
 
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Any
 
+from farm.database.models import AgentModel
 from farm.analysis.phylogenetics.compute import (
     PhylogeneticTree,
     build_phylogenetic_tree,
@@ -50,13 +51,28 @@ def process_phylogenetics_data(data: Any, **kwargs: Any) -> PhylogeneticTree:
         return data
 
     if isinstance(data, list):
-        return build_phylogenetic_tree_from_records(data, **kwargs)
+        if not data:
+            return PhylogeneticTree(nodes={}, roots=[], is_dag=False)
+
+        first_item = next((item for item in data if item is not None), None)
+        if first_item is None:
+            return PhylogeneticTree(nodes={}, roots=[], is_dag=False)
+
+        if isinstance(first_item, dict):
+            return build_phylogenetic_tree_from_records(data, **kwargs)
+
+        if hasattr(first_item, "agent_id"):
+            return build_phylogenetic_tree(data, **kwargs)
+
+        logger.warning(
+            "process_phylogenetics_data: unsupported list item type %s; returning empty tree",
+            type(first_item).__name__,
+        )
+        return PhylogeneticTree(nodes={}, roots=[], is_dag=False)
 
     # SQLAlchemy session duck-typed check
     if hasattr(data, "query"):
         try:
-            from farm.database.models import AgentModel  # noqa: PLC0415  # local import is intentional
-
             agents = data.query(AgentModel).all()
             return build_phylogenetic_tree(agents, **kwargs)
         except Exception as exc:

--- a/farm/analysis/phylogenetics/data.py
+++ b/farm/analysis/phylogenetics/data.py
@@ -8,9 +8,14 @@ raw simulation data into a
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
 from farm.database.models import AgentModel
+from farm.analysis.common.utils import find_database_path
 from farm.analysis.phylogenetics.compute import (
     PhylogeneticTree,
     build_phylogenetic_tree,
@@ -20,12 +25,20 @@ from farm.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+# Framework kwargs injected by BaseAnalysisModule.run_analysis() that must not
+# be forwarded to the builder functions.
+_FRAMEWORK_KWARGS = frozenset({"save_to_db", "db_path"})
+
 
 def process_phylogenetics_data(data: Any, **kwargs: Any) -> PhylogeneticTree:
     """Convert raw data into a :class:`~farm.analysis.phylogenetics.compute.PhylogeneticTree`.
 
     Dispatch rules:
 
+    * If ``data`` is a :class:`pathlib.Path` or :class:`str`, the function
+      locates ``simulation.db`` inside the experiment directory, queries all
+      :class:`~farm.database.models.AgentModel` rows, and calls
+      :func:`~farm.analysis.phylogenetics.compute.build_phylogenetic_tree`.
     * If ``data`` is a SQLAlchemy :class:`~sqlalchemy.orm.Session`, query
       all :class:`~farm.database.models.AgentModel` rows and call
       :func:`~farm.analysis.phylogenetics.compute.build_phylogenetic_tree`.
@@ -42,13 +55,43 @@ def process_phylogenetics_data(data: Any, **kwargs: Any) -> PhylogeneticTree:
         Raw data source.
     **kwargs:
         Forwarded to the underlying builder (e.g. ``max_depth``).
+        Framework-injected keys (``save_to_db``, ``db_path``) are silently
+        consumed and not passed to the builders.
 
     Returns
     -------
     PhylogeneticTree
     """
+    # Strip framework-injected kwargs before forwarding to builders
+    builder_kwargs = {k: v for k, v in kwargs.items() if k not in _FRAMEWORK_KWARGS}
+
     if isinstance(data, PhylogeneticTree):
         return data
+
+    if isinstance(data, (Path, str)):
+        experiment_path = Path(data)
+        try:
+            db_path = find_database_path(experiment_path, "simulation.db")
+        except FileNotFoundError:
+            logger.warning(
+                "process_phylogenetics_data: simulation.db not found in %s; returning empty tree",
+                experiment_path,
+            )
+            return PhylogeneticTree(nodes={}, roots=[], is_dag=False)
+
+        logger.info(
+            "process_phylogenetics_data: loading agent lineage from database %s", db_path
+        )
+        engine = create_engine(f"sqlite:///{db_path}")
+        try:
+            with Session(engine) as session:
+                agents = session.query(AgentModel).all()
+                return build_phylogenetic_tree(agents, **builder_kwargs)
+        except Exception as exc:
+            logger.warning("process_phylogenetics_data: DB query failed: %s", exc)
+            return PhylogeneticTree(nodes={}, roots=[], is_dag=False)
+        finally:
+            engine.dispose()
 
     if isinstance(data, list):
         if not data:
@@ -59,10 +102,10 @@ def process_phylogenetics_data(data: Any, **kwargs: Any) -> PhylogeneticTree:
             return PhylogeneticTree(nodes={}, roots=[], is_dag=False)
 
         if isinstance(first_item, dict):
-            return build_phylogenetic_tree_from_records(data, **kwargs)
+            return build_phylogenetic_tree_from_records(data, **builder_kwargs)
 
         if hasattr(first_item, "agent_id"):
-            return build_phylogenetic_tree(data, **kwargs)
+            return build_phylogenetic_tree(data, **builder_kwargs)
 
         logger.warning(
             "process_phylogenetics_data: unsupported list item type %s; returning empty tree",
@@ -74,7 +117,7 @@ def process_phylogenetics_data(data: Any, **kwargs: Any) -> PhylogeneticTree:
     if hasattr(data, "query"):
         try:
             agents = data.query(AgentModel).all()
-            return build_phylogenetic_tree(agents, **kwargs)
+            return build_phylogenetic_tree(agents, **builder_kwargs)
         except Exception as exc:
             logger.warning("process_phylogenetics_data: DB query failed: %s", exc)
             return PhylogeneticTree(nodes={}, roots=[], is_dag=False)

--- a/farm/analysis/phylogenetics/data.py
+++ b/farm/analysis/phylogenetics/data.py
@@ -1,0 +1,70 @@
+"""Phylogenetics data processor.
+
+Provides the data-processor entry point used by
+:class:`~farm.analysis.phylogenetics.module.PhylogeneticsModule` to convert
+raw simulation data into a
+:class:`~farm.analysis.phylogenetics.compute.PhylogeneticTree`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+from farm.analysis.phylogenetics.compute import (
+    PhylogeneticTree,
+    build_phylogenetic_tree,
+    build_phylogenetic_tree_from_records,
+)
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def process_phylogenetics_data(data: Any, **kwargs: Any) -> PhylogeneticTree:
+    """Convert raw data into a :class:`~farm.analysis.phylogenetics.compute.PhylogeneticTree`.
+
+    Dispatch rules:
+
+    * If ``data`` is a SQLAlchemy :class:`~sqlalchemy.orm.Session`, query
+      all :class:`~farm.database.models.AgentModel` rows and call
+      :func:`~farm.analysis.phylogenetics.compute.build_phylogenetic_tree`.
+    * If ``data`` is a list of dicts (e.g. ``evolution_lineage.json``
+      records), call
+      :func:`~farm.analysis.phylogenetics.compute.build_phylogenetic_tree_from_records`.
+    * If ``data`` is already a :class:`~farm.analysis.phylogenetics.compute.PhylogeneticTree`,
+      return it unchanged.
+    * Otherwise return an empty tree.
+
+    Parameters
+    ----------
+    data:
+        Raw data source.
+    **kwargs:
+        Forwarded to the underlying builder (e.g. ``max_depth``).
+
+    Returns
+    -------
+    PhylogeneticTree
+    """
+    if isinstance(data, PhylogeneticTree):
+        return data
+
+    if isinstance(data, list):
+        return build_phylogenetic_tree_from_records(data, **kwargs)
+
+    # SQLAlchemy session duck-typed check
+    if hasattr(data, "query"):
+        try:
+            from farm.database.models import AgentModel  # noqa: PLC0415
+
+            agents = data.query(AgentModel).all()
+            return build_phylogenetic_tree(agents, **kwargs)
+        except Exception as exc:
+            logger.warning("process_phylogenetics_data: DB query failed: %s", exc)
+            return PhylogeneticTree(nodes={}, roots=[], is_dag=False)
+
+    logger.warning(
+        "process_phylogenetics_data: unrecognised data type %s; returning empty tree",
+        type(data).__name__,
+    )
+    return PhylogeneticTree(nodes={}, roots=[], is_dag=False)

--- a/farm/analysis/phylogenetics/data.py
+++ b/farm/analysis/phylogenetics/data.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from sqlalchemy import create_engine
+from sqlalchemy.engine import URL as SqlaURL
 from sqlalchemy.orm import Session
 
 from farm.database.models import AgentModel
@@ -82,7 +83,7 @@ def process_phylogenetics_data(data: Any, **kwargs: Any) -> PhylogeneticTree:
         logger.info(
             "process_phylogenetics_data: loading agent lineage from database %s", db_path
         )
-        engine = create_engine(f"sqlite:///{db_path}")
+        engine = create_engine(SqlaURL.create("sqlite", database=str(db_path)))
         try:
             with Session(engine) as session:
                 agents = session.query(AgentModel).all()

--- a/farm/analysis/phylogenetics/module.py
+++ b/farm/analysis/phylogenetics/module.py
@@ -7,7 +7,6 @@ module registry.
 
 from farm.analysis.core import BaseAnalysisModule, SimpleDataProcessor, make_analysis_function
 
-from farm.analysis.phylogenetics.compute import PhylogeneticTree
 from farm.analysis.phylogenetics.data import process_phylogenetics_data
 from farm.analysis.phylogenetics.analyze import analyze_phylogenetics
 from farm.analysis.phylogenetics.plot import plot_phylogenetic_tree

--- a/farm/analysis/phylogenetics/module.py
+++ b/farm/analysis/phylogenetics/module.py
@@ -23,7 +23,7 @@ class _PhylogeneticTreeValidator:
     framework validation step does not raise a ``TypeError``.
     """
 
-    def validate(self, data: object) -> None:  # noqa: D401
+    def validate(self, data: object) -> None:
         """Accept any :class:`PhylogeneticTree`; raise on ``None``."""
         if data is None:
             raise ValueError("process_phylogenetics_data returned None")

--- a/farm/analysis/phylogenetics/module.py
+++ b/farm/analysis/phylogenetics/module.py
@@ -6,11 +6,28 @@ module registry.
 """
 
 from farm.analysis.core import BaseAnalysisModule, SimpleDataProcessor, make_analysis_function
-from farm.analysis.validation import ColumnValidator, DataQualityValidator, CompositeValidator
 
+from farm.analysis.phylogenetics.compute import PhylogeneticTree
 from farm.analysis.phylogenetics.data import process_phylogenetics_data
 from farm.analysis.phylogenetics.analyze import analyze_phylogenetics
 from farm.analysis.phylogenetics.plot import plot_phylogenetic_tree
+
+
+class _PhylogeneticTreeValidator:
+    """Minimal validator for :class:`PhylogeneticTree` objects.
+
+    The standard :class:`~farm.analysis.validation.ColumnValidator` and
+    :class:`~farm.analysis.validation.DataQualityValidator` assume a
+    :class:`pandas.DataFrame`.  This lightweight replacement accepts any
+    :class:`PhylogeneticTree` (even empty ones) so that the analysis
+    framework validation step does not raise a ``TypeError``.
+    """
+
+    def validate(self, data: object) -> None:  # noqa: D401
+        """Accept any :class:`PhylogeneticTree`; raise on ``None``."""
+        if data is None:
+            raise ValueError("process_phylogenetics_data returned None")
+        # PhylogeneticTree objects are always acceptable (even empty trees).
 
 
 class PhylogeneticsModule(BaseAnalysisModule):
@@ -33,13 +50,7 @@ class PhylogeneticsModule(BaseAnalysisModule):
             ),
         )
 
-        validator = CompositeValidator(
-            [
-                ColumnValidator(required_columns=[], column_types={}),
-                DataQualityValidator(min_rows=0),
-            ]
-        )
-        self.set_validator(validator)
+        self.set_validator(_PhylogeneticTreeValidator())
 
     def register_functions(self) -> None:
         """Register all phylogenetics analysis functions."""

--- a/farm/analysis/phylogenetics/module.py
+++ b/farm/analysis/phylogenetics/module.py
@@ -1,0 +1,75 @@
+"""Phylogenetics analysis module registration.
+
+Registers the phylogenetics analysis module with the analysis framework so it
+is discoverable via :class:`~farm.analysis.service.AnalysisService` and the
+module registry.
+"""
+
+from farm.analysis.core import BaseAnalysisModule, SimpleDataProcessor, make_analysis_function
+from farm.analysis.validation import ColumnValidator, DataQualityValidator, CompositeValidator
+
+from farm.analysis.phylogenetics.data import process_phylogenetics_data
+from farm.analysis.phylogenetics.analyze import analyze_phylogenetics
+from farm.analysis.phylogenetics.plot import plot_phylogenetic_tree
+
+
+class PhylogeneticsModule(BaseAnalysisModule):
+    """Analysis module for phylogenetic tree construction and visualisation.
+
+    Supports two data sources:
+
+    * **Simulation database** – queries all agents from the DB and builds a
+      phylogenetic tree from their ``genome_id`` lineage.
+    * **Evolution-experiment result** – accepts the list of records from
+      ``evolution_lineage.json`` and builds the tree from ``parent_ids`` fields.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="phylogenetics",
+            description=(
+                "Phylogenetic tree/DAG construction, serialisation, and visualisation "
+                "from GenomeId lineage (simulation DB or evolution_lineage.json)"
+            ),
+        )
+
+        validator = CompositeValidator(
+            [
+                ColumnValidator(required_columns=[], column_types={}),
+                DataQualityValidator(min_rows=0),
+            ]
+        )
+        self.set_validator(validator)
+
+    def register_functions(self) -> None:
+        """Register all phylogenetics analysis functions."""
+        self._functions = {
+            "analyze_phylogenetics": make_analysis_function(analyze_phylogenetics),
+            "plot_phylogenetic_tree": make_analysis_function(plot_phylogenetic_tree),
+        }
+
+        self._groups = {
+            "all": list(self._functions.values()),
+            "analysis": [self._functions["analyze_phylogenetics"]],
+            "plots": [self._functions["plot_phylogenetic_tree"]],
+            "basic": [
+                self._functions["analyze_phylogenetics"],
+                self._functions["plot_phylogenetic_tree"],
+            ],
+        }
+
+    def get_data_processor(self) -> SimpleDataProcessor:
+        """Return the data processor for phylogenetics analysis."""
+        return SimpleDataProcessor(process_phylogenetics_data)
+
+    def supports_database(self) -> bool:
+        """This module can use a simulation database."""
+        return True
+
+    def get_db_filename(self) -> str:
+        """Database filename used by this module."""
+        return "simulation.db"
+
+
+# Singleton instance consumed by the module registry
+phylogenetics_module = PhylogeneticsModule()

--- a/farm/analysis/phylogenetics/plot.py
+++ b/farm/analysis/phylogenetics/plot.py
@@ -137,7 +137,12 @@ def plot_phylogenetic_tree(
         # ------------------------------------------------------------------
         colour_map: Dict[str, str] = {}
         if color_by_lineage and tree.roots:
-            cmap = plt.cm.get_cmap("tab10", max(len(tree.roots), 1))  # type: ignore[attr-defined]
+            try:
+                import matplotlib
+                cmap = matplotlib.colormaps.get_cmap("tab10")
+            except AttributeError:
+                # matplotlib < 3.5 fallback
+                cmap = plt.cm.get_cmap("tab10")  # type: ignore[attr-defined]
             lineage_colour: Dict[str, Any] = {}
             for idx, root_id in enumerate(tree.roots):
                 lineage_colour[root_id] = cmap(idx % 10)
@@ -164,6 +169,7 @@ def plot_phylogenetic_tree(
             for nid in nodes_to_render:
                 colour_map[nid] = _get_lineage_colour(nid)
         else:
+            cmap = None
             default_colour = (0.2, 0.4, 0.8, 0.8)
             for nid in nodes_to_render:
                 colour_map[nid] = default_colour  # type: ignore[assignment]
@@ -220,11 +226,10 @@ def plot_phylogenetic_tree(
         ax.tick_params(axis="x", which="both", bottom=False, labelbottom=False)
 
         # Legend: lineage colours
-        if color_by_lineage and tree.roots:
+        if color_by_lineage and tree.roots and cmap is not None:
             handles = []
-            cmap2 = plt.cm.get_cmap("tab10", max(len(tree.roots), 1))  # type: ignore[attr-defined]
             for idx, root_id in enumerate(tree.roots[:10]):  # cap legend entries
-                patch = mpatches.Patch(color=cmap2(idx % 10), label=f"Lineage: {root_id}")
+                patch = mpatches.Patch(color=cmap(idx % 10), label=f"Lineage: {root_id}")
                 handles.append(patch)
             if len(tree.roots) > 10:
                 handles.append(

--- a/farm/analysis/phylogenetics/plot.py
+++ b/farm/analysis/phylogenetics/plot.py
@@ -34,7 +34,7 @@ _DEFAULT_MAX_DEPTH_LARGE = 6
 
 
 def plot_phylogenetic_tree(
-    tree: PhylogeneticTree,
+    df: PhylogeneticTree,
     ctx: AnalysisContext,
     *,
     max_depth: Optional[int] = None,
@@ -47,8 +47,9 @@ def plot_phylogenetic_tree(
 
     Parameters
     ----------
-    tree:
-        :class:`~farm.analysis.phylogenetics.compute.PhylogeneticTree` to plot.
+    df:
+        :class:`~farm.analysis.phylogenetics.compute.PhylogeneticTree` to plot
+        (parameter name ``df`` for the analysis framework wrapper).
     ctx:
         :class:`~farm.analysis.common.context.AnalysisContext` supplying the
         output directory and a logger.
@@ -71,7 +72,7 @@ def plot_phylogenetic_tree(
     pathlib.Path or None
         Path to the saved PNG file on success, ``None`` on failure.
     """
-    if not tree.nodes:
+    if not df.nodes:
         logger.warning("plot_phylogenetic_tree: tree is empty; skipping")
         return None
 
@@ -90,29 +91,29 @@ def plot_phylogenetic_tree(
         # 1. Determine which nodes to render (pruning)
         # ------------------------------------------------------------------
         effective_max_depth = max_depth
-        if effective_max_depth is None and len(tree.nodes) > max_nodes:
+        if effective_max_depth is None and len(df.nodes) > max_nodes:
             effective_max_depth = _DEFAULT_MAX_DEPTH_LARGE
 
         if effective_max_depth is not None:
             render_ids: Set[str] = {
                 nid
-                for nid, n in tree.nodes.items()
+                for nid, n in df.nodes.items()
                 if 0 <= n.depth <= effective_max_depth
             }
         else:
-            render_ids = set(tree.nodes.keys())
+            render_ids = set(df.nodes.keys())
 
         # Per-depth sampling when still too large
         if len(render_ids) > max_nodes:
             by_depth: Dict[int, List[str]] = defaultdict(list)
             for nid in sorted(render_ids):
-                by_depth[tree.nodes[nid].depth].append(nid)
+                by_depth[df.nodes[nid].depth].append(nid)
             per_level = max(1, max_nodes // max(1, len(by_depth)))
             render_ids = set()
             for depth_level in sorted(by_depth):
                 render_ids.update(sorted(by_depth[depth_level])[:per_level])
 
-        nodes_to_render = {nid: tree.nodes[nid] for nid in render_ids}
+        nodes_to_render = {nid: df.nodes[nid] for nid in render_ids}
 
         # ------------------------------------------------------------------
         # 2. Assign positions
@@ -136,7 +137,7 @@ def plot_phylogenetic_tree(
         # 3. Assign lineage colours
         # ------------------------------------------------------------------
         colour_map: Dict[str, str] = {}
-        if color_by_lineage and tree.roots:
+        if color_by_lineage and df.roots:
             try:
                 import matplotlib
                 cmap = matplotlib.colormaps.get_cmap("tab10")
@@ -144,7 +145,7 @@ def plot_phylogenetic_tree(
                 # matplotlib < 3.5 fallback
                 cmap = plt.cm.get_cmap("tab10")  # type: ignore[attr-defined]
             lineage_colour: Dict[str, Any] = {}
-            for idx, root_id in enumerate(tree.roots):
+            for idx, root_id in enumerate(df.roots):
                 lineage_colour[root_id] = cmap(idx % 10)
 
             def _get_lineage_colour(nid: str) -> Any:
@@ -162,7 +163,7 @@ def plot_phylogenetic_tree(
                         break
                     current = parents[0]
                 return lineage_colour.get(
-                    tree.roots[0] if tree.roots else list(nodes_to_render)[0],
+                    df.roots[0] if df.roots else list(nodes_to_render)[0],
                     (0.5, 0.5, 0.5, 1.0),
                 )
 
@@ -226,19 +227,19 @@ def plot_phylogenetic_tree(
         ax.tick_params(axis="x", which="both", bottom=False, labelbottom=False)
 
         # Legend: lineage colours
-        if color_by_lineage and tree.roots and cmap is not None:
+        if color_by_lineage and df.roots and cmap is not None:
             handles = []
-            for idx, root_id in enumerate(tree.roots[:10]):  # cap legend entries
+            for idx, root_id in enumerate(df.roots[:10]):  # cap legend entries
                 patch = mpatches.Patch(color=cmap(idx % 10), label=f"Lineage: {root_id}")
                 handles.append(patch)
-            if len(tree.roots) > 10:
+            if len(df.roots) > 10:
                 handles.append(
-                    mpatches.Patch(color="white", label=f"… +{len(tree.roots) - 10} more")
+                    mpatches.Patch(color="white", label=f"… +{len(df.roots) - 10} more")
                 )
             ax.legend(handles=handles, loc="upper right", fontsize=7, framealpha=0.7)
 
         # DAG annotation
-        if tree.is_dag:
+        if df.is_dag:
             ax.text(
                 0.01,
                 0.01,
@@ -250,11 +251,11 @@ def plot_phylogenetic_tree(
             )
 
         # Pruning annotation
-        if len(nodes_to_render) < len(tree.nodes):
+        if len(nodes_to_render) < len(df.nodes):
             ax.text(
                 0.99,
                 0.01,
-                f"Showing {len(nodes_to_render)} of {len(tree.nodes)} nodes",
+                f"Showing {len(nodes_to_render)} of {len(df.nodes)} nodes",
                 transform=ax.transAxes,
                 fontsize=7,
                 color="gray",

--- a/farm/analysis/phylogenetics/plot.py
+++ b/farm/analysis/phylogenetics/plot.py
@@ -1,0 +1,268 @@
+"""Phylogenetic tree visualization.
+
+Provides a matplotlib-based phylogeny plot integrated with the
+``farm/charts/``-style API.  The layout is a layered dendrogram:
+
+* **Y-axis** – depth from root (founders at the top, deepest leaves at the
+  bottom).
+* **X-axis** – horizontal spread within each depth level.
+* **Edges** – lines from each parent node to each of its children.
+* **Colours** – nodes are coloured by their founder lineage when
+  ``color_by_lineage=True``.
+
+Large populations
+~~~~~~~~~~~~~~~~~
+When the tree has more nodes than ``max_nodes``, the function prunes to the
+first ``max_depth`` levels (defaulting to 6 when not specified) and, if still
+too large, samples at most ``max_nodes`` nodes per depth level before drawing.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from farm.analysis.common.context import AnalysisContext
+from farm.analysis.phylogenetics.compute import PhylogeneticTree
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Default caps for large-population pruning
+_DEFAULT_MAX_NODES = 300
+_DEFAULT_MAX_DEPTH_LARGE = 6
+
+
+def plot_phylogenetic_tree(
+    tree: PhylogeneticTree,
+    ctx: AnalysisContext,
+    *,
+    max_depth: Optional[int] = None,
+    max_nodes: int = _DEFAULT_MAX_NODES,
+    title: str = "Phylogenetic Tree",
+    color_by_lineage: bool = True,
+    **kwargs: Any,
+) -> Optional[Any]:
+    """Plot the phylogenetic tree/DAG as a layered dendrogram.
+
+    Parameters
+    ----------
+    tree:
+        :class:`~farm.analysis.phylogenetics.compute.PhylogeneticTree` to plot.
+    ctx:
+        :class:`~farm.analysis.common.context.AnalysisContext` supplying the
+        output directory and a logger.
+    max_depth:
+        Maximum depth level to render.  When ``None`` and the tree is large
+        (more nodes than ``max_nodes``), the plot is automatically pruned to
+        ``_DEFAULT_MAX_DEPTH_LARGE`` levels.
+    max_nodes:
+        Maximum total nodes to render.  When the pruned tree still exceeds
+        this limit, each depth level is sampled (deterministically, sorted
+        by node ID).
+    title:
+        Plot title.
+    color_by_lineage:
+        When ``True`` nodes belonging to different founder lineages are drawn
+        in different colours.
+
+    Returns
+    -------
+    pathlib.Path or None
+        Path to the saved PNG file on success, ``None`` on failure.
+    """
+    if not tree.nodes:
+        logger.warning("plot_phylogenetic_tree: tree is empty; skipping")
+        return None
+
+    try:
+        import matplotlib
+        matplotlib.use("Agg")  # non-interactive backend for server/test contexts
+        import matplotlib.pyplot as plt
+        import matplotlib.patches as mpatches
+        from matplotlib.lines import Line2D
+    except ImportError as exc:
+        logger.warning("plot_phylogenetic_tree: matplotlib not available: %s", exc)
+        return None
+
+    try:
+        # ------------------------------------------------------------------
+        # 1. Determine which nodes to render (pruning)
+        # ------------------------------------------------------------------
+        effective_max_depth = max_depth
+        if effective_max_depth is None and len(tree.nodes) > max_nodes:
+            effective_max_depth = _DEFAULT_MAX_DEPTH_LARGE
+
+        if effective_max_depth is not None:
+            render_ids: Set[str] = {
+                nid
+                for nid, n in tree.nodes.items()
+                if 0 <= n.depth <= effective_max_depth
+            }
+        else:
+            render_ids = set(tree.nodes.keys())
+
+        # Per-depth sampling when still too large
+        if len(render_ids) > max_nodes:
+            by_depth: Dict[int, List[str]] = defaultdict(list)
+            for nid in sorted(render_ids):
+                by_depth[tree.nodes[nid].depth].append(nid)
+            per_level = max(1, max_nodes // max(1, len(by_depth)))
+            render_ids = set()
+            for depth_level in sorted(by_depth):
+                render_ids.update(sorted(by_depth[depth_level])[:per_level])
+
+        nodes_to_render = {nid: tree.nodes[nid] for nid in render_ids}
+
+        # ------------------------------------------------------------------
+        # 2. Assign positions
+        # ------------------------------------------------------------------
+        by_depth_render: Dict[int, List[str]] = defaultdict(list)
+        for nid, node in nodes_to_render.items():
+            by_depth_render[node.depth].append(nid)
+        for depth_level in by_depth_render:
+            by_depth_render[depth_level].sort()
+
+        positions: Dict[str, Tuple[float, float]] = {}
+        depths_present = sorted(by_depth_render.keys())
+        for depth_level in depths_present:
+            ids_at_depth = by_depth_render[depth_level]
+            count = len(ids_at_depth)
+            for i, nid in enumerate(ids_at_depth):
+                x = (i + 1) / (count + 1)
+                positions[nid] = (x, -depth_level)
+
+        # ------------------------------------------------------------------
+        # 3. Assign lineage colours
+        # ------------------------------------------------------------------
+        colour_map: Dict[str, str] = {}
+        if color_by_lineage and tree.roots:
+            cmap = plt.cm.get_cmap("tab10", max(len(tree.roots), 1))  # type: ignore[attr-defined]
+            lineage_colour: Dict[str, Any] = {}
+            for idx, root_id in enumerate(tree.roots):
+                lineage_colour[root_id] = cmap(idx % 10)
+
+            def _get_lineage_colour(nid: str) -> Any:
+                visited_set: Set[str] = set()
+                current = nid
+                while current in nodes_to_render:
+                    if current in visited_set:
+                        break
+                    visited_set.add(current)
+                    if current in lineage_colour:
+                        return lineage_colour[current]
+                    node = nodes_to_render[current]
+                    parents = [p for p in node.parent_ids if p in nodes_to_render]
+                    if not parents:
+                        break
+                    current = parents[0]
+                return lineage_colour.get(
+                    tree.roots[0] if tree.roots else list(nodes_to_render)[0],
+                    (0.5, 0.5, 0.5, 1.0),
+                )
+
+            for nid in nodes_to_render:
+                colour_map[nid] = _get_lineage_colour(nid)
+        else:
+            default_colour = (0.2, 0.4, 0.8, 0.8)
+            for nid in nodes_to_render:
+                colour_map[nid] = default_colour  # type: ignore[assignment]
+
+        # ------------------------------------------------------------------
+        # 4. Draw
+        # ------------------------------------------------------------------
+        fig_width = max(8.0, len(nodes_to_render) / 5)
+        fig_height = max(5.0, (len(depths_present) + 1) * 0.8)
+        fig, ax = plt.subplots(figsize=(min(fig_width, 24.0), min(fig_height, 16.0)))
+
+        # Draw edges first (so they appear behind nodes)
+        for nid, node in nodes_to_render.items():
+            if nid not in positions:
+                continue
+            x_child, y_child = positions[nid]
+            for pid in node.parent_ids:
+                if pid in positions:
+                    x_parent, y_parent = positions[pid]
+                    ax.plot(
+                        [x_parent, x_child],
+                        [y_parent, y_child],
+                        color=(0.6, 0.6, 0.6),
+                        linewidth=0.8,
+                        zorder=1,
+                    )
+
+        # Draw nodes
+        node_size = max(20, min(60, 400 // max(len(nodes_to_render), 1)))
+        for nid, (x, y) in positions.items():
+            colour = colour_map.get(nid, (0.5, 0.5, 0.5, 1.0))
+            marker = "*" if nodes_to_render[nid].is_root else "o"
+            ax.scatter(
+                x,
+                y,
+                s=node_size,
+                c=[colour],
+                marker=marker,
+                zorder=2,
+                linewidths=0.3,
+                edgecolors="black",
+            )
+
+        # ------------------------------------------------------------------
+        # 5. Annotations
+        # ------------------------------------------------------------------
+        ax.set_xlim(0, 1)
+        ax.set_ylim(-max(depths_present) - 0.5, 0.5)
+        ax.set_xlabel("Relative position within depth level")
+        ax.set_ylabel("Depth from founder")
+        ax.set_title(title)
+        ax.set_yticks([-d for d in depths_present])
+        ax.set_yticklabels([str(d) for d in depths_present])
+        ax.tick_params(axis="x", which="both", bottom=False, labelbottom=False)
+
+        # Legend: lineage colours
+        if color_by_lineage and tree.roots:
+            handles = []
+            cmap2 = plt.cm.get_cmap("tab10", max(len(tree.roots), 1))  # type: ignore[attr-defined]
+            for idx, root_id in enumerate(tree.roots[:10]):  # cap legend entries
+                patch = mpatches.Patch(color=cmap2(idx % 10), label=f"Lineage: {root_id}")
+                handles.append(patch)
+            if len(tree.roots) > 10:
+                handles.append(
+                    mpatches.Patch(color="white", label=f"… +{len(tree.roots) - 10} more")
+                )
+            ax.legend(handles=handles, loc="upper right", fontsize=7, framealpha=0.7)
+
+        # DAG annotation
+        if tree.is_dag:
+            ax.text(
+                0.01,
+                0.01,
+                "DAG (dual-parent reproduction; single-parent edges shown)",
+                transform=ax.transAxes,
+                fontsize=7,
+                color="gray",
+                va="bottom",
+            )
+
+        # Pruning annotation
+        if len(nodes_to_render) < len(tree.nodes):
+            ax.text(
+                0.99,
+                0.01,
+                f"Showing {len(nodes_to_render)} of {len(tree.nodes)} nodes",
+                transform=ax.transAxes,
+                fontsize=7,
+                color="gray",
+                ha="right",
+                va="bottom",
+            )
+
+        output_file = ctx.get_output_file("phylogenetics_tree.png")
+        fig.savefig(output_file, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        logger.info("plot_phylogenetic_tree: saved to %s", output_file)
+        return output_file
+
+    except Exception as exc:
+        logger.warning("plot_phylogenetic_tree: failed: %s", exc, exc_info=True)
+        return None

--- a/farm/analysis/phylogenetics/plot.py
+++ b/farm/analysis/phylogenetics/plot.py
@@ -81,7 +81,6 @@ def plot_phylogenetic_tree(
         matplotlib.use("Agg")  # non-interactive backend for server/test contexts
         import matplotlib.pyplot as plt
         import matplotlib.patches as mpatches
-        from matplotlib.lines import Line2D
     except ImportError as exc:
         logger.warning("plot_phylogenetic_tree: matplotlib not available: %s", exc)
         return None
@@ -101,7 +100,11 @@ def plot_phylogenetic_tree(
                 if 0 <= n.depth <= effective_max_depth
             }
         else:
-            render_ids = set(df.nodes.keys())
+            render_ids = {
+                nid
+                for nid, n in df.nodes.items()
+                if n.depth >= 0
+            }
 
         # Per-depth sampling when still too large
         if len(render_ids) > max_nodes:

--- a/farm/analysis/registry.py
+++ b/farm/analysis/registry.py
@@ -235,6 +235,9 @@ def _register_builtin_modules() -> int:
 
         # Genetics analysis module
         "farm.analysis.genetics.module.genetics_module",
+
+        # Phylogenetics analysis module
+        "farm.analysis.phylogenetics.module.phylogenetics_module",
     ]
 
     count = 0

--- a/tests/analysis/test_phylogenetics.py
+++ b/tests/analysis/test_phylogenetics.py
@@ -1,0 +1,667 @@
+"""Unit tests for the phylogenetics analysis module.
+
+Covers:
+- PhylogeneticNode and PhylogeneticTree data structures
+- build_phylogenetic_tree: single founder, multi-founder, dual-parent,
+  broken/missing parent IDs, orphan nodes
+- build_phylogenetic_tree_from_records: evolution_lineage.json format
+- JSON and Newick serialisation
+- PhylogeneticTree.summary() statistics
+- analyze_phylogenetics()
+- process_phylogenetics_data() dispatcher
+- plot_phylogenetic_tree() (smoke-test; output saved to tmp dir)
+- PhylogeneticsModule registration and protocol compliance
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from farm.analysis.phylogenetics.compute import (
+    PhylogeneticNode,
+    PhylogeneticTree,
+    PhylogeneticTreeSummary,
+    build_phylogenetic_tree,
+    build_phylogenetic_tree_from_records,
+)
+from farm.analysis.phylogenetics.analyze import analyze_phylogenetics
+from farm.analysis.phylogenetics.data import process_phylogenetics_data
+from farm.analysis.phylogenetics.module import PhylogeneticsModule, phylogenetics_module
+from farm.analysis.common.context import AnalysisContext
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _agent(
+    agent_id: str,
+    genome_id: str = "::1",
+    generation: int = 0,
+    birth_time: int = 0,
+    death_time: int = None,
+):
+    """Create a lightweight agent-like namespace."""
+    return SimpleNamespace(
+        agent_id=agent_id,
+        genome_id=genome_id,
+        generation=generation,
+        birth_time=birth_time,
+        death_time=death_time,
+    )
+
+
+def _record(
+    candidate_id: str,
+    parent_ids: list,
+    generation: int = 0,
+):
+    return {
+        "candidate_id": candidate_id,
+        "parent_ids": parent_ids,
+        "generation": generation,
+    }
+
+
+# ---------------------------------------------------------------------------
+# build_phylogenetic_tree – single founder
+# ---------------------------------------------------------------------------
+
+
+class TestSingleFounder:
+    def test_single_agent_no_parents(self):
+        agents = [_agent("a1", genome_id="::1")]
+        tree = build_phylogenetic_tree(agents)
+        assert "a1" in tree.nodes
+        assert tree.nodes["a1"].is_root is True
+        assert tree.nodes["a1"].parent_ids == []
+        assert tree.roots == ["a1"]
+
+    def test_single_founder_with_two_generations(self):
+        agents = [
+            _agent("a1", genome_id="::1", generation=0),
+            _agent("a2", genome_id="a1:1", generation=1),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        assert tree.nodes["a1"].is_root is True
+        assert tree.nodes["a2"].is_root is False
+        assert tree.nodes["a2"].parent_ids == ["a1"]
+        assert "a2" in tree.nodes["a1"].children_ids
+        assert tree.nodes["a2"].depth == 1
+
+    def test_linear_chain_depths(self):
+        agents = [
+            _agent("a1", genome_id="::1", generation=0),
+            _agent("a2", genome_id="a1:1", generation=1),
+            _agent("a3", genome_id="a2:1", generation=2),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        assert tree.nodes["a1"].depth == 0
+        assert tree.nodes["a2"].depth == 1
+        assert tree.nodes["a3"].depth == 2
+
+    def test_branching(self):
+        agents = [
+            _agent("root", genome_id="::1"),
+            _agent("child1", genome_id="root:1"),
+            _agent("child2", genome_id="root:2"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        assert sorted(tree.nodes["root"].children_ids) == ["child1", "child2"]
+        assert tree.nodes["child1"].depth == 1
+        assert tree.nodes["child2"].depth == 1
+
+
+# ---------------------------------------------------------------------------
+# build_phylogenetic_tree – multi-founder
+# ---------------------------------------------------------------------------
+
+
+class TestMultiFounder:
+    def test_two_founders(self):
+        agents = [
+            _agent("f1", genome_id="::1"),
+            _agent("f2", genome_id="::2"),
+            _agent("c1", genome_id="f1:1"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        assert set(tree.roots) == {"f1", "f2"}
+        assert tree.nodes["f1"].is_root is True
+        assert tree.nodes["f2"].is_root is True
+
+    def test_roots_are_sorted(self):
+        agents = [
+            _agent("z_founder", genome_id="::1"),
+            _agent("a_founder", genome_id="::2"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        assert tree.roots == sorted(["z_founder", "a_founder"])
+
+    def test_independent_lineages_no_cross_edges(self):
+        agents = [
+            _agent("f1", genome_id="::1"),
+            _agent("f2", genome_id="::2"),
+            _agent("c1", genome_id="f1:1"),
+            _agent("c2", genome_id="f2:1"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        assert "c2" not in tree.nodes["f1"].children_ids
+        assert "c1" not in tree.nodes["f2"].children_ids
+
+
+# ---------------------------------------------------------------------------
+# build_phylogenetic_tree – dual-parent (DAG)
+# ---------------------------------------------------------------------------
+
+
+class TestDualParent:
+    def test_is_dag_when_two_parents(self):
+        agents = [
+            _agent("p1", genome_id="::1"),
+            _agent("p2", genome_id="::2"),
+            _agent("child", genome_id="p1:p2:1"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        assert tree.is_dag is True
+        assert tree.nodes["child"].parent_ids == ["p1", "p2"]
+
+    def test_child_registered_in_both_parents_children(self):
+        agents = [
+            _agent("p1", genome_id="::1"),
+            _agent("p2", genome_id="::2"),
+            _agent("child", genome_id="p1:p2:1"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        assert "child" in tree.nodes["p1"].children_ids
+        assert "child" in tree.nodes["p2"].children_ids
+
+    def test_dag_depth_is_one(self):
+        agents = [
+            _agent("p1", genome_id="::1"),
+            _agent("p2", genome_id="::2"),
+            _agent("child", genome_id="p1:p2:1"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        assert tree.nodes["child"].depth == 1
+
+    def test_single_parent_is_not_dag(self):
+        agents = [
+            _agent("p1", genome_id="::1"),
+            _agent("c1", genome_id="p1:1"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        assert tree.is_dag is False
+
+
+# ---------------------------------------------------------------------------
+# build_phylogenetic_tree – broken / missing parent IDs
+# ---------------------------------------------------------------------------
+
+
+class TestBrokenParentIds:
+    def test_none_genome_id_treated_as_founder(self):
+        agents = [_agent("a1", genome_id=None)]
+        tree = build_phylogenetic_tree(agents)
+        assert tree.nodes["a1"].is_root is True
+        assert tree.nodes["a1"].parent_ids == []
+
+    def test_missing_parent_creates_orphan(self):
+        # "ghost" parent is not in the dataset
+        agents = [_agent("child", genome_id="ghost:1")]
+        tree = build_phylogenetic_tree(agents)
+        node = tree.nodes["child"]
+        assert node.is_root is True
+        assert node.is_orphan is True
+        assert node.parent_ids == ["ghost"]
+
+    def test_partial_parents_present(self):
+        # p1 is real, p2 is missing
+        agents = [
+            _agent("p1", genome_id="::1"),
+            _agent("child", genome_id="p1:missing:1"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        # child's parent p1 is in tree -> child is not orphan/root
+        assert tree.nodes["child"].is_root is False
+        assert tree.nodes["child"].is_orphan is False
+
+    def test_empty_genome_id_string(self):
+        agents = [_agent("a1", genome_id="")]
+        tree = build_phylogenetic_tree(agents)
+        # Empty genome_id should parse gracefully -> founder
+        node = tree.nodes["a1"]
+        assert node.is_root is True
+
+    def test_empty_agents_list(self):
+        tree = build_phylogenetic_tree([])
+        assert tree.nodes == {}
+        assert tree.roots == []
+
+    def test_malformed_genome_id_is_handled_gracefully(self):
+        agents = [_agent("a1", genome_id="not:valid:genome:id:1:2:3")]
+        # Should not raise
+        tree = build_phylogenetic_tree(agents)
+        assert "a1" in tree.nodes
+
+
+# ---------------------------------------------------------------------------
+# build_phylogenetic_tree_from_records
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFromRecords:
+    def test_empty_records(self):
+        tree = build_phylogenetic_tree_from_records([])
+        assert tree.nodes == {}
+        assert tree.roots == []
+
+    def test_single_founder_record(self):
+        records = [_record("g0_c0", parent_ids=[])]
+        tree = build_phylogenetic_tree_from_records(records)
+        assert "g0_c0" in tree.nodes
+        assert tree.nodes["g0_c0"].is_root is True
+
+    def test_lineage_chain(self):
+        records = [
+            _record("g0_c0", parent_ids=[], generation=0),
+            _record("g1_c0", parent_ids=["g0_c0"], generation=1),
+            _record("g2_c0", parent_ids=["g1_c0"], generation=2),
+        ]
+        tree = build_phylogenetic_tree_from_records(records)
+        assert tree.nodes["g0_c0"].depth == 0
+        assert tree.nodes["g1_c0"].depth == 1
+        assert tree.nodes["g2_c0"].depth == 2
+
+    def test_dual_parent_record(self):
+        records = [
+            _record("g0_c0", parent_ids=[], generation=0),
+            _record("g0_c1", parent_ids=[], generation=0),
+            _record("g1_c0", parent_ids=["g0_c0", "g0_c1"], generation=1),
+        ]
+        tree = build_phylogenetic_tree_from_records(records)
+        assert tree.is_dag is True
+
+    def test_missing_id_key_skipped(self):
+        records = [
+            {"generation": 0, "parent_ids": []},  # missing candidate_id
+            _record("g0_c0", parent_ids=[]),
+        ]
+        tree = build_phylogenetic_tree_from_records(records)
+        # Only the valid record should appear
+        assert len(tree.nodes) == 1
+        assert "g0_c0" in tree.nodes
+
+    def test_custom_id_key(self):
+        records = [{"agent_id": "a1", "parent_ids": [], "generation": 0}]
+        tree = build_phylogenetic_tree_from_records(records, id_key="agent_id")
+        assert "a1" in tree.nodes
+
+    def test_fallback_to_agent_id_when_primary_key_absent(self):
+        records = [{"agent_id": "a1", "parent_ids": [], "generation": 0}]
+        tree = build_phylogenetic_tree_from_records(records)
+        # Falls back to "agent_id" key
+        assert "a1" in tree.nodes
+
+
+# ---------------------------------------------------------------------------
+# JSON serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestJsonExport:
+    def test_to_dict_structure(self):
+        agents = [
+            _agent("f1", genome_id="::1"),
+            _agent("c1", genome_id="f1:1"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        d = tree.to_dict()
+        assert "is_dag" in d
+        assert "roots" in d
+        assert "nodes" in d
+        assert "f1" in d["nodes"]
+        assert "c1" in d["nodes"]
+
+    def test_to_json_roundtrip(self):
+        agents = [
+            _agent("f1", genome_id="::1"),
+            _agent("c1", genome_id="f1:1"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        json_str = tree.to_json()
+        data = json.loads(json_str)
+        assert data["nodes"]["f1"]["is_root"] is True
+        assert data["nodes"]["c1"]["parent_ids"] == ["f1"]
+
+    def test_children_ids_sorted_in_json(self):
+        agents = [
+            _agent("root", genome_id="::1"),
+            _agent("z_child", genome_id="root:2"),
+            _agent("a_child", genome_id="root:1"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        d = tree.to_dict()
+        assert d["nodes"]["root"]["children_ids"] == sorted(
+            d["nodes"]["root"]["children_ids"]
+        )
+
+    def test_dag_flag_preserved_in_json(self):
+        agents = [
+            _agent("p1", genome_id="::1"),
+            _agent("p2", genome_id="::2"),
+            _agent("child", genome_id="p1:p2:1"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        data = json.loads(tree.to_json())
+        assert data["is_dag"] is True
+
+
+# ---------------------------------------------------------------------------
+# Newick export
+# ---------------------------------------------------------------------------
+
+
+class TestNewickExport:
+    def test_empty_tree(self):
+        tree = PhylogeneticTree(nodes={}, roots=[], is_dag=False)
+        assert tree.to_newick() == "();"
+
+    def test_single_root_no_children(self):
+        agents = [_agent("r1", genome_id="::1")]
+        tree = build_phylogenetic_tree(agents)
+        newick = tree.to_newick()
+        assert newick.endswith(";")
+        assert "r1" in newick
+
+    def test_root_with_two_children(self):
+        agents = [
+            _agent("root", genome_id="::1"),
+            _agent("c1", genome_id="root:1"),
+            _agent("c2", genome_id="root:2"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        newick = tree.to_newick()
+        assert newick.endswith(";")
+        assert "root" in newick
+        assert "c1" in newick
+        assert "c2" in newick
+
+    def test_multi_root_newick_wraps(self):
+        agents = [
+            _agent("r1", genome_id="::1"),
+            _agent("r2", genome_id="::2"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        newick = tree.to_newick()
+        assert newick.startswith("(")
+        assert newick.endswith(";")
+
+    def test_dag_uses_first_parent_only(self):
+        agents = [
+            _agent("p1", genome_id="::1"),
+            _agent("p2", genome_id="::2"),
+            _agent("child", genome_id="p1:p2:1"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        newick = tree.to_newick()
+        # child should appear under p1's subtree (first parent)
+        assert "child" in newick
+
+
+# ---------------------------------------------------------------------------
+# Summary statistics
+# ---------------------------------------------------------------------------
+
+
+class TestSummaryStats:
+    def test_empty_tree_summary(self):
+        tree = PhylogeneticTree(nodes={}, roots=[], is_dag=False)
+        s = tree.summary()
+        assert s.num_nodes == 0
+        assert s.max_depth == 0
+
+    def test_basic_summary(self):
+        agents = [
+            _agent("r1", genome_id="::1"),
+            _agent("c1", genome_id="r1:1"),
+            _agent("c2", genome_id="r1:2"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        s = tree.summary()
+        assert s.num_nodes == 3
+        assert s.num_founders == 1
+        assert s.max_depth == 1
+        assert s.mean_branching_factor == pytest.approx(2.0)
+
+    def test_orphan_counted(self):
+        agents = [_agent("child", genome_id="missing_parent:1")]
+        tree = build_phylogenetic_tree(agents)
+        s = tree.summary()
+        assert s.num_orphans == 1
+
+    def test_dag_flag_in_summary(self):
+        agents = [
+            _agent("p1", genome_id="::1"),
+            _agent("p2", genome_id="::2"),
+            _agent("child", genome_id="p1:p2:1"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        s = tree.summary()
+        assert s.is_dag is True
+
+    def test_lineage_survival_with_timing(self):
+        agents = [
+            _agent("root", genome_id="::1", birth_time=0, death_time=None),
+            _agent("child", genome_id="root:1", birth_time=5, death_time=None),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        # max_step derived from timing data
+        assert tree.max_step is not None
+        s = tree.summary()
+        assert s.num_surviving_lineages >= 0
+
+    def test_no_timing_lineage_stats_are_minus_one(self):
+        agents = [
+            _agent("r1", genome_id="::1", birth_time=-1, death_time=None),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        tree.max_step = None  # force no timing
+        s = tree.summary()
+        assert s.num_surviving_lineages == -1
+        assert s.num_lineages_at_final_step == -1
+
+
+# ---------------------------------------------------------------------------
+# analyze_phylogenetics
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzePhylogenetics:
+    def test_empty_tree_returns_zeros(self):
+        tree = PhylogeneticTree(nodes={}, roots=[], is_dag=False)
+        result = analyze_phylogenetics(tree)
+        assert result["num_nodes"] == 0
+        assert result["roots"] == []
+
+    def test_basic_tree_analysis(self):
+        agents = [
+            _agent("r1", genome_id="::1"),
+            _agent("c1", genome_id="r1:1"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        result = analyze_phylogenetics(tree)
+        assert result["num_nodes"] == 2
+        assert result["num_founders"] == 1
+        assert result["max_depth"] == 1
+        assert "r1" in result["roots"]
+
+    def test_dag_flag_propagated(self):
+        agents = [
+            _agent("p1", genome_id="::1"),
+            _agent("p2", genome_id="::2"),
+            _agent("child", genome_id="p1:p2:1"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        result = analyze_phylogenetics(tree)
+        assert result["is_dag"] is True
+
+
+# ---------------------------------------------------------------------------
+# process_phylogenetics_data
+# ---------------------------------------------------------------------------
+
+
+class TestProcessPhylogeneticsData:
+    def test_list_of_records(self):
+        records = [
+            _record("g0_c0", parent_ids=[], generation=0),
+            _record("g1_c0", parent_ids=["g0_c0"], generation=1),
+        ]
+        tree = process_phylogenetics_data(records)
+        assert isinstance(tree, PhylogeneticTree)
+        assert "g0_c0" in tree.nodes
+
+    def test_passthrough_for_tree_instance(self):
+        original = PhylogeneticTree(nodes={}, roots=[], is_dag=False)
+        result = process_phylogenetics_data(original)
+        assert result is original
+
+    def test_unknown_type_returns_empty_tree(self):
+        result = process_phylogenetics_data(object())
+        assert isinstance(result, PhylogeneticTree)
+        assert result.nodes == {}
+
+    def test_db_session_dispatch(self):
+        session = MagicMock()
+        # Simulate query returning two agents
+        a1 = SimpleNamespace(
+            agent_id="a1",
+            genome_id="::1",
+            generation=0,
+            birth_time=0,
+            death_time=None,
+        )
+        a2 = SimpleNamespace(
+            agent_id="a2",
+            genome_id="a1:1",
+            generation=1,
+            birth_time=1,
+            death_time=None,
+        )
+        session.query.return_value.all.return_value = [a1, a2]
+
+        # Patch the AgentModel inside farm.database.models so the import inside
+        # process_phylogenetics_data succeeds with the mock session's query result
+        with patch("farm.database.models.AgentModel"):
+            tree = process_phylogenetics_data(session)
+
+        assert isinstance(tree, PhylogeneticTree)
+
+
+# ---------------------------------------------------------------------------
+# plot_phylogenetic_tree – smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestPlotPhylogeneticTree:
+    def test_plot_small_tree(self):
+        agents = [
+            _agent("root", genome_id="::1", birth_time=0, death_time=None),
+            _agent("c1", genome_id="root:1", birth_time=1, death_time=None),
+            _agent("c2", genome_id="root:2", birth_time=1, death_time=None),
+            _agent("c3", genome_id="c1:1", birth_time=2, death_time=5),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ctx = AnalysisContext(output_path=Path(tmpdir))
+            from farm.analysis.phylogenetics.plot import plot_phylogenetic_tree
+            result = plot_phylogenetic_tree(tree, ctx)
+            assert result is not None
+            assert Path(result).exists()
+
+    def test_plot_empty_tree_returns_none(self):
+        tree = PhylogeneticTree(nodes={}, roots=[], is_dag=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ctx = AnalysisContext(output_path=Path(tmpdir))
+            from farm.analysis.phylogenetics.plot import plot_phylogenetic_tree
+            result = plot_phylogenetic_tree(tree, ctx)
+            assert result is None
+
+    def test_plot_dag(self):
+        agents = [
+            _agent("p1", genome_id="::1"),
+            _agent("p2", genome_id="::2"),
+            _agent("child", genome_id="p1:p2:1"),
+        ]
+        tree = build_phylogenetic_tree(agents)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ctx = AnalysisContext(output_path=Path(tmpdir))
+            from farm.analysis.phylogenetics.plot import plot_phylogenetic_tree
+            result = plot_phylogenetic_tree(tree, ctx)
+            assert result is not None
+
+    def test_plot_large_tree_pruned(self):
+        """Verify pruning activates without error for large trees."""
+        # Create 50 founders + 50 children each = 2500 nodes
+        agents = [_agent(f"f{i}", genome_id="::1") for i in range(50)]
+        agents += [
+            _agent(f"c{i}_{j}", genome_id=f"f{i}:{j}")
+            for i in range(50)
+            for j in range(50)
+        ]
+        tree = build_phylogenetic_tree(agents)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ctx = AnalysisContext(output_path=Path(tmpdir))
+            from farm.analysis.phylogenetics.plot import plot_phylogenetic_tree
+            result = plot_phylogenetic_tree(tree, ctx, max_nodes=100)
+            assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Module registration
+# ---------------------------------------------------------------------------
+
+
+class TestPhylogeneticsModule:
+    def test_module_name(self):
+        assert phylogenetics_module.name == "phylogenetics"
+
+    def test_module_has_description(self):
+        assert phylogenetics_module.description
+
+    def test_module_supports_database(self):
+        assert phylogenetics_module.supports_database() is True
+
+    def test_module_functions_registered(self):
+        module = PhylogeneticsModule()
+        module.register_functions()
+        function_names = module.get_function_names()
+        assert "analyze_phylogenetics" in function_names
+        assert "plot_phylogenetic_tree" in function_names
+
+    def test_module_groups_registered(self):
+        module = PhylogeneticsModule()
+        module.register_functions()
+        groups = module.get_function_groups()
+        assert "all" in groups
+        assert "analysis" in groups
+        assert "plots" in groups
+
+    def test_module_has_data_processor(self):
+        module = PhylogeneticsModule()
+        processor = module.get_data_processor()
+        assert processor is not None
+
+    def test_singleton_is_registered(self):
+        # phylogenetics_module should implement the AnalysisModule protocol
+        required = ["name", "description", "get_data_processor",
+                    "get_analysis_functions", "get_function_groups"]
+        for attr in required:
+            assert hasattr(phylogenetics_module, attr), f"Missing attribute: {attr}"

--- a/tests/analysis/test_phylogenetics.py
+++ b/tests/analysis/test_phylogenetics.py
@@ -24,7 +24,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from farm.analysis.phylogenetics.compute import (
-    PhylogeneticNode,
     PhylogeneticTree,
     PhylogeneticTreeSummary,
     build_phylogenetic_tree,

--- a/tests/analysis/test_phylogenetics.py
+++ b/tests/analysis/test_phylogenetics.py
@@ -25,7 +25,6 @@ import pytest
 
 from farm.analysis.phylogenetics.compute import (
     PhylogeneticTree,
-    PhylogeneticTreeSummary,
     build_phylogenetic_tree,
     build_phylogenetic_tree_from_records,
 )

--- a/tests/analysis/test_phylogenetics.py
+++ b/tests/analysis/test_phylogenetics.py
@@ -107,6 +107,20 @@ class TestSingleFounder:
         assert tree.nodes["a2"].depth == 1
         assert tree.nodes["a3"].depth == 2
 
+    def test_max_depth_prunes_without_unreachable_warning(self, caplog):
+        agents = [
+            _agent("a1", genome_id="::1", generation=0),
+            _agent("a2", genome_id="a1:1", generation=1),
+            _agent("a3", genome_id="a2:1", generation=2),
+        ]
+        with caplog.at_level("WARNING"):
+            tree = build_phylogenetic_tree(agents, max_depth=0)
+
+        assert tree.nodes["a1"].depth == 0
+        assert tree.nodes["a2"].depth == -1
+        assert tree.nodes["a3"].depth == -1
+        assert not any("unreachable node" in record.message for record in caplog.records)
+
     def test_branching(self):
         agents = [
             _agent("root", genome_id="::1"),
@@ -308,6 +322,22 @@ class TestBuildFromRecords:
         tree = build_phylogenetic_tree_from_records(records)
         # Falls back to "agent_id" key
         assert "a1" in tree.nodes
+
+    def test_invalid_numeric_fields_fallback_to_defaults(self):
+        records = [
+            {
+                "candidate_id": "a1",
+                "parent_ids": [],
+                "generation": "unknown",
+                "birth_time": "",
+                "death_time": "not-a-number",
+            }
+        ]
+        tree = build_phylogenetic_tree_from_records(records)
+        node = tree.nodes["a1"]
+        assert node.generation == -1
+        assert node.birth_time == -1
+        assert node.death_time is None
 
 
 # ---------------------------------------------------------------------------
@@ -527,6 +557,16 @@ class TestProcessPhylogeneticsData:
         tree = process_phylogenetics_data(records)
         assert isinstance(tree, PhylogeneticTree)
         assert "g0_c0" in tree.nodes
+
+    def test_list_of_agents_dispatches_to_agent_builder(self):
+        agents = [
+            _agent("a1", genome_id="::1", generation=0),
+            _agent("a2", genome_id="a1:1", generation=1),
+        ]
+        tree = process_phylogenetics_data(agents)
+        assert isinstance(tree, PhylogeneticTree)
+        assert "a1" in tree.nodes
+        assert tree.nodes["a2"].parent_ids == ["a1"]
 
     def test_passthrough_for_tree_instance(self):
         original = PhylogeneticTree(nodes={}, roots=[], is_dag=False)

--- a/tests/analysis/test_phylogenetics.py
+++ b/tests/analysis/test_phylogenetics.py
@@ -444,6 +444,21 @@ class TestNewickExport:
         # child should appear under p1's subtree (first parent)
         assert "child" in newick
 
+    def test_newick_skips_missing_first_parent_uses_second(self):
+        """When parent_ids[0] is absent but a later parent exists in-tree."""
+        from farm.analysis.phylogenetics.compute import PhylogeneticNode
+
+        nodes = {
+            "p2": PhylogeneticNode("p2", [], is_root=True, depth=0),
+            "child": PhylogeneticNode(
+                "child", ["missing_parent", "p2"], is_root=False, depth=1
+            ),
+        }
+        tree = PhylogeneticTree(nodes=nodes, roots=["p2"], is_dag=True)
+        newick = tree.to_newick()
+        assert "child" in newick
+        assert "p2" in newick
+
 
 # ---------------------------------------------------------------------------
 # Summary statistics


### PR DESCRIPTION
This pull request introduces a new phylogenetics analysis module to the codebase, enabling the construction, analysis, and visualization of phylogenetic trees (and DAGs for dual-parent reproduction) from agent lineage data. The module is fully integrated with the analysis framework, supports multiple data sources, and provides summary statistics and matplotlib-based visualizations. The most important changes are as follows:

**Module Integration and Registration:**
* Added the `phylogenetics` analysis module to the main analysis package and registered it with the module registry, making it discoverable and usable via the analysis service. (`farm/analysis/__init__.py`, `farm/analysis/registry.py`) [[1]](diffhunk://#diff-39b50c952c030380537aca1a71e57b02e082b678b5b5b62efe4c62c9fdf48922R61) [[2]](diffhunk://#diff-cfe16409ecb5fd080c57503a6688d3fc2b9aea91f3e6a2fa207d676e64f5f8f2R238-R240)
* Implemented the module class (`PhylogeneticsModule`) and singleton, registering analysis and plotting functions, and specifying data processing and validation logic. (`farm/analysis/phylogenetics/module.py`)

**Core Functionality:**
* Created the main package initializer with clear documentation and public API, exposing builder, analysis, and plotting functions. (`farm/analysis/phylogenetics/__init__.py`)
* Added a data processor that converts raw simulation data (database sessions, record lists, or trees) into a standardized `PhylogeneticTree` structure. (`farm/analysis/phylogenetics/data.py`)

**Analysis and Visualization:**
* Added a function to compute summary statistics (e.g., number of nodes, founders, depth, branching factor) for a phylogenetic tree or DAG. (`farm/analysis/phylogenetics/analyze.py`)
* Implemented a matplotlib-based visualization function for phylogenetic trees/DAGs, with support for large trees, founder-lineage coloring, and pruning for readability. (`farm/analysis/phylogenetics/plot.py`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new analysis/plotting code and registers it in the built-in module list, which could affect module discovery/import behavior and adds optional matplotlib runtime dependencies. Core simulation logic is unchanged, but correctness depends on lineage parsing and handling of large datasets.
> 
> **Overview**
> Adds a new `farm.analysis.phylogenetics` package that constructs an in-memory lineage **tree or DAG** (supports dual-parent reproduction, orphan handling, deterministic ordering) from either agent objects (`genome_id` via `parse_parent_ids`) or `evolution_lineage.json`-style records, with JSON and Newick export plus summary stats (depth, branching factor, lineage survival).
> 
> Integrates the module into the analysis framework by registering `PhylogeneticsModule` (data processor + `analyze_phylogenetics` + `plot_phylogenetic_tree`) and adding it to built-in module registration (`farm/analysis/__init__.py`, `farm/analysis/registry.py`).
> 
> Adds matplotlib-based plotting that prunes/samples large trees and optionally colors nodes by founder lineage, plus a comprehensive new unit test suite covering builders, serialization, plotting smoke tests, and module registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fe167fff2e6f21c2bdcbbad05db5d72af0b93b0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->