### PR TITLE
Add density-dependent reproduction cost and selection pressure knobs

### DIFF
--- a/docs/experiments/intrinsic_evolution.md
+++ b/docs/experiments/intrinsic_evolution.md
@@ -150,6 +150,8 @@ print(f"Final mean LR: {result.final_gene_statistics['learning_rate']['mean']}")
 | `coparent_strategy` | `"nearest_alive_same_type"` | Either `nearest_alive_same_type` or `random_alive_same_type`. Both filter to alive agents of the same `agent_type`. |
 | `coparent_max_radius` | `None` | Optional spatial cap on the co-parent search; `None` is unbounded. |
 | `seed` | `None` | Optional RNG seed. Falls back to `IntrinsicEvolutionExperimentConfig.seed`. |
+| `selection_pressure` | `None` | Convenience knob for density-dependent cost. Accepts `"none"`, `"low"`, `"medium"`, `"high"` or a float in *[0, 1]*. Overrides `reproduction_pressure` when set. |
+| `reproduction_pressure` | `ReproductionPressureConfig()` | Fine-grained density-dependent cost config (all zero by default). Ignored when `selection_pressure` is set. |
 
 If no eligible co-parent exists when crossover is enabled, reproduction
 silently falls back to mutation-only inheritance. This is the only way
@@ -253,21 +255,100 @@ enums serialized to plain strings so it round-trips cleanly:
   represented by a single agent. Statistical power is low until lineages
   expand. Seed diversity is intentionally aggressive (`mutation_rate=1.0`
   by default) to spread the initial population.
-- **No selection-pressure knob yet.** Reproduction cost is fixed by the
-  agent's `ReproductionConfig`; density-dependent costs and explicit
-  speciation are out of scope for v1.
 - **Crossover requires same `agent_type`.** Cross-type pollination is not
   supported. Co-parent selection always filters to identical
   `agent_type`.
 
+## Selection pressure
+
+The runner exposes two ways to strengthen (or weaken) selection without
+touching the underlying simulation's ecology:
+
+### Quick start: `selection_pressure` preset
+
+Set `selection_pressure` on `IntrinsicEvolutionPolicy` to a named preset or
+a float in *[0, 1]*:
+
+```python
+policy = IntrinsicEvolutionPolicy(
+    selection_pressure="medium",  # "none", "low", "medium", "high" or float
+)
+```
+
+A float `0.0` equals `"none"` (no density cost) and `1.0` equals `"high"`.
+Intermediate values scale the `"high"` preset's coefficients linearly.
+
+| Preset | `local_density_coefficient` | `global_carrying_capacity` | `global_cc_coefficient` |
+| --- | --- | --- | --- |
+| `"none"` | 0.0 | 0 (disabled) | 0.0 |
+| `"low"` | 0.5 | 0 (disabled) | 0.0 |
+| `"medium"` | 1.0 | 100 | 0.5 |
+| `"high"` | 2.0 | 100 | 1.0 |
+
+### Fine-grained: `ReproductionPressureConfig`
+
+For more control, set `reproduction_pressure` explicitly (ignored when
+`selection_pressure` is also set):
+
+```python
+from farm.core.agent.config.component_configs import ReproductionPressureConfig
+
+policy = IntrinsicEvolutionPolicy(
+    reproduction_pressure=ReproductionPressureConfig(
+        local_density_radius=8.0,          # cells around the parent to count
+        local_density_coefficient=1.5,     # extra resource cost per neighbour
+        global_carrying_capacity=150,      # K
+        global_carrying_capacity_coefficient=0.8,
+    ),
+)
+```
+
+The effective offspring cost for an agent at reproduction time is:
+
+```
+effective_cost = base_cost
+               + local_density_coefficient * n_neighbours_within_radius
+               + global_carrying_capacity_coefficient * base_cost * (pop / K)
+```
+
+`K` is only applied when `global_carrying_capacity > 0`.  All coefficients
+default to zero, so the default config (and any policy without
+`selection_pressure`) matches legacy behaviour exactly.
+
+### Telemetry
+
+When density-dependent costs are active, per-step trajectory records in
+`intrinsic_gene_trajectory.jsonl` include four new fields:
+
+| Field | Meaning |
+| --- | --- |
+| `mean_reproduction_cost` | Mean effective cost across alive agents at this step. |
+| `realized_birth_rate` | `births / prev_population` (0 at step 0). |
+| `realized_death_rate` | `deaths / prev_population` (0 at step 0). |
+| `effective_selection_strength` | Coefficient of variation (std/mean) of per-agent effective costs; a proxy for the opportunity for selection. Zero when all agents face identical costs. |
+
+Example trajectory record with pressure active:
+
+```json
+{
+  "step": 42,
+  "n_alive": 28,
+  "n_with_chromosome": 28,
+  "gene_stats": { "learning_rate": { ... }, ... },
+  "mean_reproduction_cost": 7.4,
+  "realized_birth_rate": 0.071,
+  "realized_death_rate": 0.036,
+  "effective_selection_strength": 0.12
+}
+```
+
 ## Out of scope (for now)
 
-- Density-dependent reproduction cost / explicit selection-pressure knobs.
 - Lineage tree visualization. The snapshot file makes this a notebook job.
 - Speciation / niche detection.
 
 ## Testing
 
-- [`tests/runners/test_intrinsic_evolution_experiment.py`](../../tests/runners/test_intrinsic_evolution_experiment.py): policy / config validation, `seed_population_diversity`, runner orchestration with mocked `run_simulation`, artifact persistence.
+- [`tests/runners/test_intrinsic_evolution_experiment.py`](../../tests/runners/test_intrinsic_evolution_experiment.py): policy / config validation, `seed_population_diversity`, runner orchestration with mocked `run_simulation`, artifact persistence, `ReproductionPressureConfig` validation, `selection_pressure` presets (none/low/medium/high/float), `_compute_effective_reproduction_cost` unit tests, trajectory telemetry field presence, and zero birth/death rates for stable populations.
 - [`tests/core/agent/test_reproduce_chromosome_policy.py`](../../tests/core/agent/test_reproduce_chromosome_policy.py): no-policy passthrough, mutation path, co-parent selection (nearest, random, radius, type-filter, alive-filter), crossover end-to-end.
 - [`tests/test_agent_reproduction_hyperparameters.py`](../../tests/test_agent_reproduction_hyperparameters.py): updated to assert the new contract (no policy = inheritance unchanged).

