### PR TITLE
Enhance fitness landscape analysis with validation and tests

### DIFF
--- a/farm/analysis/genetics/__init__.py
+++ b/farm/analysis/genetics/__init__.py
@@ -12,6 +12,7 @@ Features:
 - Normalized DataFrame output for both sources
 - Genotypic diversity metrics: heterozygosity, Shannon entropy, per-locus stats
 - Allele-frequency trajectory tracking and selection-pressure detection
+- Fitness landscape: single-locus correlations and pairwise epistasis analysis
 
 Quick Start::
 
@@ -25,6 +26,8 @@ Quick Start::
     ...     compute_evolution_diversity_timeseries,
     ...     compute_allele_frequency_timeseries,
     ...     compute_selection_pressure_summary,
+    ...     compute_fitness_gene_correlations,
+    ...     compute_pairwise_epistasis,
     ... )
 """
 
@@ -45,6 +48,10 @@ from farm.analysis.genetics.compute import (
     ALLELE_VARIANCE,
     ALLELE_FREQUENCY_COLUMNS,
     SELECTION_PRESSURE_COLUMNS,
+    compute_fitness_gene_correlations,
+    compute_pairwise_epistasis,
+    FITNESS_GENE_CORRELATION_COLUMNS,
+    PAIRWISE_EPISTASIS_COLUMNS,
 )
 from farm.analysis.genetics.analyze import analyze_genetics
 from farm.analysis.genetics.module import genetics_module, GeneticsModule
@@ -70,6 +77,11 @@ __all__ = [
     "ALLELE_VARIANCE",
     "ALLELE_FREQUENCY_COLUMNS",
     "SELECTION_PRESSURE_COLUMNS",
+    # Fitness landscape correlations and epistasis
+    "compute_fitness_gene_correlations",
+    "compute_pairwise_epistasis",
+    "FITNESS_GENE_CORRELATION_COLUMNS",
+    "PAIRWISE_EPISTASIS_COLUMNS",
     # High-level analysis
     "analyze_genetics",
     "genetics_module",

--- a/farm/analysis/genetics/compute.py
+++ b/farm/analysis/genetics/compute.py
@@ -4,8 +4,9 @@ Genetics Analysis Computation
 Core computation functions for the genetics analysis module, including the
 shared ``parse_parent_ids`` helper, population-level accessors for both
 simulation-database and evolution-experiment data sources, genotypic
-diversity metrics (heterozygosity, Shannon entropy, per-locus stats), and
-allele-frequency trajectory tracking with selection-pressure detection.
+diversity metrics (heterozygosity, Shannon entropy, per-locus stats),
+allele-frequency trajectory tracking with selection-pressure detection, and
+fitness landscape analysis (single-locus correlations, pairwise epistasis).
 """
 
 from __future__ import annotations
@@ -1219,3 +1220,431 @@ def _build_summary_diversity_from_generation_summary(
         mean_shannon_entropy=float("nan"),
         mean_heterozygosity=float("nan"),
     )
