### PR TITLE
Add Wright-Fisher simulator and F_ST analysis to genetics module

### DIFF
--- a/farm/analysis/genetics/__init__.py
+++ b/farm/analysis/genetics/__init__.py
@@ -13,6 +13,8 @@ Features:
 - Genotypic diversity metrics: heterozygosity, Shannon entropy, per-locus stats
 - Allele-frequency trajectory tracking and selection-pressure detection
 - Fitness landscape: single-locus correlations and pairwise epistasis analysis
+- Wright-Fisher neutral drift simulator (seeded, per-allele trajectories)
+- Gene-flow / F_ST differentiation across configurable subpopulations
 
 Quick Start::
 
@@ -28,6 +30,10 @@ Quick Start::
     ...     compute_selection_pressure_summary,
     ...     compute_fitness_gene_correlations,
     ...     compute_pairwise_epistasis,
+    ...     simulate_wright_fisher,
+    ...     compute_fst_pairwise,
+    ...     compute_migration_counts,
+    ...     compute_gene_flow_timeseries,
     ... )
 """
 
@@ -52,6 +58,14 @@ from farm.analysis.genetics.compute import (
     compute_pairwise_epistasis,
     FITNESS_GENE_CORRELATION_COLUMNS,
     PAIRWISE_EPISTASIS_COLUMNS,
+    simulate_wright_fisher,
+    WRIGHT_FISHER_COLUMNS,
+    compute_fst_pairwise,
+    FST_COLUMNS,
+    compute_migration_counts,
+    MIGRATION_COLUMNS,
+    compute_gene_flow_timeseries,
+    GENE_FLOW_COLUMNS,
 )
 from farm.analysis.genetics.analyze import analyze_genetics
 from farm.analysis.genetics.module import genetics_module, GeneticsModule
@@ -82,6 +96,16 @@ __all__ = [
     "compute_pairwise_epistasis",
     "FITNESS_GENE_CORRELATION_COLUMNS",
     "PAIRWISE_EPISTASIS_COLUMNS",
+    # Wright-Fisher neutral drift simulator
+    "simulate_wright_fisher",
+    "WRIGHT_FISHER_COLUMNS",
+    # Gene-flow / F_ST differentiation
+    "compute_fst_pairwise",
+    "FST_COLUMNS",
+    "compute_migration_counts",
+    "MIGRATION_COLUMNS",
+    "compute_gene_flow_timeseries",
+    "GENE_FLOW_COLUMNS",
     # High-level analysis
     "analyze_genetics",
     "genetics_module",

--- a/farm/analysis/genetics/compute.py
+++ b/farm/analysis/genetics/compute.py
@@ -1875,6 +1875,7 @@ GENE_FLOW_COLUMNS = [
     "subpopulation_b",
     "fst",
     "n_migrants",
+    "migration_data_available",
 ]
 
 #: Columns produced by :func:`compute_migration_counts`.
@@ -2271,8 +2272,11 @@ def compute_gene_flow_timeseries(
         * ``subpopulation_a`` (str)
         * ``subpopulation_b`` (str)
         * ``fst`` (float) – F_ST for this generation
-        * ``n_migrants`` (int) – number of migration events this generation
-          where offspring crossed the A↔B boundary
+        * ``n_migrants`` (int or ``NaN``) – number of migration events this
+          generation where offspring crossed the A↔B boundary.  ``NaN`` when
+          migration cannot be computed because lineage columns are unavailable.
+        * ``migration_data_available`` (bool) – whether lineage columns were
+          present and migration counts are therefore computable.
 
         Returns an empty DataFrame (with correct columns) when the input is
         insufficient (missing required columns, fewer than two subpopulations,
@@ -2285,8 +2289,18 @@ def compute_gene_flow_timeseries(
     if not has_loci:
         return pd.DataFrame(columns=GENE_FLOW_COLUMNS)
 
-    # Pre-compute migration events across all generations at once
-    migration_df = compute_migration_counts(df, subpop_col=subpop_col)
+    has_migration_columns = "parent_ids" in df.columns and (
+        "agent_id" in df.columns or "candidate_id" in df.columns
+    )
+    if has_migration_columns:
+        # Pre-compute migration events across all generations at once
+        migration_df = compute_migration_counts(df, subpop_col=subpop_col)
+    else:
+        migration_df = pd.DataFrame(columns=MIGRATION_COLUMNS)
+        logger.warning(
+            "compute_gene_flow_timeseries: migration counts unavailable because required "
+            "lineage columns are missing (need parent_ids plus agent_id/candidate_id)"
+        )
 
     rows: List[Dict[str, Any]] = []
 
@@ -2311,7 +2325,7 @@ def compute_gene_flow_timeseries(
             sp_b = str(fst_row["subpopulation_b"])
 
             # Count agents that crossed the A↔B boundary this generation
-            if not gen_migrants.empty:
+            if has_migration_columns and not gen_migrants.empty:
                 n_migrants = int(
                     gen_migrants[
                         gen_migrants["is_migrant"]
@@ -2319,8 +2333,10 @@ def compute_gene_flow_timeseries(
                         & gen_migrants["parent_subpopulation"].isin([sp_a, sp_b])
                     ].shape[0]
                 )
-            else:
+            elif has_migration_columns:
                 n_migrants = 0
+            else:
+                n_migrants = float("nan")
 
             rows.append(
                 {
@@ -2332,6 +2348,7 @@ def compute_gene_flow_timeseries(
                     "subpopulation_b": sp_b,
                     "fst": float(fst_row["fst"]),
                     "n_migrants": n_migrants,
+                    "migration_data_available": has_migration_columns,
                 }
             )
 

--- a/farm/analysis/genetics/compute.py
+++ b/farm/analysis/genetics/compute.py
@@ -5,13 +5,16 @@ Core computation functions for the genetics analysis module, including the
 shared ``parse_parent_ids`` helper, population-level accessors for both
 simulation-database and evolution-experiment data sources, genotypic
 diversity metrics (heterozygosity, Shannon entropy, per-locus stats),
-allele-frequency trajectory tracking with selection-pressure detection, and
-fitness landscape analysis (single-locus correlations, pairwise epistasis).
+allele-frequency trajectory tracking with selection-pressure detection,
+fitness landscape analysis (single-locus correlations, pairwise epistasis),
+Wright-Fisher neutral-drift simulation, and gene-flow / F_ST differentiation
+across configurable subpopulations.
 """
 
 from __future__ import annotations
 
 import math