--- a/docs/experiments/intrinsic_evolution.md
+++ b/docs/experiments/intrinsic_evolution.md
@@ -278,7 +278,7 @@ policy = IntrinsicEvolutionPolicy(
 A float `0.0` equals `"none"` (no density cost) and `1.0` equals `"high"`.
 Intermediate values scale the `"high"` preset's coefficients linearly.
 
-| Preset | `local_density_coefficient` | `global_carrying_capacity` | `global_cc_coefficient` |
+| Preset | `local_density_coefficient` | `global_carrying_capacity` | `global_carrying_capacity_coefficient` |
 | --- | --- | --- | --- |
 | `"none"` | 0.0 | 0 (disabled) | 0.0 |
 | `"low"` | 0.5 | 0 (disabled) | 0.0 |
@@ -317,8 +317,9 @@ default to zero, so the default config (and any policy without
 
 ### Telemetry
 
-When density-dependent costs are active, per-step trajectory records in
-`intrinsic_gene_trajectory.jsonl` include four new fields:
+Per-step trajectory records in `intrinsic_gene_trajectory.jsonl` always include
+four selection-pressure telemetry fields (values are 0 when density-dependent
+costs are disabled, since all agents share an identical base cost):
 
 | Field | Meaning |
 | --- | --- |

--- a/farm/core/agent/config/__init__.py
+++ b/farm/core/agent/config/__init__.py
@@ -8,6 +8,7 @@ from .component_configs import (
     MovementConfig,
     PerceptionConfig,
     ReproductionConfig,
+    ReproductionPressureConfig,
     ResourceConfig,
 )
 
@@ -19,5 +20,6 @@ __all__ = [
     "CombatConfig",
     "PerceptionConfig",
     "ReproductionConfig",
+    "ReproductionPressureConfig",
     "DecisionConfig",
 ]

--- a/farm/core/agent/config/component_configs.py
+++ b/farm/core/agent/config/component_configs.py
@@ -103,6 +103,41 @@ class ReproductionConfig:
 
 
 @dataclass(frozen=True)
+class ReproductionPressureConfig:
+    """Configuration for density-dependent reproduction cost.
+
+    When attached to an :class:`IntrinsicEvolutionPolicy` (via the
+    ``reproduction_pressure`` field), the effective offspring cost is
+    increased by:
+
+    - ``local_density_coefficient * n_neighbors`` where *n_neighbors* is
+      the number of alive agents within ``local_density_radius`` of the
+      reproducing agent.
+    - ``global_carrying_capacity_coefficient * base_cost * (pop / K)``
+      where *pop* is the current total alive population and *K* is
+      ``global_carrying_capacity``.  This term is only applied when
+      ``global_carrying_capacity > 0``.
+
+    Setting all coefficients to zero (the default) disables
+    density-dependent costs and matches legacy behaviour exactly.
+    """
+
+    local_density_radius: float = 5.0
+    """Radius (in environment units) used to count local neighbours."""
+
+    local_density_coefficient: float = 0.0
+    """Extra resource cost per local neighbour within ``local_density_radius``."""
+
+    global_carrying_capacity: int = 0
+    """Population size treated as the carrying capacity *K*.
+    Zero disables the global component entirely."""
+
+    global_carrying_capacity_coefficient: float = 0.0
+    """Scale factor for the global ``pop / K`` cost term.
+    The extra cost added is ``global_carrying_capacity_coefficient * base_cost * (pop / K)``."""
+
+
+@dataclass(frozen=True)
 class RewardConfig:
     """Configuration for reward calculation and tracking."""
     

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-def _compute_effective_reproduction_cost(agent: Any, base_cost: float) -> float:
+def compute_effective_reproduction_cost(agent: Any, base_cost: float) -> float:
     """Return the density-adjusted reproduction cost for *agent*.
 
     When the agent's environment carries an enabled
@@ -86,7 +86,7 @@ def _compute_effective_reproduction_cost(agent: Any, base_cost: float) -> float:
         alive_objects = getattr(env, "alive_agent_objects", None)
         if alive_objects is not None:
             try:
-                pop = len(list(alive_objects))
+                pop = len(alive_objects)
                 extra += global_coeff * base_cost * (pop / global_k)
             except Exception:
                 pass
@@ -849,7 +849,7 @@ class AgentCore:
 
         resource_comp = self.get_component("resource")
         base_cost = repro_comp.config.offspring_cost
-        offspring_cost = _compute_effective_reproduction_cost(self, base_cost)
+        offspring_cost = compute_effective_reproduction_cost(self, base_cost)
 
         # Store initial resources for logging
         initial_resources = self.resource_level

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -9,7 +9,7 @@ logic for reward calculation, lifecycle management, and orchestration.
 import math
 import random as _module_random
 from copy import deepcopy
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import torch
 
@@ -35,6 +35,63 @@ if TYPE_CHECKING:
 
 
 logger = get_logger(__name__)
+
+
+def _compute_effective_reproduction_cost(agent: Any, base_cost: float) -> float:
+    """Return the density-adjusted reproduction cost for *agent*.
+
+    When the agent's environment carries an enabled
+    ``intrinsic_evolution_policy`` whose ``reproduction_pressure`` config has
+    non-zero coefficients, the effective cost is:
+
+    .. code-block:: text
+
+        effective = base_cost
+                  + local_density_coefficient * n_local_neighbours
+                  + global_carrying_capacity_coefficient * base_cost * (pop / K)
+
+    The second term is only included when ``global_carrying_capacity > 0``.
+    When no policy / pressure config is present, *base_cost* is returned
+    unchanged, preserving backward compatibility.
+    """
+    env = getattr(agent, "environment", None)
+    if env is None:
+        return base_cost
+    policy = getattr(env, "intrinsic_evolution_policy", None)
+    if policy is None or not getattr(policy, "enabled", False):
+        return base_cost
+    pressure = getattr(policy, "reproduction_pressure", None)
+    if pressure is None:
+        return base_cost
+
+    extra = 0.0
+
+    # Local density term
+    local_coeff = getattr(pressure, "local_density_coefficient", 0.0)
+    local_radius = getattr(pressure, "local_density_radius", 0.0)
+    if local_coeff > 0.0 and local_radius > 0.0:
+        get_nearby = getattr(env, "get_nearby_agents", None)
+        if callable(get_nearby):
+            try:
+                nearby = get_nearby(agent.position, local_radius)
+                n_neighbours = sum(1 for a in nearby if a is not agent)
+                extra += local_coeff * n_neighbours
+            except Exception:
+                pass  # Spatial index may not be initialised yet; skip silently.
+
+    # Global carrying-capacity term
+    global_k = getattr(pressure, "global_carrying_capacity", 0)
+    global_coeff = getattr(pressure, "global_carrying_capacity_coefficient", 0.0)
+    if global_k > 0 and global_coeff > 0.0:
+        alive_objects = getattr(env, "alive_agent_objects", None)
+        if alive_objects is not None:
+            try:
+                pop = len(list(alive_objects))
+                extra += global_coeff * base_cost * (pop / global_k)
+            except Exception:
+                pass
+
+    return base_cost + extra
 
 
 class AgentCore:
@@ -765,6 +822,13 @@ class AgentCore:
         Checks if agent can reproduce, deducts resources, creates offspring
         using the factory pattern, and adds it to the environment.
 
+        When the environment carries an enabled ``intrinsic_evolution_policy``
+        with a ``reproduction_pressure`` config, the effective reproduction
+        cost is increased by density-dependent terms (local neighbour count
+        and/or global population fraction relative to carrying capacity).
+        The resource deduction uses the effective cost, so agents at high
+        density face a real resource barrier and reproduce less often.
+
         Returns:
             bool: True if reproduction succeeded, False otherwise
         """
@@ -773,7 +837,9 @@ class AgentCore:
         if not repro_comp:
             return False
 
-        # Check if agent can afford reproduction
+        # First-pass affordability check using the base cost.  This preserves
+        # the existing API contract; the final remove() below uses the
+        # (potentially higher) density-adjusted effective cost.
         if not repro_comp.can_reproduce():
             return False
 
@@ -781,16 +847,18 @@ class AgentCore:
         if not self.environment:
             return False
 
+        resource_comp = self.get_component("resource")
+        base_cost = repro_comp.config.offspring_cost
+        offspring_cost = _compute_effective_reproduction_cost(self, base_cost)
+
         # Store initial resources for logging
         initial_resources = self.resource_level
 
-        resource_comp = self.get_component("resource")
-        offspring_cost = repro_comp.config.offspring_cost
         resource_deducted = False
         offspring_id: Optional[str] = None
 
         try:
-            # Deduct reproduction cost
+            # Deduct reproduction cost (remove() returns False if insufficient).
             if resource_comp:
                 if not resource_comp.remove(offspring_cost):
                     return False

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -89,7 +89,7 @@ def compute_effective_reproduction_cost(agent: Any, base_cost: float) -> float:
                 pop = len(alive_objects)
                 extra += global_coeff * base_cost * (pop / global_k)
             except Exception:
-                pass
+                pass  # Population source may be transient/unavailable; skip adjustment.
 
     return base_cost + extra
 

--- a/farm/runners/__init__.py
+++ b/farm/runners/__init__.py
@@ -23,6 +23,12 @@ from farm.runners.evolution_experiment import (
     EvolutionGenerationSummary,
     EvolutionSelectionMethod,
 )
+from farm.runners.intrinsic_evolution_experiment import (
+    IntrinsicEvolutionExperiment,
+    IntrinsicEvolutionExperimentConfig,
+    IntrinsicEvolutionPolicy,
+    IntrinsicEvolutionResult,
+)
 
 __all__ = [
     "DEFAULT_PER_GENE_RATE_MULTIPLIERS",
@@ -42,4 +48,8 @@ __all__ = [
     "EvolutionFitnessMetric",
     "EvolutionGenerationSummary",
     "EvolutionSelectionMethod",
+    "IntrinsicEvolutionExperiment",
+    "IntrinsicEvolutionExperimentConfig",
+    "IntrinsicEvolutionPolicy",
+    "IntrinsicEvolutionResult",
 ]

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -53,12 +53,20 @@ class GeneTrajectoryLogger:
                 encoding="utf-8",
             )
 
-    def snapshot(self, environment: Any, step: int) -> None:
+    def snapshot(self, environment: Any, step: int, extra_fields: Optional[Dict[str, Any]] = None) -> None:
         """Record the chromosome distribution at ``step``.
 
         Always appends a one-line aggregate record to the trajectory file.
         Additionally appends a full per-agent snapshot when
         ``step % snapshot_interval == 0`` (so step 0 is always captured).
+
+        Args:
+            environment: The live environment object.
+            step: The current simulation step number.
+            extra_fields: Optional dict of additional key/value pairs to merge
+                into the trajectory record (e.g. telemetry computed by the
+                runner such as ``mean_reproduction_cost`` or
+                ``realized_birth_rate``).
         """
         if self._trajectory_handle is None:
             return
@@ -76,6 +84,8 @@ class GeneTrajectoryLogger:
             "n_with_chromosome": len(chromosomes),
             "gene_stats": gene_stats,
         }
+        if extra_fields:
+            trajectory_record.update(extra_fields)
         self._trajectory_handle.write(json.dumps(trajectory_record) + "\n")
 
         if self._snapshot_handle is not None and step % self._snapshot_interval == 0:

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -85,6 +85,13 @@ class GeneTrajectoryLogger:
             "gene_stats": gene_stats,
         }
         if extra_fields:
+            _RESERVED_TRAJECTORY_KEYS = {"step", "n_alive", "n_with_chromosome", "gene_stats"}
+            collisions = _RESERVED_TRAJECTORY_KEYS & extra_fields.keys()
+            if collisions:
+                raise ValueError(
+                    f"extra_fields contains reserved trajectory key(s): {sorted(collisions)}. "
+                    "Use a different name or nest telemetry under a sub-dict."
+                )
             trajectory_record.update(extra_fields)
         self._trajectory_handle.write(json.dumps(trajectory_record) + "\n")
 

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -90,6 +90,11 @@ def _preset_or_scale_to_pressure_config(
                 f"{list(_SELECTION_PRESSURE_PRESETS)}; got {selection_pressure!r}."
             )
         return _SELECTION_PRESSURE_PRESETS[selection_pressure]
+    if isinstance(selection_pressure, bool):
+        raise TypeError(
+            f"selection_pressure must be a str preset or float in [0, 1]; "
+            f"got {type(selection_pressure).__name__!r}."
+        )
     if isinstance(selection_pressure, (int, float)):
         scale = float(selection_pressure)
         if not 0.0 <= scale <= 1.0:
@@ -319,6 +324,10 @@ class IntrinsicEvolutionExperiment:
         # Track agent IDs from the previous step to compute birth/death rates.
         prev_agent_ids: set = set()
 
+        def _agent_telemetry_key(agent: Any) -> tuple:
+            """Stable per-agent key: string id when set, else object identity."""
+            return (getattr(agent, "agent_id", None), id(agent))
+
         def _capture_current_state(environment: Any, step: int) -> None:
             """Capture the same state we emit to the trajectory logger.
 
@@ -358,7 +367,7 @@ class IntrinsicEvolutionExperiment:
             """
 
             alive_agents = list(environment.alive_agent_objects)
-            current_ids = {getattr(a, "agent_id", None) for a in alive_agents}
+            current_ids = {_agent_telemetry_key(a) for a in alive_agents}
 
             prev_pop = len(prev_ids)
             births = len(current_ids - prev_ids)
@@ -407,7 +416,7 @@ class IntrinsicEvolutionExperiment:
             seed_population_diversity(environment, policy, rng)
             # At step 0 there is no previous step, so birth/death rates are 0.
             alive_agents = list(environment.alive_agent_objects)
-            prev_agent_ids = {getattr(a, "agent_id", None) for a in alive_agents}
+            prev_agent_ids = {_agent_telemetry_key(a) for a in alive_agents}
             gene_logger.snapshot(environment, step=0)
             _capture_current_state(environment, step=0)
 
@@ -416,7 +425,7 @@ class IntrinsicEvolutionExperiment:
             logical_step = step + 1
             extra = _compute_step_telemetry(environment, prev_agent_ids)
             alive_agents = list(environment.alive_agent_objects)
-            prev_agent_ids = {getattr(a, "agent_id", None) for a in alive_agents}
+            prev_agent_ids = {_agent_telemetry_key(a) for a in alive_agents}
             gene_logger.snapshot(environment, step=logical_step, extra_fields=extra)
             _capture_current_state(environment, step=logical_step)
 

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Literal, Optional, Union
 
 from farm.config import SimulationConfig
 from farm.core.agent.config.component_configs import ReproductionPressureConfig