+
+
+# ---------------------------------------------------------------------------
+# Fitness landscape: single-locus correlations and pairwise epistasis
+# ---------------------------------------------------------------------------
+
+#: Columns produced by :func:`compute_fitness_gene_correlations`.
+FITNESS_GENE_CORRELATION_COLUMNS = [
+    "gene",
+    "n_samples",
+    "pearson_r",
+    "pearson_p",
+    "spearman_r",
+    "spearman_p",
+    "ols_slope",
+    "ols_intercept",
+    "ols_r2",
+    "ols_p",
+    "ci_lower",
+    "ci_upper",
+    "effect_size",
+    "bh_rejected",
+]
+
+#: Columns produced by :func:`compute_pairwise_epistasis`.
+PAIRWISE_EPISTASIS_COLUMNS = [
+    "gene_i",
+    "gene_j",
+    "n_samples",
+    "interaction_coef",
+    "interaction_p",
+    "main_i_coef",
+    "main_j_coef",
+    "model_r2",
+    "bh_rejected",
+]
+
+
+def _extract_gene_matrix(df: pd.DataFrame) -> pd.DataFrame:
+    """Extract a (candidate × gene) numeric matrix from an evolution DataFrame.
+
+    Reads the ``chromosome_values`` dict column and flattens it into
+    individual gene columns.  Rows with missing fitness are dropped.
+    Only columns with non-zero variance are kept.
+
+    Parameters
+    ----------
+    df:
+        DataFrame with at least ``fitness`` and ``chromosome_values`` columns.
+
+    Returns
+    -------
+    pd.DataFrame
+        Index-reset numeric frame with ``fitness`` plus one column per gene.
+        May be empty if there is insufficient data.
+    """
+    required = {"fitness", "chromosome_values"}
+    if df.empty or not required.issubset(df.columns):
+        return pd.DataFrame()
+
+    rows: List[Dict[str, Any]] = []
+    for _, row in df.iterrows():
+        fitness = row["fitness"]
+        chrom = row["chromosome_values"]
+        if not isinstance(chrom, dict):
+            continue
+        try:
+            fitness_val = float(fitness)
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(fitness_val):
+            continue
+        entry: Dict[str, Any] = {"fitness": fitness_val}
+        for gene, val in chrom.items():
+            try:
+                entry[gene] = float(val)
+            except (TypeError, ValueError):
+                pass
+        rows.append(entry)
+
+    if not rows:
+        return pd.DataFrame()
+
+    matrix = pd.DataFrame(rows).dropna(subset=["fitness"]).reset_index(drop=True)
+
+    # Drop zero-variance gene columns (constant across all candidates)
+    gene_cols = [c for c in matrix.columns if c != "fitness"]
+    varying = [c for c in gene_cols if matrix[c].std(ddof=0) > 0.0]
+    return matrix[["fitness"] + varying]
+
+
+def _bh_correction(p_values: List[float], alpha: float = 0.05) -> List[bool]:
+    """Benjamini–Hochberg multiple-testing correction.
+
+    Parameters
+    ----------
+    p_values:
+        Raw p-values, one per hypothesis.
+    alpha:
+        Family-wise false-discovery-rate threshold.  Default ``0.05``.
+
+    Returns
+    -------
+    list[bool]
+        Boolean mask: ``True`` where the null hypothesis is rejected after
+        BH correction (i.e. the finding survives multiple-testing correction).
+    """
+    m = len(p_values)
+    if m == 0:
+        return []
+
+    # Pair (p_value, original_index) and sort by p
+    indexed = sorted(enumerate(p_values), key=lambda x: x[1])
+    rejected = [False] * m
+
+    # BH step-up procedure: reject H_(i) if p_(i) ≤ (i/m) * alpha
+    for rank, (orig_idx, p) in enumerate(indexed, start=1):
+        if p <= (rank / m) * alpha:
+            rejected[orig_idx] = True
+
+    # BH is a step-up procedure: once we find the largest k such that
+    # p_(k) ≤ (k/m)*alpha, all i ≤ k are rejected.
+    # Re-implement properly:
+    last_rejected_rank = 0
+    for rank, (_, p) in enumerate(indexed, start=1):
+        if p <= (rank / m) * alpha:
+            last_rejected_rank = rank
+
+    rejected = [False] * m
+    for rank, (orig_idx, _) in enumerate(indexed, start=1):
+        if rank <= last_rejected_rank:
+            rejected[orig_idx] = True
+
+    return rejected
+
+
+def compute_fitness_gene_correlations(
+    df: pd.DataFrame,
+    alpha: float = 0.05,
+    min_samples: int = 10,
+    confidence_level: float = 0.95,
+) -> pd.DataFrame:
+    """Compute single-locus fitness–gene associations for evolution data.
+
+    For each evolvable gene found in ``chromosome_values``, computes:
+
+    * Pearson and Spearman correlation with fitness (+ p-values)
+    * OLS simple linear regression slope, intercept, R², and p-value
+    * 95 % (or ``confidence_level``) bootstrap-free CI on OLS slope
+      using the *t*-distribution
+    * Benjamini–Hochberg multiple-testing correction across all genes
+
+    Results are sorted descending by absolute effect size (``|pearson_r|``).
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing at least ``fitness`` (float) and
+        ``chromosome_values`` (dict) columns.  Typically produced by
+        :func:`build_evolution_experiment_dataframe`.
+    alpha:
+        FDR level for Benjamini–Hochberg correction.  Default ``0.05``.
+    min_samples:
+        Minimum number of valid (fitness, gene) pairs required to compute
+        statistics for a gene.  Genes with fewer observations are skipped.
+    confidence_level:
+        Confidence level for the OLS slope confidence interval (e.g. 0.95
+        gives a 95 % CI).  Must be in (0, 1).
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per gene, columns defined in
+        :data:`FITNESS_GENE_CORRELATION_COLUMNS`, sorted by descending
+        ``effect_size``.  Returns an empty DataFrame (with correct columns)
+        when the input is insufficient.
+
+    Notes
+    -----
+    **Statistical caveats**
+
+    * Candidates within a generation are *not independent* – fitness is
+      assigned by the same evaluator and selection acts on the whole cohort.
+    * Candidates across generations share ancestry; effect estimates may be
+      inflated by drift-selection correlation rather than pure causal gene
+      effects.
+    * The BH correction operates over genes (columns) and ignores
+      the generational non-independence.
+    * With small ``n`` (< ~30) the *t*-distribution CI is approximate.
+    """
+    from scipy import stats as _stats
+
+    matrix = _extract_gene_matrix(df)
+    if matrix.empty:
+        return pd.DataFrame(columns=FITNESS_GENE_CORRELATION_COLUMNS)
+
+    fitness = matrix["fitness"].values
+    gene_cols = [c for c in matrix.columns if c != "fitness"]
+
+    if not gene_cols:
+        return pd.DataFrame(columns=FITNESS_GENE_CORRELATION_COLUMNS)
+
+    rows: List[Dict[str, Any]] = []
+    for gene in gene_cols:
+        gene_vals = matrix[gene].values
+        n = len(gene_vals)
+        if n < min_samples:
+            continue
+
+        # --- Pearson ---
+        pr, pp = _stats.pearsonr(gene_vals, fitness)
+
+        # --- Spearman ---
+        sr, sp = _stats.spearmanr(gene_vals, fitness)
+
+        # --- OLS simple regression ---
+        slope, intercept, r_value, ols_p, std_err = _stats.linregress(gene_vals, fitness)
+        r2 = float(r_value ** 2)
+
+        # CI on slope using t-distribution (df = n - 2)
+        if n > 2:
+            t_crit = _stats.t.ppf((1 + confidence_level) / 2, df=n - 2)
+            ci_lower = float(slope - t_crit * std_err)
+            ci_upper = float(slope + t_crit * std_err)
+        else:
+            ci_lower = float("nan")
+            ci_upper = float("nan")
+
+        rows.append(
+            {
+                "gene": gene,
+                "n_samples": int(n),
+                "pearson_r": float(pr),
+                "pearson_p": float(pp),
+                "spearman_r": float(sr),
+                "spearman_p": float(sp),
+                "ols_slope": float(slope),
+                "ols_intercept": float(intercept),
+                "ols_r2": r2,
+                "ols_p": float(ols_p),
+                "ci_lower": ci_lower,
+                "ci_upper": ci_upper,
+                "effect_size": abs(float(pr)),
+                "bh_rejected": False,  # placeholder – filled below
+            }
+        )
+
+    if not rows:
+        return pd.DataFrame(columns=FITNESS_GENE_CORRELATION_COLUMNS)
+
+    result_df = pd.DataFrame(rows, columns=FITNESS_GENE_CORRELATION_COLUMNS)
+
+    # Benjamini–Hochberg correction on OLS p-values
+    bh_mask = _bh_correction(result_df["ols_p"].tolist(), alpha=alpha)
+    result_df["bh_rejected"] = bh_mask
+
+    # Sort by descending effect size
+    result_df = result_df.sort_values("effect_size", ascending=False).reset_index(drop=True)
+
+    logger.info(
+        "compute_fitness_gene_correlations: %d gene(s) tested; %d significant after BH correction",
+        len(result_df),
+        int(result_df["bh_rejected"].sum()),
+    )
+    return result_df
+
+
+def compute_pairwise_epistasis(
+    df: pd.DataFrame,
+    alpha: float = 0.05,
+    min_samples: int = 20,
+    min_gene_variance: float = 1e-8,
+) -> pd.DataFrame:
+    """Estimate pairwise epistasis between all evolvable gene pairs.
+
+    For each pair (g_i, g_j) with sufficient variance, fits the linear
+    interaction model::
+
+        fitness ~ β₀ + β₁·g_i + β₂·g_j + β₃·(g_i × g_j) + ε
+
+    and reports the interaction coefficient β₃ and its p-value.
+    Benjamini–Hochberg correction is applied across all tested pairs.
+    Results are sorted by descending absolute interaction coefficient.
+
+    Parameters
+    ----------
+    df:
+        DataFrame with ``fitness`` and ``chromosome_values`` columns.
+    alpha:
+        FDR level for Benjamini–Hochberg correction.  Default ``0.05``.
+    min_samples:
+        Minimum number of rows required to attempt the interaction fit for a
+        pair.  Default ``20`` (4 parameters need headroom).
+    min_gene_variance:
+        Pairs where either gene column has variance below this threshold are
+        skipped (near-constant genes make the model ill-conditioned).
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per (gene_i, gene_j) pair, columns defined in
+        :data:`PAIRWISE_EPISTASIS_COLUMNS`, sorted by descending absolute
+        ``interaction_coef``.  Returns an empty DataFrame (with correct
+        columns) when the input is insufficient.
+
+    Notes
+    -----
+    **Statistical caveats**
+
+    * Linear interaction in gene values is a first-order approximation to
+      epistasis; non-linear or sign-epistasis is not captured.
+    * Generational non-independence inflates effective sample size; treat
+      p-values as descriptive rather than strictly inferential.
+    * The number of pairs grows as O(k²) in the number of genes; with many
+      genes the BH correction becomes conservative.  Consider Holm or other
+      corrections for very large gene sets.
+    """
+    from itertools import combinations
+    from scipy import stats as _stats
+
+    matrix = _extract_gene_matrix(df)
+    if matrix.empty:
+        return pd.DataFrame(columns=PAIRWISE_EPISTASIS_COLUMNS)
+
+    fitness = matrix["fitness"].values
+    gene_cols = [c for c in matrix.columns if c != "fitness"]
+
+    if len(gene_cols) < 2:
+        return pd.DataFrame(columns=PAIRWISE_EPISTASIS_COLUMNS)
+
+    # Further filter genes with sufficient variance
+    varying = [g for g in gene_cols if float(matrix[g].var(ddof=0)) >= min_gene_variance]
+    if len(varying) < 2:
+        return pd.DataFrame(columns=PAIRWISE_EPISTASIS_COLUMNS)
+
+    rows: List[Dict[str, Any]] = []
+
+    for gene_i, gene_j in combinations(varying, 2):
+        gi = matrix[gene_i].values.astype(float)
+        gj = matrix[gene_j].values.astype(float)
+        n = len(gi)
+
+        if n < min_samples:
+            continue
+
+        interaction = gi * gj
+
+        # Design matrix: intercept, g_i, g_j, g_i*g_j
+        X = np.column_stack([np.ones(n), gi, gj, interaction])
+
+        # OLS via numpy least-squares
+        try:
+            coeffs, residuals_ss, rank, _ = np.linalg.lstsq(X, fitness, rcond=None)
+        except np.linalg.LinAlgError:
+            continue
+
+        if rank < 4:
+            # Collinear – skip this pair
+            continue
+
+        beta0, beta_i, beta_j, beta_ij = float(coeffs[0]), float(coeffs[1]), float(coeffs[2]), float(coeffs[3])
+
+        # Compute residual variance and standard errors
+        predicted = X @ coeffs
+        resid = fitness - predicted
+        rss = float(np.dot(resid, resid))
+        df_resid = n - 4  # n observations - 4 parameters
+
+        if df_resid < 1:
+            continue
+
+        sigma2 = rss / df_resid
+        try:
+            XtX_inv = np.linalg.inv(X.T @ X)
+        except np.linalg.LinAlgError:
+            continue
+
+        var_coeffs = sigma2 * np.diag(XtX_inv)
+        if var_coeffs[3] < 0.0:
+            interaction_p = float("nan")
+        else:
+            se_ij = math.sqrt(float(var_coeffs[3]))
+            if se_ij > 0.0:
+                t_stat = beta_ij / se_ij
+                interaction_p = float(2.0 * _stats.t.sf(abs(t_stat), df=df_resid))
+            else:
+                interaction_p = float("nan")
+
+        # R² of the full model
+        tss = float(np.dot(fitness - float(np.mean(fitness)), fitness - float(np.mean(fitness))))
+        r2 = 1.0 - rss / tss if tss > 0.0 else float("nan")
+
+        rows.append(
+            {
+                "gene_i": gene_i,
+                "gene_j": gene_j,
+                "n_samples": int(n),
+                "interaction_coef": beta_ij,
+                "interaction_p": interaction_p,
+                "main_i_coef": beta_i,
+                "main_j_coef": beta_j,
+                "model_r2": r2,
+                "bh_rejected": False,  # placeholder
+            }
+        )
+
+    if not rows:
+        return pd.DataFrame(columns=PAIRWISE_EPISTASIS_COLUMNS)
+
+    result_df = pd.DataFrame(rows, columns=PAIRWISE_EPISTASIS_COLUMNS)
+
+    # BH correction on interaction p-values (drop NaN for correction)
+    valid_mask = result_df["interaction_p"].notna()
+    valid_ps = result_df.loc[valid_mask, "interaction_p"].tolist()
+    bh_valid = _bh_correction(valid_ps, alpha=alpha)
+    result_df.loc[valid_mask, "bh_rejected"] = bh_valid
+
+    # Sort by descending absolute interaction coefficient
+    result_df = result_df.reindex(
+        result_df["interaction_coef"].abs().sort_values(ascending=False).index
+    ).reset_index(drop=True)
+
+    logger.info(
+        "compute_pairwise_epistasis: %d pair(s) tested; %d significant after BH correction",
+        len(result_df),
+        int(result_df["bh_rejected"].sum()),
+    )
+    return result_df