+from collections import Counter
 from itertools import combinations
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, TYPE_CHECKING
@@ -1714,5 +1717,631 @@ def compute_pairwise_epistasis(
         "compute_pairwise_epistasis: %d pair(s) tested; %d significant after BH correction",
         len(result_df),
         int(result_df["bh_rejected"].sum()),
+    )
+    return result_df
+
+
+# ---------------------------------------------------------------------------
+# Wright-Fisher neutral drift simulator
+# ---------------------------------------------------------------------------
+
+#: Columns produced by :func:`simulate_wright_fisher`.
+WRIGHT_FISHER_COLUMNS = ["generation", "allele", "frequency"]
+
+
+def simulate_wright_fisher(
+    initial_frequencies: Mapping[str, float],
+    n_effective: int,
+    n_generations: int,
+    seed: Optional[int] = None,
+) -> pd.DataFrame:
+    """Simulate allele-frequency drift under the Wright-Fisher model.
+
+    At each generation the allele counts are drawn from a multinomial
+    distribution parameterised by the current frequencies and the effective
+    population size ``N_e``.  The simulation is fully neutral — no selection,
+    mutation, or migration.  It is intended as a neutral baseline against
+    which observed allele-frequency trajectories can be compared.
+
+    Parameters
+    ----------
+    initial_frequencies:
+        Mapping from allele name to its initial frequency.  Values must be
+        non-negative and must sum to ``1.0`` within a tolerance of ``1e-6``.
+        At least one allele is required.
+    n_effective:
+        Effective population size *N_e*.  Must be ``>= 1``.
+    n_generations:
+        Number of generations to simulate beyond generation 0.  Must be
+        ``>= 0``.  Passing ``0`` returns only the initial frequencies.
+    seed:
+        Optional integer seed for the random number generator.  When
+        provided, the simulation is fully deterministic.
+
+    Returns
+    -------
+    pd.DataFrame
+        Tidy frame with columns defined in :data:`WRIGHT_FISHER_COLUMNS`:
+
+        * ``generation`` (int) – ``0`` to ``n_generations`` inclusive
+        * ``allele`` (str) – allele name from *initial_frequencies*
+        * ``frequency`` (float) – allele frequency in ``[0, 1]``
+
+        The returned frame contains
+        ``(n_generations + 1) * len(initial_frequencies)`` rows, sorted by
+        ``(allele, generation)``.
+
+    Raises
+    ------
+    ValueError
+        If *initial_frequencies* is empty, contains negative values, or
+        does not sum to approximately ``1.0``.
+        If *n_effective* ``< 1`` or *n_generations* ``< 0``.
+
+    Notes
+    -----
+    * The expected allele frequency is conserved across generations:
+      ``E[p(t)] = p(0)`` for all *t*.
+    * The variance of the allele frequency after *t* generations is
+      approximately ``p(0)·(1−p(0))/N_e`` per generation under the
+      standard diffusion approximation.
+    * The simulation uses ``numpy.random.Generator.multinomial``, which
+      guarantees reproducibility with the same *seed* across NumPy versions
+      that support the new-style Generator API (NumPy ≥ 1.17).
+    """
+    if not initial_frequencies:
+        raise ValueError("simulate_wright_fisher: initial_frequencies must not be empty")
+
+    alleles = list(initial_frequencies.keys())
+    freqs = np.array([float(initial_frequencies[a]) for a in alleles], dtype=float)
+
+    if np.any(freqs < 0.0):
+        raise ValueError(
+            "simulate_wright_fisher: all initial frequencies must be >= 0"
+        )
+
+    total = float(np.sum(freqs))
+    if not math.isclose(total, 1.0, abs_tol=1e-6):
+        raise ValueError(
+            f"simulate_wright_fisher: initial frequencies must sum to 1.0, got {total}"
+        )
+
+    if n_effective < 1:
+        raise ValueError(
+            f"simulate_wright_fisher: n_effective must be >= 1, got {n_effective}"
+        )
+
+    if n_generations < 0:
+        raise ValueError(
+            f"simulate_wright_fisher: n_generations must be >= 0, got {n_generations}"
+        )
+
+    # Normalise to sum exactly to 1.0 (guard against accumulated floating-point error)
+    freqs = freqs / freqs.sum()
+
+    rng = np.random.default_rng(seed)
+
+    rows: List[Dict[str, Any]] = []
+
+    # Generation 0: record the initial frequencies
+    for allele, freq in zip(alleles, freqs):
+        rows.append({"generation": 0, "allele": allele, "frequency": float(freq)})
+
+    current_freqs = freqs.copy()
+
+    # Simulate generations 1 … n_generations
+    for gen in range(1, n_generations + 1):
+        counts = rng.multinomial(n_effective, current_freqs)
+        current_freqs = counts.astype(float) / float(n_effective)
+        for allele, freq in zip(alleles, current_freqs):
+            rows.append({"generation": gen, "allele": allele, "frequency": float(freq)})
+
+    result_df = (
+        pd.DataFrame(rows, columns=WRIGHT_FISHER_COLUMNS)
+        .sort_values(["allele", "generation"])
+        .reset_index(drop=True)
+    )
+    logger.info(
+        "simulate_wright_fisher: %d generation(s) simulated; N_e=%d; %d allele(s)",
+        n_generations,
+        n_effective,
+        len(alleles),
+    )
+    return result_df
+
+
+# ---------------------------------------------------------------------------
+# Gene-flow / F_ST differentiation across subpopulations
+# ---------------------------------------------------------------------------
+
+#: Columns produced by :func:`compute_fst_pairwise`.
+FST_COLUMNS = [
+    "locus",
+    "locus_type",
+    "subpopulation_a",
+    "subpopulation_b",
+    "n_a",
+    "n_b",
+    "fst",
+]
+
+#: Columns produced by :func:`compute_gene_flow_timeseries`.
+GENE_FLOW_COLUMNS = [
+    "generation",
+    "subpop_definition",
+    "locus",
+    "locus_type",
+    "subpopulation_a",
+    "subpopulation_b",
+    "fst",
+    "n_migrants",
+]
+
+#: Columns produced by :func:`compute_migration_counts`.
+MIGRATION_COLUMNS = [
+    "agent_id",
+    "generation",
+    "subpop_definition",
+    "offspring_subpopulation",
+    "parent_subpopulation",
+    "is_migrant",
+]
+
+
+def _fst_continuous_pairwise(
+    vals_a: np.ndarray,
+    vals_b: np.ndarray,
+) -> float:
+    """Compute F_ST analog (η²) for a continuous trait between two groups.
+
+    Uses the variance-partitioning formula::
+
+        F_ST = V_B / V_T
+
+    where ``V_T`` is the total (pooled) variance and
+    ``V_B = V_T - V_W`` is the between-group variance component
+    (ANOVA decomposition: ``SST = SSW + SSB``).
+
+    Returns ``0.0`` when total variance is zero (monomorphic locus).
+    Result is clamped to ``[0.0, 1.0]``.
+    """
+    n_a, n_b = len(vals_a), len(vals_b)
+    all_vals = np.concatenate([vals_a, vals_b])
+    v_t = float(np.var(all_vals, ddof=0))
+    if v_t <= 0.0:
+        return 0.0
+    var_a = float(np.var(vals_a, ddof=0))
+    var_b = float(np.var(vals_b, ddof=0))
+    v_w = (n_a * var_a + n_b * var_b) / (n_a + n_b)
+    fst = float((v_t - v_w) / v_t)
+    return float(np.clip(fst, 0.0, 1.0))
+
+
+def _fst_categorical_pairwise(
+    freq_a: Mapping[str, float],
+    freq_b: Mapping[str, float],
+    n_a: int,
+    n_b: int,
+) -> float:
+    """Compute classical multi-allele F_ST between two subpopulations.
+
+    Uses the expected-heterozygosity formula::
+
+        F_ST = (H_T - H_S) / H_T
+
+    where ``H_T`` is the expected heterozygosity of the merged population
+    and ``H_S`` is the size-weighted mean within-subpopulation expected
+    heterozygosity.
+
+    Returns ``0.0`` when ``H_T == 0`` (all alleles fixed identically in both
+    subpopulations).  Result is clamped to ``[0.0, 1.0]``.
+    """
+    all_alleles = sorted(set(freq_a.keys()) | set(freq_b.keys()))
+    # Total allele frequencies (size-weighted)
+    freq_t = {
+        a: (n_a * freq_a.get(a, 0.0) + n_b * freq_b.get(a, 0.0)) / (n_a + n_b)
+        for a in all_alleles
+    }
+    h_t = 1.0 - sum(p * p for p in freq_t.values())
+    if h_t <= 0.0:
+        return 0.0
+    h_a = 1.0 - sum(p * p for p in freq_a.values())
+    h_b = 1.0 - sum(p * p for p in freq_b.values())
+    h_s = (n_a * h_a + n_b * h_b) / (n_a + n_b)
+    fst = float((h_t - h_s) / h_t)
+    return float(np.clip(fst, 0.0, 1.0))
+
+
+def _mean_allele_freqs(
+    weight_vectors: List[Dict[str, float]],
+) -> Dict[str, float]:
+    """Compute normalised mean allele frequencies from a list of weight dicts."""
+    if not weight_vectors:
+        return {}
+    all_actions = sorted({a for wv in weight_vectors for a in wv})
+    n = len(weight_vectors)
+    means: Dict[str, float] = {
+        a: sum(float(wv.get(a, 0.0)) for wv in weight_vectors) / n
+        for a in all_actions
+    }
+    total = sum(means.values())
+    if total > 0.0:
+        return {a: w / total for a, w in means.items()}
+    k = len(all_actions)
+    return {a: 1.0 / k for a in all_actions} if k > 0 else {}
+
+
+def compute_fst_pairwise(
+    df: pd.DataFrame,
+    subpop_col: str = "agent_type",
+) -> pd.DataFrame:
+    """Compute pairwise F_ST differentiation per locus between subpopulation pairs.
+
+    Analyses both continuous loci (``chromosome_values`` column) and
+    categorical loci (``action_weights`` column) when present.
+
+    **Continuous loci** (hyperparameter genes from ``chromosome_values``):
+    Uses the variance-partitioning F_ST analog (η²)::
+
+        F_ST = V_B / V_T
+
+    where ``V_T`` is the total variance and ``V_B = V_T − V_W`` is the
+    between-group variance component.
+
+    **Categorical loci** (action weights):
+    Uses the classical multi-allele Wright–Cockerham F_ST::
+
+        F_ST = (H_T − H_S) / H_T
+
+    where ``H_T`` and ``H_S`` are the expected heterozygosities of the total
+    and sub-populations respectively.
+
+    Parameters
+    ----------
+    df:
+        DataFrame with a *subpop_col* column and at least one of
+        ``chromosome_values`` (dict) or ``action_weights`` (dict).
+        Typically produced by :func:`build_agent_genetics_dataframe` or
+        :func:`build_evolution_experiment_dataframe`.
+    subpop_col:
+        Name of the column whose distinct values define subpopulations.
+        Default ``"agent_type"``.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per *(locus, subpopulation_a, subpopulation_b)* combination,
+        with columns defined in :data:`FST_COLUMNS`:
+
+        * ``locus`` (str)
+        * ``locus_type`` (str) – ``"continuous"`` or ``"categorical"``
+        * ``subpopulation_a`` (str)
+        * ``subpopulation_b`` (str)
+        * ``n_a`` (int) – individuals in subpopulation A
+        * ``n_b`` (int) – individuals in subpopulation B
+        * ``fst`` (float) – F_ST value in ``[0, 1]``
+
+        Returns an empty DataFrame (with correct columns) when the input is
+        insufficient (fewer than two non-null subpopulations, or no recognised
+        locus column).
+    """
+    has_continuous = "chromosome_values" in df.columns
+    has_categorical = "action_weights" in df.columns
+
+    if df.empty or subpop_col not in df.columns:
+        return pd.DataFrame(columns=FST_COLUMNS)
+
+    if not has_continuous and not has_categorical:
+        return pd.DataFrame(columns=FST_COLUMNS)
+
+    subpops = sorted(df[subpop_col].dropna().unique())
+    if len(subpops) < 2:
+        return pd.DataFrame(columns=FST_COLUMNS)
+
+    rows: List[Dict[str, Any]] = []
+
+    # ---- Continuous loci (chromosome_values) ----
+    if has_continuous:
+        gene_subpop_values: Dict[str, Dict[Any, List[float]]] = {}
+        for _, row in df.iterrows():
+            subpop = row[subpop_col]
+            if pd.isna(subpop):
+                continue
+            cv = row.get("chromosome_values")
+            if not isinstance(cv, dict):
+                continue
+            for gene, val in cv.items():
+                try:
+                    v = float(val)
+                except (TypeError, ValueError):
+                    continue
+                if not math.isfinite(v):
+                    continue
+                gene_subpop_values.setdefault(gene, {}).setdefault(subpop, []).append(v)
+
+        for gene, subpop_vals in sorted(gene_subpop_values.items()):
+            eligible = [sp for sp in subpops if sp in subpop_vals and len(subpop_vals[sp]) >= 1]
+            for sp_a, sp_b in combinations(eligible, 2):
+                vals_a = np.array(subpop_vals[sp_a], dtype=float)
+                vals_b = np.array(subpop_vals[sp_b], dtype=float)
+                rows.append(
+                    {
+                        "locus": gene,
+                        "locus_type": "continuous",
+                        "subpopulation_a": str(sp_a),
+                        "subpopulation_b": str(sp_b),
+                        "n_a": int(len(vals_a)),
+                        "n_b": int(len(vals_b)),
+                        "fst": _fst_continuous_pairwise(vals_a, vals_b),
+                    }
+                )
+
+    # ---- Categorical loci (action_weights) ----
+    if has_categorical:
+        subpop_weight_vectors: Dict[Any, List[Dict[str, float]]] = {}
+        for _, row in df.iterrows():
+            subpop = row[subpop_col]
+            if pd.isna(subpop):
+                continue
+            raw_wv = row.get("action_weights")
+            if not isinstance(raw_wv, dict) or len(raw_wv) == 0:
+                continue
+            sanitized: Dict[str, float] = {}
+            for action, raw_weight in raw_wv.items():
+                try:
+                    w = float(raw_weight)
+                except (TypeError, ValueError):
+                    continue
+                if math.isfinite(w):
+                    sanitized[action] = w
+            if sanitized:
+                subpop_weight_vectors.setdefault(subpop, []).append(sanitized)
+
+        eligible_cat = [sp for sp in subpops if sp in subpop_weight_vectors]
+        if len(eligible_cat) >= 2:
+            subpop_freq: Dict[Any, Dict[str, float]] = {
+                sp: _mean_allele_freqs(subpop_weight_vectors[sp])
+                for sp in eligible_cat
+            }
+            for sp_a, sp_b in combinations(eligible_cat, 2):
+                n_a = len(subpop_weight_vectors[sp_a])
+                n_b = len(subpop_weight_vectors[sp_b])
+                rows.append(
+                    {
+                        "locus": "action_weights",
+                        "locus_type": "categorical",
+                        "subpopulation_a": str(sp_a),
+                        "subpopulation_b": str(sp_b),
+                        "n_a": n_a,
+                        "n_b": n_b,
+                        "fst": _fst_categorical_pairwise(
+                            subpop_freq[sp_a], subpop_freq[sp_b], n_a, n_b
+                        ),
+                    }
+                )
+
+    if not rows:
+        return pd.DataFrame(columns=FST_COLUMNS)
+
+    result_df = pd.DataFrame(rows, columns=FST_COLUMNS)
+    logger.info(
+        "compute_fst_pairwise: %d locus–pair row(s) for %d subpopulation(s)",
+        len(result_df),
+        len(subpops),
+    )
+    return result_df
+
+
+def compute_migration_counts(
+    df: pd.DataFrame,
+    subpop_col: str = "agent_type",
+) -> pd.DataFrame:
+    """Track gene-flow events (migrations) between subpopulations.
+
+    An agent is classified as a *migrant* when at least one of its parents
+    belongs to a different subpopulation than the agent itself.  The parent's
+    subpopulation is the majority subpopulation among all recorded parents
+    (tie broken by first occurrence).
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing a *subpop_col* column, a ``parent_ids`` column,
+        and either an ``agent_id`` or ``candidate_id`` column.  Typically
+        produced by :func:`build_agent_genetics_dataframe` or
+        :func:`build_evolution_experiment_dataframe`.
+    subpop_col:
+        Column name whose distinct values define subpopulations.
+        Default ``"agent_type"``.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per agent that has at least one traceable parent, with
+        columns defined in :data:`MIGRATION_COLUMNS`:
+
+        * ``agent_id`` (str)
+        * ``generation`` (int or ``NaN``)
+        * ``subpop_definition`` (str) – the value of *subpop_col*
+        * ``offspring_subpopulation`` (str)
+        * ``parent_subpopulation`` (str) – majority subpopulation of parents
+        * ``is_migrant`` (bool) – ``True`` when
+          ``offspring_subpopulation != parent_subpopulation``
+
+        Returns an empty DataFrame (with correct columns) when required
+        columns are absent or no traceable parent relationships exist.
+    """
+    required = {subpop_col, "parent_ids"}
+    if df.empty or not required.issubset(df.columns):
+        return pd.DataFrame(columns=MIGRATION_COLUMNS)
+
+    # Determine the individual-identifier column
+    id_col: Optional[str] = None
+    for candidate in ("agent_id", "candidate_id"):
+        if candidate in df.columns:
+            id_col = candidate
+            break
+    if id_col is None:
+        return pd.DataFrame(columns=MIGRATION_COLUMNS)
+
+    # Build id -> subpopulation lookup
+    agent_subpop: Dict[str, str] = {}
+    for _, row in df.iterrows():
+        sp = row[subpop_col]
+        if not pd.isna(sp):
+            agent_subpop[str(row[id_col])] = str(sp)
+
+    rows: List[Dict[str, Any]] = []
+    for _, row in df.iterrows():
+        agent_id = str(row[id_col])
+        sp_val = row[subpop_col]
+        if pd.isna(sp_val):
+            continue
+        offspring_subpop = str(sp_val)
+
+        parent_ids = row.get("parent_ids", [])
+        if not isinstance(parent_ids, (list, tuple)) or len(parent_ids) == 0:
+            continue  # genesis agent – no parents to compare against
+
+        parent_subpops = [agent_subpop[pid] for pid in parent_ids if pid in agent_subpop]
+        if not parent_subpops:
+            continue  # parents not present in this DataFrame
+
+        parent_subpop = Counter(parent_subpops).most_common(1)[0][0]
+
+        rows.append(
+            {
+                "agent_id": agent_id,
+                "generation": row.get("generation"),
+                "subpop_definition": subpop_col,
+                "offspring_subpopulation": offspring_subpop,
+                "parent_subpopulation": parent_subpop,
+                "is_migrant": offspring_subpop != parent_subpop,
+            }
+        )
+
+    if not rows:
+        return pd.DataFrame(columns=MIGRATION_COLUMNS)
+
+    result_df = pd.DataFrame(rows, columns=MIGRATION_COLUMNS)
+    n_migrants = int(result_df["is_migrant"].sum())
+    logger.info(
+        "compute_migration_counts: %d agent(s) tracked; %d migrant(s) (%s definition)",
+        len(result_df),
+        n_migrants,
+        subpop_col,
+    )
+    return result_df
+
+
+def compute_gene_flow_timeseries(
+    df: pd.DataFrame,
+    subpop_col: str = "agent_type",
+) -> pd.DataFrame:
+    """Compute per-generation F_ST differentiation and migration counts.
+
+    For each generation, computes pairwise F_ST between all subpopulations
+    (using :func:`compute_fst_pairwise` on the generation's subset) and
+    counts directed migration events between each subpopulation pair (using
+    :func:`compute_migration_counts` on the full DataFrame).
+
+    Parameters
+    ----------
+    df:
+        DataFrame with a ``generation`` column, a *subpop_col* column, and
+        at least one of ``chromosome_values`` or ``action_weights``.
+    subpop_col:
+        Column name whose distinct values define subpopulations.
+        Default ``"agent_type"``.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per *(generation, subpopulation_a, subpopulation_b, locus)*,
+        with columns defined in :data:`GENE_FLOW_COLUMNS`:
+
+        * ``generation`` (int)
+        * ``subpop_definition`` (str) – the value of *subpop_col*
+        * ``locus`` (str)
+        * ``locus_type`` (str)
+        * ``subpopulation_a`` (str)
+        * ``subpopulation_b`` (str)
+        * ``fst`` (float) – F_ST for this generation
+        * ``n_migrants`` (int) – number of migration events this generation
+          where offspring crossed the A↔B boundary
+
+        Returns an empty DataFrame (with correct columns) when the input is
+        insufficient (missing required columns, fewer than two subpopulations,
+        or no recognised locus column).
+    """
+    if df.empty or "generation" not in df.columns or subpop_col not in df.columns:
+        return pd.DataFrame(columns=GENE_FLOW_COLUMNS)
+
+    has_loci = "chromosome_values" in df.columns or "action_weights" in df.columns
+    if not has_loci:
+        return pd.DataFrame(columns=GENE_FLOW_COLUMNS)
+
+    # Pre-compute migration events across all generations at once
+    migration_df = compute_migration_counts(df, subpop_col=subpop_col)
+
+    rows: List[Dict[str, Any]] = []
+
+    for gen, gen_group in df.groupby("generation"):
+        try:
+            gen_int = int(float(gen))
+        except (TypeError, ValueError):
+            continue
+
+        fst_df = compute_fst_pairwise(gen_group, subpop_col=subpop_col)
+        if fst_df.empty:
+            continue
+
+        # Subset migration events for this generation
+        if not migration_df.empty and "generation" in migration_df.columns:
+            gen_migrants = migration_df[migration_df["generation"] == gen]
+        else:
+            gen_migrants = pd.DataFrame()
+
+        for _, fst_row in fst_df.iterrows():
+            sp_a = str(fst_row["subpopulation_a"])
+            sp_b = str(fst_row["subpopulation_b"])
+
+            # Count agents that crossed the A↔B boundary this generation
+            if not gen_migrants.empty:
+                n_migrants = int(
+                    gen_migrants[
+                        gen_migrants["is_migrant"]
+                        & gen_migrants["offspring_subpopulation"].isin([sp_a, sp_b])
+                        & gen_migrants["parent_subpopulation"].isin([sp_a, sp_b])
+                    ].shape[0]
+                )
+            else:
+                n_migrants = 0
+
+            rows.append(
+                {
+                    "generation": gen_int,
+                    "subpop_definition": subpop_col,
+                    "locus": fst_row["locus"],
+                    "locus_type": fst_row["locus_type"],
+                    "subpopulation_a": sp_a,
+                    "subpopulation_b": sp_b,
+                    "fst": float(fst_row["fst"]),
+                    "n_migrants": n_migrants,
+                }
+            )
+
+    if not rows:
+        return pd.DataFrame(columns=GENE_FLOW_COLUMNS)
+
+    result_df = (
+        pd.DataFrame(rows, columns=GENE_FLOW_COLUMNS)
+        .sort_values(["generation", "locus", "subpopulation_a", "subpopulation_b"])
+        .reset_index(drop=True)
+    )
+    logger.info(
+        "compute_gene_flow_timeseries: %d row(s) across %d generation(s)",
+        len(result_df),
+        result_df["generation"].nunique(),
     )
     return result_df