+from farm.core.agent.core import _compute_effective_reproduction_cost
 from farm.core.hyperparameter_chromosome import (
     BoundaryMode,
     CrossoverMode,
@@ -355,7 +356,6 @@ class IntrinsicEvolutionExperiment:
               mean) of per-agent effective reproduction costs; a proxy for the
               opportunity-for-selection imposed by density-dependent costs.
             """
-            from farm.core.agent.core import _compute_effective_reproduction_cost  # local import to avoid circularity
 
             alive_agents = list(environment.alive_agent_objects)
             current_ids = {getattr(a, "agent_id", None) for a in alive_agents}

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -16,9 +16,10 @@ import json
 import os
 import random
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from farm.config import SimulationConfig
+from farm.core.agent.config.component_configs import ReproductionPressureConfig
 from farm.core.hyperparameter_chromosome import (
     BoundaryMode,
     CrossoverMode,
@@ -36,6 +37,76 @@ logger = get_logger(__name__)
 
 
 CoparentStrategy = Literal["nearest_alive_same_type", "random_alive_same_type"]
+SelectionPressurePreset = Literal["none", "low", "medium", "high"]
+
+# ── Preset definitions ────────────────────────────────────────────────────────
+# Each preset maps to a ReproductionPressureConfig with sensible defaults that
+# give progressively stronger selection without requiring the user to tune raw
+# coefficients.  "none" is the identity (no density cost).
+
+_SELECTION_PRESSURE_PRESETS: Dict[str, ReproductionPressureConfig] = {
+    "none": ReproductionPressureConfig(
+        local_density_radius=5.0,
+        local_density_coefficient=0.0,
+        global_carrying_capacity=0,
+        global_carrying_capacity_coefficient=0.0,
+    ),
+    "low": ReproductionPressureConfig(
+        local_density_radius=5.0,
+        local_density_coefficient=0.5,
+        global_carrying_capacity=0,
+        global_carrying_capacity_coefficient=0.0,
+    ),
+    "medium": ReproductionPressureConfig(
+        local_density_radius=5.0,
+        local_density_coefficient=1.0,
+        global_carrying_capacity=100,
+        global_carrying_capacity_coefficient=0.5,
+    ),
+    "high": ReproductionPressureConfig(
+        local_density_radius=5.0,
+        local_density_coefficient=2.0,
+        global_carrying_capacity=100,
+        global_carrying_capacity_coefficient=1.0,
+    ),
+}
+
+
+def _preset_or_scale_to_pressure_config(
+    selection_pressure: Any,
+) -> ReproductionPressureConfig:
+    """Derive a :class:`ReproductionPressureConfig` from a preset name or scale.
+
+    - A ``str`` must be one of ``"none"``, ``"low"``, ``"medium"``, ``"high"``
+      and maps to the corresponding preset.
+    - A ``float`` in *[0, 1]* is treated as a linear scale factor applied to
+      the ``"high"`` preset's coefficients.
+    """
+    if isinstance(selection_pressure, str):
+        if selection_pressure not in _SELECTION_PRESSURE_PRESETS:
+            raise ValueError(
+                f"selection_pressure preset must be one of "
+                f"{list(_SELECTION_PRESSURE_PRESETS)}; got {selection_pressure!r}."
+            )
+        return _SELECTION_PRESSURE_PRESETS[selection_pressure]
+    if isinstance(selection_pressure, (int, float)):
+        scale = float(selection_pressure)
+        if not 0.0 <= scale <= 1.0:
+            raise ValueError(
+                "selection_pressure as a float must be in [0, 1]; "
+                f"got {scale}."
+            )
+        high = _SELECTION_PRESSURE_PRESETS["high"]
+        return ReproductionPressureConfig(
+            local_density_radius=high.local_density_radius,
+            local_density_coefficient=high.local_density_coefficient * scale,
+            global_carrying_capacity=high.global_carrying_capacity,
+            global_carrying_capacity_coefficient=high.global_carrying_capacity_coefficient * scale,
+        )
+    raise TypeError(
+        f"selection_pressure must be a str preset or float in [0, 1]; "
+        f"got {type(selection_pressure).__name__!r}."
+    )
 
 
 @dataclass(frozen=True)
@@ -73,6 +144,15 @@ class IntrinsicEvolutionPolicy:
             ``None`` means unbounded.
         seed: Optional seed for the policy's RNG; when ``None`` the runner
             seeds from its own configured seed.
+        selection_pressure: Convenience knob that sets density-dependent
+            reproduction costs.  Accepts a named preset (``"none"``,
+            ``"low"``, ``"medium"``, ``"high"``) or a float in *[0, 1]*
+            that scales the ``"high"`` preset's coefficients.  When set,
+            ``reproduction_pressure`` is derived automatically and any
+            explicit ``reproduction_pressure`` value is ignored.  When
+            ``None`` (default), ``reproduction_pressure`` is used as-is.
+        reproduction_pressure: Fine-grained density-dependent cost config.
+            Ignored when ``selection_pressure`` is not ``None``.
     """
 
     enabled: bool = True
@@ -91,6 +171,10 @@ class IntrinsicEvolutionPolicy:
     coparent_strategy: CoparentStrategy = "nearest_alive_same_type"
     coparent_max_radius: Optional[float] = None
     seed: Optional[int] = None
+    selection_pressure: Union[SelectionPressurePreset, float, None] = None
+    reproduction_pressure: ReproductionPressureConfig = field(
+        default_factory=ReproductionPressureConfig
+    )
 
     def __post_init__(self) -> None:
         if not 0.0 <= self.mutation_rate <= 1.0:
@@ -117,6 +201,10 @@ class IntrinsicEvolutionPolicy:
             raise ValueError(
                 "coparent_strategy must be 'nearest_alive_same_type' or 'random_alive_same_type'."
             )
+        # Derive reproduction_pressure from the selection_pressure preset/scale when set.
+        if self.selection_pressure is not None:
+            derived = _preset_or_scale_to_pressure_config(self.selection_pressure)
+            object.__setattr__(self, "reproduction_pressure", derived)
 
 
 @dataclass(frozen=True)
@@ -227,6 +315,9 @@ class IntrinsicEvolutionExperiment:
         latest_population = 0
         latest_gene_statistics: Dict[str, Dict[str, float]] = {}
 
