### PR TITLE
Add intrinsic lineage tree visualization and related analysis tools

### DIFF
--- a/docs/experiments/intrinsic_evolution.md
+++ b/docs/experiments/intrinsic_evolution.md
@@ -342,9 +342,66 @@ Example trajectory record with pressure active:
 }
 ```
 
+## Lineage tree visualization
+
+The `intrinsic_gene_snapshots.jsonl` artifact contains everything needed to
+reconstruct a full lineage DAG for any intrinsic run.  The
+`farm.analysis.phylogenetics` module provides a first-class loader and plot
+helper.
+
+### Quick start
+
+```python
+from farm.analysis.phylogenetics import (
+    build_intrinsic_lineage_dag,
+    extract_chromosomes_from_snapshots,
+    load_intrinsic_snapshots,
+    compute_surviving_lineage_count_over_time,
+    compute_lineage_depth_over_time,
+    plot_intrinsic_lineage_tree,
+)
+from farm.analysis.common.context import AnalysisContext
+import pathlib
+
+# Build the lineage DAG from a run directory (or direct file path)
+tree = build_intrinsic_lineage_dag("experiments/my_intrinsic_run")
+
+# Summary statistics
+s = tree.summary()
+print(f"Nodes: {s.num_nodes}, max depth: {s.max_depth}, is_dag: {tree.is_dag}")
+
+# Per-step surviving-lineage count and depth
+snaps = load_intrinsic_snapshots("experiments/my_intrinsic_run")
+lineage_counts  = compute_surviving_lineage_count_over_time(tree, snaps)
+depth_over_time = compute_lineage_depth_over_time(tree, snaps)
+
+# Plot – colour nodes by learning_rate chromosome value
+chromosomes = extract_chromosomes_from_snapshots(snaps)
+ctx = AnalysisContext(output_path=pathlib.Path("experiments/my_intrinsic_run"))
+plot_intrinsic_lineage_tree(tree, ctx, gene="learning_rate", chromosomes=chromosomes)
+```
+
+See [`notebooks/intrinsic_lineage_tree.ipynb`](../../notebooks/intrinsic_lineage_tree.ipynb)
+for a full walkthrough including synthetic fixture data that runs without a
+real experiment on disk.
+
+### API reference
+
+| Function | Description |
+| --- | --- |
+| `load_intrinsic_snapshots(path)` | Parse JSONL; return list of step dicts. |
+| `flatten_snapshots_to_agent_records(snaps)` | Deduplicate agents; infer `birth_time` / `death_time`. |
+| `build_intrinsic_lineage_dag(path)` | One-stop loader → DAG builder. |
+| `extract_chromosomes_from_snapshots(snaps)` | `agent_id → chromosome` dict (last-seen values). |
+| `compute_surviving_lineage_count_over_time(tree, snaps)` | List of `(step, count)` tuples. |
+| `compute_lineage_depth_over_time(tree, snaps)` | List of `(step, max_depth, mean_depth)` tuples. |
+| `plot_intrinsic_lineage_tree(tree, ctx, *, gene, chromosomes, …)` | Layered dendrogram; optional gene-value colouring. |
+
+The `PhylogeneticTree` object returned by `build_intrinsic_lineage_dag` also
+supports `.to_json()` and `.to_newick()` export for external tree viewers.
+
 ## Out of scope (for now)
 
-- Lineage tree visualization. The snapshot file makes this a notebook job.
 - Speciation / niche detection.
 
 ## Testing
@@ -352,3 +409,4 @@ Example trajectory record with pressure active:
 - [`tests/runners/test_intrinsic_evolution_experiment.py`](../../tests/runners/test_intrinsic_evolution_experiment.py): policy / config validation, `seed_population_diversity`, runner orchestration with mocked `run_simulation`, artifact persistence, `ReproductionPressureConfig` validation, `selection_pressure` presets (none/low/medium/high/float), `_compute_effective_reproduction_cost` unit tests, trajectory telemetry field presence, and zero birth/death rates for stable populations.
 - [`tests/core/agent/test_reproduce_chromosome_policy.py`](../../tests/core/agent/test_reproduce_chromosome_policy.py): no-policy passthrough, mutation path, co-parent selection (nearest, random, radius, type-filter, alive-filter), crossover end-to-end.
 - [`tests/test_agent_reproduction_hyperparameters.py`](../../tests/test_agent_reproduction_hyperparameters.py): updated to assert the new contract (no policy = inheritance unchanged).
+- [`tests/analysis/test_intrinsic_lineage.py`](../../tests/analysis/test_intrinsic_lineage.py): `load_intrinsic_snapshots`, `flatten_snapshots_to_agent_records`, `build_intrinsic_lineage_dag`, `compute_surviving_lineage_count_over_time`, `compute_lineage_depth_over_time`, `extract_chromosomes_from_snapshots`, `plot_intrinsic_lineage_tree` (with and without gene colouring).

--- a/farm/analysis/phylogenetics/__init__.py
+++ b/farm/analysis/phylogenetics/__init__.py
@@ -11,6 +11,9 @@ Features
 - JSON export (full tree/DAG) and Newick export (single-parent projection)
 - Summary statistics: depth, branching factor, lineage survival
 - Matplotlib visualisation integrated with the ``farm/charts/``-style API
+- Intrinsic-evolution loader: parse ``intrinsic_gene_snapshots.jsonl`` into a
+  lineage DAG; per-gene coloured tree plot; surviving-lineage and depth
+  statistics over time.
 
 Quick Start::
 
@@ -22,6 +25,17 @@ Quick Start::
     ...     PhylogeneticTreeSummary,
     ...     analyze_phylogenetics,
     ...     plot_phylogenetic_tree,
+    ... )
+
+Intrinsic-evolution quick start::
+
+    >>> from farm.analysis.phylogenetics import (
+    ...     build_intrinsic_lineage_dag,
+    ...     plot_intrinsic_lineage_tree,
+    ...     compute_surviving_lineage_count_over_time,
+    ...     compute_lineage_depth_over_time,
+    ...     load_intrinsic_snapshots,
+    ...     extract_chromosomes_from_snapshots,
     ... )
 
 Two-parent (DAG) note
@@ -41,8 +55,16 @@ from farm.analysis.phylogenetics.compute import (
     build_phylogenetic_tree_from_records,
 )
 from farm.analysis.phylogenetics.analyze import analyze_phylogenetics
-from farm.analysis.phylogenetics.plot import plot_phylogenetic_tree
+from farm.analysis.phylogenetics.plot import plot_phylogenetic_tree, plot_intrinsic_lineage_tree
 from farm.analysis.phylogenetics.module import PhylogeneticsModule, phylogenetics_module
+from farm.analysis.phylogenetics.intrinsic_loader import (
+    load_intrinsic_snapshots,
+    flatten_snapshots_to_agent_records,
+    build_intrinsic_lineage_dag,
+    compute_surviving_lineage_count_over_time,
+    compute_lineage_depth_over_time,
+    extract_chromosomes_from_snapshots,
+)
 
 __all__ = [
     # Data structures
@@ -56,6 +78,14 @@ __all__ = [
     "analyze_phylogenetics",
     # Visualisation
     "plot_phylogenetic_tree",
+    "plot_intrinsic_lineage_tree",
+    # Intrinsic-evolution loader & summaries
+    "load_intrinsic_snapshots",
+    "flatten_snapshots_to_agent_records",
+    "build_intrinsic_lineage_dag",
+    "compute_surviving_lineage_count_over_time",
+    "compute_lineage_depth_over_time",
+    "extract_chromosomes_from_snapshots",
     # Module
     "PhylogeneticsModule",
     "phylogenetics_module",

--- a/farm/analysis/phylogenetics/__init__.py
+++ b/farm/analysis/phylogenetics/__init__.py
@@ -64,6 +64,7 @@ from farm.analysis.phylogenetics.intrinsic_loader import (
     compute_surviving_lineage_count_over_time,
     compute_lineage_depth_over_time,
     extract_chromosomes_from_snapshots,
+    trace_to_founder,
 )
 
 __all__ = [
@@ -86,6 +87,7 @@ __all__ = [
     "compute_surviving_lineage_count_over_time",
     "compute_lineage_depth_over_time",
     "extract_chromosomes_from_snapshots",
+    "trace_to_founder",
     # Module
     "PhylogeneticsModule",
     "phylogenetics_module",

--- a/farm/analysis/phylogenetics/intrinsic_loader.py
+++ b/farm/analysis/phylogenetics/intrinsic_loader.py
@@ -1,0 +1,451 @@
+"""Loader and summary helpers for ``intrinsic_gene_snapshots.jsonl``.
+
+Parses the JSONL artifact written by
+:class:`~farm.runners.gene_trajectory_logger.GeneTrajectoryLogger` and
+constructs a :class:`~farm.analysis.phylogenetics.compute.PhylogeneticTree`
+(really a DAG when two-parent reproduction is active) suitable for
+lineage-tree visualisation.
+
+Each line of ``intrinsic_gene_snapshots.jsonl`` has the shape::
+
+    {
+        "step": <int>,
+        "agents": [
+            {
+                "agent_id": "abc",
+                "agent_type": "system",
+                "generation": 5,
+                "parent_ids": ["parent1"],
+                "chromosome": {"learning_rate": 0.012, "gamma": 0.99, ...}
+            },
+            ...
+        ]
+    }
+
+The loader stitches together all snapshot steps into per-agent records where
+``birth_time`` is the **first snapshot step** the agent appeared in and
+``death_time`` is **None** when the agent was still alive at the final
+snapshot step, or the **next snapshot step** after the last one it appeared
+in (giving an approximate death window).
+
+Public API
+----------
+- :func:`load_intrinsic_snapshots` – parse JSONL; return list of raw dicts.
+- :func:`flatten_snapshots_to_agent_records` – flatten to per-agent records
+  with inferred timing.
+- :func:`build_intrinsic_lineage_dag` – load + flatten + build tree; the
+  one-stop convenience function for notebooks.
+- :func:`compute_surviving_lineage_count_over_time` – per-step lineage count.
+- :func:`compute_lineage_depth_over_time` – per-step depth statistics.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from farm.analysis.phylogenetics.compute import (
+    PhylogeneticTree,
+    build_phylogenetic_tree_from_records,
+)
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Raw file loading
+# ---------------------------------------------------------------------------
+
+
+def load_intrinsic_snapshots(path: str | Path) -> List[Dict[str, Any]]:
+    """Parse ``intrinsic_gene_snapshots.jsonl`` into a list of step dicts.
+
+    Each element of the returned list corresponds to one line (snapshot) in
+    the file and has the form ``{"step": <int>, "agents": [...]}``.  Lines
+    that cannot be parsed as JSON are logged as warnings and skipped.
+
+    Parameters
+    ----------
+    path:
+        Path to the JSONL file (or the directory that contains it; in the
+        latter case the function looks for
+        ``intrinsic_gene_snapshots.jsonl`` inside that directory).
+
+    Returns
+    -------
+    list of dict
+        Snapshot dicts in file order (i.e. ascending step order for a
+        well-formed run).
+    """
+    p = Path(path)
+    if p.is_dir():
+        p = p / "intrinsic_gene_snapshots.jsonl"
+
+    if not p.exists():
+        logger.warning("load_intrinsic_snapshots: file not found: %s", p)
+        return []
+
+    snapshots: List[Dict[str, Any]] = []
+    with p.open("r", encoding="utf-8") as fh:
+        for lineno, line in enumerate(fh, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:
+                logger.warning(
+                    "load_intrinsic_snapshots: skipping malformed line %d in %s: %s",
+                    lineno,
+                    p,
+                    exc,
+                )
+                continue
+            if not isinstance(obj, dict):
+                logger.warning(
+                    "load_intrinsic_snapshots: skipping non-dict line %d in %s",
+                    lineno,
+                    p,
+                )
+                continue
+            snapshots.append(obj)
+
+    logger.info(
+        "load_intrinsic_snapshots: loaded %d snapshot(s) from %s", len(snapshots), p
+    )
+    return snapshots
+
+
+# ---------------------------------------------------------------------------
+# Flattening
+# ---------------------------------------------------------------------------
+
+
+def flatten_snapshots_to_agent_records(
+    snapshots: Sequence[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Flatten per-step snapshot dicts into deduplicated per-agent records.
+
+    Each record in the returned list has the keys::
+
+        agent_id, agent_type, generation, parent_ids,
+        birth_time, death_time, chromosome
+
+    ``birth_time`` is the first snapshot step the agent appeared in.
+
+    ``death_time`` is:
+
+    * ``None`` when the agent was present in the **final** snapshot step
+      (still alive at the end of the run), or
+    * the **next** snapshot step after its last appearance when it was absent
+      from the final snapshot (bounding the death window from above).
+
+    When only one snapshot step exists every agent has ``death_time = None``.
+
+    Parameters
+    ----------
+    snapshots:
+        List of raw snapshot dicts as returned by
+        :func:`load_intrinsic_snapshots`.
+
+    Returns
+    -------
+    list of dict
+        One dict per unique ``agent_id``, suitable for passing to
+        :func:`~farm.analysis.phylogenetics.compute.build_phylogenetic_tree_from_records`
+        with ``id_key="agent_id"``.
+    """
+    if not snapshots:
+        return []
+
+    # Collect steps in sorted order
+    steps: List[int] = sorted(
+        {int(s.get("step", 0)) for s in snapshots if isinstance(s.get("step"), (int, float))}
+    )
+    if not steps:
+        return []
+
+    final_step = steps[-1]
+
+    # Build step -> next_step map (for death_time approximation)
+    next_step: Dict[int, int] = {}
+    for i, step in enumerate(steps[:-1]):
+        next_step[step] = steps[i + 1]
+
+    # Index snapshots by step
+    snap_by_step: Dict[int, Dict[str, Any]] = {}
+    for snap in snapshots:
+        s = int(snap.get("step", 0))
+        snap_by_step[s] = snap
+
+    # Per-agent tracking: first_step, last_step, last_record
+    first_seen: Dict[str, int] = {}
+    last_seen: Dict[str, int] = {}
+    last_record: Dict[str, Dict[str, Any]] = {}
+
+    for step in steps:
+        snap = snap_by_step.get(step, {})
+        agents = snap.get("agents", [])
+        if not isinstance(agents, list):
+            continue
+        for agent in agents:
+            if not isinstance(agent, dict):
+                continue
+            agent_id = agent.get("agent_id")
+            if agent_id is None:
+                continue
+            agent_id = str(agent_id)
+            if agent_id not in first_seen:
+                first_seen[agent_id] = step
+            last_seen[agent_id] = step
+            last_record[agent_id] = agent
+
+    records: List[Dict[str, Any]] = []
+    for agent_id, agent_rec in last_record.items():
+        birth_time = first_seen[agent_id]
+        ls = last_seen[agent_id]
+        if ls == final_step:
+            death_time: Optional[int] = None
+        else:
+            # Approximate: agent died before the next snapshot after its last appearance
+            death_time = next_step.get(ls, ls + 1)
+
+        # Normalise parent_ids: filter out None
+        raw_parents = agent_rec.get("parent_ids", [])
+        if isinstance(raw_parents, (list, tuple)):
+            parent_ids = [str(p) for p in raw_parents if p is not None]
+        else:
+            parent_ids = []
+
+        records.append(
+            {
+                "agent_id": agent_id,
+                "agent_type": agent_rec.get("agent_type"),
+                "generation": agent_rec.get("generation"),
+                "parent_ids": parent_ids,
+                "birth_time": birth_time,
+                "death_time": death_time,
+                "chromosome": agent_rec.get("chromosome") or {},
+            }
+        )
+
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Convenience builder
+# ---------------------------------------------------------------------------
+
+
+def build_intrinsic_lineage_dag(
+    path: str | Path,
+    *,
+    max_depth: Optional[int] = None,
+) -> PhylogeneticTree:
+    """Load ``intrinsic_gene_snapshots.jsonl`` and return a lineage DAG.
+
+    This is the one-stop convenience function for notebooks and scripts:
+
+    1. Loads the JSONL file (or finds it in a directory).
+    2. Flattens per-step snapshots into per-agent records with inferred
+       ``birth_time`` / ``death_time``.
+    3. Calls
+       :func:`~farm.analysis.phylogenetics.compute.build_phylogenetic_tree_from_records`
+       with ``id_key="agent_id"``.
+
+    Parameters
+    ----------
+    path:
+        Path to the JSONL file **or** the run output directory that contains
+        it.
+    max_depth:
+        Optional depth cap forwarded to
+        :func:`~farm.analysis.phylogenetics.compute.build_phylogenetic_tree_from_records`.
+
+    Returns
+    -------
+    PhylogeneticTree
+        The built DAG.  :attr:`~farm.analysis.phylogenetics.compute.PhylogeneticTree.is_dag`
+        will be ``True`` when any agent has two parents (crossover active).
+    """
+    snapshots = load_intrinsic_snapshots(path)
+    if not snapshots:
+        logger.warning("build_intrinsic_lineage_dag: no snapshots found at %s", path)
+        return PhylogeneticTree(nodes={}, roots=[], is_dag=False)
+
+    records = flatten_snapshots_to_agent_records(snapshots)
+    if not records:
+        logger.warning(
+            "build_intrinsic_lineage_dag: no agent records after flattening at %s", path
+        )
+        return PhylogeneticTree(nodes={}, roots=[], is_dag=False)
+
+    return build_phylogenetic_tree_from_records(
+        records, id_key="agent_id", max_depth=max_depth
+    )
+
+
+# ---------------------------------------------------------------------------
+# Summary statistics
+# ---------------------------------------------------------------------------
+
+
+def compute_surviving_lineage_count_over_time(
+    tree: PhylogeneticTree,
+    snapshots: Sequence[Dict[str, Any]],
+) -> List[Tuple[int, int]]:
+    """Return the number of distinct founder lineages alive at each snapshot.
+
+    For each snapshot step *S* the function looks at the set of agents alive
+    at that step (the ``"agents"`` list in the snapshot dict), traces each
+    agent up to its founder via the lineage DAG, and counts distinct founders.
+
+    Parameters
+    ----------
+    tree:
+        A :class:`~farm.analysis.phylogenetics.compute.PhylogeneticTree`
+        built from the same snapshots (e.g. via
+        :func:`build_intrinsic_lineage_dag`).
+    snapshots:
+        Raw snapshot dicts as returned by :func:`load_intrinsic_snapshots`.
+
+    Returns
+    -------
+    list of (step, count) tuples
+        Sorted by step.  ``count`` is the number of distinct founder lineages
+        represented at that step.  Returns an empty list when there are no
+        snapshots or the tree is empty.
+    """
+    if not snapshots or not tree.nodes:
+        return []
+
+    result: List[Tuple[int, int]] = []
+    for snap in sorted(snapshots, key=lambda s: int(s.get("step", 0))):
+        step = int(snap.get("step", 0))
+        agents_at_step = snap.get("agents", [])
+        if not isinstance(agents_at_step, list):
+            result.append((step, 0))
+            continue
+
+        founders_seen: set[str] = set()
+        for agent in agents_at_step:
+            if not isinstance(agent, dict):
+                continue
+            agent_id = agent.get("agent_id")
+            if agent_id is None:
+                continue
+            agent_id = str(agent_id)
+            founder = _trace_to_founder(tree, agent_id)
+            if founder is not None:
+                founders_seen.add(founder)
+
+        result.append((step, len(founders_seen)))
+
+    return result
+
+
+def compute_lineage_depth_over_time(
+    tree: PhylogeneticTree,
+    snapshots: Sequence[Dict[str, Any]],
+) -> List[Tuple[int, int, float]]:
+    """Return lineage-depth statistics at each snapshot step.
+
+    At each snapshot step, only considers agents alive at that step (present
+    in the snapshot's ``"agents"`` list) and reports their depths in the full
+    lineage tree.
+
+    Parameters
+    ----------
+    tree:
+        A :class:`~farm.analysis.phylogenetics.compute.PhylogeneticTree`
+        built from the same snapshots.
+    snapshots:
+        Raw snapshot dicts as returned by :func:`load_intrinsic_snapshots`.
+
+    Returns
+    -------
+    list of (step, max_depth, mean_depth) tuples
+        Sorted by step.  ``max_depth`` and ``mean_depth`` are 0 when there
+        are no agents with known depth at that step.
+    """
+    if not snapshots or not tree.nodes:
+        return []
+
+    result: List[Tuple[int, int, float]] = []
+    for snap in sorted(snapshots, key=lambda s: int(s.get("step", 0))):
+        step = int(snap.get("step", 0))
+        agents_at_step = snap.get("agents", [])
+        if not isinstance(agents_at_step, list):
+            result.append((step, 0, 0.0))
+            continue
+
+        depths: List[int] = []
+        for agent in agents_at_step:
+            if not isinstance(agent, dict):
+                continue
+            agent_id = str(agent.get("agent_id", ""))
+            node = tree.nodes.get(agent_id)
+            if node is not None and node.depth >= 0:
+                depths.append(node.depth)
+
+        if depths:
+            result.append((step, max(depths), sum(depths) / len(depths)))
+        else:
+            result.append((step, 0, 0.0))
+
+    return result
+
+
+def extract_chromosomes_from_snapshots(
+    snapshots: Sequence[Dict[str, Any]],
+) -> Dict[str, Dict[str, float]]:
+    """Return a mapping from ``agent_id`` to chromosome dict (last-seen values).
+
+    Parameters
+    ----------
+    snapshots:
+        Raw snapshot dicts as returned by :func:`load_intrinsic_snapshots`.
+
+    Returns
+    -------
+    dict
+        ``{agent_id: {"learning_rate": 0.012, ...}}``  Values come from the
+        **last** snapshot in which the agent appeared (most recent chromosome).
+    """
+    chromosomes: Dict[str, Dict[str, float]] = {}
+    for snap in sorted(snapshots, key=lambda s: int(s.get("step", 0))):
+        for agent in snap.get("agents", []):
+            if not isinstance(agent, dict):
+                continue
+            agent_id = agent.get("agent_id")
+            if agent_id is None:
+                continue
+            chrom = agent.get("chromosome")
+            if isinstance(chrom, dict):
+                chromosomes[str(agent_id)] = chrom
+    return chromosomes
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _trace_to_founder(tree: PhylogeneticTree, node_id: str) -> Optional[str]:
+    """Walk up single-parent projection to the root; return its id or None."""
+    visited: set[str] = set()
+    current = node_id
+    while current in tree.nodes:
+        if current in visited:
+            break  # cycle guard
+        visited.add(current)
+        node = tree.nodes[current]
+        if node.is_root:
+            return current
+        parents_in_tree = [p for p in node.parent_ids if p in tree.nodes]
+        if not parents_in_tree:
+            return current
+        current = parents_in_tree[0]
+    return None

--- a/farm/analysis/phylogenetics/intrinsic_loader.py
+++ b/farm/analysis/phylogenetics/intrinsic_loader.py
@@ -160,10 +160,18 @@ def flatten_snapshots_to_agent_records(
     if not snapshots:
         return []
 
-    # Collect steps in sorted order
-    steps: List[int] = sorted(
-        {int(s.get("step", 0)) for s in snapshots if isinstance(s.get("step"), (int, float))}
-    )
+    # Collect steps in sorted order, accepting int/float/numeric-string values
+    steps_set: set[int] = set()
+    for s in snapshots:
+        raw = s.get("step", 0)
+        try:
+            steps_set.add(int(raw))
+        except (TypeError, ValueError):
+            logger.warning(
+                "flatten_snapshots_to_agent_records: skipping snapshot with invalid step value: %r",
+                raw,
+            )
+    steps: List[int] = sorted(steps_set)
     if not steps:
         return []
 
@@ -177,7 +185,15 @@ def flatten_snapshots_to_agent_records(
     # Index snapshots by step
     snap_by_step: Dict[int, Dict[str, Any]] = {}
     for snap in snapshots:
-        s = int(snap.get("step", 0))
+        raw = snap.get("step", 0)
+        try:
+            s = int(raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                "flatten_snapshots_to_agent_records: skipping snapshot with invalid step value: %r",
+                raw,
+            )
+            continue
         snap_by_step[s] = snap
 
     # Per-agent tracking: first_step, last_step, last_record
@@ -321,12 +337,24 @@ def compute_surviving_lineage_count_over_time(
     if not snapshots or not tree.nodes:
         return []
 
+    valid_snapshots: List[Tuple[int, Dict[str, Any]]] = []
+    for snap in snapshots:
+        raw = snap.get("step", 0)
+        try:
+            step_val = int(raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                "compute_surviving_lineage_count_over_time: skipping snapshot with invalid step value: %r",
+                raw,
+            )
+            continue
+        valid_snapshots.append((step_val, snap))
+
     result: List[Tuple[int, int]] = []
-    for snap in sorted(snapshots, key=lambda s: int(s.get("step", 0))):
-        step = int(snap.get("step", 0))
+    for step_val, snap in sorted(valid_snapshots, key=lambda item: item[0]):
         agents_at_step = snap.get("agents", [])
         if not isinstance(agents_at_step, list):
-            result.append((step, 0))
+            result.append((step_val, 0))
             continue
 
         founders_seen: set[str] = set()
@@ -341,7 +369,7 @@ def compute_surviving_lineage_count_over_time(
             if founder is not None:
                 founders_seen.add(founder)
 
-        result.append((step, len(founders_seen)))
+        result.append((step_val, len(founders_seen)))
 
     return result
 
@@ -373,12 +401,24 @@ def compute_lineage_depth_over_time(
     if not snapshots or not tree.nodes:
         return []
 
+    valid_snapshots_depth: List[Tuple[int, Dict[str, Any]]] = []
+    for snap in snapshots:
+        raw = snap.get("step", 0)
+        try:
+            step_val = int(raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                "compute_lineage_depth_over_time: skipping snapshot with invalid step value: %r",
+                raw,
+            )
+            continue
+        valid_snapshots_depth.append((step_val, snap))
+
     result: List[Tuple[int, int, float]] = []
-    for snap in sorted(snapshots, key=lambda s: int(s.get("step", 0))):
-        step = int(snap.get("step", 0))
+    for step_val, snap in sorted(valid_snapshots_depth, key=lambda item: item[0]):
         agents_at_step = snap.get("agents", [])
         if not isinstance(agents_at_step, list):
-            result.append((step, 0, 0.0))
+            result.append((step_val, 0, 0.0))
             continue
 
         depths: List[int] = []
@@ -391,9 +431,9 @@ def compute_lineage_depth_over_time(
                 depths.append(node.depth)
 
         if depths:
-            result.append((step, max(depths), sum(depths) / len(depths)))
+            result.append((step_val, max(depths), sum(depths) / len(depths)))
         else:
-            result.append((step, 0, 0.0))
+            result.append((step_val, 0, 0.0))
 
     return result
 
@@ -415,8 +455,43 @@ def extract_chromosomes_from_snapshots(
         **last** snapshot in which the agent appeared (most recent chromosome).
     """
     chromosomes: Dict[str, Dict[str, float]] = {}
-    for snap in sorted(snapshots, key=lambda s: int(s.get("step", 0))):
-        for agent in snap.get("agents", []):
+    ordered_snapshots: List[Tuple[int, int, Dict[str, Any]]] = []
+
+    for index, snap in enumerate(snapshots):
+        if not isinstance(snap, dict):
+            logger.warning(
+                "extract_chromosomes_from_snapshots: skipping malformed snapshot at index %s:"
+                " expected dict, got %s",
+                index,
+                type(snap).__name__,
+            )
+            continue
+
+        raw_step = snap.get("step", 0)
+        try:
+            step = int(raw_step)
+        except (TypeError, ValueError):
+            logger.warning(
+                "extract_chromosomes_from_snapshots: skipping snapshot at index %s with"
+                " non-numeric step %r",
+                index,
+                raw_step,
+            )
+            continue
+
+        ordered_snapshots.append((step, index, snap))
+
+    for _, _, snap in sorted(ordered_snapshots, key=lambda item: (item[0], item[1])):
+        agents = snap.get("agents", [])
+        if not isinstance(agents, list):
+            logger.warning(
+                "extract_chromosomes_from_snapshots: skipping agents for snapshot step %r:"
+                " expected list, got %s",
+                snap.get("step"),
+                type(agents).__name__,
+            )
+            continue
+        for agent in agents:
             if not isinstance(agent, dict):
                 continue
             agent_id = agent.get("agent_id")
@@ -431,6 +506,26 @@ def extract_chromosomes_from_snapshots(
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def trace_to_founder(tree: PhylogeneticTree, node_id: str) -> Optional[str]:
+    """Walk up the single-parent projection of *tree* and return the founder id.
+
+    Parameters
+    ----------
+    tree:
+        A :class:`~farm.analysis.phylogenetics.compute.PhylogeneticTree`
+        built from intrinsic snapshot data.
+    node_id:
+        The id of the agent whose founder should be found.
+
+    Returns
+    -------
+    str or None
+        The id of the root ancestor (founder) of *node_id*, or ``None`` when
+        *node_id* is not present in the tree.
+    """
+    return _trace_to_founder(tree, node_id)
 
 
 def _trace_to_founder(tree: PhylogeneticTree, node_id: str) -> Optional[str]:

--- a/farm/analysis/phylogenetics/plot.py
+++ b/farm/analysis/phylogenetics/plot.py
@@ -40,6 +40,17 @@ _DEFAULT_MAX_NODES = 300
 _DEFAULT_MAX_DEPTH_LARGE = 6
 
 
+def _get_cmap(name: str) -> Any:
+    """Return a matplotlib colormap by name, compatible with matplotlib ≥3.5 and older."""
+    import matplotlib
+    import matplotlib.pyplot as plt  # noqa: F401 (needed for plt.cm fallback)
+
+    try:
+        return matplotlib.colormaps.get_cmap(name)
+    except AttributeError:
+        return plt.cm.get_cmap(name)  # type: ignore[attr-defined]
+
+
 def plot_phylogenetic_tree(
     df: PhylogeneticTree,
     ctx: AnalysisContext,
@@ -148,12 +159,7 @@ def plot_phylogenetic_tree(
         # ------------------------------------------------------------------
         colour_map: Dict[str, str] = {}
         if color_by_lineage and df.roots:
-            try:
-                import matplotlib
-                cmap = matplotlib.colormaps.get_cmap("tab10")
-            except AttributeError:
-                # matplotlib < 3.5 fallback
-                cmap = plt.cm.get_cmap("tab10")  # type: ignore[attr-defined]
+            cmap = _get_cmap("tab10")
             lineage_colour: Dict[str, Any] = {}
             for idx, root_id in enumerate(df.roots):
                 lineage_colour[root_id] = cmap(idx % 10)
@@ -417,10 +423,7 @@ def plot_intrinsic_lineage_tree(
                 use_gene_colouring = True
                 v_min = min(gene_values.values())
                 v_max = max(gene_values.values())
-                try:
-                    cmap = matplotlib.colormaps.get_cmap("viridis")
-                except AttributeError:
-                    cmap = plt.cm.get_cmap("viridis")  # type: ignore[attr-defined]
+                cmap = _get_cmap("viridis")
                 if v_max > v_min:
                     norm = mcolors.Normalize(vmin=v_min, vmax=v_max)
                 else:
@@ -434,10 +437,7 @@ def plot_intrinsic_lineage_tree(
 
         if not use_gene_colouring:
             if color_by_lineage and df.roots:
-                try:
-                    _cmap = matplotlib.colormaps.get_cmap("tab10")
-                except AttributeError:
-                    _cmap = plt.cm.get_cmap("tab10")  # type: ignore[attr-defined]
+                _cmap = _get_cmap("tab10")
                 lineage_colour: Dict[str, Any] = {}
                 for idx, root_id in enumerate(df.roots):
                     lineage_colour[root_id] = _cmap(idx % 10)

--- a/farm/analysis/phylogenetics/plot.py
+++ b/farm/analysis/phylogenetics/plot.py
@@ -15,6 +15,13 @@ Large populations
 When the tree has more nodes than ``max_nodes``, the function prunes to the
 first ``max_depth`` levels (defaulting to 6 when not specified) and, if still
 too large, samples at most ``max_nodes`` nodes per depth level before drawing.
+
+Intrinsic lineage variant
+~~~~~~~~~~~~~~~~~~~~~~~~~
+:func:`plot_intrinsic_lineage_tree` is a specialised variant for the
+``intrinsic_gene_snapshots.jsonl`` data source.  It accepts an optional
+``gene`` parameter to colour nodes by a specific chromosome gene value
+(continuous colormap) rather than by founder lineage.
 """
 
 from __future__ import annotations
@@ -274,4 +281,289 @@ def plot_phylogenetic_tree(
 
     except Exception as exc:
         logger.warning("plot_phylogenetic_tree: failed: %s", exc, exc_info=True)
+        return None
+
+
+def plot_intrinsic_lineage_tree(
+    df: PhylogeneticTree,
+    ctx: AnalysisContext,
+    *,
+    gene: Optional[str] = None,
+    chromosomes: Optional[Dict[str, Dict[str, float]]] = None,
+    max_depth: Optional[int] = None,
+    max_nodes: int = _DEFAULT_MAX_NODES,
+    title: str = "Intrinsic Lineage Tree",
+    color_by_lineage: bool = True,
+    **kwargs: Any,
+) -> Optional[Any]:
+    """Plot the intrinsic-evolution lineage tree with optional gene-value colouring.
+
+    Extends :func:`plot_phylogenetic_tree` with per-gene chromosome colouring
+    sourced from ``intrinsic_gene_snapshots.jsonl`` data.
+
+    Parameters
+    ----------
+    df:
+        :class:`~farm.analysis.phylogenetics.compute.PhylogeneticTree` built
+        from intrinsic snapshot data (e.g. via
+        :func:`~farm.analysis.phylogenetics.intrinsic_loader.build_intrinsic_lineage_dag`).
+    ctx:
+        :class:`~farm.analysis.common.context.AnalysisContext` supplying the
+        output directory.
+    gene:
+        Name of the chromosome gene to use for colouring nodes (e.g.
+        ``"learning_rate"``).  When provided and ``chromosomes`` contains the
+        gene values, nodes are coloured on a continuous ``viridis`` scale.
+        When ``None`` or ``chromosomes`` does not contain the gene, falls back
+        to founder-lineage colouring (same as :func:`plot_phylogenetic_tree`).
+    chromosomes:
+        Mapping of ``agent_id`` → ``{gene_name: value, ...}`` produced by
+        :func:`~farm.analysis.phylogenetics.intrinsic_loader.extract_chromosomes_from_snapshots`.
+        Required when ``gene`` is set.
+    max_depth:
+        Maximum depth level to render.
+    max_nodes:
+        Maximum total nodes to render.
+    title:
+        Plot title.
+    color_by_lineage:
+        When ``True`` and ``gene`` is not set (or gene values are unavailable),
+        colour nodes by founder lineage.
+
+    Returns
+    -------
+    pathlib.Path or None
+        Path to the saved PNG file on success, ``None`` on failure.
+    """
+    if not df.nodes:
+        logger.warning("plot_intrinsic_lineage_tree: tree is empty; skipping")
+        return None
+
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import matplotlib.patches as mpatches
+        import matplotlib.colors as mcolors
+    except ImportError as exc:
+        logger.warning("plot_intrinsic_lineage_tree: matplotlib not available: %s", exc)
+        return None
+
+    try:
+        # ------------------------------------------------------------------
+        # 1. Determine which nodes to render (pruning)
+        # ------------------------------------------------------------------
+        effective_max_depth = max_depth
+        if effective_max_depth is None and len(df.nodes) > max_nodes:
+            effective_max_depth = _DEFAULT_MAX_DEPTH_LARGE
+
+        if effective_max_depth is not None:
+            render_ids: Set[str] = {
+                nid for nid, n in df.nodes.items() if 0 <= n.depth <= effective_max_depth
+            }
+        else:
+            render_ids = {nid for nid, n in df.nodes.items() if n.depth >= 0}
+
+        if len(render_ids) > max_nodes:
+            by_depth: Dict[int, List[str]] = defaultdict(list)
+            for nid in sorted(render_ids):
+                by_depth[df.nodes[nid].depth].append(nid)
+            per_level = max(1, max_nodes // max(1, len(by_depth)))
+            render_ids = set()
+            for depth_level in sorted(by_depth):
+                render_ids.update(sorted(by_depth[depth_level])[:per_level])
+
+        nodes_to_render = {nid: df.nodes[nid] for nid in render_ids}
+
+        # ------------------------------------------------------------------
+        # 2. Assign positions
+        # ------------------------------------------------------------------
+        by_depth_render: Dict[int, List[str]] = defaultdict(list)
+        for nid, node in nodes_to_render.items():
+            by_depth_render[node.depth].append(nid)
+        for depth_level in by_depth_render:
+            by_depth_render[depth_level].sort()
+
+        positions: Dict[str, Tuple[float, float]] = {}
+        depths_present = sorted(by_depth_render.keys())
+        for depth_level in depths_present:
+            ids_at_depth = by_depth_render[depth_level]
+            count = len(ids_at_depth)
+            for i, nid in enumerate(ids_at_depth):
+                x = (i + 1) / (count + 1)
+                positions[nid] = (x, -depth_level)
+
+        # ------------------------------------------------------------------
+        # 3. Assign colours (gene-value or lineage)
+        # ------------------------------------------------------------------
+        colour_map: Dict[str, Any] = {}
+        use_gene_colouring = False
+        gene_values: Dict[str, float] = {}
+        cmap = None
+        norm = None
+
+        if gene and chromosomes:
+            # Collect gene values for rendered nodes
+            for nid in render_ids:
+                chrom = chromosomes.get(nid, {})
+                val = chrom.get(gene)
+                if val is not None:
+                    try:
+                        gene_values[nid] = float(val)
+                    except (TypeError, ValueError):
+                        pass
+
+            if gene_values:
+                use_gene_colouring = True
+                v_min = min(gene_values.values())
+                v_max = max(gene_values.values())
+                try:
+                    cmap = matplotlib.colormaps.get_cmap("viridis")
+                except AttributeError:
+                    cmap = plt.cm.get_cmap("viridis")  # type: ignore[attr-defined]
+                if v_max > v_min:
+                    norm = mcolors.Normalize(vmin=v_min, vmax=v_max)
+                else:
+                    norm = mcolors.Normalize(vmin=v_min - 1e-9, vmax=v_max + 1e-9)
+                default_gene_colour = cmap(0.5)
+                for nid in nodes_to_render:
+                    if nid in gene_values:
+                        colour_map[nid] = cmap(norm(gene_values[nid]))
+                    else:
+                        colour_map[nid] = default_gene_colour
+
+        if not use_gene_colouring:
+            if color_by_lineage and df.roots:
+                try:
+                    _cmap = matplotlib.colormaps.get_cmap("tab10")
+                except AttributeError:
+                    _cmap = plt.cm.get_cmap("tab10")  # type: ignore[attr-defined]
+                lineage_colour: Dict[str, Any] = {}
+                for idx, root_id in enumerate(df.roots):
+                    lineage_colour[root_id] = _cmap(idx % 10)
+
+                def _get_lineage_colour(nid: str) -> Any:
+                    visited_set: Set[str] = set()
+                    current = nid
+                    while current in nodes_to_render:
+                        if current in visited_set:
+                            break
+                        visited_set.add(current)
+                        if current in lineage_colour:
+                            return lineage_colour[current]
+                        node = nodes_to_render[current]
+                        parents = [p for p in node.parent_ids if p in nodes_to_render]
+                        if not parents:
+                            break
+                        current = parents[0]
+                    return lineage_colour.get(
+                        df.roots[0] if df.roots else list(nodes_to_render)[0],
+                        (0.5, 0.5, 0.5, 1.0),
+                    )
+
+                for nid in nodes_to_render:
+                    colour_map[nid] = _get_lineage_colour(nid)
+                cmap = _cmap
+            else:
+                default_colour = (0.2, 0.4, 0.8, 0.8)
+                for nid in nodes_to_render:
+                    colour_map[nid] = default_colour  # type: ignore[assignment]
+
+        # ------------------------------------------------------------------
+        # 4. Draw
+        # ------------------------------------------------------------------
+        fig_width = max(8.0, len(nodes_to_render) / 5)
+        fig_height = max(5.0, (len(depths_present) + 1) * 0.8)
+        fig, ax = plt.subplots(figsize=(min(fig_width, 24.0), min(fig_height, 16.0)))
+
+        for nid, node in nodes_to_render.items():
+            if nid not in positions:
+                continue
+            x_child, y_child = positions[nid]
+            for pid in node.parent_ids:
+                if pid in positions:
+                    x_parent, y_parent = positions[pid]
+                    ax.plot(
+                        [x_parent, x_child],
+                        [y_parent, y_child],
+                        color=(0.6, 0.6, 0.6),
+                        linewidth=0.8,
+                        zorder=1,
+                    )
+
+        node_size = max(20, min(60, 400 // max(len(nodes_to_render), 1)))
+        for nid, (x, y) in positions.items():
+            colour = colour_map.get(nid, (0.5, 0.5, 0.5, 1.0))
+            marker = "*" if nodes_to_render[nid].is_root else "o"
+            ax.scatter(
+                x,
+                y,
+                s=node_size,
+                c=[colour],
+                marker=marker,
+                zorder=2,
+                linewidths=0.3,
+                edgecolors="black",
+            )
+
+        # ------------------------------------------------------------------
+        # 5. Annotations / legend
+        # ------------------------------------------------------------------
+        ax.set_xlim(0, 1)
+        ax.set_ylim(-max(depths_present) - 0.5, 0.5)
+        ax.set_xlabel("Relative position within depth level")
+        ax.set_ylabel("Depth from founder")
+        ax.set_title(title)
+        ax.set_yticks([-d for d in depths_present])
+        ax.set_yticklabels([str(d) for d in depths_present])
+        ax.tick_params(axis="x", which="both", bottom=False, labelbottom=False)
+
+        if use_gene_colouring and cmap is not None and norm is not None:
+            sm = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
+            sm.set_array([])
+            plt.colorbar(sm, ax=ax, label=gene, fraction=0.03, pad=0.04)
+        elif color_by_lineage and not use_gene_colouring and df.roots and cmap is not None:
+            handles = []
+            for idx, root_id in enumerate(df.roots[:10]):
+                patch = mpatches.Patch(color=cmap(idx % 10), label=f"Lineage: {root_id}")
+                handles.append(patch)
+            if len(df.roots) > 10:
+                handles.append(
+                    mpatches.Patch(color="white", label=f"… +{len(df.roots) - 10} more")
+                )
+            ax.legend(handles=handles, loc="upper right", fontsize=7, framealpha=0.7)
+
+        if df.is_dag:
+            ax.text(
+                0.01,
+                0.01,
+                "DAG (dual-parent reproduction; single-parent edges shown)",
+                transform=ax.transAxes,
+                fontsize=7,
+                color="gray",
+                va="bottom",
+            )
+
+        if len(nodes_to_render) < len(df.nodes):
+            ax.text(
+                0.99,
+                0.01,
+                f"Showing {len(nodes_to_render)} of {len(df.nodes)} nodes",
+                transform=ax.transAxes,
+                fontsize=7,
+                color="gray",
+                ha="right",
+                va="bottom",
+            )
+
+        output_file = ctx.get_output_file("intrinsic_lineage_tree.png")
+        fig.savefig(output_file, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        logger.info("plot_intrinsic_lineage_tree: saved to %s", output_file)
+        return output_file
+
+    except Exception as exc:
+        logger.warning(
+            "plot_intrinsic_lineage_tree: failed: %s", exc, exc_info=True
+        )
         return None

--- a/farm/analysis/phylogenetics/plot.py
+++ b/farm/analysis/phylogenetics/plot.py
@@ -181,7 +181,7 @@ def _render_layered_dendrogram_figure(
         ax.text(
             0.01,
             0.01,
-            "DAG (dual-parent reproduction; single-parent edges shown)",
+            "DAG (dual-parent reproduction; all edges shown)",
             transform=ax.transAxes,
             fontsize=7,
             color="gray",
@@ -350,7 +350,9 @@ def plot_intrinsic_lineage_tree(
     chromosomes:
         Mapping of ``agent_id`` → ``{gene_name: value, ...}`` produced by
         :func:`~farm.analysis.phylogenetics.intrinsic_loader.extract_chromosomes_from_snapshots`.
-        Required when ``gene`` is set.
+        Used for gene-based colouring when ``gene`` is set; if omitted or if
+        the requested gene value is unavailable for a node, the plot falls
+        back to founder-lineage colouring.
     max_depth:
         Maximum depth level to render.
     max_nodes:
@@ -415,6 +417,18 @@ def plot_intrinsic_lineage_tree(
                     else:
                         colour_map[nid] = default_gene_colour
                 gene_colorbar = (gcmap, gnorm, gene)
+            else:
+                logger.warning(
+                    "plot_intrinsic_lineage_tree: gene %r not found in chromosomes;"
+                    " falling back to founder-lineage colouring",
+                    gene,
+                )
+        elif gene and chromosomes is None:
+            logger.warning(
+                "plot_intrinsic_lineage_tree: gene %r provided but chromosomes is None;"
+                " falling back to founder-lineage colouring",
+                gene,
+            )
 
         if not use_gene_colouring:
             if color_by_lineage and df.roots:

--- a/farm/analysis/phylogenetics/plot.py
+++ b/farm/analysis/phylogenetics/plot.py
@@ -399,6 +399,8 @@ def plot_intrinsic_lineage_tree(
                     try:
                         gene_values[nid] = float(val)
                     except (TypeError, ValueError):
+                        # Non-numeric/malformed gene values are expected in some records;
+                        # skip them so colouring uses only valid numeric values.
                         pass
 
             if gene_values:

--- a/farm/analysis/phylogenetics/plot.py
+++ b/farm/analysis/phylogenetics/plot.py
@@ -30,7 +30,7 @@ from collections import defaultdict
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from farm.analysis.common.context import AnalysisContext
-from farm.analysis.phylogenetics.compute import PhylogeneticTree
+from farm.analysis.phylogenetics.compute import PhylogeneticNode, PhylogeneticTree
 from farm.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -49,6 +49,162 @@ def _get_cmap(name: str) -> Any:
         return matplotlib.colormaps.get_cmap(name)
     except AttributeError:
         return plt.cm.get_cmap(name)  # type: ignore[attr-defined]
+
+
+def _prune_and_layout_layered_dendrogram(
+    df: PhylogeneticTree,
+    max_depth: Optional[int],
+    max_nodes: int,
+) -> Tuple[Dict[str, PhylogeneticNode], Dict[str, Tuple[float, float]], List[int]]:
+    """Prune to render set and assign layered dendrogram coordinates (shared by tree plotters)."""
+    effective_max_depth = max_depth
+    if effective_max_depth is None and len(df.nodes) > max_nodes:
+        effective_max_depth = _DEFAULT_MAX_DEPTH_LARGE
+
+    if effective_max_depth is not None:
+        render_ids: Set[str] = {
+            nid for nid, n in df.nodes.items() if 0 <= n.depth <= effective_max_depth
+        }
+    else:
+        render_ids = {nid for nid, n in df.nodes.items() if n.depth >= 0}
+
+    if len(render_ids) > max_nodes:
+        by_depth: Dict[int, List[str]] = defaultdict(list)
+        for nid in sorted(render_ids):
+            by_depth[df.nodes[nid].depth].append(nid)
+        per_level = max(1, max_nodes // max(1, len(by_depth)))
+        render_ids = set()
+        for depth_level in sorted(by_depth):
+            render_ids.update(sorted(by_depth[depth_level])[:per_level])
+
+    nodes_to_render = {nid: df.nodes[nid] for nid in render_ids}
+
+    by_depth_render: Dict[int, List[str]] = defaultdict(list)
+    for nid, node in nodes_to_render.items():
+        by_depth_render[node.depth].append(nid)
+    for depth_level in by_depth_render:
+        by_depth_render[depth_level].sort()
+
+    positions: Dict[str, Tuple[float, float]] = {}
+    depths_present = sorted(by_depth_render.keys())
+    for depth_level in depths_present:
+        ids_at_depth = by_depth_render[depth_level]
+        count = len(ids_at_depth)
+        for i, nid in enumerate(ids_at_depth):
+            x = (i + 1) / (count + 1)
+            positions[nid] = (x, -depth_level)
+
+    return nodes_to_render, positions, depths_present
+
+
+def _render_layered_dendrogram_figure(
+    df: PhylogeneticTree,
+    ctx: AnalysisContext,
+    *,
+    nodes_to_render: Dict[str, PhylogeneticNode],
+    positions: Dict[str, Tuple[float, float]],
+    depths_present: List[int],
+    colour_map: Dict[str, Any],
+    title: str,
+    output_basename: str,
+    log_prefix: str,
+    show_lineage_legend: bool = False,
+    lineage_legend_cmap: Any = None,
+    gene_colorbar: Optional[Tuple[Any, Any, str]] = None,
+) -> Any:
+    """Draw edges, nodes, axes, optional lineage legend or gene colorbar, save PNG."""
+    import matplotlib.pyplot as plt
+    import matplotlib.patches as mpatches
+
+    fig_width = max(8.0, len(nodes_to_render) / 5)
+    fig_height = max(5.0, (len(depths_present) + 1) * 0.8)
+    fig, ax = plt.subplots(figsize=(min(fig_width, 24.0), min(fig_height, 16.0)))
+
+    for nid, node in nodes_to_render.items():
+        if nid not in positions:
+            continue
+        x_child, y_child = positions[nid]
+        for pid in node.parent_ids:
+            if pid in positions:
+                x_parent, y_parent = positions[pid]
+                ax.plot(
+                    [x_parent, x_child],
+                    [y_parent, y_child],
+                    color=(0.6, 0.6, 0.6),
+                    linewidth=0.8,
+                    zorder=1,
+                )
+
+    node_size = max(20, min(60, 400 // max(len(nodes_to_render), 1)))
+    for nid, (x, y) in positions.items():
+        colour = colour_map.get(nid, (0.5, 0.5, 0.5, 1.0))
+        marker = "*" if nodes_to_render[nid].is_root else "o"
+        ax.scatter(
+            x,
+            y,
+            s=node_size,
+            c=[colour],
+            marker=marker,
+            zorder=2,
+            linewidths=0.3,
+            edgecolors="black",
+        )
+
+    ax.set_xlim(0, 1)
+    ax.set_ylim(-max(depths_present) - 0.5, 0.5)
+    ax.set_xlabel("Relative position within depth level")
+    ax.set_ylabel("Depth from founder")
+    ax.set_title(title)
+    ax.set_yticks([-d for d in depths_present])
+    ax.set_yticklabels([str(d) for d in depths_present])
+    ax.tick_params(axis="x", which="both", bottom=False, labelbottom=False)
+
+    if gene_colorbar is not None:
+        gcmap, gnorm, gene_label = gene_colorbar
+        sm = plt.cm.ScalarMappable(cmap=gcmap, norm=gnorm)
+        sm.set_array([])
+        plt.colorbar(sm, ax=ax, label=gene_label, fraction=0.03, pad=0.04)
+    elif show_lineage_legend and df.roots and lineage_legend_cmap is not None:
+        handles = []
+        for idx, root_id in enumerate(df.roots[:10]):
+            patch = mpatches.Patch(
+                color=lineage_legend_cmap(idx % 10), label=f"Lineage: {root_id}"
+            )
+            handles.append(patch)
+        if len(df.roots) > 10:
+            handles.append(
+                mpatches.Patch(color="white", label=f"… +{len(df.roots) - 10} more")
+            )
+        ax.legend(handles=handles, loc="upper right", fontsize=7, framealpha=0.7)
+
+    if df.is_dag:
+        ax.text(
+            0.01,
+            0.01,
+            "DAG (dual-parent reproduction; single-parent edges shown)",
+            transform=ax.transAxes,
+            fontsize=7,
+            color="gray",
+            va="bottom",
+        )
+
+    if len(nodes_to_render) < len(df.nodes):
+        ax.text(
+            0.99,
+            0.01,
+            f"Showing {len(nodes_to_render)} of {len(df.nodes)} nodes",
+            transform=ax.transAxes,
+            fontsize=7,
+            color="gray",
+            ha="right",
+            va="bottom",
+        )
+
+    output_file = ctx.get_output_file(output_basename)
+    fig.savefig(output_file, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.info("%s: saved to %s", log_prefix, output_file)
+    return output_file
 
 
 def plot_phylogenetic_tree(
@@ -97,72 +253,22 @@ def plot_phylogenetic_tree(
     try:
         import matplotlib
         matplotlib.use("Agg")  # non-interactive backend for server/test contexts
-        import matplotlib.pyplot as plt
-        import matplotlib.patches as mpatches
     except ImportError as exc:
         logger.warning("plot_phylogenetic_tree: matplotlib not available: %s", exc)
         return None
 
     try:
-        # ------------------------------------------------------------------
-        # 1. Determine which nodes to render (pruning)
-        # ------------------------------------------------------------------
-        effective_max_depth = max_depth
-        if effective_max_depth is None and len(df.nodes) > max_nodes:
-            effective_max_depth = _DEFAULT_MAX_DEPTH_LARGE
+        nodes_to_render, positions, depths_present = _prune_and_layout_layered_dendrogram(
+            df, max_depth, max_nodes
+        )
 
-        if effective_max_depth is not None:
-            render_ids: Set[str] = {
-                nid
-                for nid, n in df.nodes.items()
-                if 0 <= n.depth <= effective_max_depth
-            }
-        else:
-            render_ids = {
-                nid
-                for nid, n in df.nodes.items()
-                if n.depth >= 0
-            }
-
-        # Per-depth sampling when still too large
-        if len(render_ids) > max_nodes:
-            by_depth: Dict[int, List[str]] = defaultdict(list)
-            for nid in sorted(render_ids):
-                by_depth[df.nodes[nid].depth].append(nid)
-            per_level = max(1, max_nodes // max(1, len(by_depth)))
-            render_ids = set()
-            for depth_level in sorted(by_depth):
-                render_ids.update(sorted(by_depth[depth_level])[:per_level])
-
-        nodes_to_render = {nid: df.nodes[nid] for nid in render_ids}
-
-        # ------------------------------------------------------------------
-        # 2. Assign positions
-        # ------------------------------------------------------------------
-        by_depth_render: Dict[int, List[str]] = defaultdict(list)
-        for nid, node in nodes_to_render.items():
-            by_depth_render[node.depth].append(nid)
-        for depth_level in by_depth_render:
-            by_depth_render[depth_level].sort()
-
-        positions: Dict[str, Tuple[float, float]] = {}
-        depths_present = sorted(by_depth_render.keys())
-        for depth_level in depths_present:
-            ids_at_depth = by_depth_render[depth_level]
-            count = len(ids_at_depth)
-            for i, nid in enumerate(ids_at_depth):
-                x = (i + 1) / (count + 1)
-                positions[nid] = (x, -depth_level)
-
-        # ------------------------------------------------------------------
-        # 3. Assign lineage colours
-        # ------------------------------------------------------------------
-        colour_map: Dict[str, str] = {}
+        colour_map: Dict[str, Any] = {}
+        lineage_legend_cmap = None
         if color_by_lineage and df.roots:
-            cmap = _get_cmap("tab10")
+            lineage_legend_cmap = _get_cmap("tab10")
             lineage_colour: Dict[str, Any] = {}
             for idx, root_id in enumerate(df.roots):
-                lineage_colour[root_id] = cmap(idx % 10)
+                lineage_colour[root_id] = lineage_legend_cmap(idx % 10)
 
             def _get_lineage_colour(nid: str) -> Any:
                 visited_set: Set[str] = set()
@@ -186,104 +292,23 @@ def plot_phylogenetic_tree(
             for nid in nodes_to_render:
                 colour_map[nid] = _get_lineage_colour(nid)
         else:
-            cmap = None
             default_colour = (0.2, 0.4, 0.8, 0.8)
             for nid in nodes_to_render:
                 colour_map[nid] = default_colour  # type: ignore[assignment]
 
-        # ------------------------------------------------------------------
-        # 4. Draw
-        # ------------------------------------------------------------------
-        fig_width = max(8.0, len(nodes_to_render) / 5)
-        fig_height = max(5.0, (len(depths_present) + 1) * 0.8)
-        fig, ax = plt.subplots(figsize=(min(fig_width, 24.0), min(fig_height, 16.0)))
-
-        # Draw edges first (so they appear behind nodes)
-        for nid, node in nodes_to_render.items():
-            if nid not in positions:
-                continue
-            x_child, y_child = positions[nid]
-            for pid in node.parent_ids:
-                if pid in positions:
-                    x_parent, y_parent = positions[pid]
-                    ax.plot(
-                        [x_parent, x_child],
-                        [y_parent, y_child],
-                        color=(0.6, 0.6, 0.6),
-                        linewidth=0.8,
-                        zorder=1,
-                    )
-
-        # Draw nodes
-        node_size = max(20, min(60, 400 // max(len(nodes_to_render), 1)))
-        for nid, (x, y) in positions.items():
-            colour = colour_map.get(nid, (0.5, 0.5, 0.5, 1.0))
-            marker = "*" if nodes_to_render[nid].is_root else "o"
-            ax.scatter(
-                x,
-                y,
-                s=node_size,
-                c=[colour],
-                marker=marker,
-                zorder=2,
-                linewidths=0.3,
-                edgecolors="black",
-            )
-
-        # ------------------------------------------------------------------
-        # 5. Annotations
-        # ------------------------------------------------------------------
-        ax.set_xlim(0, 1)
-        ax.set_ylim(-max(depths_present) - 0.5, 0.5)
-        ax.set_xlabel("Relative position within depth level")
-        ax.set_ylabel("Depth from founder")
-        ax.set_title(title)
-        ax.set_yticks([-d for d in depths_present])
-        ax.set_yticklabels([str(d) for d in depths_present])
-        ax.tick_params(axis="x", which="both", bottom=False, labelbottom=False)
-
-        # Legend: lineage colours
-        if color_by_lineage and df.roots and cmap is not None:
-            handles = []
-            for idx, root_id in enumerate(df.roots[:10]):  # cap legend entries
-                patch = mpatches.Patch(color=cmap(idx % 10), label=f"Lineage: {root_id}")
-                handles.append(patch)
-            if len(df.roots) > 10:
-                handles.append(
-                    mpatches.Patch(color="white", label=f"… +{len(df.roots) - 10} more")
-                )
-            ax.legend(handles=handles, loc="upper right", fontsize=7, framealpha=0.7)
-
-        # DAG annotation
-        if df.is_dag:
-            ax.text(
-                0.01,
-                0.01,
-                "DAG (dual-parent reproduction; single-parent edges shown)",
-                transform=ax.transAxes,
-                fontsize=7,
-                color="gray",
-                va="bottom",
-            )
-
-        # Pruning annotation
-        if len(nodes_to_render) < len(df.nodes):
-            ax.text(
-                0.99,
-                0.01,
-                f"Showing {len(nodes_to_render)} of {len(df.nodes)} nodes",
-                transform=ax.transAxes,
-                fontsize=7,
-                color="gray",
-                ha="right",
-                va="bottom",
-            )
-
-        output_file = ctx.get_output_file("phylogenetics_tree.png")
-        fig.savefig(output_file, dpi=150, bbox_inches="tight")
-        plt.close(fig)
-        logger.info("plot_phylogenetic_tree: saved to %s", output_file)
-        return output_file
+        return _render_layered_dendrogram_figure(
+            df,
+            ctx,
+            nodes_to_render=nodes_to_render,
+            positions=positions,
+            depths_present=depths_present,
+            colour_map=colour_map,
+            title=title,
+            output_basename="phylogenetics_tree.png",
+            log_prefix="plot_phylogenetic_tree",
+            show_lineage_legend=bool(color_by_lineage and df.roots),
+            lineage_legend_cmap=lineage_legend_cmap,
+        )
 
     except Exception as exc:
         logger.warning("plot_phylogenetic_tree: failed: %s", exc, exc_info=True)
@@ -348,69 +373,24 @@ def plot_intrinsic_lineage_tree(
     try:
         import matplotlib
         matplotlib.use("Agg")
-        import matplotlib.pyplot as plt
-        import matplotlib.patches as mpatches
         import matplotlib.colors as mcolors
     except ImportError as exc:
         logger.warning("plot_intrinsic_lineage_tree: matplotlib not available: %s", exc)
         return None
 
     try:
-        # ------------------------------------------------------------------
-        # 1. Determine which nodes to render (pruning)
-        # ------------------------------------------------------------------
-        effective_max_depth = max_depth
-        if effective_max_depth is None and len(df.nodes) > max_nodes:
-            effective_max_depth = _DEFAULT_MAX_DEPTH_LARGE
+        nodes_to_render, positions, depths_present = _prune_and_layout_layered_dendrogram(
+            df, max_depth, max_nodes
+        )
 
-        if effective_max_depth is not None:
-            render_ids: Set[str] = {
-                nid for nid, n in df.nodes.items() if 0 <= n.depth <= effective_max_depth
-            }
-        else:
-            render_ids = {nid for nid, n in df.nodes.items() if n.depth >= 0}
-
-        if len(render_ids) > max_nodes:
-            by_depth: Dict[int, List[str]] = defaultdict(list)
-            for nid in sorted(render_ids):
-                by_depth[df.nodes[nid].depth].append(nid)
-            per_level = max(1, max_nodes // max(1, len(by_depth)))
-            render_ids = set()
-            for depth_level in sorted(by_depth):
-                render_ids.update(sorted(by_depth[depth_level])[:per_level])
-
-        nodes_to_render = {nid: df.nodes[nid] for nid in render_ids}
-
-        # ------------------------------------------------------------------
-        # 2. Assign positions
-        # ------------------------------------------------------------------
-        by_depth_render: Dict[int, List[str]] = defaultdict(list)
-        for nid, node in nodes_to_render.items():
-            by_depth_render[node.depth].append(nid)
-        for depth_level in by_depth_render:
-            by_depth_render[depth_level].sort()
-
-        positions: Dict[str, Tuple[float, float]] = {}
-        depths_present = sorted(by_depth_render.keys())
-        for depth_level in depths_present:
-            ids_at_depth = by_depth_render[depth_level]
-            count = len(ids_at_depth)
-            for i, nid in enumerate(ids_at_depth):
-                x = (i + 1) / (count + 1)
-                positions[nid] = (x, -depth_level)
-
-        # ------------------------------------------------------------------
-        # 3. Assign colours (gene-value or lineage)
-        # ------------------------------------------------------------------
         colour_map: Dict[str, Any] = {}
         use_gene_colouring = False
-        gene_values: Dict[str, float] = {}
-        cmap = None
-        norm = None
+        gene_colorbar: Optional[Tuple[Any, Any, str]] = None
+        lineage_legend_cmap = None
 
         if gene and chromosomes:
-            # Collect gene values for rendered nodes
-            for nid in render_ids:
+            gene_values: Dict[str, float] = {}
+            for nid in nodes_to_render:
                 chrom = chromosomes.get(nid, {})
                 val = chrom.get(gene)
                 if val is not None:
@@ -423,24 +403,25 @@ def plot_intrinsic_lineage_tree(
                 use_gene_colouring = True
                 v_min = min(gene_values.values())
                 v_max = max(gene_values.values())
-                cmap = _get_cmap("viridis")
+                gcmap = _get_cmap("viridis")
                 if v_max > v_min:
-                    norm = mcolors.Normalize(vmin=v_min, vmax=v_max)
+                    gnorm = mcolors.Normalize(vmin=v_min, vmax=v_max)
                 else:
-                    norm = mcolors.Normalize(vmin=v_min - 1e-9, vmax=v_max + 1e-9)
-                default_gene_colour = cmap(0.5)
+                    gnorm = mcolors.Normalize(vmin=v_min - 1e-9, vmax=v_max + 1e-9)
+                default_gene_colour = gcmap(0.5)
                 for nid in nodes_to_render:
                     if nid in gene_values:
-                        colour_map[nid] = cmap(norm(gene_values[nid]))
+                        colour_map[nid] = gcmap(gnorm(gene_values[nid]))
                     else:
                         colour_map[nid] = default_gene_colour
+                gene_colorbar = (gcmap, gnorm, gene)
 
         if not use_gene_colouring:
             if color_by_lineage and df.roots:
-                _cmap = _get_cmap("tab10")
+                lineage_legend_cmap = _get_cmap("tab10")
                 lineage_colour: Dict[str, Any] = {}
                 for idx, root_id in enumerate(df.roots):
-                    lineage_colour[root_id] = _cmap(idx % 10)
+                    lineage_colour[root_id] = lineage_legend_cmap(idx % 10)
 
                 def _get_lineage_colour(nid: str) -> Any:
                     visited_set: Set[str] = set()
@@ -463,104 +444,27 @@ def plot_intrinsic_lineage_tree(
 
                 for nid in nodes_to_render:
                     colour_map[nid] = _get_lineage_colour(nid)
-                cmap = _cmap
             else:
                 default_colour = (0.2, 0.4, 0.8, 0.8)
                 for nid in nodes_to_render:
                     colour_map[nid] = default_colour  # type: ignore[assignment]
 
-        # ------------------------------------------------------------------
-        # 4. Draw
-        # ------------------------------------------------------------------
-        fig_width = max(8.0, len(nodes_to_render) / 5)
-        fig_height = max(5.0, (len(depths_present) + 1) * 0.8)
-        fig, ax = plt.subplots(figsize=(min(fig_width, 24.0), min(fig_height, 16.0)))
-
-        for nid, node in nodes_to_render.items():
-            if nid not in positions:
-                continue
-            x_child, y_child = positions[nid]
-            for pid in node.parent_ids:
-                if pid in positions:
-                    x_parent, y_parent = positions[pid]
-                    ax.plot(
-                        [x_parent, x_child],
-                        [y_parent, y_child],
-                        color=(0.6, 0.6, 0.6),
-                        linewidth=0.8,
-                        zorder=1,
-                    )
-
-        node_size = max(20, min(60, 400 // max(len(nodes_to_render), 1)))
-        for nid, (x, y) in positions.items():
-            colour = colour_map.get(nid, (0.5, 0.5, 0.5, 1.0))
-            marker = "*" if nodes_to_render[nid].is_root else "o"
-            ax.scatter(
-                x,
-                y,
-                s=node_size,
-                c=[colour],
-                marker=marker,
-                zorder=2,
-                linewidths=0.3,
-                edgecolors="black",
-            )
-
-        # ------------------------------------------------------------------
-        # 5. Annotations / legend
-        # ------------------------------------------------------------------
-        ax.set_xlim(0, 1)
-        ax.set_ylim(-max(depths_present) - 0.5, 0.5)
-        ax.set_xlabel("Relative position within depth level")
-        ax.set_ylabel("Depth from founder")
-        ax.set_title(title)
-        ax.set_yticks([-d for d in depths_present])
-        ax.set_yticklabels([str(d) for d in depths_present])
-        ax.tick_params(axis="x", which="both", bottom=False, labelbottom=False)
-
-        if use_gene_colouring and cmap is not None and norm is not None:
-            sm = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
-            sm.set_array([])
-            plt.colorbar(sm, ax=ax, label=gene, fraction=0.03, pad=0.04)
-        elif color_by_lineage and not use_gene_colouring and df.roots and cmap is not None:
-            handles = []
-            for idx, root_id in enumerate(df.roots[:10]):
-                patch = mpatches.Patch(color=cmap(idx % 10), label=f"Lineage: {root_id}")
-                handles.append(patch)
-            if len(df.roots) > 10:
-                handles.append(
-                    mpatches.Patch(color="white", label=f"… +{len(df.roots) - 10} more")
-                )
-            ax.legend(handles=handles, loc="upper right", fontsize=7, framealpha=0.7)
-
-        if df.is_dag:
-            ax.text(
-                0.01,
-                0.01,
-                "DAG (dual-parent reproduction; single-parent edges shown)",
-                transform=ax.transAxes,
-                fontsize=7,
-                color="gray",
-                va="bottom",
-            )
-
-        if len(nodes_to_render) < len(df.nodes):
-            ax.text(
-                0.99,
-                0.01,
-                f"Showing {len(nodes_to_render)} of {len(df.nodes)} nodes",
-                transform=ax.transAxes,
-                fontsize=7,
-                color="gray",
-                ha="right",
-                va="bottom",
-            )
-
-        output_file = ctx.get_output_file("intrinsic_lineage_tree.png")
-        fig.savefig(output_file, dpi=150, bbox_inches="tight")
-        plt.close(fig)
-        logger.info("plot_intrinsic_lineage_tree: saved to %s", output_file)
-        return output_file
+        return _render_layered_dendrogram_figure(
+            df,
+            ctx,
+            nodes_to_render=nodes_to_render,
+            positions=positions,
+            depths_present=depths_present,
+            colour_map=colour_map,
+            title=title,
+            output_basename="intrinsic_lineage_tree.png",
+            log_prefix="plot_intrinsic_lineage_tree",
+            show_lineage_legend=bool(
+                color_by_lineage and not use_gene_colouring and df.roots
+            ),
+            lineage_legend_cmap=lineage_legend_cmap,
+            gene_colorbar=gene_colorbar,
+        )
 
     except Exception as exc:
         logger.warning(

--- a/notebooks/intrinsic_lineage_tree.ipynb
+++ b/notebooks/intrinsic_lineage_tree.ipynb
@@ -1,0 +1,390 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "# Intrinsic Lineage Tree Visualization\n",
+    "\n",
+    "This notebook walks through the lineage / phylogeny visualization workflow\n",
+    "for `IntrinsicEvolutionExperiment` runs using the\n",
+    "`intrinsic_gene_snapshots.jsonl` artifact.\n",
+    "\n",
+    "## What this notebook covers\n",
+    "\n",
+    "1. **Load** `intrinsic_gene_snapshots.jsonl` produced by a run\n",
+    "2. **Build** the lineage DAG (two-parent reproduction makes it a DAG, not a\n",
+    "   strict tree)\n",
+    "3. **Plot** the lineage tree with optional per-gene chromosome colouring\n",
+    "4. **Compute** summary statistics:\n",
+    "   - Surviving-lineage count over time\n",
+    "   - Lineage depth over time\n",
+    "5. **Inspect** raw chromosome trajectories for individual lineages\n",
+    "\n",
+    "### Data source\n",
+    "\n",
+    "Set `SNAPSHOT_PATH` to the path of your\n",
+    "`intrinsic_gene_snapshots.jsonl` file **or** the directory that contains it.\n",
+    "The cell below creates a small synthetic fixture so the notebook runs\n",
+    "out-of-the-box without a real experiment on disk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1c2d3e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import pathlib\n",
+    "import tempfile\n",
+    "\n",
+    "# ── Configuration ──────────────────────────────────────────────────────────\n",
+    "# Change SNAPSHOT_PATH to point at a real run directory, e.g.:\n",
+    "#   SNAPSHOT_PATH = \"experiments/intrinsic_evolution_smoke\"\n",
+    "# or directly to the file:\n",
+    "#   SNAPSHOT_PATH = \"experiments/intrinsic_evolution_smoke/intrinsic_gene_snapshots.jsonl\"\n",
+    "SNAPSHOT_PATH = None  # None → use the synthetic fixture created below\n",
+    "\n",
+    "# ── Synthetic fixture (skip when SNAPSHOT_PATH is set) ─────────────────────\n",
+    "if SNAPSHOT_PATH is None:\n",
+    "    _tmp = tempfile.mkdtemp(prefix=\"lineage_nb_\")\n",
+    "    _fixture = pathlib.Path(_tmp) / \"intrinsic_gene_snapshots.jsonl\"\n",
+    "\n",
+    "    def _agent(agent_id, parent_ids, generation=0, lr=0.01, gamma=0.99):\n",
+    "        return {\n",
+    "            \"agent_id\": agent_id,\n",
+    "            \"agent_type\": \"system\",\n",
+    "            \"generation\": generation,\n",
+    "            \"parent_ids\": parent_ids,\n",
+    "            \"chromosome\": {\"learning_rate\": lr, \"gamma\": gamma},\n",
+    "        }\n",
+    "\n",
+    "    snapshots = [\n",
+    "        # Step 0 – two founder lineages, 4 agents\n",
+    "        {\"step\": 0, \"agents\": [\n",
+    "            _agent(\"r1\", [], lr=0.005, gamma=0.95),\n",
+    "            _agent(\"r2\", [], lr=0.020, gamma=0.99),\n",
+    "            _agent(\"r3\", [], lr=0.010, gamma=0.97),\n",
+    "            _agent(\"r4\", [], lr=0.015, gamma=0.98),\n",
+    "        ]},\n",
+    "        # Step 50 – r2 lineage expands\n",
+    "        {\"step\": 50, \"agents\": [\n",
+    "            _agent(\"r1\", [], generation=0, lr=0.005),\n",
+    "            _agent(\"r2\", [], generation=0, lr=0.020),\n",
+    "            _agent(\"c1\", [\"r2\"], generation=1, lr=0.018),\n",
+    "            _agent(\"c2\", [\"r2\"], generation=1, lr=0.022),\n",
+    "            _agent(\"r3\", [], generation=0, lr=0.010),\n",
+    "            # r4 gone\n",
+    "        ]},\n",
+    "        # Step 100 – r1 lineage extinct; r2 lineage deeper; dual-parent child\n",
+    "        {\"step\": 100, \"agents\": [\n",
+    "            _agent(\"r2\",  [], generation=0, lr=0.020),\n",
+    "            _agent(\"c1\",  [\"r2\"], generation=1, lr=0.018),\n",
+    "            _agent(\"c2\",  [\"r2\"], generation=1, lr=0.022),\n",
+    "            _agent(\"gc1\", [\"c1\", \"c2\"], generation=2, lr=0.020),  # crossover child\n",
+    "            _agent(\"r3\",  [], generation=0, lr=0.010),\n",
+    "            _agent(\"c3\",  [\"r3\"], generation=1, lr=0.011),\n",
+    "        ]},\n",
+    "        # Step 150 – final snapshot\n",
+    "        {\"step\": 150, \"agents\": [\n",
+    "            _agent(\"r2\",  [], generation=0, lr=0.020),\n",
+    "            _agent(\"gc1\", [\"c1\", \"c2\"], generation=2, lr=0.021),\n",
+    "            _agent(\"ggc1\", [\"gc1\"], generation=3, lr=0.021),\n",
+    "            _agent(\"r3\",  [], generation=0, lr=0.010),\n",
+    "            _agent(\"c3\",  [\"r3\"], generation=1, lr=0.012),\n",
+    "        ]},\n",
+    "    ]\n",
+    "\n",
+    "    with _fixture.open(\"w\") as fh:\n",
+    "        for snap in snapshots:\n",
+    "            fh.write(json.dumps(snap) + \"\\n\")\n",
+    "\n",
+    "    SNAPSHOT_PATH = str(_fixture)\n",
+    "    print(f\"Using synthetic fixture at {SNAPSHOT_PATH}\")\n",
+    "else:\n",
+    "    print(f\"Using snapshot file: {SNAPSHOT_PATH}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2d3e4f5",
+   "metadata": {},
+   "source": [
+    "## 1. Load the snapshots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3e4f5a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from farm.analysis.phylogenetics import (\n",
+    "    load_intrinsic_snapshots,\n",
+    "    flatten_snapshots_to_agent_records,\n",
+    "    build_intrinsic_lineage_dag,\n",
+    "    extract_chromosomes_from_snapshots,\n",
+    "    compute_surviving_lineage_count_over_time,\n",
+    "    compute_lineage_depth_over_time,\n",
+    "    plot_intrinsic_lineage_tree,\n",
+    ")\n",
+    "\n",
+    "snapshots = load_intrinsic_snapshots(SNAPSHOT_PATH)\n",
+    "print(f\"Loaded {len(snapshots)} snapshot steps\")\n",
+    "steps = sorted(s['step'] for s in snapshots)\n",
+    "print(f\"Steps: {steps}\")\n",
+    "print(f\"Agents at final step: {len(snapshots[-1]['agents'])}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4f5a6b7",
+   "metadata": {},
+   "source": [
+    "## 2. Build the lineage DAG"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5a6b7c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tree = build_intrinsic_lineage_dag(SNAPSHOT_PATH)\n",
+    "summary = tree.summary()\n",
+    "\n",
+    "print(f\"Nodes  : {summary.num_nodes}\")\n",
+    "print(f\"Founders (roots): {summary.num_founders}  → {tree.roots}\")\n",
+    "print(f\"Max depth: {summary.max_depth}\")\n",
+    "print(f\"Mean depth: {summary.mean_depth:.2f}\")\n",
+    "print(f\"Mean branching factor: {summary.mean_branching_factor:.2f}\")\n",
+    "print(f\"Is DAG (dual-parent): {tree.is_dag}\")\n",
+    "print(f\"Orphan nodes: {summary.num_orphans}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6b7c8d9",
+   "metadata": {},
+   "source": [
+    "## 3. Plot – lineage colouring"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7c8d9e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pathlib, tempfile\n",
+    "from farm.analysis.common.context import AnalysisContext\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib\n",
+    "matplotlib.use(\"Agg\")  # non-interactive; change to \"inline\" in Jupyter\n",
+    "\n",
+    "out_dir = pathlib.Path(tempfile.mkdtemp(prefix=\"lineage_plots_\"))\n",
+    "ctx = AnalysisContext(output_path=out_dir)\n",
+    "\n",
+    "out_path = plot_intrinsic_lineage_tree(\n",
+    "    tree, ctx,\n",
+    "    color_by_lineage=True,\n",
+    "    title=\"Intrinsic Lineage Tree – coloured by founder lineage\",\n",
+    ")\n",
+    "print(f\"Saved: {out_path}\")\n",
+    "from IPython.display import Image\n",
+    "Image(str(out_path))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8d9e0f1",
+   "metadata": {},
+   "source": [
+    "## 4. Plot – gene-value colouring\n",
+    "\n",
+    "Nodes are coloured by the `learning_rate` chromosome value on a continuous\n",
+    "`viridis` scale.  Founders that have no chromosome entry (e.g. synthetic\n",
+    "\"seed\" parents) appear at the midpoint colour."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9e0f1a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chromosomes = extract_chromosomes_from_snapshots(snapshots)\n",
+    "print(f\"Chromosome entries: {len(chromosomes)}\")\n",
+    "\n",
+    "out_path_gene = plot_intrinsic_lineage_tree(\n",
+    "    tree, ctx,\n",
+    "    gene=\"learning_rate\",\n",
+    "    chromosomes=chromosomes,\n",
+    "    title=\"Intrinsic Lineage Tree – coloured by learning_rate\",\n",
+    ")\n",
+    "print(f\"Saved: {out_path_gene}\")\n",
+    "Image(str(out_path_gene))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0f1a2b3",
+   "metadata": {},
+   "source": [
+    "## 5. Surviving-lineage count over time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1a2b3c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib\n",
+    "matplotlib.use(\"Agg\")\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "lineage_counts = compute_surviving_lineage_count_over_time(tree, snapshots)\n",
+    "print(\"Step  →  Surviving lineages\")\n",
+    "for step, count in lineage_counts:\n",
+    "    print(f\"  {step:>5}  →  {count}\")\n",
+    "\n",
+    "steps_lc, counts_lc = zip(*lineage_counts) if lineage_counts else ([], [])\n",
+    "fig, ax = plt.subplots(figsize=(7, 3))\n",
+    "ax.step(steps_lc, counts_lc, where=\"post\", lw=2)\n",
+    "ax.set_xlabel(\"Simulation step\")\n",
+    "ax.set_ylabel(\"Distinct founder lineages\")\n",
+    "ax.set_title(\"Surviving lineage count over time\")\n",
+    "ax.yaxis.get_major_locator().set_params(integer=True)\n",
+    "plt.tight_layout()\n",
+    "lc_path = out_dir / \"lineage_count_over_time.png\"\n",
+    "fig.savefig(lc_path, dpi=150, bbox_inches=\"tight\")\n",
+    "plt.close(fig)\n",
+    "print(f\"Saved: {lc_path}\")\n",
+    "Image(str(lc_path))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2b3c4d5",
+   "metadata": {},
+   "source": [
+    "## 6. Lineage depth over time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3c4d5e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "depth_series = compute_lineage_depth_over_time(tree, snapshots)\n",
+    "print(\"Step  →  max_depth / mean_depth\")\n",
+    "for step, max_d, mean_d in depth_series:\n",
+    "    print(f\"  {step:>5}  →  max={max_d}  mean={mean_d:.2f}\")\n",
+    "\n",
+    "if depth_series:\n",
+    "    steps_d, max_depths, mean_depths = zip(*depth_series)\n",
+    "    fig, ax = plt.subplots(figsize=(7, 3))\n",
+    "    ax.plot(steps_d, max_depths, label=\"max depth\", lw=2)\n",
+    "    ax.plot(steps_d, mean_depths, label=\"mean depth\", lw=2, linestyle=\"--\")\n",
+    "    ax.set_xlabel(\"Simulation step\")\n",
+    "    ax.set_ylabel(\"Lineage depth\")\n",
+    "    ax.set_title(\"Lineage depth of alive agents over time\")\n",
+    "    ax.legend()\n",
+    "    plt.tight_layout()\n",
+    "    depth_path = out_dir / \"lineage_depth_over_time.png\"\n",
+    "    fig.savefig(depth_path, dpi=150, bbox_inches=\"tight\")\n",
+    "    plt.close(fig)\n",
+    "    print(f\"Saved: {depth_path}\")\n",
+    "    Image(str(depth_path))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4d5e6f7",
+   "metadata": {},
+   "source": [
+    "## 7. Inspect individual lineages\n",
+    "\n",
+    "Trace which chromosome values were observed along the ancestry path of a\n",
+    "specific agent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5e6f7a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from farm.analysis.phylogenetics.intrinsic_loader import _trace_to_founder\n",
+    "\n",
+    "FOCUS_AGENT = tree.roots[0] if tree.roots else None\n",
+    "if FOCUS_AGENT:\n",
+    "    print(f\"Founder of all inspected agents: {FOCUS_AGENT}\")\n",
+    "\n",
+    "# Walk every alive agent at the final step back to its founder\n",
+    "final_agents = [a[\"agent_id\"] for a in snapshots[-1].get(\"agents\", [])]\n",
+    "print(\"\\nAgent  →  founder  →  learning_rate\")\n",
+    "for aid in final_agents:\n",
+    "    founder = _trace_to_founder(tree, str(aid))\n",
+    "    lr = chromosomes.get(str(aid), {}).get(\"learning_rate\", \"n/a\")\n",
+    "    print(f\"  {aid:<12}  →  {founder:<12}  →  {lr}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6f7a8b9",
+   "metadata": {},
+   "source": [
+    "## 8. Export tree as JSON / Newick\n",
+    "\n",
+    "The underlying `PhylogeneticTree` object supports JSON and Newick export for\n",
+    "use with external tree viewers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7a8b9c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json, pathlib\n",
+    "\n",
+    "json_path = out_dir / \"lineage_tree.json\"\n",
+    "json_path.write_text(tree.to_json())\n",
+    "print(f\"JSON tree saved to: {json_path}\")\n",
+    "\n",
+    "newick_str = tree.to_newick()\n",
+    "newick_path = out_dir / \"lineage_tree.newick\"\n",
+    "newick_path.write_text(newick_str)\n",
+    "print(f\"Newick string: {newick_str[:200]}{'...' if len(newick_str) > 200 else ''}\")\n",
+    "print(f\"Newick saved to: {newick_path}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/intrinsic_lineage_tree.ipynb
+++ b/notebooks/intrinsic_lineage_tree.ipynb
@@ -184,9 +184,9 @@
    "source": [
     "import pathlib, tempfile\n",
     "from farm.analysis.common.context import AnalysisContext\n",
-    "import matplotlib.pyplot as plt\n",
     "import matplotlib\n",
     "matplotlib.use(\"Agg\")  # non-interactive; change to \"inline\" in Jupyter\n",
+    "import matplotlib.pyplot as plt\n",
     "\n",
     "out_dir = pathlib.Path(tempfile.mkdtemp(prefix=\"lineage_plots_\"))\n",
     "ctx = AnalysisContext(output_path=out_dir)\n",
@@ -327,7 +327,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from farm.analysis.phylogenetics.intrinsic_loader import _trace_to_founder\n",
+    "from farm.analysis.phylogenetics import trace_to_founder\n",
     "\n",
     "FOCUS_AGENT = tree.roots[0] if tree.roots else None\n",
     "if FOCUS_AGENT:\n",
@@ -337,7 +337,7 @@
     "final_agents = [a[\"agent_id\"] for a in snapshots[-1].get(\"agents\", [])]\n",
     "print(\"\\nAgent  →  founder  →  learning_rate\")\n",
     "for aid in final_agents:\n",
-    "    founder = _trace_to_founder(tree, str(aid))\n",
+    "    founder = trace_to_founder(tree, str(aid))\n",
     "    lr = chromosomes.get(str(aid), {}).get(\"learning_rate\", \"n/a\")\n",
     "    print(f\"  {aid:<12}  →  {founder:<12}  →  {lr}\")"
    ]

--- a/tests/analysis/test_intrinsic_lineage.py
+++ b/tests/analysis/test_intrinsic_lineage.py
@@ -1,0 +1,528 @@
+"""Tests for intrinsic lineage loader and summary helpers.
+
+Covers:
+- load_intrinsic_snapshots: JSONL parsing, missing file, directory dispatch,
+  malformed lines
+- flatten_snapshots_to_agent_records: deduplication, birth/death time
+  inference, parent_id normalisation
+- build_intrinsic_lineage_dag: end-to-end from JSONL file
+- compute_surviving_lineage_count_over_time: per-step founder count
+- compute_lineage_depth_over_time: per-step depth stats
+- extract_chromosomes_from_snapshots: last-seen chromosome extraction
+- plot_intrinsic_lineage_tree: smoke test with gene colouring
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from farm.analysis.phylogenetics.intrinsic_loader import (
+    load_intrinsic_snapshots,
+    flatten_snapshots_to_agent_records,
+    build_intrinsic_lineage_dag,
+    compute_surviving_lineage_count_over_time,
+    compute_lineage_depth_over_time,
+    extract_chromosomes_from_snapshots,
+)
+from farm.analysis.phylogenetics.compute import PhylogeneticTree
+
+
+# ---------------------------------------------------------------------------
+# Fixtures helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_snapshot(step: int, agents: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return {"step": step, "agents": agents}
+
+
+def _make_agent(
+    agent_id: str,
+    parent_ids: List[str],
+    generation: int = 0,
+    chromosome: Dict[str, float] | None = None,
+) -> Dict[str, Any]:
+    return {
+        "agent_id": agent_id,
+        "agent_type": "system",
+        "generation": generation,
+        "parent_ids": parent_ids,
+        "chromosome": chromosome or {"learning_rate": 0.01, "gamma": 0.99},
+    }
+
+
+def _write_snapshots(path: Path, snapshots: List[Dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for snap in snapshots:
+            fh.write(json.dumps(snap) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# load_intrinsic_snapshots
+# ---------------------------------------------------------------------------
+
+
+class TestLoadIntrinsicSnapshots:
+    def test_missing_file_returns_empty(self, tmp_path):
+        result = load_intrinsic_snapshots(tmp_path / "nonexistent.jsonl")
+        assert result == []
+
+    def test_directory_dispatch(self, tmp_path):
+        snap_file = tmp_path / "intrinsic_gene_snapshots.jsonl"
+        _write_snapshots(snap_file, [_make_snapshot(0, [_make_agent("a1", [])])])
+        result = load_intrinsic_snapshots(tmp_path)  # pass directory
+        assert len(result) == 1
+        assert result[0]["step"] == 0
+
+    def test_basic_load(self, tmp_path):
+        snap_file = tmp_path / "snaps.jsonl"
+        snaps = [
+            _make_snapshot(0, [_make_agent("a1", [])]),
+            _make_snapshot(100, [_make_agent("a1", []), _make_agent("a2", ["a1"])]),
+        ]
+        _write_snapshots(snap_file, snaps)
+        result = load_intrinsic_snapshots(snap_file)
+        assert len(result) == 2
+        assert result[0]["step"] == 0
+        assert result[1]["step"] == 100
+
+    def test_malformed_line_skipped(self, tmp_path):
+        snap_file = tmp_path / "snaps.jsonl"
+        with snap_file.open("w") as fh:
+            fh.write('{"step": 0, "agents": []}\n')
+            fh.write("NOT JSON\n")
+            fh.write('{"step": 100, "agents": []}\n')
+        result = load_intrinsic_snapshots(snap_file)
+        assert len(result) == 2
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        snap_file = tmp_path / "snaps.jsonl"
+        snap_file.write_text("")
+        result = load_intrinsic_snapshots(snap_file)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# flatten_snapshots_to_agent_records
+# ---------------------------------------------------------------------------
+
+
+class TestFlattenSnapshots:
+    def test_empty_snapshots_returns_empty(self):
+        assert flatten_snapshots_to_agent_records([]) == []
+
+    def test_single_snapshot_all_alive(self):
+        snaps = [_make_snapshot(0, [_make_agent("a1", []), _make_agent("a2", ["a1"])])]
+        records = flatten_snapshots_to_agent_records(snaps)
+        assert len(records) == 2
+        ids = {r["agent_id"] for r in records}
+        assert ids == {"a1", "a2"}
+        # Both alive at final step → death_time == None
+        for r in records:
+            assert r["death_time"] is None
+
+    def test_birth_time_is_first_seen_step(self):
+        snaps = [
+            _make_snapshot(0, [_make_agent("a1", [])]),
+            _make_snapshot(100, [_make_agent("a1", []), _make_agent("a2", ["a1"])]),
+        ]
+        records = flatten_snapshots_to_agent_records(snaps)
+        by_id = {r["agent_id"]: r for r in records}
+        assert by_id["a1"]["birth_time"] == 0
+        assert by_id["a2"]["birth_time"] == 100
+
+    def test_death_time_inferred_for_absent_agent(self):
+        """Agent absent at final step should have approximate death_time."""
+        snaps = [
+            _make_snapshot(0, [_make_agent("a1", []), _make_agent("a2", ["a1"])]),
+            _make_snapshot(100, [_make_agent("a1", [])]),  # a2 absent
+        ]
+        records = flatten_snapshots_to_agent_records(snaps)
+        by_id = {r["agent_id"]: r for r in records}
+        assert by_id["a1"]["death_time"] is None  # still alive at step 100
+        # a2 last seen at step 0; next step is 100
+        assert by_id["a2"]["death_time"] == 100
+
+    def test_agent_alive_at_final_step_has_none_death(self):
+        snaps = [
+            _make_snapshot(0, [_make_agent("a1", [])]),
+            _make_snapshot(200, [_make_agent("a1", [])]),
+        ]
+        records = flatten_snapshots_to_agent_records(snaps)
+        assert records[0]["death_time"] is None
+
+    def test_deduplication(self):
+        """Same agent_id across multiple steps results in one record."""
+        snaps = [
+            _make_snapshot(0, [_make_agent("a1", [])]),
+            _make_snapshot(100, [_make_agent("a1", [])]),
+            _make_snapshot(200, [_make_agent("a1", [])]),
+        ]
+        records = flatten_snapshots_to_agent_records(snaps)
+        assert len(records) == 1
+        assert records[0]["agent_id"] == "a1"
+
+    def test_chromosome_from_last_snapshot(self):
+        """The chromosome in the record should be from the last-seen snapshot."""
+        snaps = [
+            _make_snapshot(0, [_make_agent("a1", [], chromosome={"learning_rate": 0.01})]),
+            _make_snapshot(100, [_make_agent("a1", [], chromosome={"learning_rate": 0.02})]),
+        ]
+        records = flatten_snapshots_to_agent_records(snaps)
+        assert records[0]["chromosome"]["learning_rate"] == pytest.approx(0.02)
+
+    def test_parent_ids_normalised(self):
+        snaps = [_make_snapshot(0, [_make_agent("a1", ["p1", "p2"])])]
+        records = flatten_snapshots_to_agent_records(snaps)
+        assert records[0]["parent_ids"] == ["p1", "p2"]
+
+    def test_none_parent_ids_filtered(self):
+        agent = _make_agent("a1", [])
+        agent["parent_ids"] = [None, "p1"]
+        snaps = [_make_snapshot(0, [agent])]
+        records = flatten_snapshots_to_agent_records(snaps)
+        assert records[0]["parent_ids"] == ["p1"]
+
+
+# ---------------------------------------------------------------------------
+# build_intrinsic_lineage_dag
+# ---------------------------------------------------------------------------
+
+
+class TestBuildIntrinsicLineageDag:
+    def test_missing_file_returns_empty_tree(self, tmp_path):
+        tree = build_intrinsic_lineage_dag(tmp_path / "nonexistent.jsonl")
+        assert isinstance(tree, PhylogeneticTree)
+        assert tree.nodes == {}
+
+    def test_basic_lineage(self, tmp_path):
+        snap_file = tmp_path / "snaps.jsonl"
+        snaps = [
+            _make_snapshot(0, [_make_agent("founder", [])]),
+            _make_snapshot(100, [
+                _make_agent("founder", []),
+                _make_agent("child1", ["founder"], generation=1),
+                _make_agent("child2", ["founder"], generation=1),
+            ]),
+        ]
+        _write_snapshots(snap_file, snaps)
+        tree = build_intrinsic_lineage_dag(snap_file)
+        assert "founder" in tree.nodes
+        assert "child1" in tree.nodes
+        assert "child2" in tree.nodes
+        assert tree.nodes["founder"].is_root is True
+        assert tree.nodes["child1"].depth == 1
+        assert tree.nodes["child2"].depth == 1
+
+    def test_dag_when_two_parents(self, tmp_path):
+        snap_file = tmp_path / "snaps.jsonl"
+        snaps = [
+            _make_snapshot(0, [
+                _make_agent("p1", []),
+                _make_agent("p2", []),
+            ]),
+            _make_snapshot(100, [
+                _make_agent("p1", []),
+                _make_agent("p2", []),
+                _make_agent("child", ["p1", "p2"], generation=1),
+            ]),
+        ]
+        _write_snapshots(snap_file, snaps)
+        tree = build_intrinsic_lineage_dag(snap_file)
+        assert tree.is_dag is True
+        assert tree.nodes["child"].parent_ids == ["p1", "p2"]
+
+    def test_directory_path_dispatch(self, tmp_path):
+        snap_file = tmp_path / "intrinsic_gene_snapshots.jsonl"
+        snaps = [_make_snapshot(0, [_make_agent("a1", [])])]
+        _write_snapshots(snap_file, snaps)
+        tree = build_intrinsic_lineage_dag(tmp_path)
+        assert "a1" in tree.nodes
+
+    def test_deterministic_roots(self, tmp_path):
+        snap_file = tmp_path / "snaps.jsonl"
+        snaps = [
+            _make_snapshot(0, [
+                _make_agent("z_founder", []),
+                _make_agent("a_founder", []),
+            ]),
+        ]
+        _write_snapshots(snap_file, snaps)
+        tree = build_intrinsic_lineage_dag(snap_file)
+        assert tree.roots == sorted(tree.roots)
+
+
+# ---------------------------------------------------------------------------
+# compute_surviving_lineage_count_over_time
+# ---------------------------------------------------------------------------
+
+
+class TestSurvivingLineageCountOverTime:
+    def test_empty_inputs(self):
+        tree = PhylogeneticTree(nodes={}, roots=[], is_dag=False)
+        assert compute_surviving_lineage_count_over_time(tree, []) == []
+
+    def test_single_lineage_throughout(self, tmp_path):
+        snap_file = tmp_path / "snaps.jsonl"
+        snaps = [
+            _make_snapshot(0, [_make_agent("root", [])]),
+            _make_snapshot(100, [
+                _make_agent("root", []),
+                _make_agent("child", ["root"], generation=1),
+            ]),
+        ]
+        _write_snapshots(snap_file, snaps)
+        tree = build_intrinsic_lineage_dag(snap_file)
+        raw = load_intrinsic_snapshots(snap_file)
+        result = compute_surviving_lineage_count_over_time(tree, raw)
+        # Both steps should show 1 lineage (root's lineage)
+        assert len(result) == 2
+        steps = [r[0] for r in result]
+        counts = [r[1] for r in result]
+        assert steps == [0, 100]
+        assert all(c == 1 for c in counts)
+
+    def test_two_independent_lineages(self, tmp_path):
+        snap_file = tmp_path / "snaps.jsonl"
+        snaps = [
+            _make_snapshot(0, [
+                _make_agent("r1", []),
+                _make_agent("r2", []),
+            ]),
+            _make_snapshot(100, [
+                _make_agent("r1", []),
+                _make_agent("c1", ["r1"], generation=1),
+                _make_agent("r2", []),
+                _make_agent("c2", ["r2"], generation=1),
+            ]),
+        ]
+        _write_snapshots(snap_file, snaps)
+        tree = build_intrinsic_lineage_dag(snap_file)
+        raw = load_intrinsic_snapshots(snap_file)
+        result = compute_surviving_lineage_count_over_time(tree, raw)
+        counts = [r[1] for r in result]
+        assert all(c == 2 for c in counts)
+
+    def test_lineage_extinction(self, tmp_path):
+        """When a lineage dies out between snapshots, count drops."""
+        snap_file = tmp_path / "snaps.jsonl"
+        snaps = [
+            _make_snapshot(0, [
+                _make_agent("r1", []),
+                _make_agent("r2", []),
+            ]),
+            _make_snapshot(100, [
+                _make_agent("r1", []),  # r2 lineage extinct
+            ]),
+        ]
+        _write_snapshots(snap_file, snaps)
+        tree = build_intrinsic_lineage_dag(snap_file)
+        raw = load_intrinsic_snapshots(snap_file)
+        result = compute_surviving_lineage_count_over_time(tree, raw)
+        assert result[0] == (0, 2)
+        assert result[1] == (100, 1)
+
+    def test_sorted_by_step(self, tmp_path):
+        snap_file = tmp_path / "snaps.jsonl"
+        # Write in reverse order to verify sorting
+        snaps_reversed = [
+            _make_snapshot(200, [_make_agent("r1", [])]),
+            _make_snapshot(100, [_make_agent("r1", [])]),
+            _make_snapshot(0, [_make_agent("r1", [])]),
+        ]
+        with snap_file.open("w") as fh:
+            for s in snaps_reversed:
+                fh.write(json.dumps(s) + "\n")
+        tree = build_intrinsic_lineage_dag(snap_file)
+        raw = load_intrinsic_snapshots(snap_file)
+        result = compute_surviving_lineage_count_over_time(tree, raw)
+        steps = [r[0] for r in result]
+        assert steps == sorted(steps)
+
+
+# ---------------------------------------------------------------------------
+# compute_lineage_depth_over_time
+# ---------------------------------------------------------------------------
+
+
+class TestLineageDepthOverTime:
+    def test_empty_returns_empty(self):
+        tree = PhylogeneticTree(nodes={}, roots=[], is_dag=False)
+        assert compute_lineage_depth_over_time(tree, []) == []
+
+    def test_depth_grows_over_time(self, tmp_path):
+        snap_file = tmp_path / "snaps.jsonl"
+        snaps = [
+            _make_snapshot(0, [_make_agent("r", [])]),
+            _make_snapshot(100, [
+                _make_agent("r", []),
+                _make_agent("c", ["r"], generation=1),
+            ]),
+            _make_snapshot(200, [
+                _make_agent("c", ["r"]),
+                _make_agent("gc", ["c"], generation=2),
+            ]),
+        ]
+        _write_snapshots(snap_file, snaps)
+        tree = build_intrinsic_lineage_dag(snap_file)
+        raw = load_intrinsic_snapshots(snap_file)
+        result = compute_lineage_depth_over_time(tree, raw)
+        # step 0: only root at depth 0
+        # step 100: root (0) + child (1)
+        # step 200: child (1) + grandchild (2)
+        assert len(result) == 3
+        by_step = {r[0]: r for r in result}
+        assert by_step[0][1] == 0   # max_depth at step 0
+        assert by_step[100][1] == 1  # max_depth at step 100
+        assert by_step[200][1] == 2  # max_depth at step 200
+
+    def test_result_sorted_by_step(self, tmp_path):
+        snap_file = tmp_path / "snaps.jsonl"
+        snaps = [
+            _make_snapshot(0, [_make_agent("r", [])]),
+            _make_snapshot(50, [_make_agent("r", [])]),
+        ]
+        _write_snapshots(snap_file, snaps)
+        tree = build_intrinsic_lineage_dag(snap_file)
+        raw = load_intrinsic_snapshots(snap_file)
+        result = compute_lineage_depth_over_time(tree, raw)
+        steps = [r[0] for r in result]
+        assert steps == sorted(steps)
+
+
+# ---------------------------------------------------------------------------
+# extract_chromosomes_from_snapshots
+# ---------------------------------------------------------------------------
+
+
+class TestExtractChromosomes:
+    def test_empty_snapshots(self):
+        assert extract_chromosomes_from_snapshots([]) == {}
+
+    def test_basic_extraction(self):
+        snaps = [
+            _make_snapshot(0, [_make_agent("a1", [], chromosome={"learning_rate": 0.01})]),
+        ]
+        result = extract_chromosomes_from_snapshots(snaps)
+        assert "a1" in result
+        assert result["a1"]["learning_rate"] == pytest.approx(0.01)
+
+    def test_last_seen_value_wins(self):
+        snaps = [
+            _make_snapshot(0, [_make_agent("a1", [], chromosome={"learning_rate": 0.01})]),
+            _make_snapshot(100, [_make_agent("a1", [], chromosome={"learning_rate": 0.02})]),
+        ]
+        result = extract_chromosomes_from_snapshots(snaps)
+        assert result["a1"]["learning_rate"] == pytest.approx(0.02)
+
+    def test_multiple_agents(self):
+        snaps = [
+            _make_snapshot(0, [
+                _make_agent("a1", [], chromosome={"lr": 0.01}),
+                _make_agent("a2", [], chromosome={"lr": 0.05}),
+            ]),
+        ]
+        result = extract_chromosomes_from_snapshots(snaps)
+        assert set(result.keys()) == {"a1", "a2"}
+
+
+# ---------------------------------------------------------------------------
+# plot_intrinsic_lineage_tree – smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestPlotIntrinsicLineageTree:
+    def _make_tree_and_chroms(self, tmp_path):
+        snap_file = tmp_path / "snaps.jsonl"
+        snaps = [
+            _make_snapshot(0, [
+                _make_agent("r", [], chromosome={"learning_rate": 0.005}),
+            ]),
+            _make_snapshot(100, [
+                _make_agent("r", [], chromosome={"learning_rate": 0.005}),
+                _make_agent("c1", ["r"], generation=1, chromosome={"learning_rate": 0.01}),
+                _make_agent("c2", ["r"], generation=1, chromosome={"learning_rate": 0.02}),
+            ]),
+            _make_snapshot(200, [
+                _make_agent("r", [], chromosome={"learning_rate": 0.005}),
+                _make_agent("c1", ["r"], generation=1, chromosome={"learning_rate": 0.01}),
+                _make_agent("gc1", ["c1"], generation=2, chromosome={"learning_rate": 0.015}),
+            ]),
+        ]
+        _write_snapshots(snap_file, snaps)
+        tree = build_intrinsic_lineage_dag(snap_file)
+        raw = load_intrinsic_snapshots(snap_file)
+        chroms = extract_chromosomes_from_snapshots(raw)
+        return tree, chroms
+
+    def test_plot_lineage_colouring(self, tmp_path):
+        from farm.analysis.phylogenetics.plot import plot_intrinsic_lineage_tree
+        from farm.analysis.common.context import AnalysisContext
+
+        tree, chroms = self._make_tree_and_chroms(tmp_path)
+        ctx = AnalysisContext(output_path=tmp_path)
+        result = plot_intrinsic_lineage_tree(tree, ctx)
+        assert result is not None
+        assert Path(result).exists()
+
+    def test_plot_gene_colouring(self, tmp_path):
+        from farm.analysis.phylogenetics.plot import plot_intrinsic_lineage_tree
+        from farm.analysis.common.context import AnalysisContext
+
+        tree, chroms = self._make_tree_and_chroms(tmp_path)
+        ctx = AnalysisContext(output_path=tmp_path)
+        result = plot_intrinsic_lineage_tree(
+            tree, ctx, gene="learning_rate", chromosomes=chroms
+        )
+        assert result is not None
+        assert Path(result).exists()
+
+    def test_plot_empty_tree_returns_none(self, tmp_path):
+        from farm.analysis.phylogenetics.plot import plot_intrinsic_lineage_tree
+        from farm.analysis.common.context import AnalysisContext
+
+        tree = PhylogeneticTree(nodes={}, roots=[], is_dag=False)
+        ctx = AnalysisContext(output_path=tmp_path)
+        result = plot_intrinsic_lineage_tree(tree, ctx)
+        assert result is None
+
+    def test_plot_gene_missing_falls_back_gracefully(self, tmp_path):
+        """When gene not in chromosomes, falls back to lineage colouring."""
+        from farm.analysis.phylogenetics.plot import plot_intrinsic_lineage_tree
+        from farm.analysis.common.context import AnalysisContext
+
+        tree, chroms = self._make_tree_and_chroms(tmp_path)
+        ctx = AnalysisContext(output_path=tmp_path)
+        result = plot_intrinsic_lineage_tree(
+            tree, ctx, gene="nonexistent_gene", chromosomes=chroms
+        )
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Public API import smoke test
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_importable():
+    from farm.analysis.phylogenetics import (
+        load_intrinsic_snapshots,
+        flatten_snapshots_to_agent_records,
+        build_intrinsic_lineage_dag,
+        compute_surviving_lineage_count_over_time,
+        compute_lineage_depth_over_time,
+        extract_chromosomes_from_snapshots,
+        plot_intrinsic_lineage_tree,
+    )
+    assert callable(load_intrinsic_snapshots)
+    assert callable(flatten_snapshots_to_agent_records)
+    assert callable(build_intrinsic_lineage_dag)
+    assert callable(compute_surviving_lineage_count_over_time)
+    assert callable(compute_lineage_depth_over_time)
+    assert callable(extract_chromosomes_from_snapshots)
+    assert callable(plot_intrinsic_lineage_tree)

--- a/tests/analysis/test_intrinsic_lineage.py
+++ b/tests/analysis/test_intrinsic_lineage.py
@@ -174,7 +174,10 @@ class TestFlattenSnapshots:
             _make_snapshot(100, [_make_agent("a1", [], chromosome={"learning_rate": 0.02})]),
         ]
         records = flatten_snapshots_to_agent_records(snaps)
-        assert records[0]["chromosome"]["learning_rate"] == pytest.approx(0.02)
+        lr = records[0]["chromosome"]["learning_rate"]
+        assert lr == pytest.approx(0.02)
+        # Confirm the initial value (0.01) was overwritten, not retained
+        assert lr != pytest.approx(0.01)
 
     def test_parent_ids_normalised(self):
         snaps = [_make_snapshot(0, [_make_agent("a1", ["p1", "p2"])])]


### PR DESCRIPTION
This pull request introduces a first-class intrinsic-evolution lineage tree visualization feature, including a new plotting function, improved documentation, and a streamlined API for loading and analyzing intrinsic evolution runs. The changes provide an easy way to reconstruct, analyze, and visualize evolutionary lineages from `intrinsic_gene_snapshots.jsonl` artifacts, including per-gene coloring and summary statistics.

**Intrinsic-evolution lineage tree visualization:**
- Added a comprehensive quick-start guide, API reference, and notebook walkthrough to `intrinsic_evolution.md`, detailing how to load, analyze, and plot intrinsic lineage trees using the new API.
- Updated the module documentation in `farm/analysis/phylogenetics/__init__.py` to highlight the new intrinsic-evolution loader, per-gene coloring, and summary statistics. [[1]](diffhunk://#diff-bef469cb9435d9e20edc2916e9c7c8bcc48fd16e37216f606c2749da057642f5R14-R16) [[2]](diffhunk://#diff-bef469cb9435d9e20edc2916e9c7c8bcc48fd16e37216f606c2749da057642f5R30-R40)

**API and code enhancements:**
- Exported new loader, analysis, and plotting functions from `farm.analysis.phylogenetics`, including `build_intrinsic_lineage_dag`, `load_intrinsic_snapshots`, `extract_chromosomes_from_snapshots`, and `plot_intrinsic_lineage_tree`. [[1]](diffhunk://#diff-bef469cb9435d9e20edc2916e9c7c8bcc48fd16e37216f606c2749da057642f5L44-R67) [[2]](diffhunk://#diff-bef469cb9435d9e20edc2916e9c7c8bcc48fd16e37216f606c2749da057642f5R81-R88)
- Implemented `plot_intrinsic_lineage_tree` in `plot.py`, a specialized plotting function for intrinsic-evolution runs that supports per-gene (continuous) coloring and founder-lineage coloring, with automatic pruning for large trees.
- Refactored colormap selection into a helper for compatibility and replaced inline code with this helper in the main plotting function. [[1]](diffhunk://#diff-aa008e440bdc665ae155042ca6fc23d01d0dd650f0593b1d3065e0f33a23b765R43-R53) [[2]](diffhunk://#diff-aa008e440bdc665ae155042ca6fc23d01d0dd650f0593b1d3065e0f33a23b765L144-R162)

These changes make it straightforward to visualize and analyze evolutionary lineages from intrinsic runs, with robust support for large datasets and customizable coloring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new lineage-DAG loading and visualization paths for intrinsic evolution runs, plus time-series lineage metrics; risk is mainly around correctness/performance on large snapshot files and plotting behavior in headless environments.
> 
> **Overview**
> Adds first-class intrinsic-evolution lineage analysis by introducing an `intrinsic_gene_snapshots.jsonl` loader that flattens snapshots into per-agent records (with inferred `birth_time`/`death_time`) and builds a lineage DAG via `build_intrinsic_lineage_dag`.
> 
> Extends phylogenetics visualization with `plot_intrinsic_lineage_tree`, supporting founder-lineage colouring or continuous per-gene chromosome colouring (with pruning for large trees), and refactors colormap selection into a compatibility helper used by existing plots.
> 
> Exports the new APIs from `farm.analysis.phylogenetics`, adds comprehensive docs + a runnable notebook walkthrough, and introduces a dedicated test suite covering parsing, DAG construction, metrics (`compute_surviving_lineage_count_over_time`, `compute_lineage_depth_over_time`), chromosome extraction, and plotting smoke tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3763f58dc4b652838d0d19ae4106169c3c419b78. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->