--- a/farm/analysis/genetics/compute.py
+++ b/farm/analysis/genetics/compute.py
@@ -1786,8 +1786,8 @@ def simulate_wright_fisher(
       approximately ``p(0)·(1−p(0))/N_e`` per generation under the
       standard diffusion approximation.
     * The simulation uses ``numpy.random.Generator.multinomial``, which
-      guarantees reproducibility with the same *seed* across NumPy versions
-      that support the new-style Generator API (NumPy ≥ 1.17).
+      guarantees reproducibility with the same *seed* using NumPy's
+      new-style Generator API.
     """
     if not initial_frequencies:
         raise ValueError("simulate_wright_fisher: initial_frequencies must not be empty")
@@ -1955,7 +1955,7 @@ def _fst_categorical_pairwise(
 def _mean_allele_freqs(
     weight_vectors: List[Dict[str, float]],
 ) -> Dict[str, float]:
-    """Compute normalised mean allele frequencies from a list of weight dicts."""
+    """Compute normalized mean allele frequencies from a list of weight dicts."""
     if not weight_vectors:
         return {}
     all_actions = sorted({a for wv in weight_vectors for a in wv})
@@ -1977,7 +1977,7 @@ def compute_fst_pairwise(
 ) -> pd.DataFrame:
     """Compute pairwise F_ST differentiation per locus between subpopulation pairs.
 
-    Analyses both continuous loci (``chromosome_values`` column) and
+    Analyzes both continuous loci (``chromosome_values`` column) and
     categorical loci (``action_weights`` column) when present.
 
     **Continuous loci** (hyperparameter genes from ``chromosome_values``):

--- a/farm/analysis/genetics/compute.py
+++ b/farm/analysis/genetics/compute.py
@@ -1989,9 +1989,9 @@ def compute_fst_pairwise(
     between-group variance component.
 
     **Categorical loci** (action weights):
-    Uses the classical multi-allele Wright–Cockerham F_ST::
+    Uses the heterozygosity-based G_ST estimator (Nei 1973)::
 
-        F_ST = (H_T − H_S) / H_T
+        G_ST = (H_T − H_S) / H_T
 
     where ``H_T`` and ``H_S`` are the expected heterozygosities of the total
     and sub-populations respectively.
@@ -2140,8 +2140,8 @@ def compute_migration_counts(
 
     An agent is classified as a *migrant* when at least one of its parents
     belongs to a different subpopulation than the agent itself.  The parent's
-    subpopulation is the majority subpopulation among all recorded parents
-    (tie broken by first occurrence).
+    subpopulation is the majority subpopulation among all recorded parents;
+    ties are broken by the first occurrence in ``parent_ids``.
 
     Parameters
     ----------
@@ -2207,7 +2207,9 @@ def compute_migration_counts(
         if not parent_subpops:
             continue  # parents not present in this DataFrame
 
-        parent_subpop = Counter(parent_subpops).most_common(1)[0][0]
+        counts = Counter(parent_subpops)
+        max_count = max(counts.values())
+        parent_subpop = next(sp for sp in parent_subpops if counts[sp] == max_count)
 
         rows.append(
             {
@@ -2242,8 +2244,10 @@ def compute_gene_flow_timeseries(
 
     For each generation, computes pairwise F_ST between all subpopulations
     (using :func:`compute_fst_pairwise` on the generation's subset) and
-    counts directed migration events between each subpopulation pair (using
-    :func:`compute_migration_counts` on the full DataFrame).
+    counts boundary-crossing migration events between each subpopulation pair
+    (using :func:`compute_migration_counts` on the full DataFrame).  Migration
+    counts are undirected: agents moving A→B and B→A are both included in the
+    A↔B count.
 
     Parameters
     ----------

--- a/farm/analysis/genetics/module.py
+++ b/farm/analysis/genetics/module.py
@@ -20,6 +20,10 @@ from farm.analysis.genetics.plot import (
 from farm.analysis.genetics.compute import (
     compute_fitness_gene_correlations,
     compute_pairwise_epistasis,
+    simulate_wright_fisher,
+    compute_fst_pairwise,
+    compute_migration_counts,
+    compute_gene_flow_timeseries,
 )
 
 
@@ -66,6 +70,10 @@ class GeneticsModule(BaseAnalysisModule):
             "compute_pairwise_epistasis": make_analysis_function(compute_pairwise_epistasis),
             "plot_marginal_fitness_effect": make_analysis_function(plot_marginal_fitness_effect),
             "plot_fitness_landscape_2d": make_analysis_function(plot_fitness_landscape_2d),
+            "simulate_wright_fisher": make_analysis_function(simulate_wright_fisher),
+            "compute_fst_pairwise": make_analysis_function(compute_fst_pairwise),
+            "compute_migration_counts": make_analysis_function(compute_migration_counts),
+            "compute_gene_flow_timeseries": make_analysis_function(compute_gene_flow_timeseries),
         }
 
         self._groups = {
@@ -90,6 +98,12 @@ class GeneticsModule(BaseAnalysisModule):
                 self._functions["compute_pairwise_epistasis"],
                 self._functions["plot_marginal_fitness_effect"],
                 self._functions["plot_fitness_landscape_2d"],
+            ],
+            "population_genetics": [
+                self._functions["simulate_wright_fisher"],
+                self._functions["compute_fst_pairwise"],
+                self._functions["compute_migration_counts"],
+                self._functions["compute_gene_flow_timeseries"],
             ],
         }
 

--- a/farm/analysis/genetics/module.py
+++ b/farm/analysis/genetics/module.py
@@ -6,6 +6,8 @@ discoverable via :class:`~farm.analysis.service.AnalysisService` and the
 module registry.
 """
 
+from typing import Any, Dict, Optional
+
 from farm.analysis.core import BaseAnalysisModule, SimpleDataProcessor, make_analysis_function
 from farm.analysis.validation import ColumnValidator, DataQualityValidator, CompositeValidator
 
@@ -25,6 +27,37 @@ from farm.analysis.genetics.compute import (
     compute_migration_counts,
     compute_gene_flow_timeseries,
 )
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _simulate_wright_fisher_for_analysis(
+    df: Any,
+    initial_frequencies: Optional[Dict[str, float]] = None,
+    n_effective: Optional[int] = None,
+    n_generations: Optional[int] = None,
+    seed: Optional[int] = None,
+) -> Any:
+    """Adapter for module-run execution of Wright-Fisher simulation.
+
+    The analysis runner always calls registered functions with DataFrame-oriented
+    signatures. This adapter allows the Wright-Fisher simulator to be included
+    in groups safely while still requiring explicit simulation parameters.
+    """
+    _ = df  # Unused by design; simulation is parameter-driven.
+    if initial_frequencies is None or n_effective is None or n_generations is None:
+        logger.warning(
+            "simulate_wright_fisher skipped: provide initial_frequencies, "
+            "n_effective, and n_generations via analysis kwargs"
+        )
+        return None
+    return simulate_wright_fisher(
+        initial_frequencies=initial_frequencies,
+        n_effective=n_effective,
+        n_generations=n_generations,
+        seed=seed,
+    )
 
 
 class GeneticsModule(BaseAnalysisModule):
@@ -70,7 +103,7 @@ class GeneticsModule(BaseAnalysisModule):
             "compute_pairwise_epistasis": make_analysis_function(compute_pairwise_epistasis),
             "plot_marginal_fitness_effect": make_analysis_function(plot_marginal_fitness_effect),
             "plot_fitness_landscape_2d": make_analysis_function(plot_fitness_landscape_2d),
-            "simulate_wright_fisher": make_analysis_function(simulate_wright_fisher),
+            "simulate_wright_fisher": make_analysis_function(_simulate_wright_fisher_for_analysis),
             "compute_fst_pairwise": make_analysis_function(compute_fst_pairwise),
             "compute_migration_counts": make_analysis_function(compute_migration_counts),
             "compute_gene_flow_timeseries": make_analysis_function(compute_gene_flow_timeseries),

--- a/tests/analysis/test_genetics.py
+++ b/tests/analysis/test_genetics.py
@@ -2370,7 +2370,8 @@ class TestComputeGeneFlowTimeseries:
         df = _make_multigen_evolution_df(n_gens=3, migration_rate=0.2)
         result = compute_gene_flow_timeseries(df)
         assert (result["n_migrants"] >= 0).all()
-        assert result["n_migrants"].dtype in (int, np.int64, np.int32, object)
+        # n_migrants should hold integer counts
+        assert np.issubdtype(result["n_migrants"].dtype, np.integer)
 
     def test_isolated_pops_high_fst_over_time(self):
         """Isolated subpopulations with very different gene ranges → high F_ST every gen."""

--- a/tests/analysis/test_genetics.py
+++ b/tests/analysis/test_genetics.py
@@ -409,6 +409,40 @@ class TestGeneticsModule:
         assert len(df) == 2
         assert set(AGENT_GENETICS_COLUMNS).issubset(df.columns)
 
+    def test_population_genetics_group_skips_wright_fisher_without_kwargs(self, tmp_path):
+        db_file = tmp_path / "simulation.db"
+        engine = create_engine(f"sqlite:///{db_file}")
+        Base.metadata.create_all(engine)
+        with Session(engine) as session:
+            session.add_all(
+                [
+                    AgentModel(
+                        agent_id="a1",
+                        agent_type="A",
+                        birth_time=0,
+                        genome_id="::1",
+                        generation=0,
+                        action_weights={"move": 1.0},
+                    ),
+                    AgentModel(
+                        agent_id="b1",
+                        agent_type="B",
+                        birth_time=0,
+                        genome_id="::1",
+                        generation=0,
+                        action_weights={"gather": 1.0},
+                    ),
+                ]
+            )
+            session.commit()
+        engine.dispose()
+
+        output_dir = tmp_path / "analysis_output"
+        out_path, df = genetics_module.run_analysis(tmp_path, output_dir, group="population_genetics")
+        assert out_path == output_dir
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+
 
 # ---------------------------------------------------------------------------
 # Diversity metrics
@@ -2368,9 +2402,11 @@ class TestComputeGeneFlowTimeseries:
     def test_n_migrants_non_negative_integers(self):
         df = _make_multigen_evolution_df(n_gens=3, migration_rate=0.2)
         result = compute_gene_flow_timeseries(df)
-        assert (result["n_migrants"] >= 0).all()
+        available = result[result["migration_data_available"]]
+        assert not available.empty
+        assert (available["n_migrants"] >= 0).all()
         # n_migrants should hold integer counts
-        assert np.issubdtype(result["n_migrants"].dtype, np.integer)
+        assert np.issubdtype(available["n_migrants"].dtype, np.integer)
 
     def test_isolated_pops_high_fst_over_time(self):
         """Isolated subpopulations with very different gene ranges → high F_ST every gen."""
@@ -2420,3 +2456,17 @@ class TestComputeGeneFlowTimeseries:
         result = compute_gene_flow_timeseries(df)
         # At least some generations/pairs should show migrants
         assert result["n_migrants"].sum() > 0
+
+    def test_missing_lineage_marks_migration_unavailable(self):
+        df = pd.DataFrame(
+            [
+                {"generation": 0, "agent_type": "A", "chromosome_values": {"lr": 0.1}},
+                {"generation": 0, "agent_type": "B", "chromosome_values": {"lr": 0.9}},
+                {"generation": 1, "agent_type": "A", "chromosome_values": {"lr": 0.2}},
+                {"generation": 1, "agent_type": "B", "chromosome_values": {"lr": 0.8}},
+            ]
+        )
+        result = compute_gene_flow_timeseries(df)
+        assert not result.empty
+        assert result["migration_data_available"].eq(False).all()
+        assert result["n_migrants"].isna().all()

--- a/tests/analysis/test_genetics.py
+++ b/tests/analysis/test_genetics.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import math
 from types import SimpleNamespace
+from typing import Optional
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -43,6 +44,14 @@ from farm.analysis.genetics.compute import (
     compute_pairwise_epistasis,
     FITNESS_GENE_CORRELATION_COLUMNS,
     PAIRWISE_EPISTASIS_COLUMNS,
+    simulate_wright_fisher,
+    WRIGHT_FISHER_COLUMNS,
+    compute_fst_pairwise,
+    FST_COLUMNS,
+    compute_migration_counts,
+    MIGRATION_COLUMNS,
+    compute_gene_flow_timeseries,
+    GENE_FLOW_COLUMNS,
 )
 from farm.analysis.genetics.utils import parse_parent_ids
 from farm.analysis.genetics.analyze import analyze_genetics
@@ -1766,3 +1775,648 @@ class TestComputePairwiseEpistasis:
             compute_pairwise_epistasis(df, min_samples=1)
         with pytest.raises(ValueError, match="min_gene_variance"):
             compute_pairwise_epistasis(df, min_gene_variance=-1.0)
+
+
+# ---------------------------------------------------------------------------
+# simulate_wright_fisher
+# ---------------------------------------------------------------------------
+
+
+def _make_two_allele_freqs(p: float = 0.5) -> dict:
+    return {"A": p, "B": 1.0 - p}
+
+
+class TestSimulateWrightFisher:
+    """Tests for simulate_wright_fisher."""
+
+    # --- Output shape and columns ---
+
+    def test_output_columns_correct(self):
+        result = simulate_wright_fisher({"A": 1.0}, n_effective=10, n_generations=5)
+        assert list(result.columns) == WRIGHT_FISHER_COLUMNS
+
+    def test_output_row_count(self):
+        result = simulate_wright_fisher(
+            _make_two_allele_freqs(), n_effective=10, n_generations=5
+        )
+        # (n_generations + 1) rows per allele
+        assert len(result) == 2 * 6
+
+    def test_generation_zero_matches_initial(self):
+        init = {"A": 0.3, "B": 0.7}
+        result = simulate_wright_fisher(init, n_effective=50, n_generations=3)
+        gen0 = result[result["generation"] == 0].set_index("allele")["frequency"]
+        assert abs(gen0["A"] - 0.3) < 1e-9
+        assert abs(gen0["B"] - 0.7) < 1e-9
+
+    def test_frequencies_sum_to_one_per_generation(self):
+        result = simulate_wright_fisher(
+            {"A": 0.4, "B": 0.4, "C": 0.2}, n_effective=100, n_generations=10, seed=0
+        )
+        for gen, grp in result.groupby("generation"):
+            total = grp["frequency"].sum()
+            assert abs(total - 1.0) < 1e-9, f"generation {gen}: sum={total}"
+
+    def test_frequencies_in_unit_interval(self):
+        result = simulate_wright_fisher(
+            _make_two_allele_freqs(0.5), n_effective=20, n_generations=20, seed=1
+        )
+        assert (result["frequency"] >= 0.0).all()
+        assert (result["frequency"] <= 1.0).all()
+
+    def test_zero_generations_returns_only_initial(self):
+        result = simulate_wright_fisher({"A": 0.6, "B": 0.4}, n_effective=50, n_generations=0)
+        assert set(result["generation"].unique()) == {0}
+        assert len(result) == 2
+
+    def test_single_allele_stays_fixed(self):
+        result = simulate_wright_fisher({"X": 1.0}, n_effective=100, n_generations=10, seed=42)
+        assert (result["frequency"] == 1.0).all()
+
+    # --- Determinism with seed ---
+
+    def test_seeded_runs_are_identical(self):
+        kwargs = dict(
+            initial_frequencies=_make_two_allele_freqs(0.3),
+            n_effective=50,
+            n_generations=10,
+        )
+        r1 = simulate_wright_fisher(**kwargs, seed=7)
+        r2 = simulate_wright_fisher(**kwargs, seed=7)
+        assert r1["frequency"].tolist() == r2["frequency"].tolist()
+
+    def test_different_seeds_differ(self):
+        kwargs = dict(
+            initial_frequencies=_make_two_allele_freqs(0.5),
+            n_effective=20,
+            n_generations=20,
+        )
+        r1 = simulate_wright_fisher(**kwargs, seed=0)
+        r2 = simulate_wright_fisher(**kwargs, seed=99)
+        # With high probability the trajectories will differ
+        assert r1["frequency"].tolist() != r2["frequency"].tolist()
+
+    # --- Statistical properties ---
+
+    def test_mean_trajectory_preserved(self):
+        """E[p(t)] = p(0) across many independent runs (neutral drift)."""
+        rng = np.random.default_rng(42)
+        p0 = 0.4
+        n_reps = 500
+        n_eff = 200
+        n_gen = 20
+        final_freqs = []
+        for s in range(n_reps):
+            r = simulate_wright_fisher(
+                {"A": p0, "B": 1.0 - p0},
+                n_effective=n_eff,
+                n_generations=n_gen,
+                seed=int(rng.integers(0, 10**6)),
+            )
+            last_gen = r[r["generation"] == n_gen]
+            freq_a = float(last_gen.loc[last_gen["allele"] == "A", "frequency"].iloc[0])
+            final_freqs.append(freq_a)
+        mean_final = float(np.mean(final_freqs))
+        # Mean should be close to p0; allow 3 SEM tolerance
+        sem = float(np.std(final_freqs)) / (n_reps ** 0.5)
+        assert abs(mean_final - p0) < 3 * sem, (
+            f"mean final frequency {mean_final:.4f} deviates too much from p0={p0}"
+        )
+
+    def test_variance_scales_with_population_size(self):
+        """Smaller N_e → greater drift variance."""
+        p0 = 0.5
+        n_gen = 30
+        n_reps = 300
+        results = {}
+        for n_eff in (10, 500):
+            final_freqs = []
+            for s in range(n_reps):
+                r = simulate_wright_fisher(
+                    {"A": p0, "B": 1.0 - p0},
+                    n_effective=n_eff,
+                    n_generations=n_gen,
+                    seed=s,
+                )
+                last = r[(r["generation"] == n_gen) & (r["allele"] == "A")]
+                final_freqs.append(float(last["frequency"].iloc[0]))
+            results[n_eff] = float(np.var(final_freqs))
+        assert results[10] > results[500], (
+            "smaller N_e should show higher variance: "
+            f"var(N=10)={results[10]:.4f}, var(N=500)={results[500]:.4f}"
+        )
+
+    # --- Input validation ---
+
+    def test_empty_frequencies_raises(self):
+        with pytest.raises(ValueError, match="initial_frequencies"):
+            simulate_wright_fisher({}, n_effective=10, n_generations=5)
+
+    def test_negative_frequency_raises(self):
+        with pytest.raises(ValueError, match=">= 0"):
+            simulate_wright_fisher({"A": -0.1, "B": 1.1}, n_effective=10, n_generations=5)
+
+    def test_frequencies_not_summing_to_one_raises(self):
+        with pytest.raises(ValueError, match="sum to 1.0"):
+            simulate_wright_fisher({"A": 0.3, "B": 0.3}, n_effective=10, n_generations=5)
+
+    def test_zero_n_effective_raises(self):
+        with pytest.raises(ValueError, match="n_effective"):
+            simulate_wright_fisher({"A": 1.0}, n_effective=0, n_generations=5)
+
+    def test_negative_n_generations_raises(self):
+        with pytest.raises(ValueError, match="n_generations"):
+            simulate_wright_fisher({"A": 1.0}, n_effective=10, n_generations=-1)
+
+
+# ---------------------------------------------------------------------------
+# compute_fst_pairwise
+# ---------------------------------------------------------------------------
+
+
+def _make_evolution_df_subpop(
+    n_per_subpop: int,
+    subpops: dict,  # {subpop_name: {gene: (lo, hi)}}
+    seed: int = 0,
+) -> pd.DataFrame:
+    """Build an evolution-style DataFrame with agent_type subpopulations.
+
+    Each subpop has distinct gene ranges to create differentiation.
+    """
+    rng = np.random.default_rng(seed)
+    rows = []
+    cand_idx = 0
+    for subpop, gene_ranges in subpops.items():
+        for _ in range(n_per_subpop):
+            chrom = {
+                gene: float(rng.uniform(lo, hi))
+                for gene, (lo, hi) in gene_ranges.items()
+            }
+            rows.append(
+                {
+                    "candidate_id": f"c{cand_idx}",
+                    "generation": 0,
+                    "fitness": 1.0,
+                    "parent_ids": [],
+                    "chromosome_values": chrom,
+                    "agent_type": subpop,
+                }
+            )
+            cand_idx += 1
+    return pd.DataFrame(rows)
+
+
+def _make_agent_df_subpop(
+    n_per_subpop: int,
+    subpops: dict,  # {subpop_name: {action: (lo, hi)}}
+    seed: int = 0,
+) -> pd.DataFrame:
+    """Build an agent genetics DataFrame with agent_type subpopulations."""
+    rng = np.random.default_rng(seed)
+    rows = []
+    agent_idx = 0
+    for subpop, action_ranges in subpops.items():
+        for _ in range(n_per_subpop):
+            weights_raw = {a: float(rng.uniform(lo, hi)) for a, (lo, hi) in action_ranges.items()}
+            total = sum(weights_raw.values())
+            weights = {a: w / total for a, w in weights_raw.items()}
+            rows.append(
+                {
+                    "agent_id": f"a{agent_idx}",
+                    "agent_type": subpop,
+                    "generation": 0,
+                    "birth_time": 0,
+                    "death_time": None,
+                    "genome_id": f"::{agent_idx}",
+                    "parent_ids": [],
+                    "action_weights": weights,
+                }
+            )
+            agent_idx += 1
+    return pd.DataFrame(rows)
+
+
+class TestComputeFstPairwise:
+    """Tests for compute_fst_pairwise."""
+
+    # --- Output shape and columns ---
+
+    def test_output_columns_correct(self):
+        df = _make_evolution_df_subpop(
+            20, {"A": {"lr": (0.0, 0.1)}, "B": {"lr": (0.9, 1.0)}}
+        )
+        result = compute_fst_pairwise(df)
+        assert list(result.columns) == FST_COLUMNS
+
+    def test_empty_df_returns_empty(self):
+        result = compute_fst_pairwise(pd.DataFrame())
+        assert result.empty
+        assert list(result.columns) == FST_COLUMNS
+
+    def test_missing_subpop_col_returns_empty(self):
+        df = _make_evolution_df_subpop(10, {"A": {"lr": (0.0, 1.0)}})
+        result = compute_fst_pairwise(df, subpop_col="nonexistent")
+        assert result.empty
+
+    def test_single_subpopulation_returns_empty(self):
+        df = _make_evolution_df_subpop(20, {"A": {"lr": (0.0, 0.5)}})
+        result = compute_fst_pairwise(df)
+        assert result.empty
+
+    def test_no_locus_columns_returns_empty(self):
+        df = pd.DataFrame({"agent_type": ["A", "B", "A"], "other": [1, 2, 3]})
+        result = compute_fst_pairwise(df)
+        assert result.empty
+
+    # --- F_ST values for continuous loci ---
+
+    def test_isolated_subpops_high_fst_continuous(self):
+        """Subpopulations with completely non-overlapping gene ranges → high F_ST."""
+        df = _make_evolution_df_subpop(
+            100,
+            {"A": {"lr": (0.0, 0.01)}, "B": {"lr": (0.99, 1.0)}},
+            seed=0,
+        )
+        result = compute_fst_pairwise(df)
+        fst_vals = result[result["locus"] == "lr"]["fst"].values
+        assert len(fst_vals) == 1
+        assert fst_vals[0] > 0.9, f"expected high F_ST, got {fst_vals[0]:.4f}"
+
+    def test_fully_mixed_subpops_low_fst_continuous(self):
+        """Subpopulations drawn from the same distribution → F_ST ≈ 0."""
+        rng = np.random.default_rng(42)
+        vals = rng.uniform(0.0, 1.0, 200)
+        rows = [
+            {
+                "chromosome_values": {"lr": float(v)},
+                "agent_type": "A" if i < 100 else "B",
+                "generation": 0,
+            }
+            for i, v in enumerate(vals)
+        ]
+        df = pd.DataFrame(rows)
+        result = compute_fst_pairwise(df)
+        fst_vals = result[result["locus"] == "lr"]["fst"].values
+        assert len(fst_vals) == 1
+        assert fst_vals[0] < 0.05, f"expected ~0 F_ST for mixed pops, got {fst_vals[0]:.4f}"
+
+    # --- F_ST values for categorical loci ---
+
+    def test_isolated_subpops_high_fst_categorical(self):
+        """Subpopulations with completely different action preferences → high F_ST."""
+        n = 50
+        rows = []
+        for i in range(n):
+            rows.append(
+                {"agent_type": "A", "action_weights": {"move": 1.0, "gather": 0.0}, "generation": 0}
+            )
+        for i in range(n):
+            rows.append(
+                {"agent_type": "B", "action_weights": {"move": 0.0, "gather": 1.0}, "generation": 0}
+            )
+        df = pd.DataFrame(rows)
+        result = compute_fst_pairwise(df)
+        fst_row = result[result["locus"] == "action_weights"]
+        assert len(fst_row) == 1
+        assert float(fst_row["fst"].iloc[0]) > 0.9
+
+    def test_identical_subpops_zero_fst_categorical(self):
+        """Subpopulations with identical action distributions → F_ST == 0."""
+        n = 30
+        weights = {"move": 0.5, "gather": 0.5}
+        rows = (
+            [{"agent_type": "A", "action_weights": weights, "generation": 0}] * n
+            + [{"agent_type": "B", "action_weights": weights, "generation": 0}] * n
+        )
+        df = pd.DataFrame(rows)
+        result = compute_fst_pairwise(df)
+        fst_row = result[result["locus"] == "action_weights"]
+        assert len(fst_row) == 1
+        assert abs(float(fst_row["fst"].iloc[0])) < 1e-9
+
+    # --- F_ST range ---
+
+    def test_fst_in_unit_interval(self):
+        df = _make_evolution_df_subpop(
+            30,
+            {
+                "A": {"lr": (0.0, 0.5), "gamma": (0.8, 1.0)},
+                "B": {"lr": (0.5, 1.0), "gamma": (0.0, 0.2)},
+                "C": {"lr": (0.2, 0.7), "gamma": (0.3, 0.7)},
+            },
+            seed=5,
+        )
+        result = compute_fst_pairwise(df)
+        assert (result["fst"] >= 0.0).all()
+        assert (result["fst"] <= 1.0).all()
+
+    def test_three_subpops_produce_three_pairs(self):
+        df = _make_evolution_df_subpop(
+            20,
+            {
+                "A": {"lr": (0.0, 0.1)},
+                "B": {"lr": (0.45, 0.55)},
+                "C": {"lr": (0.9, 1.0)},
+            },
+            seed=7,
+        )
+        result = compute_fst_pairwise(df)
+        locus_result = result[result["locus"] == "lr"]
+        assert len(locus_result) == 3
+
+    def test_custom_subpop_col(self):
+        df = _make_evolution_df_subpop(20, {"A": {"lr": (0.0, 0.1)}, "B": {"lr": (0.9, 1.0)}})
+        df = df.rename(columns={"agent_type": "region"})
+        result = compute_fst_pairwise(df, subpop_col="region")
+        assert not result.empty
+        assert (result["fst"] > 0.0).any()
+
+
+# ---------------------------------------------------------------------------
+# compute_migration_counts
+# ---------------------------------------------------------------------------
+
+
+def _make_lineage_df(
+    n_agents: int = 20,
+    n_generations: int = 3,
+    migration_rate: float = 0.1,
+    seed: int = 0,
+) -> pd.DataFrame:
+    """Build a DataFrame that mimics lineage-based migration.
+
+    Agents in generation 0 are assigned to subpopulations A or B.
+    Each subsequent generation, offspring mostly inherit their parent's
+    subpopulation; a fraction ``migration_rate`` switches subpopulation.
+    """
+    rng = np.random.default_rng(seed)
+    rows = []
+    agent_idx = 0
+
+    # Generation 0: genesis agents, equally split
+    gen0_ids = []
+    for i in range(n_agents):
+        aid = f"g0_a{i}"
+        subpop = "A" if i < n_agents // 2 else "B"
+        rows.append(
+            {
+                "agent_id": aid,
+                "agent_type": subpop,
+                "generation": 0,
+                "parent_ids": [],
+                "action_weights": {"move": 0.5, "gather": 0.5},
+            }
+        )
+        gen0_ids.append((aid, subpop))
+
+    prev_gen = gen0_ids
+    for gen in range(1, n_generations + 1):
+        new_gen = []
+        for i in range(n_agents):
+            parent_aid, parent_subpop = prev_gen[rng.integers(0, len(prev_gen))]
+            # Occasionally migrate
+            if rng.random() < migration_rate:
+                child_subpop = "B" if parent_subpop == "A" else "A"
+            else:
+                child_subpop = parent_subpop
+            aid = f"g{gen}_a{i}"
+            rows.append(
+                {
+                    "agent_id": aid,
+                    "agent_type": child_subpop,
+                    "generation": gen,
+                    "parent_ids": [parent_aid],
+                    "action_weights": {"move": 0.5, "gather": 0.5},
+                }
+            )
+            new_gen.append((aid, child_subpop))
+        prev_gen = new_gen
+
+    return pd.DataFrame(rows)
+
+
+class TestComputeMigrationCounts:
+    """Tests for compute_migration_counts."""
+
+    def test_output_columns_correct(self):
+        df = _make_lineage_df()
+        result = compute_migration_counts(df)
+        assert list(result.columns) == MIGRATION_COLUMNS
+
+    def test_empty_df_returns_empty(self):
+        result = compute_migration_counts(pd.DataFrame())
+        assert result.empty
+        assert list(result.columns) == MIGRATION_COLUMNS
+
+    def test_missing_subpop_col_returns_empty(self):
+        df = _make_lineage_df()
+        result = compute_migration_counts(df, subpop_col="nonexistent")
+        assert result.empty
+
+    def test_missing_parent_ids_col_returns_empty(self):
+        df = pd.DataFrame({"agent_id": ["a1"], "agent_type": ["A"]})
+        result = compute_migration_counts(df)
+        assert result.empty
+
+    def test_genesis_agents_excluded(self):
+        """Genesis agents (empty parent_ids) must not appear in the result."""
+        df = _make_lineage_df(n_agents=10, n_generations=2)
+        result = compute_migration_counts(df)
+        # Generation-0 agents have no parents; none should appear in result
+        gen0_ids = set(df[df["generation"] == 0]["agent_id"])
+        assert len(set(result["agent_id"]) & gen0_ids) == 0
+
+    def test_zero_migration_rate_no_migrants(self):
+        """With migration_rate=0, no agents should be flagged as migrants."""
+        df = _make_lineage_df(n_agents=20, n_generations=3, migration_rate=0.0)
+        result = compute_migration_counts(df)
+        assert not result.empty
+        assert result["is_migrant"].sum() == 0
+
+    def test_full_migration_rate_all_migrants(self):
+        """With migration_rate=1.0, all offspring switch subpopulation."""
+        df = _make_lineage_df(n_agents=20, n_generations=2, migration_rate=1.0, seed=1)
+        result = compute_migration_counts(df)
+        assert not result.empty
+        assert result["is_migrant"].all()
+
+    def test_partial_migration_some_migrants(self):
+        df = _make_lineage_df(n_agents=40, n_generations=5, migration_rate=0.3, seed=3)
+        result = compute_migration_counts(df)
+        n_migrants = int(result["is_migrant"].sum())
+        n_non_migrants = int((~result["is_migrant"]).sum())
+        assert n_migrants > 0 and n_non_migrants > 0
+
+    def test_subpop_definition_column_reflects_subpop_col(self):
+        df = _make_lineage_df()
+        result = compute_migration_counts(df, subpop_col="agent_type")
+        assert (result["subpop_definition"] == "agent_type").all()
+
+    def test_candidate_id_column_supported(self):
+        """Supports candidate_id as the individual identifier (evolution DataFrames)."""
+        df = _make_lineage_df()
+        df = df.rename(columns={"agent_id": "candidate_id"})
+        result = compute_migration_counts(df)
+        assert not result.empty
+        assert "agent_id" in result.columns
+
+
+# ---------------------------------------------------------------------------
+# compute_gene_flow_timeseries
+# ---------------------------------------------------------------------------
+
+
+def _make_multigen_evolution_df(
+    n_gens: int = 5,
+    n_per_subpop_per_gen: int = 20,
+    gene_ranges_a: Optional[dict] = None,
+    gene_ranges_b: Optional[dict] = None,
+    migration_rate: float = 0.1,
+    seed: int = 0,
+) -> pd.DataFrame:
+    """Multi-generation evolution DataFrame with two subpopulations."""
+    if gene_ranges_a is None:
+        gene_ranges_a = {"lr": (0.0, 0.1), "gamma": (0.9, 1.0)}
+    if gene_ranges_b is None:
+        gene_ranges_b = {"lr": (0.9, 1.0), "gamma": (0.0, 0.1)}
+    rng = np.random.default_rng(seed)
+    rows = []
+    cand_idx = 0
+    prev_gen_info = {}  # cand_id -> agent_type
+
+    for gen in range(n_gens):
+        gen_info = {}
+        for subpop, gene_ranges in [("A", gene_ranges_a), ("B", gene_ranges_b)]:
+            for _ in range(n_per_subpop_per_gen):
+                cid = f"c{cand_idx}"
+                # Choose parent from previous generation
+                if gen == 0 or not prev_gen_info:
+                    parent_ids = []
+                    effective_subpop = subpop
+                else:
+                    prev_ids = list(prev_gen_info.keys())
+                    parent_id = prev_ids[rng.integers(0, len(prev_ids))]
+                    parent_type = prev_gen_info[parent_id]
+                    # Occasionally migrate
+                    if rng.random() < migration_rate:
+                        effective_subpop = "B" if parent_type == "A" else "A"
+                    else:
+                        effective_subpop = parent_type
+                    parent_ids = [parent_id]
+                # Gene values from this subpop's distribution
+                effective_ranges = gene_ranges_a if effective_subpop == "A" else gene_ranges_b
+                chrom = {g: float(rng.uniform(lo, hi)) for g, (lo, hi) in effective_ranges.items()}
+                rows.append(
+                    {
+                        "agent_id": cid,
+                        "agent_type": effective_subpop,
+                        "generation": gen,
+                        "parent_ids": parent_ids,
+                        "chromosome_values": chrom,
+                    }
+                )
+                gen_info[cid] = effective_subpop
+                cand_idx += 1
+        prev_gen_info = gen_info
+
+    return pd.DataFrame(rows)
+
+
+class TestComputeGeneFlowTimeseries:
+    """Tests for compute_gene_flow_timeseries."""
+
+    def test_output_columns_correct(self):
+        df = _make_multigen_evolution_df(n_gens=3)
+        result = compute_gene_flow_timeseries(df)
+        assert list(result.columns) == GENE_FLOW_COLUMNS
+
+    def test_empty_df_returns_empty(self):
+        result = compute_gene_flow_timeseries(pd.DataFrame())
+        assert result.empty
+        assert list(result.columns) == GENE_FLOW_COLUMNS
+
+    def test_missing_generation_col_returns_empty(self):
+        df = _make_multigen_evolution_df()
+        df = df.drop(columns=["generation"])
+        result = compute_gene_flow_timeseries(df)
+        assert result.empty
+
+    def test_missing_subpop_col_returns_empty(self):
+        df = _make_multigen_evolution_df()
+        result = compute_gene_flow_timeseries(df, subpop_col="nonexistent")
+        assert result.empty
+
+    def test_no_locus_columns_returns_empty(self):
+        df = _make_multigen_evolution_df()
+        df = df.drop(columns=["chromosome_values"])
+        result = compute_gene_flow_timeseries(df)
+        assert result.empty
+
+    def test_rows_per_generation(self):
+        n_gens = 4
+        df = _make_multigen_evolution_df(n_gens=n_gens, n_per_subpop_per_gen=20)
+        result = compute_gene_flow_timeseries(df)
+        assert not result.empty
+        # Exactly n_gens unique generations represented
+        assert result["generation"].nunique() == n_gens
+
+    def test_fst_in_unit_interval(self):
+        df = _make_multigen_evolution_df(n_gens=3)
+        result = compute_gene_flow_timeseries(df)
+        assert (result["fst"] >= 0.0).all()
+        assert (result["fst"] <= 1.0).all()
+
+    def test_n_migrants_non_negative_integers(self):
+        df = _make_multigen_evolution_df(n_gens=3, migration_rate=0.2)
+        result = compute_gene_flow_timeseries(df)
+        assert (result["n_migrants"] >= 0).all()
+        assert result["n_migrants"].dtype in (int, np.int64, np.int32, object)
+
+    def test_isolated_pops_high_fst_over_time(self):
+        """Isolated subpopulations with very different gene ranges → high F_ST every gen."""
+        df = _make_multigen_evolution_df(
+            n_gens=5,
+            n_per_subpop_per_gen=30,
+            gene_ranges_a={"lr": (0.0, 0.01)},
+            gene_ranges_b={"lr": (0.99, 1.0)},
+            migration_rate=0.0,
+            seed=11,
+        )
+        result = compute_gene_flow_timeseries(df)
+        lr_rows = result[result["locus"] == "lr"]
+        assert not lr_rows.empty
+        assert (lr_rows["fst"] > 0.9).all(), lr_rows["fst"].tolist()
+
+    def test_fully_mixed_pops_low_fst_over_time(self):
+        """Subpopulations drawn from the same gene distribution → F_ST ≈ 0."""
+        rng = np.random.default_rng(99)
+        n = 30
+        rows = []
+        for gen in range(4):
+            vals = rng.uniform(0.0, 1.0, n * 2)
+            for i, v in enumerate(vals):
+                rows.append(
+                    {
+                        "agent_type": "A" if i < n else "B",
+                        "generation": gen,
+                        "chromosome_values": {"lr": float(v)},
+                        "parent_ids": [],
+                    }
+                )
+        df = pd.DataFrame(rows)
+        result = compute_gene_flow_timeseries(df)
+        lr_rows = result[result["locus"] == "lr"]
+        assert not lr_rows.empty
+        assert (lr_rows["fst"] < 0.15).all(), lr_rows["fst"].tolist()
+
+    def test_migration_events_counted_per_generation(self):
+        """With migration, n_migrants > 0 in at least some generations."""
+        df = _make_multigen_evolution_df(
+            n_gens=4,
+            n_per_subpop_per_gen=30,
+            migration_rate=0.5,
+            seed=77,
+        )
+        result = compute_gene_flow_timeseries(df)
+        # At least some generations/pairs should show migrants
+        assert result["n_migrants"].sum() > 0

--- a/tests/analysis/test_genetics.py
+++ b/tests/analysis/test_genetics.py
@@ -2151,7 +2151,6 @@ def _make_lineage_df(
     """
     rng = np.random.default_rng(seed)
     rows = []
-    agent_idx = 0
 
     # Generation 0: genesis agents, equally split
     gen0_ids = []


### PR DESCRIPTION
This pull request adds new population genetics analysis features to the `farm.analysis.genetics` module, focusing on Wright-Fisher simulation and gene flow/F_ST differentiation tools. It updates the module's API, function registry, and documentation to expose and organize these new functionalities.

**New population genetics analysis features:**

* Added Wright-Fisher neutral drift simulator (`simulate_wright_fisher`) and associated output columns (`WRIGHT_FISHER_COLUMNS`) for simulating per-allele trajectories. [[1]](diffhunk://#diff-e48c0a1bfa859d80141b05ad7d1edb99efe3d165a5a3acddfbc8de448e5d1002R16-R17) [[2]](diffhunk://#diff-e48c0a1bfa859d80141b05ad7d1edb99efe3d165a5a3acddfbc8de448e5d1002R33-R36) [[3]](diffhunk://#diff-e48c0a1bfa859d80141b05ad7d1edb99efe3d165a5a3acddfbc8de448e5d1002R61-R68) [[4]](diffhunk://#diff-e48c0a1bfa859d80141b05ad7d1edb99efe3d165a5a3acddfbc8de448e5d1002R99-R108) [[5]](diffhunk://#diff-92fc7c1c80119c0927702d21f447654b5fa95ef3734f6ebb3d188243de94d251R23-R26) [[6]](diffhunk://#diff-92fc7c1c80119c0927702d21f447654b5fa95ef3734f6ebb3d188243de94d251R73-R76)
* Added gene-flow and F_ST differentiation analysis functions: `compute_fst_pairwise`, `compute_migration_counts`, `compute_gene_flow_timeseries`, with their respective output columns (`FST_COLUMNS`, `MIGRATION_COLUMNS`, `GENE_FLOW_COLUMNS`). [[1]](diffhunk://#diff-e48c0a1bfa859d80141b05ad7d1edb99efe3d165a5a3acddfbc8de448e5d1002R16-R17) [[2]](diffhunk://#diff-e48c0a1bfa859d80141b05ad7d1edb99efe3d165a5a3acddfbc8de448e5d1002R33-R36) [[3]](diffhunk://#diff-e48c0a1bfa859d80141b05ad7d1edb99efe3d165a5a3acddfbc8de448e5d1002R61-R68) [[4]](diffhunk://#diff-e48c0a1bfa859d80141b05ad7d1edb99efe3d165a5a3acddfbc8de448e5d1002R99-R108) [[5]](diffhunk://#diff-92fc7c1c80119c0927702d21f447654b5fa95ef3734f6ebb3d188243de94d251R23-R26) [[6]](diffhunk://#diff-92fc7c1c80119c0927702d21f447654b5fa95ef3734f6ebb3d188243de94d251R73-R76)

**Module API and documentation updates:**

* Updated the `__all__` list and import statements in `__init__.py` to export all new functions and their column definitions. [[1]](diffhunk://#diff-e48c0a1bfa859d80141b05ad7d1edb99efe3d165a5a3acddfbc8de448e5d1002R61-R68) [[2]](diffhunk://#diff-e48c0a1bfa859d80141b05ad7d1edb99efe3d165a5a3acddfbc8de448e5d1002R99-R108)
* Extended the quick-start documentation in `__init__.py` to mention the new simulators and gene flow analysis tools.

**Function registration and organization:**

* Registered new analysis functions in the genetics module and grouped them under a new `population_genetics` group for easier discovery and use. [[1]](diffhunk://#diff-92fc7c1c80119c0927702d21f447654b5fa95ef3734f6ebb3d188243de94d251R73-R76) [[2]](diffhunk://#diff-92fc7c1c80119c0927702d21f447654b5fa95ef3734f6ebb3d188243de94d251R102-R107)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new population-genetics computations (simulation, F_ST, migration tracking) that may affect analysis outputs and runtime on large DataFrames, but does not touch security- or data-integrity-critical paths.
> 
> **Overview**
> **Adds population genetics tooling to `farm.analysis.genetics`.** Introduces `simulate_wright_fisher` to generate seeded neutral drift allele-frequency trajectories and exposes its tidy output via `WRIGHT_FISHER_COLUMNS`.
> 
> **Adds gene-flow/differentiation analysis across subpopulations.** Implements `compute_fst_pairwise` (continuous and categorical loci), `compute_migration_counts` (lineage-based migrant detection), and `compute_gene_flow_timeseries` (per-generation F_ST plus migrant counts), exporting associated column schemas (`FST_COLUMNS`, `MIGRATION_COLUMNS`, `GENE_FLOW_COLUMNS`).
> 
> **Wires the new APIs into the module surface.** Updates `__init__.py` exports/quickstart, registers the functions in `GeneticsModule`, adds a new `population_genetics` function group, and adds comprehensive unit tests for the new functionality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b21fcf8699620e9af06e46367ed9cb1eda5ce32f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->