+        # Track agent IDs from the previous step to compute birth/death rates.
+        prev_agent_ids: set = set()
+
         def _capture_current_state(environment: Any, step: int) -> None:
             """Capture the same state we emit to the trajectory logger.
 
@@ -248,16 +339,85 @@ class IntrinsicEvolutionExperiment:
                 evolvable_only=True,
             )
 
+        def _compute_step_telemetry(
+            environment: Any, prev_ids: set
+        ) -> Dict[str, Any]:
+            """Compute selection-pressure telemetry for the current step.
+
+            Returns a dict of extra fields for the trajectory record:
+            - ``mean_reproduction_cost``: average effective reproduction cost
+              over alive agents (using the current density).
+            - ``realized_birth_rate``: births / previous population (0 when
+              the previous population was 0).
+            - ``realized_death_rate``: deaths / previous population (0 when
+              the previous population was 0).
+            - ``effective_selection_strength``: coefficient of variation (std /
+              mean) of per-agent effective reproduction costs; a proxy for the
+              opportunity-for-selection imposed by density-dependent costs.
+            """
+            from farm.core.agent.core import _compute_effective_reproduction_cost  # local import to avoid circularity
+
+            alive_agents = list(environment.alive_agent_objects)
+            current_ids = {getattr(a, "agent_id", None) for a in alive_agents}
+
+            prev_pop = len(prev_ids)
+            births = len(current_ids - prev_ids)
+            deaths = len(prev_ids - current_ids)
+
+            realized_birth_rate = births / prev_pop if prev_pop > 0 else 0.0
+            realized_death_rate = deaths / prev_pop if prev_pop > 0 else 0.0
+
+            # Per-agent effective reproduction costs for alive agents.
+            effective_costs: List[float] = []
+            for agent in alive_agents:
+                repro_comp = (
+                    agent.get_component("reproduction")
+                    if callable(getattr(agent, "get_component", None))
+                    else None
+                )
+                if repro_comp is None:
+                    continue
+                base = getattr(getattr(repro_comp, "config", None), "offspring_cost", 0.0)
+                effective_costs.append(_compute_effective_reproduction_cost(agent, base))
+
+            if effective_costs:
+                import statistics
+
+                mean_cost = statistics.mean(effective_costs)
+                if len(effective_costs) > 1 and mean_cost > 0:
+                    std_cost = statistics.stdev(effective_costs)
+                    sel_strength = std_cost / mean_cost
+                else:
+                    sel_strength = 0.0
+            else:
+                mean_cost = 0.0
+                sel_strength = 0.0
+
+            return {
+                "mean_reproduction_cost": mean_cost,
+                "realized_birth_rate": realized_birth_rate,
+                "realized_death_rate": realized_death_rate,
+                "effective_selection_strength": sel_strength,
+            }
+
         def _on_environment_ready(environment: Any) -> None:
+            nonlocal prev_agent_ids
             environment.intrinsic_evolution_policy = policy
             environment.intrinsic_evolution_rng = rng
             seed_population_diversity(environment, policy, rng)
+            # At step 0 there is no previous step, so birth/death rates are 0.
+            alive_agents = list(environment.alive_agent_objects)
+            prev_agent_ids = {getattr(a, "agent_id", None) for a in alive_agents}
             gene_logger.snapshot(environment, step=0)
             _capture_current_state(environment, step=0)
 
         def _on_step_end(environment: Any, step: int) -> None:
+            nonlocal prev_agent_ids
             logical_step = step + 1
-            gene_logger.snapshot(environment, step=logical_step)
+            extra = _compute_step_telemetry(environment, prev_agent_ids)
+            alive_agents = list(environment.alive_agent_objects)
+            prev_agent_ids = {getattr(a, "agent_id", None) for a in alive_agents}
+            gene_logger.snapshot(environment, step=logical_step, extra_fields=extra)
             _capture_current_state(environment, step=logical_step)
 
         try:

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Literal, Optional, Union
 
 from farm.config import SimulationConfig
 from farm.core.agent.config.component_configs import ReproductionPressureConfig
-from farm.core.agent.core import _compute_effective_reproduction_cost
+from farm.core.agent.core import compute_effective_reproduction_cost
 from farm.core.hyperparameter_chromosome import (
     BoundaryMode,
     CrossoverMode,
@@ -376,18 +376,26 @@ class IntrinsicEvolutionExperiment:
             realized_birth_rate = births / prev_pop if prev_pop > 0 else 0.0
             realized_death_rate = deaths / prev_pop if prev_pop > 0 else 0.0
 
-            # Per-agent effective reproduction costs for alive agents.
+            # Per-agent effective reproduction costs — only computed when at
+            # least one pressure coefficient is non-zero, to avoid O(N) spatial
+            # neighbour queries on every step when pressure is disabled.
+            pressure = getattr(policy, "reproduction_pressure", None)
+            pressure_active = pressure is not None and (
+                getattr(pressure, "local_density_coefficient", 0.0) > 0.0
+                or getattr(pressure, "global_carrying_capacity_coefficient", 0.0) > 0.0
+            )
             effective_costs: List[float] = []
-            for agent in alive_agents:
-                repro_comp = (
-                    agent.get_component("reproduction")
-                    if callable(getattr(agent, "get_component", None))
-                    else None
-                )
-                if repro_comp is None:
-                    continue
-                base = getattr(getattr(repro_comp, "config", None), "offspring_cost", 0.0)
-                effective_costs.append(_compute_effective_reproduction_cost(agent, base))
+            if pressure_active:
+                for agent in alive_agents:
+                    repro_comp = (
+                        agent.get_component("reproduction")
+                        if callable(getattr(agent, "get_component", None))
+                        else None
+                    )
+                    if repro_comp is None:
+                        continue
+                    base = getattr(getattr(repro_comp, "config", None), "offspring_cost", 0.0)
+                    effective_costs.append(compute_effective_reproduction_cost(agent, base))
 
             if effective_costs:
                 import statistics

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -439,9 +439,11 @@ class TestEffectiveReproductionCost(unittest.TestCase):
         policy = IntrinsicEvolutionPolicy(reproduction_pressure=pressure)
 
         agent = SimpleNamespace(position=(0.0, 0.0))
-        # Build fake nearby agents (excluding self via 'a is not agent')
-        nearby_agents = [SimpleNamespace() for _ in range(n_nearby + 1)]  # +1 self
-        nearby_agents[0] = agent  # first is self
+        # Build fake nearby agents (includes self as the first item so that the
+        # 'a is not agent' filter in _compute_effective_reproduction_cost
+        # correctly yields n_nearby neighbours).
+        nearby_agents = [SimpleNamespace() for _ in range(n_nearby + 1)]
+        nearby_agents[0] = agent  # first slot is self
 
         alive = [SimpleNamespace() for _ in range(pop)]
 
@@ -531,10 +533,15 @@ class TestTrajectoryTelemetryFields(unittest.TestCase):
         agents = [_make_fake_agent(0.01) for _ in range(num_agents)]
 
         # Add get_component stub so telemetry computation works.
+        def _make_get_component(rc):
+            def _get_component(name):
+                return rc if name == "reproduction" else None
+            return _get_component
+
         for agent in agents:
             repro_cfg = SimpleNamespace(offspring_cost=5.0)
             repro_comp = SimpleNamespace(config=repro_cfg)
-            agent.get_component = lambda name, rc=repro_comp: rc if name == "reproduction" else None
+            agent.get_component = _make_get_component(repro_comp)
             agent.position = (0.0, 0.0)
             agent.environment = None  # No density adjustment for simple test
 

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -423,7 +423,7 @@ class TestSelectionPressurePresets(unittest.TestCase):
 
 
 class TestEffectiveReproductionCost(unittest.TestCase):
-    """Tests for _compute_effective_reproduction_cost."""
+    """Tests for compute_effective_reproduction_cost."""
 
     def _make_agent_with_env(self, n_nearby: int = 0, pop: int = 10):
         """Build a minimal agent with a fake environment for cost computation."""
@@ -440,7 +440,7 @@ class TestEffectiveReproductionCost(unittest.TestCase):
 
         agent = SimpleNamespace(position=(0.0, 0.0))
         # Build fake nearby agents (includes self as the first item so that the
-        # 'a is not agent' filter in _compute_effective_reproduction_cost
+        # 'a is not agent' filter in compute_effective_reproduction_cost
         # correctly yields n_nearby neighbours).
         nearby_agents = [SimpleNamespace() for _ in range(n_nearby + 1)]
         nearby_agents[0] = agent  # first slot is self
@@ -456,7 +456,7 @@ class TestEffectiveReproductionCost(unittest.TestCase):
         return agent
 
     def test_zero_pressure_returns_base_cost(self):
-        from farm.core.agent.core import _compute_effective_reproduction_cost
+        from farm.core.agent.core import compute_effective_reproduction_cost
 
         policy = IntrinsicEvolutionPolicy(selection_pressure="none")
         agent = SimpleNamespace(
@@ -467,44 +467,44 @@ class TestEffectiveReproductionCost(unittest.TestCase):
                 alive_agent_objects=[],
             ),
         )
-        cost = _compute_effective_reproduction_cost(agent, base_cost=5.0)
+        cost = compute_effective_reproduction_cost(agent, base_cost=5.0)
         self.assertEqual(cost, 5.0)
 
     def test_local_density_increases_cost(self):
-        from farm.core.agent.core import _compute_effective_reproduction_cost
+        from farm.core.agent.core import compute_effective_reproduction_cost
 
         agent = self._make_agent_with_env(n_nearby=3, pop=10)
-        cost = _compute_effective_reproduction_cost(agent, base_cost=5.0)
+        cost = compute_effective_reproduction_cost(agent, base_cost=5.0)
         # 5.0 + 1.0*3 + 0.5*5.0*(10/100) = 5.0 + 3.0 + 0.25 = 8.25
         self.assertGreater(cost, 5.0)
         self.assertAlmostEqual(cost, 5.0 + 1.0 * 3 + 0.5 * 5.0 * (10 / 100), places=6)
 
     def test_no_environment_returns_base_cost(self):
-        from farm.core.agent.core import _compute_effective_reproduction_cost
+        from farm.core.agent.core import compute_effective_reproduction_cost
 
         agent = SimpleNamespace(environment=None)
-        self.assertEqual(_compute_effective_reproduction_cost(agent, 5.0), 5.0)
+        self.assertEqual(compute_effective_reproduction_cost(agent, 5.0), 5.0)
 
     def test_no_policy_returns_base_cost(self):
-        from farm.core.agent.core import _compute_effective_reproduction_cost
+        from farm.core.agent.core import compute_effective_reproduction_cost
 
         agent = SimpleNamespace(
             environment=SimpleNamespace(intrinsic_evolution_policy=None)
         )
-        self.assertEqual(_compute_effective_reproduction_cost(agent, 5.0), 5.0)
+        self.assertEqual(compute_effective_reproduction_cost(agent, 5.0), 5.0)
 
     def test_disabled_policy_returns_base_cost(self):
-        from farm.core.agent.core import _compute_effective_reproduction_cost
+        from farm.core.agent.core import compute_effective_reproduction_cost
 
         policy = IntrinsicEvolutionPolicy(enabled=False)
         agent = SimpleNamespace(
             environment=SimpleNamespace(intrinsic_evolution_policy=policy)
         )
-        self.assertEqual(_compute_effective_reproduction_cost(agent, 5.0), 5.0)
+        self.assertEqual(compute_effective_reproduction_cost(agent, 5.0), 5.0)
 
     def test_carrying_capacity_term_alone(self):
         from farm.core.agent.config.component_configs import ReproductionPressureConfig
-        from farm.core.agent.core import _compute_effective_reproduction_cost
+        from farm.core.agent.core import compute_effective_reproduction_cost
 
         pressure = ReproductionPressureConfig(
             local_density_coefficient=0.0,
@@ -521,7 +521,7 @@ class TestEffectiveReproductionCost(unittest.TestCase):
                 alive_agent_objects=pop_count,
             ),
         )
-        cost = _compute_effective_reproduction_cost(agent, base_cost=10.0)
+        cost = compute_effective_reproduction_cost(agent, base_cost=10.0)
         # 10.0 + 1.0 * 10.0 * (25/50) = 10.0 + 5.0 = 15.0
         self.assertAlmostEqual(cost, 15.0, places=6)
 

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -323,5 +323,288 @@ class TestRunnerOrchestration(unittest.TestCase):
         self.assertEqual(result.num_steps_completed, 1)
 
 
+class TestReproductionPressureConfig(unittest.TestCase):
+    """Tests for the ReproductionPressureConfig dataclass."""
+
+    def test_defaults_are_all_zero(self):
+        from farm.core.agent.config.component_configs import ReproductionPressureConfig
+
+        cfg = ReproductionPressureConfig()
+        self.assertEqual(cfg.local_density_coefficient, 0.0)
+        self.assertEqual(cfg.global_carrying_capacity, 0)
+        self.assertEqual(cfg.global_carrying_capacity_coefficient, 0.0)
+
+    def test_custom_values_round_trip(self):
+        from farm.core.agent.config.component_configs import ReproductionPressureConfig
+
+        cfg = ReproductionPressureConfig(
+            local_density_radius=10.0,
+            local_density_coefficient=1.5,
+            global_carrying_capacity=200,
+            global_carrying_capacity_coefficient=0.8,
+        )
+        self.assertEqual(cfg.local_density_radius, 10.0)
+        self.assertEqual(cfg.local_density_coefficient, 1.5)
+        self.assertEqual(cfg.global_carrying_capacity, 200)
+        self.assertEqual(cfg.global_carrying_capacity_coefficient, 0.8)
+
+
+class TestSelectionPressurePresets(unittest.TestCase):
+    """Tests for the selection_pressure preset knob on IntrinsicEvolutionPolicy."""
+
+    def test_none_preset_string_sets_zero_coefficients(self):
+        policy = IntrinsicEvolutionPolicy(selection_pressure="none")
+        self.assertEqual(policy.reproduction_pressure.local_density_coefficient, 0.0)
+        self.assertEqual(policy.reproduction_pressure.global_carrying_capacity_coefficient, 0.0)
+
+    def test_low_preset_string(self):
+        policy = IntrinsicEvolutionPolicy(selection_pressure="low")
+        self.assertGreater(policy.reproduction_pressure.local_density_coefficient, 0.0)
+
+    def test_medium_preset_string(self):
+        policy = IntrinsicEvolutionPolicy(selection_pressure="medium")
+        p = policy.reproduction_pressure
+        self.assertGreater(p.local_density_coefficient, 0.0)
+        self.assertGreater(p.global_carrying_capacity, 0)
+
+    def test_high_preset_string(self):
+        policy = IntrinsicEvolutionPolicy(selection_pressure="high")
+        p = policy.reproduction_pressure
+        self.assertGreater(p.local_density_coefficient, 0.0)
+        self.assertGreater(p.global_carrying_capacity, 0)
+
+    def test_low_pressure_less_than_high(self):
+        low = IntrinsicEvolutionPolicy(selection_pressure="low")
+        high = IntrinsicEvolutionPolicy(selection_pressure="high")
+        self.assertLess(
+            low.reproduction_pressure.local_density_coefficient,
+            high.reproduction_pressure.local_density_coefficient,
+        )
+
+    def test_float_zero_equals_none_preset(self):
+        p_float = IntrinsicEvolutionPolicy(selection_pressure=0.0)
+        p_none = IntrinsicEvolutionPolicy(selection_pressure="none")
+        self.assertEqual(
+            p_float.reproduction_pressure.local_density_coefficient,
+            p_none.reproduction_pressure.local_density_coefficient,
+        )
+
+    def test_float_one_equals_high_preset(self):
+        p_float = IntrinsicEvolutionPolicy(selection_pressure=1.0)
+        p_high = IntrinsicEvolutionPolicy(selection_pressure="high")
+        self.assertEqual(
+            p_float.reproduction_pressure.local_density_coefficient,
+            p_high.reproduction_pressure.local_density_coefficient,
+        )
+
+    def test_float_out_of_range_raises(self):
+        with self.assertRaises(ValueError):
+            IntrinsicEvolutionPolicy(selection_pressure=1.5)
+        with self.assertRaises(ValueError):
+            IntrinsicEvolutionPolicy(selection_pressure=-0.1)
+
+    def test_unknown_preset_string_raises(self):
+        with self.assertRaises(ValueError):
+            IntrinsicEvolutionPolicy(selection_pressure="ultra")
+
+    def test_default_no_selection_pressure(self):
+        """Default policy has zero density-dependent cost."""
+        policy = IntrinsicEvolutionPolicy()
+        self.assertIsNone(policy.selection_pressure)
+        self.assertEqual(policy.reproduction_pressure.local_density_coefficient, 0.0)
+
+    def test_explicit_reproduction_pressure_respected_when_no_preset(self):
+        """When selection_pressure=None, explicit reproduction_pressure is used."""
+        from farm.core.agent.config.component_configs import ReproductionPressureConfig
+
+        custom = ReproductionPressureConfig(local_density_coefficient=3.0)
+        policy = IntrinsicEvolutionPolicy(reproduction_pressure=custom)
+        self.assertEqual(policy.reproduction_pressure.local_density_coefficient, 3.0)
+
+
+class TestEffectiveReproductionCost(unittest.TestCase):
+    """Tests for _compute_effective_reproduction_cost."""
+
+    def _make_agent_with_env(self, n_nearby: int = 0, pop: int = 10):
+        """Build a minimal agent with a fake environment for cost computation."""
+        from farm.core.agent.config.component_configs import ReproductionPressureConfig
+        from farm.runners.intrinsic_evolution_experiment import IntrinsicEvolutionPolicy
+
+        pressure = ReproductionPressureConfig(
+            local_density_radius=5.0,
+            local_density_coefficient=1.0,
+            global_carrying_capacity=100,
+            global_carrying_capacity_coefficient=0.5,
+        )
+        policy = IntrinsicEvolutionPolicy(reproduction_pressure=pressure)
+
+        agent = SimpleNamespace(position=(0.0, 0.0))
+        # Build fake nearby agents (excluding self via 'a is not agent')
+        nearby_agents = [SimpleNamespace() for _ in range(n_nearby + 1)]  # +1 self
+        nearby_agents[0] = agent  # first is self
+
+        alive = [SimpleNamespace() for _ in range(pop)]
+
+        env = SimpleNamespace(
+            intrinsic_evolution_policy=policy,
+            get_nearby_agents=lambda pos, radius: nearby_agents,
+            alive_agent_objects=alive,
+        )
+        agent.environment = env
+        return agent
+
+    def test_zero_pressure_returns_base_cost(self):
+        from farm.core.agent.core import _compute_effective_reproduction_cost
+
+        policy = IntrinsicEvolutionPolicy(selection_pressure="none")
+        agent = SimpleNamespace(
+            position=(0.0, 0.0),
+            environment=SimpleNamespace(
+                intrinsic_evolution_policy=policy,
+                get_nearby_agents=lambda pos, r: [],
+                alive_agent_objects=[],
+            ),
+        )
+        cost = _compute_effective_reproduction_cost(agent, base_cost=5.0)
+        self.assertEqual(cost, 5.0)
+
+    def test_local_density_increases_cost(self):
+        from farm.core.agent.core import _compute_effective_reproduction_cost
+
+        agent = self._make_agent_with_env(n_nearby=3, pop=10)
+        cost = _compute_effective_reproduction_cost(agent, base_cost=5.0)
+        # 5.0 + 1.0*3 + 0.5*5.0*(10/100) = 5.0 + 3.0 + 0.25 = 8.25
+        self.assertGreater(cost, 5.0)
+        self.assertAlmostEqual(cost, 5.0 + 1.0 * 3 + 0.5 * 5.0 * (10 / 100), places=6)
+
+    def test_no_environment_returns_base_cost(self):
+        from farm.core.agent.core import _compute_effective_reproduction_cost
+
+        agent = SimpleNamespace(environment=None)
+        self.assertEqual(_compute_effective_reproduction_cost(agent, 5.0), 5.0)
+
+    def test_no_policy_returns_base_cost(self):
+        from farm.core.agent.core import _compute_effective_reproduction_cost
+
+        agent = SimpleNamespace(
+            environment=SimpleNamespace(intrinsic_evolution_policy=None)
+        )
+        self.assertEqual(_compute_effective_reproduction_cost(agent, 5.0), 5.0)
+
+    def test_disabled_policy_returns_base_cost(self):
+        from farm.core.agent.core import _compute_effective_reproduction_cost
+
+        policy = IntrinsicEvolutionPolicy(enabled=False)
+        agent = SimpleNamespace(
+            environment=SimpleNamespace(intrinsic_evolution_policy=policy)
+        )
+        self.assertEqual(_compute_effective_reproduction_cost(agent, 5.0), 5.0)
+
+    def test_carrying_capacity_term_alone(self):
+        from farm.core.agent.config.component_configs import ReproductionPressureConfig
+        from farm.core.agent.core import _compute_effective_reproduction_cost
+
+        pressure = ReproductionPressureConfig(
+            local_density_coefficient=0.0,
+            global_carrying_capacity=50,
+            global_carrying_capacity_coefficient=1.0,
+        )
+        policy = IntrinsicEvolutionPolicy(reproduction_pressure=pressure)
+        pop_count = [SimpleNamespace()] * 25  # pop / K = 0.5
+        agent = SimpleNamespace(
+            position=(0.0, 0.0),
+            environment=SimpleNamespace(
+                intrinsic_evolution_policy=policy,
+                get_nearby_agents=lambda pos, r: [],
+                alive_agent_objects=pop_count,
+            ),
+        )
+        cost = _compute_effective_reproduction_cost(agent, base_cost=10.0)
+        # 10.0 + 1.0 * 10.0 * (25/50) = 10.0 + 5.0 = 15.0
+        self.assertAlmostEqual(cost, 15.0, places=6)
+
+
+class TestTrajectoryTelemetryFields(unittest.TestCase):
+    """Tests for the new selection-pressure telemetry in trajectory records."""
+
+    def _stub_run_simulation(self, num_agents: int = 4, num_steps: int = 3):
+        agents = [_make_fake_agent(0.01) for _ in range(num_agents)]
+
+        # Add get_component stub so telemetry computation works.
+        for agent in agents:
+            repro_cfg = SimpleNamespace(offspring_cost=5.0)
+            repro_comp = SimpleNamespace(config=repro_cfg)
+            agent.get_component = lambda name, rc=repro_comp: rc if name == "reproduction" else None
+            agent.position = (0.0, 0.0)
+            agent.environment = None  # No density adjustment for simple test
+
+        env = _FakeEnvironment(agents)
+
+        def _side_effect(*args, **kwargs):
+            on_environment_ready = kwargs.get("on_environment_ready")
+            on_step_end = kwargs.get("on_step_end")
+            if on_environment_ready is not None:
+                on_environment_ready(env)
+            for step in range(num_steps):
+                env.time = step + 1
+                if on_step_end is not None:
+                    on_step_end(env, step)
+            env.time += 1
+            return env
+
+        return _side_effect, env
+
+    def test_trajectory_records_contain_telemetry_fields(self):
+        side_effect, _env = self._stub_run_simulation(num_agents=3, num_steps=3)
+        with tempfile.TemporaryDirectory() as output_dir, patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation",
+            side_effect=side_effect,
+        ):
+            cfg = IntrinsicEvolutionExperimentConfig(
+                num_steps=3,
+                snapshot_interval=3,
+                output_dir=output_dir,
+                seed=5,
+            )
+            IntrinsicEvolutionExperiment(SimulationConfig(), cfg).run()
+
+            traj_path = os.path.join(output_dir, "intrinsic_gene_trajectory.jsonl")
+            with open(traj_path, encoding="utf-8") as fh:
+                lines = [json.loads(line) for line in fh if line.strip()]
+
+        # Step 0 record (from on_environment_ready) has no extra fields.
+        step0 = lines[0]
+        self.assertIn("step", step0)
+        # Step 1+ records must carry the new telemetry fields.
+        for record in lines[1:]:
+            self.assertIn("mean_reproduction_cost", record)
+            self.assertIn("realized_birth_rate", record)
+            self.assertIn("realized_death_rate", record)
+            self.assertIn("effective_selection_strength", record)
+
+    def test_stable_population_has_zero_birth_and_death_rates(self):
+        """When population is unchanged between steps, rates should be 0."""
+        side_effect, _env = self._stub_run_simulation(num_agents=3, num_steps=2)
+        with tempfile.TemporaryDirectory() as output_dir, patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation",
+            side_effect=side_effect,
+        ):
+            cfg = IntrinsicEvolutionExperimentConfig(
+                num_steps=2,
+                snapshot_interval=5,
+                output_dir=output_dir,
+                seed=9,
+            )
+            IntrinsicEvolutionExperiment(SimulationConfig(), cfg).run()
+
+            traj_path = os.path.join(output_dir, "intrinsic_gene_trajectory.jsonl")
+            with open(traj_path, encoding="utf-8") as fh:
+                lines = [json.loads(line) for line in fh if line.strip()]
+
+        for record in lines[1:]:  # skip step 0
+            self.assertAlmostEqual(record["realized_birth_rate"], 0.0)
+            self.assertAlmostEqual(record["realized_death_rate"], 0.0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request introduces a configurable selection pressure mechanism for intrinsic evolution experiments, allowing users to control density-dependent reproduction costs via simple presets or fine-grained parameters. The changes add a new `ReproductionPressureConfig`, update the agent reproduction logic to support density-dependent costs, and expose these options through the `IntrinsicEvolutionPolicy`. Additionally, telemetry fields and documentation are updated to reflect these enhancements.

**Selection pressure and density-dependent reproduction cost:**

* Added `ReproductionPressureConfig` dataclass to encapsulate local and global density-dependent reproduction cost parameters, with all coefficients defaulting to zero for backward compatibility (`farm/core/agent/config/component_configs.py`).
* Implemented `_compute_effective_reproduction_cost` function and integrated it into the agent's `reproduce()` method, so reproduction cost now accounts for local neighbor density and global carrying capacity when configured (`farm/core/agent/core.py`). [[1]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393R40-R96) [[2]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393R825-R831) [[3]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393L776-R861)

**Runner and policy configuration:**

* Extended `IntrinsicEvolutionPolicy` with a new `selection_pressure` field, which can be set to a preset ("none", "low", "medium", "high") or a float in [0, 1], and added logic to derive `reproduction_pressure` from this preset or scale. Also exposed these options in the runner API (`farm/runners/intrinsic_evolution_experiment.py`, `farm/runners/__init__.py`). [[1]](diffhunk://#diff-7df2829374038ce4ba23f7d77ce0f8c289eb1ff9b3959afc3c853239c703ec5eR41-R110) [[2]](diffhunk://#diff-7df2829374038ce4ba23f7d77ce0f8c289eb1ff9b3959afc3c853239c703ec5eR148-R156) [[3]](diffhunk://#diff-7df2829374038ce4ba23f7d77ce0f8c289eb1ff9b3959afc3c853239c703ec5eR175-R178) [[4]](diffhunk://#diff-7df2829374038ce4ba23f7d77ce0f8c289eb1ff9b3959afc3c853239c703ec5eR205-R208) [[5]](diffhunk://#diff-c8139a827bd991793bde210cf38e1257269e4a1665fe89dcc4aa8823325337b4R26-R31) [[6]](diffhunk://#diff-c8139a827bd991793bde210cf38e1257269e4a1665fe89dcc4aa8823325337b4R51-R54)

**Telemetry and logging:**

* Updated the gene trajectory logger to accept and store additional telemetry fields (e.g., mean reproduction cost, birth/death rates, selection strength) for each simulation step (`farm/runners/gene_trajectory_logger.py`). [[1]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70L56-R69) [[2]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R87-R88)

**Documentation and testing:**

* Expanded documentation to describe the selection pressure options, their effects, and the new telemetry fields. Updated the testing section to cover the new configuration and telemetry contract (`docs/experiments/intrinsic_evolution.md`). [[1]](diffhunk://#diff-f8f1cf3d39bba02a52815918226df4a0245877364494e01281b047791334226dR153-R154) [[2]](diffhunk://#diff-f8f1cf3d39bba02a52815918226df4a0245877364494e01281b047791334226dL256-R352)

**Public API exposure:**

* Re-exported `ReproductionPressureConfig` and updated `__all__` in `farm/core/agent/config/__init__.py` to make the new config available for import. [[1]](diffhunk://#diff-6f1052efc4ad84919101e7a33f82c6b026c8e1852e47c62f6db9e6e55e90e686R11) [[2]](diffhunk://#diff-6f1052efc4ad84919101e7a33f82c6b026c8e1852e47c62f6db9e6e55e90e686R23)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `AgentCore.reproduce()` resource deduction logic and adds new policy/config knobs that can change population dynamics when enabled, though defaults preserve legacy behavior (zero coefficients / policy gating). Main risk is unexpected reproduction-rate shifts or telemetry/schema assumptions in downstream analysis.
> 
> **Overview**
> Adds density-dependent reproduction cost to intrinsic evolution via new `ReproductionPressureConfig` and a `selection_pressure` convenience knob (presets or 0–1 scaling) on `IntrinsicEvolutionPolicy`, which derives `reproduction_pressure` automatically when set.
> 
> `AgentCore.reproduce()` now deducts an *effective* offspring cost computed from local neighbor density and/or global carrying capacity when an enabled intrinsic-evolution policy is attached.
> 
> Extends per-step trajectory logging to accept runner-provided `extra_fields`, and the intrinsic runner now records selection-pressure telemetry (`mean_reproduction_cost`, realized birth/death rates, and an effective selection-strength proxy). Documentation and tests are expanded accordingly, and `ReproductionPressureConfig`/intrinsic runner symbols are re-exported for public use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9983f1eff2d2e85bbaa5bc2d57e2f6bead81f66. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->