--- a/farm/analysis/genetics/compute.py
+++ b/farm/analysis/genetics/compute.py
@@ -1307,7 +1307,8 @@ def _extract_gene_matrix(df: pd.DataFrame) -> pd.DataFrame:
 
     # Drop zero-variance gene columns (constant across all candidates)
     gene_cols = [c for c in matrix.columns if c != "fitness"]
-    varying = [c for c in gene_cols if matrix[c].std(ddof=0) > 0.0]
+    stds = matrix[gene_cols].std(ddof=0)
+    varying = stds[stds > 0.0].index.tolist()
     return matrix[["fitness"] + varying]
 
 
@@ -1609,7 +1610,9 @@ def compute_pairwise_epistasis(
                 interaction_p = float("nan")
 
         # R² of the full model
-        tss = float(np.dot(fitness - float(np.mean(fitness)), fitness - float(np.mean(fitness))))
+        fitness_mean = float(np.mean(fitness))
+        fitness_centered = fitness - fitness_mean
+        tss = float(np.dot(fitness_centered, fitness_centered))
         r2 = 1.0 - rss / tss if tss > 0.0 else float("nan")
 
         rows.append(

--- a/farm/analysis/genetics/compute.py
+++ b/farm/analysis/genetics/compute.py
@@ -1299,7 +1299,8 @@ def _extract_gene_matrix(df: pd.DataFrame) -> pd.DataFrame:
             try:
                 entry[gene] = float(val)
             except (TypeError, ValueError):
-                pass
+                # Ignore non-numeric gene values; retain other valid loci for this row.
+                continue
         rows.append(entry)
 
     if not rows:

--- a/farm/analysis/genetics/compute.py
+++ b/farm/analysis/genetics/compute.py
@@ -1322,7 +1322,7 @@ def _bh_correction(p_values: List[float], alpha: float = 0.05) -> List[bool]:
     p_values:
         Raw p-values, one per hypothesis.
     alpha:
-        Family-wise false-discovery-rate threshold.  Default ``0.05``.
+        False discovery rate threshold.  Default ``0.05``.
 
     Returns
     -------
@@ -1693,10 +1693,21 @@ def compute_pairwise_epistasis(
     bh_valid = _bh_correction(valid_ps, alpha=alpha)
     result_df.loc[valid_mask, "bh_rejected"] = bh_valid
 
-    # Sort by descending absolute interaction coefficient
-    result_df = result_df.reindex(
-        result_df["interaction_coef"].abs().sort_values(ascending=False).index
-    ).reset_index(drop=True)
+    # Sort primarily by scale-invariant statistical evidence (BH rejection, then
+    # raw interaction p-value), using absolute interaction coefficient only as a
+    # tie-breaker.  Sorting by raw coefficient magnitude is misleading because
+    # coefficients are scale-dependent (e.g. learning_rate spans orders of
+    # magnitude while gamma is in [0, 1]).
+    result_df = (
+        result_df.assign(_abs_interaction_coef=result_df["interaction_coef"].abs())
+        .sort_values(
+            by=["bh_rejected", "interaction_p", "_abs_interaction_coef"],
+            ascending=[False, True, False],
+            na_position="last",
+        )
+        .drop(columns=["_abs_interaction_coef"])
+        .reset_index(drop=True)
+    )
 
     logger.info(
         "compute_pairwise_epistasis: %d pair(s) tested; %d significant after BH correction",

--- a/farm/analysis/genetics/compute.py
+++ b/farm/analysis/genetics/compute.py
@@ -12,11 +12,13 @@ fitness landscape analysis (single-locus correlations, pairwise epistasis).
 from __future__ import annotations
 
 import math
+from itertools import combinations
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
+from scipy import stats as scipy_stats
 
 from farm.analysis.genetics.utils import parse_parent_ids
 from farm.utils.logging import get_logger
@@ -1334,16 +1336,8 @@ def _bh_correction(p_values: List[float], alpha: float = 0.05) -> List[bool]:
 
     # Pair (p_value, original_index) and sort by p
     indexed = sorted(enumerate(p_values), key=lambda x: x[1])
-    rejected = [False] * m
 
-    # BH step-up procedure: reject H_(i) if p_(i) ≤ (i/m) * alpha
-    for rank, (orig_idx, p) in enumerate(indexed, start=1):
-        if p <= (rank / m) * alpha:
-            rejected[orig_idx] = True
-
-    # BH is a step-up procedure: once we find the largest k such that
-    # p_(k) ≤ (k/m)*alpha, all i ≤ k are rejected.
-    # Re-implement properly:
+    # BH step-up procedure: find largest k such that p_(k) <= (k/m) * alpha
     last_rejected_rank = 0
     for rank, (_, p) in enumerate(indexed, start=1):
         if p <= (rank / m) * alpha:
@@ -1355,6 +1349,30 @@ def _bh_correction(p_values: List[float], alpha: float = 0.05) -> List[bool]:
             rejected[orig_idx] = True
 
     return rejected
+
+
+def _validate_fitness_landscape_params(
+    alpha: float,
+    min_samples: int,
+    confidence_level: Optional[float] = None,
+    min_gene_variance: Optional[float] = None,
+) -> None:
+    """Validate common parameters for fitness-landscape computations."""
+    if not (0.0 < alpha <= 1.0):
+        raise ValueError(f"alpha must be in (0, 1], got {alpha}")
+
+    if min_samples < 2:
+        raise ValueError(f"min_samples must be >= 2, got {min_samples}")
+
+    if confidence_level is not None and not (0.0 < confidence_level < 1.0):
+        raise ValueError(
+            f"confidence_level must be in (0, 1), got {confidence_level}"
+        )
+
+    if min_gene_variance is not None and min_gene_variance < 0.0:
+        raise ValueError(
+            f"min_gene_variance must be >= 0, got {min_gene_variance}"
+        )
 
 
 def compute_fitness_gene_correlations(
@@ -1411,13 +1429,17 @@ def compute_fitness_gene_correlations(
       the generational non-independence.
     * With small ``n`` (< ~30) the *t*-distribution CI is approximate.
     """
-    from scipy import stats as _stats
+    _validate_fitness_landscape_params(
+        alpha=alpha,
+        min_samples=min_samples,
+        confidence_level=confidence_level,
+    )
 
     matrix = _extract_gene_matrix(df)
     if matrix.empty:
         return pd.DataFrame(columns=FITNESS_GENE_CORRELATION_COLUMNS)
 
-    fitness = matrix["fitness"].values
+    fitness = matrix["fitness"].values.astype(float)
     gene_cols = [c for c in matrix.columns if c != "fitness"]
 
     if not gene_cols:
@@ -1425,24 +1447,34 @@ def compute_fitness_gene_correlations(
 
     rows: List[Dict[str, Any]] = []
     for gene in gene_cols:
-        gene_vals = matrix[gene].values
-        n = len(gene_vals)
+        gene_vals = matrix[gene].values.astype(float)
+        valid_mask = np.isfinite(fitness) & np.isfinite(gene_vals)
+        n = int(valid_mask.sum())
         if n < min_samples:
             continue
 
+        gene_valid = gene_vals[valid_mask]
+        fitness_valid = fitness[valid_mask]
+
+        # Per-gene masking can reduce variance to zero; skip these degenerate fits.
+        if float(np.std(gene_valid, ddof=0)) <= 0.0:
+            continue
+
         # --- Pearson ---
-        pr, pp = _stats.pearsonr(gene_vals, fitness)
+        pr, pp = scipy_stats.pearsonr(gene_valid, fitness_valid)
 
         # --- Spearman ---
-        sr, sp = _stats.spearmanr(gene_vals, fitness)
+        sr, sp = scipy_stats.spearmanr(gene_valid, fitness_valid)
 
         # --- OLS simple regression ---
-        slope, intercept, r_value, ols_p, std_err = _stats.linregress(gene_vals, fitness)
+        slope, intercept, r_value, ols_p, std_err = scipy_stats.linregress(
+            gene_valid, fitness_valid
+        )
         r2 = float(r_value ** 2)
 
         # CI on slope using t-distribution (df = n - 2)
         if n > 2:
-            t_crit = _stats.t.ppf((1 + confidence_level) / 2, df=n - 2)
+            t_crit = scipy_stats.t.ppf((1 + confidence_level) / 2, df=n - 2)
             ci_lower = float(slope - t_crit * std_err)
             ci_upper = float(slope + t_crit * std_err)
         else:
@@ -1473,12 +1505,18 @@ def compute_fitness_gene_correlations(
 
     result_df = pd.DataFrame(rows, columns=FITNESS_GENE_CORRELATION_COLUMNS)
 
-    # Benjamini–Hochberg correction on OLS p-values
-    bh_mask = _bh_correction(result_df["ols_p"].tolist(), alpha=alpha)
-    result_df["bh_rejected"] = bh_mask
+    # Benjamini–Hochberg correction on finite OLS p-values
+    valid_ols_mask = result_df["ols_p"].notna() & np.isfinite(result_df["ols_p"])
+    if valid_ols_mask.any():
+        bh_mask = _bh_correction(
+            result_df.loc[valid_ols_mask, "ols_p"].tolist(), alpha=alpha
+        )
+        result_df.loc[valid_ols_mask, "bh_rejected"] = bh_mask
 
     # Sort by descending effect size
-    result_df = result_df.sort_values("effect_size", ascending=False).reset_index(drop=True)
+    result_df = result_df.sort_values(
+        "effect_size", ascending=False, na_position="last"
+    ).reset_index(drop=True)
 
     logger.info(
         "compute_fitness_gene_correlations: %d gene(s) tested; %d significant after BH correction",
@@ -1538,21 +1576,31 @@ def compute_pairwise_epistasis(
       genes the BH correction becomes conservative.  Consider Holm or other
       corrections for very large gene sets.
     """
-    from itertools import combinations
-    from scipy import stats as _stats
+    _validate_fitness_landscape_params(
+        alpha=alpha,
+        min_samples=min_samples,
+        min_gene_variance=min_gene_variance,
+    )
 
     matrix = _extract_gene_matrix(df)
     if matrix.empty:
         return pd.DataFrame(columns=PAIRWISE_EPISTASIS_COLUMNS)
 
-    fitness = matrix["fitness"].values
+    fitness = matrix["fitness"].values.astype(float)
     gene_cols = [c for c in matrix.columns if c != "fitness"]
 
     if len(gene_cols) < 2:
         return pd.DataFrame(columns=PAIRWISE_EPISTASIS_COLUMNS)
 
     # Further filter genes with sufficient variance
-    varying = [g for g in gene_cols if float(matrix[g].var(ddof=0)) >= min_gene_variance]
+    varying = [
+        g
+        for g in gene_cols
+        if (
+            matrix[g].notna().any()
+            and float(matrix[g].dropna().var(ddof=0)) >= min_gene_variance
+        )
+    ]
     if len(varying) < 2:
         return pd.DataFrame(columns=PAIRWISE_EPISTASIS_COLUMNS)
 
@@ -1561,10 +1609,15 @@ def compute_pairwise_epistasis(
     for gene_i, gene_j in combinations(varying, 2):
         gi = matrix[gene_i].values.astype(float)
         gj = matrix[gene_j].values.astype(float)
-        n = len(gi)
+        valid_mask = np.isfinite(fitness) & np.isfinite(gi) & np.isfinite(gj)
+        n = int(valid_mask.sum())
 
         if n < min_samples:
             continue
+
+        gi = gi[valid_mask]
+        gj = gj[valid_mask]
+        fitness_valid = fitness[valid_mask]
 
         interaction = gi * gj
 
@@ -1573,7 +1626,7 @@ def compute_pairwise_epistasis(
 
         # OLS via numpy least-squares
         try:
-            coeffs, residuals_ss, rank, _ = np.linalg.lstsq(X, fitness, rcond=None)
+            coeffs, residuals_ss, rank, _ = np.linalg.lstsq(X, fitness_valid, rcond=None)
         except np.linalg.LinAlgError:
             continue
 
@@ -1585,7 +1638,7 @@ def compute_pairwise_epistasis(
 
         # Compute residual variance and standard errors
         predicted = X @ coeffs
-        resid = fitness - predicted
+        resid = fitness_valid - predicted
         rss = float(np.dot(resid, resid))
         df_resid = n - 4  # n observations - 4 parameters
 
@@ -1605,13 +1658,13 @@ def compute_pairwise_epistasis(
             se_ij = math.sqrt(float(var_coeffs[3]))
             if se_ij > 0.0:
                 t_stat = beta_ij / se_ij
-                interaction_p = float(2.0 * _stats.t.sf(abs(t_stat), df=df_resid))
+                interaction_p = float(2.0 * scipy_stats.t.sf(abs(t_stat), df=df_resid))
             else:
                 interaction_p = float("nan")
 
         # R² of the full model
-        fitness_mean = float(np.mean(fitness))
-        fitness_centered = fitness - fitness_mean
+        fitness_mean = float(np.mean(fitness_valid))
+        fitness_centered = fitness_valid - fitness_mean
         tss = float(np.dot(fitness_centered, fitness_centered))
         r2 = 1.0 - rss / tss if tss > 0.0 else float("nan")
 
@@ -1635,7 +1688,7 @@ def compute_pairwise_epistasis(
     result_df = pd.DataFrame(rows, columns=PAIRWISE_EPISTASIS_COLUMNS)
 
     # BH correction on interaction p-values (drop NaN for correction)
-    valid_mask = result_df["interaction_p"].notna()
+    valid_mask = result_df["interaction_p"].notna() & np.isfinite(result_df["interaction_p"])
     valid_ps = result_df.loc[valid_mask, "interaction_p"].tolist()
     bh_valid = _bh_correction(valid_ps, alpha=alpha)
     result_df.loc[valid_mask, "bh_rejected"] = bh_valid

--- a/farm/analysis/genetics/module.py
+++ b/farm/analysis/genetics/module.py
@@ -14,6 +14,12 @@ from farm.analysis.genetics.analyze import analyze_genetics
 from farm.analysis.genetics.plot import (
     plot_generation_distribution,
     plot_fitness_over_generations,
+    plot_marginal_fitness_effect,
+    plot_fitness_landscape_2d,
+)
+from farm.analysis.genetics.compute import (
+    compute_fitness_gene_correlations,
+    compute_pairwise_epistasis,
 )
 
 
@@ -54,18 +60,36 @@ class GeneticsModule(BaseAnalysisModule):
             "analyze_genetics": make_analysis_function(analyze_genetics),
             "plot_generation_distribution": make_analysis_function(plot_generation_distribution),
             "plot_fitness_over_generations": make_analysis_function(plot_fitness_over_generations),
+            "compute_fitness_gene_correlations": make_analysis_function(
+                compute_fitness_gene_correlations
+            ),
+            "compute_pairwise_epistasis": make_analysis_function(compute_pairwise_epistasis),
+            "plot_marginal_fitness_effect": make_analysis_function(plot_marginal_fitness_effect),
+            "plot_fitness_landscape_2d": make_analysis_function(plot_fitness_landscape_2d),
         }
 
         self._groups = {
             "all": list(self._functions.values()),
-            "analysis": [self._functions["analyze_genetics"]],
+            "analysis": [
+                self._functions["analyze_genetics"],
+                self._functions["compute_fitness_gene_correlations"],
+                self._functions["compute_pairwise_epistasis"],
+            ],
             "plots": [
                 self._functions["plot_generation_distribution"],
                 self._functions["plot_fitness_over_generations"],
+                self._functions["plot_marginal_fitness_effect"],
+                self._functions["plot_fitness_landscape_2d"],
             ],
             "basic": [
                 self._functions["analyze_genetics"],
                 self._functions["plot_generation_distribution"],
+            ],
+            "fitness_landscape": [
+                self._functions["compute_fitness_gene_correlations"],
+                self._functions["compute_pairwise_epistasis"],
+                self._functions["plot_marginal_fitness_effect"],
+                self._functions["plot_fitness_landscape_2d"],
             ],
         }
 

--- a/farm/analysis/genetics/plot.py
+++ b/farm/analysis/genetics/plot.py
@@ -6,6 +6,7 @@ Placeholder visualization functions for the genetics analysis module.
 
 from __future__ import annotations
 
+import re
 from typing import Any, Optional
 
 import pandas as pd
@@ -14,6 +15,14 @@ from farm.analysis.common.context import AnalysisContext
 from farm.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+_SAFE_OUTPUT_TOKEN_RE = re.compile(r"[^0-9A-Za-z_.-]+")
+
+
+def _sanitize_output_token(value: str) -> str:
+    """Normalize arbitrary labels into filesystem-safe filename fragments."""
+    sanitized = _SAFE_OUTPUT_TOKEN_RE.sub("_", value).strip("_")
+    return sanitized or "unknown"
 
 
 def plot_generation_distribution(df: pd.DataFrame, ctx: AnalysisContext, **kwargs: Any) -> Optional[Any]:
@@ -161,7 +170,7 @@ def plot_marginal_fitness_effect(
         ax.set_title(f"Marginal fitness effect: {gene}")
         ax.legend()
 
-        safe_gene = gene.replace("/", "_")
+        safe_gene = _sanitize_output_token(gene)
         output_file = ctx.get_output_file(f"genetics_marginal_{safe_gene}.png")
         fig.savefig(output_file, dpi=150, bbox_inches="tight")
         plt.close(fig)
@@ -240,6 +249,13 @@ def plot_fitness_landscape_2d(
 
         fig, ax = plt.subplots(figsize=(8, 6))
 
+        if plot_type not in {"scatter", "heatmap"}:
+            logger.warning(
+                "plot_fitness_landscape_2d: invalid plot_type %r; expected 'scatter' or 'heatmap'",
+                plot_type,
+            )
+            return None
+
         if plot_type == "heatmap":
             bins = kwargs.get("bins", 20)
             h, xedges, yedges = np.histogram2d(xi_arr, xj_arr, bins=bins)
@@ -263,8 +279,8 @@ def plot_fitness_landscape_2d(
         ax.set_ylabel(gene_j)
         ax.set_title(f"Fitness landscape: {gene_i} × {gene_j}")
 
-        safe_i = gene_i.replace("/", "_")
-        safe_j = gene_j.replace("/", "_")
+        safe_i = _sanitize_output_token(gene_i)
+        safe_j = _sanitize_output_token(gene_j)
         output_file = ctx.get_output_file(f"genetics_landscape_{safe_i}_x_{safe_j}.png")
         fig.savefig(output_file, dpi=150, bbox_inches="tight")
         plt.close(fig)

--- a/farm/analysis/genetics/plot.py
+++ b/farm/analysis/genetics/plot.py
@@ -6,7 +6,7 @@ Placeholder visualization functions for the genetics analysis module.
 
 from __future__ import annotations
 
-from typing import Any, Optional, Sequence
+from typing import Any, Optional
 
 import pandas as pd
 

--- a/farm/analysis/genetics/plot.py
+++ b/farm/analysis/genetics/plot.py
@@ -6,7 +6,7 @@ Placeholder visualization functions for the genetics analysis module.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 import pandas as pd
 
@@ -88,4 +88,188 @@ def plot_fitness_over_generations(df: pd.DataFrame, ctx: AnalysisContext, **kwar
         return output_file
     except Exception as exc:
         logger.warning("plot_fitness_over_generations failed: %s", exc)
+        return None
+
+
+def plot_marginal_fitness_effect(
+    df: pd.DataFrame,
+    gene: str,
+    ctx: AnalysisContext,
+    **kwargs: Any,
+) -> Optional[Any]:
+    """Scatter plot of gene value vs fitness with an OLS regression line.
+
+    Visualises the marginal effect of a single gene on fitness across all
+    candidates in the evolution DataFrame.
+
+    Parameters
+    ----------
+    df:
+        DataFrame with at least ``fitness`` (float) and ``chromosome_values``
+        (dict) columns.  Typically produced by
+        :func:`~farm.analysis.genetics.compute.build_evolution_experiment_dataframe`.
+    gene:
+        Name of the gene to plot on the x-axis.
+    ctx:
+        Analysis context supplying output paths and a logger.
+
+    Returns
+    -------
+    str or None
+        Path to the saved PNG file, or ``None`` on error / missing data.
+    """
+    if df.empty or "fitness" not in df.columns or "chromosome_values" not in df.columns:
+        logger.warning("plot_marginal_fitness_effect: missing required columns")
+        return None
+
+    try:
+        import matplotlib.pyplot as plt
+        from scipy import stats as _stats
+
+        gene_vals = []
+        fit_vals = []
+        for _, row in df.iterrows():
+            chrom = row.get("chromosome_values")
+            if not isinstance(chrom, dict) or gene not in chrom:
+                continue
+            try:
+                gv = float(chrom[gene])
+                fv = float(row["fitness"])
+            except (TypeError, ValueError):
+                continue
+            gene_vals.append(gv)
+            fit_vals.append(fv)
+
+        if len(gene_vals) < 3:
+            logger.warning("plot_marginal_fitness_effect: not enough data for gene %r", gene)
+            return None
+
+        import numpy as np
+
+        gene_arr = np.array(gene_vals)
+        fit_arr = np.array(fit_vals)
+        slope, intercept, r_value, p_value, _ = _stats.linregress(gene_arr, fit_arr)
+        x_line = np.linspace(gene_arr.min(), gene_arr.max(), 200)
+        y_line = slope * x_line + intercept
+
+        fig, ax = plt.subplots(figsize=(8, 5))
+        ax.scatter(gene_arr, fit_arr, alpha=0.5, s=20, label="Candidates")
+        ax.plot(x_line, y_line, color="red", linewidth=1.5,
+                label=f"OLS (r={r_value:.2f}, p={p_value:.3g})")
+        ax.set_xlabel(gene)
+        ax.set_ylabel("Fitness")
+        ax.set_title(f"Marginal fitness effect: {gene}")
+        ax.legend()
+
+        safe_gene = gene.replace("/", "_")
+        output_file = ctx.get_output_file(f"genetics_marginal_{safe_gene}.png")
+        fig.savefig(output_file, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        logger.info("Saved marginal fitness effect plot to %s", output_file)
+        return output_file
+    except Exception as exc:
+        logger.warning("plot_marginal_fitness_effect failed: %s", exc)
+        return None
+
+
+def plot_fitness_landscape_2d(
+    df: pd.DataFrame,
+    gene_i: str,
+    gene_j: str,
+    ctx: AnalysisContext,
+    plot_type: str = "scatter",
+    **kwargs: Any,
+) -> Optional[Any]:
+    """2D scatter or heatmap of two genes coloured by fitness.
+
+    Parameters
+    ----------
+    df:
+        DataFrame with ``fitness`` and ``chromosome_values`` columns.
+    gene_i:
+        Name of the gene for the x-axis.
+    gene_j:
+        Name of the gene for the y-axis.
+    ctx:
+        Analysis context supplying output paths and a logger.
+    plot_type:
+        ``"scatter"`` (default) – scatter plot where colour encodes fitness;
+        ``"heatmap"`` – bin (gene_i, gene_j) into a 2D grid, colour = mean
+        fitness per bin.
+
+    Returns
+    -------
+    str or None
+        Path to the saved PNG file, or ``None`` on error / missing data.
+    """
+    if df.empty or "fitness" not in df.columns or "chromosome_values" not in df.columns:
+        logger.warning("plot_fitness_landscape_2d: missing required columns")
+        return None
+
+    try:
+        import matplotlib.pyplot as plt
+        import numpy as np
+
+        xi_vals, xj_vals, fit_vals = [], [], []
+        for _, row in df.iterrows():
+            chrom = row.get("chromosome_values")
+            if not isinstance(chrom, dict):
+                continue
+            if gene_i not in chrom or gene_j not in chrom:
+                continue
+            try:
+                xi = float(chrom[gene_i])
+                xj = float(chrom[gene_j])
+                fv = float(row["fitness"])
+            except (TypeError, ValueError):
+                continue
+            xi_vals.append(xi)
+            xj_vals.append(xj)
+            fit_vals.append(fv)
+
+        if len(xi_vals) < 3:
+            logger.warning(
+                "plot_fitness_landscape_2d: not enough data for genes %r / %r",
+                gene_i, gene_j,
+            )
+            return None
+
+        xi_arr = np.array(xi_vals)
+        xj_arr = np.array(xj_vals)
+        fit_arr = np.array(fit_vals)
+
+        fig, ax = plt.subplots(figsize=(8, 6))
+
+        if plot_type == "heatmap":
+            bins = kwargs.get("bins", 20)
+            h, xedges, yedges = np.histogram2d(xi_arr, xj_arr, bins=bins)
+            # Mean fitness per bin
+            fit_sum, _, _ = np.histogram2d(xi_arr, xj_arr, bins=bins, weights=fit_arr)
+            with np.errstate(invalid="ignore"):
+                mean_fit = np.where(h > 0, fit_sum / h, np.nan)
+            im = ax.imshow(
+                mean_fit.T,
+                origin="lower",
+                extent=[xedges[0], xedges[-1], yedges[0], yedges[-1]],
+                aspect="auto",
+                cmap="viridis",
+            )
+            fig.colorbar(im, ax=ax, label="Mean fitness")
+        else:
+            sc = ax.scatter(xi_arr, xj_arr, c=fit_arr, cmap="viridis", alpha=0.6, s=20)
+            fig.colorbar(sc, ax=ax, label="Fitness")
+
+        ax.set_xlabel(gene_i)
+        ax.set_ylabel(gene_j)
+        ax.set_title(f"Fitness landscape: {gene_i} × {gene_j}")
+
+        safe_i = gene_i.replace("/", "_")
+        safe_j = gene_j.replace("/", "_")
+        output_file = ctx.get_output_file(f"genetics_landscape_{safe_i}_x_{safe_j}.png")
+        fig.savefig(output_file, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        logger.info("Saved 2D fitness landscape plot to %s", output_file)
+        return output_file
+    except Exception as exc:
+        logger.warning("plot_fitness_landscape_2d failed: %s", exc)
         return None

--- a/farm/analysis/genetics/plot.py
+++ b/farm/analysis/genetics/plot.py
@@ -7,6 +7,7 @@ Placeholder visualization functions for the genetics analysis module.
 from __future__ import annotations
 
 import re
+from pathlib import Path
 from typing import Any, Optional
 
 import pandas as pd
@@ -105,7 +106,7 @@ def plot_marginal_fitness_effect(
     ctx: AnalysisContext,
     gene: Optional[str] = None,
     **kwargs: Any,
-) -> Optional[Any]:
+) -> Optional[Path]:
     """Scatter plot of gene value vs fitness with an OLS regression line.
 
     Visualises the marginal effect of a single gene on fitness across all
@@ -126,7 +127,7 @@ def plot_marginal_fitness_effect(
 
     Returns
     -------
-    str or None
+    Path or None
         Path to the saved PNG file, or ``None`` on error / missing data.
     """
     if df.empty or "fitness" not in df.columns or "chromosome_values" not in df.columns:
@@ -194,7 +195,7 @@ def plot_fitness_landscape_2d(
     gene_j: Optional[str] = None,
     plot_type: str = "scatter",
     **kwargs: Any,
-) -> Optional[Any]:
+) -> Optional[Path]:
     """2D scatter or heatmap of two genes coloured by fitness.
 
     Parameters
@@ -216,7 +217,7 @@ def plot_fitness_landscape_2d(
 
     Returns
     -------
-    str or None
+    Path or None
         Path to the saved PNG file, or ``None`` on error / missing data.
     """
     if df.empty or "fitness" not in df.columns or "chromosome_values" not in df.columns:

--- a/farm/analysis/genetics/plot.py
+++ b/farm/analysis/genetics/plot.py
@@ -102,8 +102,8 @@ def plot_fitness_over_generations(df: pd.DataFrame, ctx: AnalysisContext, **kwar
 
 def plot_marginal_fitness_effect(
     df: pd.DataFrame,
-    gene: str,
     ctx: AnalysisContext,
+    gene: Optional[str] = None,
     **kwargs: Any,
 ) -> Optional[Any]:
     """Scatter plot of gene value vs fitness with an OLS regression line.
@@ -118,7 +118,9 @@ def plot_marginal_fitness_effect(
         (dict) columns.  Typically produced by
         :func:`~farm.analysis.genetics.compute.build_evolution_experiment_dataframe`.
     gene:
-        Name of the gene to plot on the x-axis.
+        Name of the gene to plot on the x-axis. If omitted, the function logs
+        and returns ``None`` (for example when invoked via a group without
+        per-function kwargs).
     ctx:
         Analysis context supplying output paths and a logger.
 
@@ -129,6 +131,10 @@ def plot_marginal_fitness_effect(
     """
     if df.empty or "fitness" not in df.columns or "chromosome_values" not in df.columns:
         logger.warning("plot_marginal_fitness_effect: missing required columns")
+        return None
+
+    if not gene:
+        logger.warning("plot_marginal_fitness_effect: missing required gene name")
         return None
 
     try:
@@ -183,9 +189,9 @@ def plot_marginal_fitness_effect(
 
 def plot_fitness_landscape_2d(
     df: pd.DataFrame,
-    gene_i: str,
-    gene_j: str,
     ctx: AnalysisContext,
+    gene_i: Optional[str] = None,
+    gene_j: Optional[str] = None,
     plot_type: str = "scatter",
     **kwargs: Any,
 ) -> Optional[Any]:
@@ -196,9 +202,11 @@ def plot_fitness_landscape_2d(
     df:
         DataFrame with ``fitness`` and ``chromosome_values`` columns.
     gene_i:
-        Name of the gene for the x-axis.
+        Name of the gene for the x-axis. If omitted (with ``gene_j``), the
+        function logs and returns ``None``.
     gene_j:
-        Name of the gene for the y-axis.
+        Name of the gene for the y-axis. If omitted (with ``gene_i``), the
+        function logs and returns ``None``.
     ctx:
         Analysis context supplying output paths and a logger.
     plot_type:
@@ -213,6 +221,19 @@ def plot_fitness_landscape_2d(
     """
     if df.empty or "fitness" not in df.columns or "chromosome_values" not in df.columns:
         logger.warning("plot_fitness_landscape_2d: missing required columns")
+        return None
+
+    if plot_type not in {"scatter", "heatmap"}:
+        logger.warning(
+            "plot_fitness_landscape_2d: invalid plot_type %r; expected 'scatter' or 'heatmap'",
+            plot_type,
+        )
+        return None
+
+    if not gene_i or not gene_j:
+        logger.warning(
+            "plot_fitness_landscape_2d: missing required gene_i / gene_j names",
+        )
         return None
 
     try:
@@ -248,13 +269,6 @@ def plot_fitness_landscape_2d(
         fit_arr = np.array(fit_vals)
 
         fig, ax = plt.subplots(figsize=(8, 6))
-
-        if plot_type not in {"scatter", "heatmap"}:
-            logger.warning(
-                "plot_fitness_landscape_2d: invalid plot_type %r; expected 'scatter' or 'heatmap'",
-                plot_type,
-            )
-            return None
 
         if plot_type == "heatmap":
             bins = kwargs.get("bins", 20)

--- a/tests/analysis/test_genetics.py
+++ b/tests/analysis/test_genetics.py
@@ -38,6 +38,10 @@ from farm.analysis.genetics.compute import (
     compute_evolution_diversity_timeseries,
     compute_population_diversity,
     compute_selection_pressure_summary,
+    compute_fitness_gene_correlations,
+    compute_pairwise_epistasis,
+    FITNESS_GENE_CORRELATION_COLUMNS,
+    PAIRWISE_EPISTASIS_COLUMNS,
 )
 from farm.analysis.genetics.utils import parse_parent_ids
 from farm.analysis.genetics.analyze import analyze_genetics
@@ -1345,3 +1349,327 @@ class TestComputeSelectionPressureSummary:
         n_low = int(result_low["is_under_selection"].sum())
         n_high = int(result_high["is_under_selection"].sum())
         assert n_low >= n_high  # higher threshold cannot flag more
+
+
+# ---------------------------------------------------------------------------
+# Helpers for fitness landscape tests
+# ---------------------------------------------------------------------------
+
+
+def _make_evolution_df(
+    n_candidates: int,
+    gene_specs: dict,
+    fitness_fn,
+    seed: int = 0,
+) -> pd.DataFrame:
+    """Build a synthetic evolution DataFrame.
+
+    Parameters
+    ----------
+    n_candidates:
+        Total number of candidate rows.
+    gene_specs:
+        ``{gene_name: (min_val, max_val)}`` defining uniform sampling bounds.
+    fitness_fn:
+        Callable ``(gene_dict) -> float``.
+    seed:
+        NumPy random seed for reproducibility.
+    """
+    rng = np.random.default_rng(seed)
+    rows = []
+    for i in range(n_candidates):
+        chrom = {
+            gene: float(rng.uniform(lo, hi))
+            for gene, (lo, hi) in gene_specs.items()
+        }
+        rows.append(
+            {
+                "candidate_id": f"c{i}",
+                "generation": i % 5,
+                "fitness": fitness_fn(chrom),
+                "parent_ids": ["seed"],
+                "chromosome_values": chrom,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# TestComputeFitnessGeneCorrelations
+# ---------------------------------------------------------------------------
+
+
+import numpy as np
+
+
+class TestComputeFitnessGeneCorrelations:
+    """Tests for compute_fitness_gene_correlations."""
+
+    def test_empty_df_returns_empty_with_correct_columns(self):
+        result = compute_fitness_gene_correlations(pd.DataFrame())
+        assert result.empty
+        assert list(result.columns) == FITNESS_GENE_CORRELATION_COLUMNS
+
+    def test_missing_columns_returns_empty(self):
+        df = pd.DataFrame({"fitness": [1.0, 2.0]})  # no chromosome_values
+        result = compute_fitness_gene_correlations(df)
+        assert result.empty
+
+    def test_output_columns_are_correct(self):
+        df = _make_evolution_df(50, {"lr": (0.0, 1.0)}, lambda g: g["lr"])
+        result = compute_fitness_gene_correlations(df)
+        assert list(result.columns) == FITNESS_GENE_CORRELATION_COLUMNS
+
+    def test_one_row_per_gene(self):
+        df = _make_evolution_df(
+            50,
+            {"lr": (0.0, 1.0), "gamma": (0.8, 1.0)},
+            lambda g: g["lr"] + g["gamma"],
+        )
+        result = compute_fitness_gene_correlations(df)
+        assert set(result["gene"]) == {"lr", "gamma"}
+
+    def test_known_linear_effect_recovered(self):
+        """fitness = 10 * lr + noise → high |pearson_r| for lr."""
+        rng = np.random.default_rng(42)
+        n = 200
+        lr_vals = rng.uniform(0.0, 1.0, n)
+        noise = rng.normal(0, 0.1, n)
+        fitness = 10.0 * lr_vals + noise
+
+        rows = [
+            {
+                "candidate_id": f"c{i}",
+                "generation": 0,
+                "fitness": float(fitness[i]),
+                "parent_ids": ["seed"],
+                "chromosome_values": {"lr": float(lr_vals[i])},
+            }
+            for i in range(n)
+        ]
+        df = pd.DataFrame(rows)
+        result = compute_fitness_gene_correlations(df)
+        assert len(result) == 1
+        row = result.iloc[0]
+        assert row["gene"] == "lr"
+        assert row["pearson_r"] > 0.9, f"Expected strong positive correlation, got {row['pearson_r']}"
+        assert row["ols_slope"] > 8.0, f"Expected slope ~10, got {row['ols_slope']}"
+        assert row["ols_p"] < 1e-10
+
+    def test_noise_only_not_significant_after_bh(self):
+        """Pure noise → no gene should survive BH correction."""
+        rng = np.random.default_rng(7)
+        n = 100
+        lr_vals = rng.uniform(0.0, 1.0, n)
+        gamma_vals = rng.uniform(0.8, 1.0, n)
+        fitness = rng.normal(0, 1.0, n)  # completely independent
+
+        rows = [
+            {
+                "candidate_id": f"c{i}",
+                "generation": 0,
+                "fitness": float(fitness[i]),
+                "parent_ids": ["seed"],
+                "chromosome_values": {
+                    "lr": float(lr_vals[i]),
+                    "gamma": float(gamma_vals[i]),
+                },
+            }
+            for i in range(n)
+        ]
+        df = pd.DataFrame(rows)
+        result = compute_fitness_gene_correlations(df)
+        # With pure noise, BH should reject nothing at α=0.05
+        assert not result["bh_rejected"].any(), (
+            f"Expected no BH rejections for pure noise, got {result['bh_rejected'].sum()}"
+        )
+
+    def test_sorted_by_descending_effect_size(self):
+        df = _make_evolution_df(
+            100,
+            {"strong": (0.0, 1.0), "weak": (0.0, 1.0)},
+            lambda g: 10 * g["strong"] + 0.1 * g["weak"],
+        )
+        result = compute_fitness_gene_correlations(df)
+        assert len(result) >= 2
+        effect_sizes = result["effect_size"].tolist()
+        assert effect_sizes == sorted(effect_sizes, reverse=True)
+
+    def test_ci_bounds_present_and_ordered(self):
+        df = _make_evolution_df(50, {"lr": (0.0, 1.0)}, lambda g: 5 * g["lr"])
+        result = compute_fitness_gene_correlations(df)
+        row = result.iloc[0]
+        assert row["ci_lower"] < row["ols_slope"] < row["ci_upper"]
+
+    def test_min_samples_filter(self):
+        """Genes with fewer than min_samples rows should be skipped."""
+        df = _make_evolution_df(5, {"lr": (0.0, 1.0)}, lambda g: g["lr"])
+        result = compute_fitness_gene_correlations(df, min_samples=10)
+        assert result.empty
+
+    def test_constant_gene_excluded(self):
+        """Zero-variance genes must not appear in results."""
+        rows = [
+            {
+                "candidate_id": f"c{i}",
+                "generation": 0,
+                "fitness": float(i),
+                "parent_ids": ["seed"],
+                "chromosome_values": {"lr": 0.5, "gamma": float(i) / 50},
+            }
+            for i in range(50)
+        ]
+        df = pd.DataFrame(rows)
+        result = compute_fitness_gene_correlations(df)
+        assert "lr" not in result["gene"].values
+
+    def test_bh_rejected_column_is_bool(self):
+        df = _make_evolution_df(50, {"lr": (0.0, 1.0)}, lambda g: g["lr"])
+        result = compute_fitness_gene_correlations(df)
+        assert result["bh_rejected"].dtype == bool or result["bh_rejected"].isin([True, False]).all()
+
+
+# ---------------------------------------------------------------------------
+# TestComputePairwiseEpistasis
+# ---------------------------------------------------------------------------
+
+
+class TestComputePairwiseEpistasis:
+    """Tests for compute_pairwise_epistasis."""
+
+    def test_empty_df_returns_empty_with_correct_columns(self):
+        result = compute_pairwise_epistasis(pd.DataFrame())
+        assert result.empty
+        assert list(result.columns) == PAIRWISE_EPISTASIS_COLUMNS
+
+    def test_single_gene_returns_empty(self):
+        df = _make_evolution_df(50, {"lr": (0.0, 1.0)}, lambda g: g["lr"])
+        result = compute_pairwise_epistasis(df)
+        assert result.empty
+
+    def test_output_columns_are_correct(self):
+        df = _make_evolution_df(
+            50,
+            {"lr": (0.0, 1.0), "gamma": (0.8, 1.0)},
+            lambda g: g["lr"] * g["gamma"],
+        )
+        result = compute_pairwise_epistasis(df, min_samples=20)
+        assert list(result.columns) == PAIRWISE_EPISTASIS_COLUMNS
+
+    def test_known_interaction_recovered(self):
+        """fitness = 5 * lr * gamma → large |interaction_coef| for lr × gamma."""
+        rng = np.random.default_rng(99)
+        n = 300
+        lr_vals = rng.uniform(0.0, 1.0, n)
+        gamma_vals = rng.uniform(0.0, 1.0, n)
+        noise = rng.normal(0, 0.05, n)
+        fitness = 5.0 * lr_vals * gamma_vals + noise
+
+        rows = [
+            {
+                "candidate_id": f"c{i}",
+                "generation": 0,
+                "fitness": float(fitness[i]),
+                "parent_ids": ["seed"],
+                "chromosome_values": {
+                    "lr": float(lr_vals[i]),
+                    "gamma": float(gamma_vals[i]),
+                },
+            }
+            for i in range(n)
+        ]
+        df = pd.DataFrame(rows)
+        result = compute_pairwise_epistasis(df, min_samples=20)
+        assert len(result) == 1
+        row = result.iloc[0]
+        assert abs(row["interaction_coef"]) > 3.0, (
+            f"Expected interaction ~5, got {row['interaction_coef']}"
+        )
+        assert row["interaction_p"] < 1e-5
+
+    def test_pure_noise_no_significant_hits_after_bh(self):
+        """Pure additive noise → no pair significant after BH correction."""
+        rng = np.random.default_rng(13)
+        n = 200
+        lr_vals = rng.uniform(0.0, 1.0, n)
+        gamma_vals = rng.uniform(0.8, 1.0, n)
+        epsilon_vals = rng.uniform(0.9, 1.0, n)
+        fitness = rng.normal(0, 1.0, n)  # independent of all genes
+
+        rows = [
+            {
+                "candidate_id": f"c{i}",
+                "generation": 0,
+                "fitness": float(fitness[i]),
+                "parent_ids": ["seed"],
+                "chromosome_values": {
+                    "lr": float(lr_vals[i]),
+                    "gamma": float(gamma_vals[i]),
+                    "epsilon": float(epsilon_vals[i]),
+                },
+            }
+            for i in range(n)
+        ]
+        df = pd.DataFrame(rows)
+        result = compute_pairwise_epistasis(df, min_samples=20)
+        # Pure noise: BH should not reject any interaction
+        assert not result["bh_rejected"].any(), (
+            f"Expected no BH rejections for pure noise, got {result['bh_rejected'].sum()}"
+        )
+
+    def test_sorted_by_descending_absolute_interaction(self):
+        rng = np.random.default_rng(55)
+        n = 200
+        a = rng.uniform(0, 1, n)
+        b = rng.uniform(0, 1, n)
+        c = rng.uniform(0, 1, n)
+        # Strong a*b interaction, no a*c or b*c
+        fitness = 10 * a * b + 0.5 * c + rng.normal(0, 0.1, n)
+
+        rows = [
+            {
+                "candidate_id": f"c{i}",
+                "generation": 0,
+                "fitness": float(fitness[i]),
+                "parent_ids": ["seed"],
+                "chromosome_values": {
+                    "a": float(a[i]),
+                    "b": float(b[i]),
+                    "c": float(c[i]),
+                },
+            }
+            for i in range(n)
+        ]
+        df = pd.DataFrame(rows)
+        result = compute_pairwise_epistasis(df, min_samples=20)
+        assert len(result) >= 1
+        abs_coefs = result["interaction_coef"].abs().tolist()
+        assert abs_coefs == sorted(abs_coefs, reverse=True)
+
+    def test_min_samples_filter(self):
+        df = _make_evolution_df(
+            15,
+            {"lr": (0.0, 1.0), "gamma": (0.8, 1.0)},
+            lambda g: g["lr"] * g["gamma"],
+        )
+        result = compute_pairwise_epistasis(df, min_samples=20)
+        assert result.empty
+
+    def test_bh_column_is_bool(self):
+        df = _make_evolution_df(
+            60,
+            {"lr": (0.0, 1.0), "gamma": (0.8, 1.0)},
+            lambda g: g["lr"] * g["gamma"],
+        )
+        result = compute_pairwise_epistasis(df, min_samples=20)
+        if not result.empty:
+            assert result["bh_rejected"].isin([True, False]).all()
+
+    def test_three_genes_produces_three_pairs(self):
+        df = _make_evolution_df(
+            60,
+            {"a": (0.0, 1.0), "b": (0.0, 1.0), "c": (0.0, 1.0)},
+            lambda g: g["a"] + g["b"] + g["c"],
+        )
+        result = compute_pairwise_epistasis(df, min_samples=20)
+        assert len(result) == 3

--- a/tests/analysis/test_genetics.py
+++ b/tests/analysis/test_genetics.py
@@ -1526,6 +1526,63 @@ class TestComputeFitnessGeneCorrelations:
         result = compute_fitness_gene_correlations(df)
         assert result["bh_rejected"].dtype == bool or result["bh_rejected"].isin([True, False]).all()
 
+    def test_missing_gene_values_use_complete_cases_per_gene(self):
+        rows = [
+            {
+                "candidate_id": "c0",
+                "generation": 0,
+                "fitness": 1.0,
+                "parent_ids": ["seed"],
+                "chromosome_values": {"a": 1.0, "b": 1.0},
+            },
+            {
+                "candidate_id": "c1",
+                "generation": 0,
+                "fitness": 2.0,
+                "parent_ids": ["seed"],
+                "chromosome_values": {"a": 2.0},
+            },
+            {
+                "candidate_id": "c2",
+                "generation": 0,
+                "fitness": 3.0,
+                "parent_ids": ["seed"],
+                "chromosome_values": {"b": 3.0},
+            },
+            {
+                "candidate_id": "c3",
+                "generation": 0,
+                "fitness": 4.0,
+                "parent_ids": ["seed"],
+                "chromosome_values": {"a": 4.0, "b": 4.0},
+            },
+            {
+                "candidate_id": "c4",
+                "generation": 0,
+                "fitness": 5.0,
+                "parent_ids": ["seed"],
+                "chromosome_values": {"a": 5.0},
+            },
+        ]
+        df = pd.DataFrame(rows)
+        result = compute_fitness_gene_correlations(df, min_samples=3)
+
+        assert set(result["gene"]) == {"a", "b"}
+        n_samples_by_gene = dict(zip(result["gene"], result["n_samples"]))
+        assert n_samples_by_gene["a"] == 4
+        assert n_samples_by_gene["b"] == 3
+        assert result["pearson_r"].notna().all()
+        assert result["ols_p"].notna().all()
+
+    def test_invalid_parameters_raise(self):
+        df = _make_evolution_df(20, {"lr": (0.0, 1.0)}, lambda g: g["lr"])
+        with pytest.raises(ValueError, match="alpha"):
+            compute_fitness_gene_correlations(df, alpha=0.0)
+        with pytest.raises(ValueError, match="min_samples"):
+            compute_fitness_gene_correlations(df, min_samples=1)
+        with pytest.raises(ValueError, match="confidence_level"):
+            compute_fitness_gene_correlations(df, confidence_level=1.0)
+
 
 # ---------------------------------------------------------------------------
 # TestComputePairwiseEpistasis
@@ -1671,3 +1728,41 @@ class TestComputePairwiseEpistasis:
         )
         result = compute_pairwise_epistasis(df, min_samples=20)
         assert len(result) == 3
+
+    def test_pairwise_uses_complete_cases_when_gene_values_missing(self):
+        rng = np.random.default_rng(101)
+        rows = []
+        for i in range(30):
+            a = float(rng.uniform(0.0, 1.0))
+            b = float(rng.uniform(0.0, 1.0))
+            fitness = 4.0 * a * b
+            chrom = {"a": a, "b": b} if i % 2 == 0 else {"a": a}
+            rows.append(
+                {
+                    "candidate_id": f"c{i}",
+                    "generation": 0,
+                    "fitness": fitness,
+                    "parent_ids": ["seed"],
+                    "chromosome_values": chrom,
+                }
+            )
+
+        df = pd.DataFrame(rows)
+        result = compute_pairwise_epistasis(df, min_samples=10)
+
+        assert len(result) == 1
+        assert int(result.iloc[0]["n_samples"]) == 15
+        assert pd.notna(result.iloc[0]["interaction_p"])
+
+    def test_invalid_parameters_raise(self):
+        df = _make_evolution_df(
+            60,
+            {"lr": (0.0, 1.0), "gamma": (0.8, 1.0)},
+            lambda g: g["lr"] * g["gamma"],
+        )
+        with pytest.raises(ValueError, match="alpha"):
+            compute_pairwise_epistasis(df, alpha=1.5)
+        with pytest.raises(ValueError, match="min_samples"):
+            compute_pairwise_epistasis(df, min_samples=1)
+        with pytest.raises(ValueError, match="min_gene_variance"):
+            compute_pairwise_epistasis(df, min_gene_variance=-1.0)

--- a/tests/analysis/test_genetics.py
+++ b/tests/analysis/test_genetics.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
+import numpy as np
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
@@ -1397,9 +1398,6 @@ def _make_evolution_df(
 # ---------------------------------------------------------------------------
 # TestComputeFitnessGeneCorrelations
 # ---------------------------------------------------------------------------
-
-
-import numpy as np
 
 
 class TestComputeFitnessGeneCorrelations:


### PR DESCRIPTION
This pull request adds new functionality for analyzing and visualizing the fitness landscape in genetic data analysis. The main additions include functions for computing gene-fitness correlations, pairwise epistasis, and new plotting utilities for visualizing marginal effects and 2D fitness landscapes. These features are integrated into the public API and the genetics analysis module for easy access.

**Fitness landscape analysis and computation:**
* Added `compute_fitness_gene_correlations` and `compute_pairwise_epistasis` functions, as well as their associated column constants, to the public API in `farm/analysis/genetics/__init__.py` and registered them in the genetics module. [[1]](diffhunk://#diff-e48c0a1bfa859d80141b05ad7d1edb99efe3d165a5a3acddfbc8de448e5d1002R29-R30) [[2]](diffhunk://#diff-e48c0a1bfa859d80141b05ad7d1edb99efe3d165a5a3acddfbc8de448e5d1002R51-R54) [[3]](diffhunk://#diff-e48c0a1bfa859d80141b05ad7d1edb99efe3d165a5a3acddfbc8de448e5d1002R80-R84) [[4]](diffhunk://#diff-92fc7c1c80119c0927702d21f447654b5fa95ef3734f6ebb3d188243de94d251R17-R22) [[5]](diffhunk://#diff-92fc7c1c80119c0927702d21f447654b5fa95ef3734f6ebb3d188243de94d251R63-R93)
* Updated the documentation and quick start guide to mention single-locus correlations and pairwise epistasis analysis.

**Plotting utilities for fitness landscape:**
* Added `plot_marginal_fitness_effect` for visualizing the marginal effect of a single gene on fitness, and `plot_fitness_landscape_2d` for visualizing the joint effect of two genes on fitness using scatter or heatmap plots. Both are registered in the genetics module and exposed in the public API. [[1]](diffhunk://#diff-c09646207cf642affeff11e4868d47af676e466440b8f496c6f8ed1c492119b3R101-R291) [[2]](diffhunk://#diff-92fc7c1c80119c0927702d21f447654b5fa95ef3734f6ebb3d188243de94d251R17-R22) [[3]](diffhunk://#diff-92fc7c1c80119c0927702d21f447654b5fa95ef3734f6ebb3d188243de94d251R63-R93)
* Added a helper function `_sanitize_output_token` to safely generate output filenames from gene names.

**Module and API integration:**
* Registered all new analysis and plotting functions under a new `"fitness_landscape"` group in the genetics module for organized access.

These changes significantly expand the analytical and visualization capabilities for studying genetic fitness landscapes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new statistical computation paths (correlations, OLS, pairwise interaction OLS with multiple-testing correction) that may be computationally heavy on large gene sets and are sensitive to input shape/quality, but are largely additive and covered by tests.
> 
> **Overview**
> Adds **fitness landscape analysis** to the genetics module: `compute_fitness_gene_correlations` computes per-gene fitness associations (Pearson/Spearman + OLS with t-based CI) and applies Benjamini–Hochberg FDR correction; `compute_pairwise_epistasis` fits a two-gene interaction model across all gene pairs and also BH-corrects interaction p-values.
> 
> Introduces new plotting helpers to visualise these relationships (`plot_marginal_fitness_effect` and `plot_fitness_landscape_2d` with safe filename sanitization), and wires the new compute/plot functions into the public API and `GeneticsModule` function groups (including a new `fitness_landscape` group).
> 
> Expands unit tests with synthetic evolution fixtures to validate output schemas, parameter validation, sorting, missing-data handling, and that known linear/interaction signals are recovered while noise does not survive BH correction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 461a8f9f772d48479f8a9490022eb275f62dd0e5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->