### PR TITLE
Add speciation and niche detection for intrinsic evolution

### DIFF
--- a/docs/experiments/intrinsic_evolution.md
+++ b/docs/experiments/intrinsic_evolution.md
@@ -81,9 +81,10 @@ signal.
 | Module | Purpose |
 | --- | --- |
 | [`farm/runners/intrinsic_evolution_experiment.py`](../../farm/runners/intrinsic_evolution_experiment.py) | `IntrinsicEvolutionPolicy`, `IntrinsicEvolutionExperimentConfig`, `IntrinsicEvolutionResult`, `seed_population_diversity()`, `IntrinsicEvolutionExperiment` |
-| [`farm/runners/gene_trajectory_logger.py`](../../farm/runners/gene_trajectory_logger.py) | `GeneTrajectoryLogger`: writes per-step aggregates and periodic full snapshots |
+| [`farm/runners/gene_trajectory_logger.py`](../../farm/runners/gene_trajectory_logger.py) | `GeneTrajectoryLogger`: writes per-step aggregates, periodic full snapshots, and (optionally) per-step speciation index + `cluster_lineage.jsonl` |
 | [`farm/core/agent/core.py`](../../farm/core/agent/core.py) | `AgentCore._derive_child_chromosome` and `_select_coparent` (called from `reproduce`) |
 | [`farm/core/simulation.py`](../../farm/core/simulation.py) | `run_simulation(..., on_environment_ready, on_step_end)` callback hooks the runner uses |
+| [`farm/analysis/speciation/`](../../farm/analysis/speciation/) | `detect_clusters_gmm`, `detect_clusters_dbscan`, `match_clusters_greedy`, `compute_speciation_index`, `compute_niche_correlation`, `plot_chromosome_space_clusters` |
 
 ## Quick start
 
@@ -403,7 +404,125 @@ supports `.to_json()` and `.to_newick()` export for external tree viewers.
 
 ## Out of scope (for now)
 
-- Speciation / niche detection.
+- Nothing previously listed here is out of scope; speciation / niche detection
+  is now implemented (see `farm/analysis/speciation/`).
+
+## Speciation and niche detection
+
+Frequency-dependent dynamics naturally produce multimodal gene distributions
+(e.g., a high-LR explorer cluster coexisting with a low-LR exploiter cluster).
+The `farm.analysis.speciation` module detects and tracks this structure.
+
+### Enabling speciation tracking at run time
+
+Pass `enable_speciation=True` to `GeneTrajectoryLogger` (or the corresponding
+`IntrinsicEvolutionExperimentConfig` knob) to activate per-snapshot cluster
+detection:
+
+```python
+from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+# Inside the experiment runner (or standalone usage):
+logger = GeneTrajectoryLogger(
+    output_dir="experiments/my_run",
+    snapshot_interval=100,
+    enable_speciation=True,       # default: False
+    speciation_algorithm="gmm",   # "gmm" (BIC-selected k) or "dbscan"
+    speciation_max_k=5,           # max components to try for GMM
+    speciation_seed=42,           # for reproducibility
+)
+```
+
+When enabled:
+
+- Every `intrinsic_gene_trajectory.jsonl` record gains a `speciation_index`
+  field (float in `[0, 1]`).  `0.0` means the population is a single cluster;
+  values approaching `1.0` indicate well-separated sub-populations.  The index
+  is re-computed at every snapshot step and held constant between snapshots.
+- A new `cluster_lineage.jsonl` file is written alongside the existing
+  artifacts.  Each line has the fields `step`, `cluster_id` (stable across
+  snapshots), `centroid`, `size`, and `parent_cluster_id`.
+
+### Offline cluster analysis
+
+```python
+from farm.analysis.speciation import (
+    detect_clusters_gmm,
+    detect_clusters_dbscan,
+    match_clusters_greedy,
+    compute_speciation_index,
+    compute_niche_correlation,
+    plot_chromosome_space_clusters,
+)
+from farm.analysis.phylogenetics import load_intrinsic_snapshots, extract_chromosomes_from_snapshots
+from farm.analysis.common.context import AnalysisContext
+import pathlib
+
+# Load snapshot data
+snapshots = load_intrinsic_snapshots("experiments/my_run")
+
+# Detect clusters at a chosen snapshot step
+last_snap = snapshots[-1]
+chrom_dicts = [a["chromosome"] for a in last_snap["agents"]]
+
+# GMM-BIC approach (primary)
+result = detect_clusters_gmm(chrom_dicts, max_k=5, seed=42)
+print(f"Detected k={result.k} clusters, speciation index={compute_speciation_index(result):.3f}")
+
+# DBSCAN baseline
+result_db = detect_clusters_dbscan(chrom_dicts, eps=0.05, min_samples=3)
+
+# Niche correlation (spatial / resource stats per cluster)
+agents_at_step = last_snap["agents"]
+niche = compute_niche_correlation(result, agents_at_step)
+for cluster in niche:
+    print(f"Cluster {cluster['cluster_id']}: n={cluster['size']}, "
+          f"mean_x={cluster['mean_x']}, mean_energy={cluster['mean_energy']}")
+
+# PCA scatter plot
+ctx = AnalysisContext(output_path=pathlib.Path("experiments/my_run"))
+plot_chromosome_space_clusters(chrom_dicts, result, ctx, step=last_snap["step"])
+```
+
+### Cluster persistence across snapshots
+
+The `match_clusters_greedy` function assigns stable string IDs (e.g., `"c0"`,
+`"c1"`) to clusters detected at consecutive snapshots by greedily matching
+cluster centroids at minimum Euclidean distance.
+
+```python
+prev_records = []
+id_counter = 0
+
+for snap in snapshots:
+    chrom_dicts = [a["chromosome"] for a in snap["agents"]]
+    result = detect_clusters_gmm(chrom_dicts, max_k=5, seed=42)
+    new_records, id_counter = match_clusters_greedy(
+        prev_records,
+        result.centroids,
+        result.sizes,
+        result.gene_names,
+        step=snap["step"],
+        id_counter_start=id_counter,
+    )
+    prev_records = new_records
+    for rec in new_records:
+        print(f"step={rec.step} cluster={rec.cluster_id} "
+              f"parent={rec.parent_cluster_id} size={rec.size}")
+```
+
+### API reference
+
+| Symbol | Description |
+| --- | --- |
+| `detect_clusters_gmm(chromosomes, *, max_k, seed)` | GMM with BIC-selected k; returns `ClusterResult`. |
+| `detect_clusters_dbscan(chromosomes, *, eps, min_samples)` | DBSCAN baseline; returns `ClusterResult`. |
+| `match_clusters_greedy(prev, centroids, sizes, gene_names, step, …)` | Greedy centroid matcher; returns `(records, next_counter)`. |
+| `compute_speciation_index(cluster_result)` | Silhouette-based scalar in `[0, 1]`. |
+| `compute_niche_correlation(cluster_result, agents, …)` | Per-cluster spatial / resource means. |
+| `plot_chromosome_space_clusters(chromosomes, result, ctx, …)` | PCA / scatter plot coloured by cluster. |
+| `ClusterResult` | Dataclass: `algorithm`, `k`, `labels`, `centroids`, `sizes`, `gene_names`, `silhouette_score`, `bic_scores`. |
+| `ClusterLineageRecord` | Dataclass: `step`, `cluster_id`, `centroid`, `size`, `parent_cluster_id`, `gene_stats`. |
 
 ## Testing
 
@@ -411,3 +530,4 @@ supports `.to_json()` and `.to_newick()` export for external tree viewers.
 - [`tests/core/agent/test_reproduce_chromosome_policy.py`](../../tests/core/agent/test_reproduce_chromosome_policy.py): no-policy passthrough, mutation path, co-parent selection (nearest, random, radius, type-filter, alive-filter), crossover end-to-end.
 - [`tests/test_agent_reproduction_hyperparameters.py`](../../tests/test_agent_reproduction_hyperparameters.py): updated to assert the new contract (no policy = inheritance unchanged).
 - [`tests/analysis/test_intrinsic_lineage.py`](../../tests/analysis/test_intrinsic_lineage.py): `load_intrinsic_snapshots`, `flatten_snapshots_to_agent_records`, `build_intrinsic_lineage_dag`, `compute_surviving_lineage_count_over_time`, `compute_lineage_depth_over_time`, `extract_chromosomes_from_snapshots`, `plot_intrinsic_lineage_tree` (with and without gene colouring).
+- [`tests/analysis/test_speciation.py`](../../tests/analysis/test_speciation.py): `detect_clusters_gmm` (empty/single/bimodal, determinism, gene-name override), `detect_clusters_dbscan`, `match_clusters_greedy` (stable IDs, new-ID allocation, known-fixture split), `compute_speciation_index`, `compute_niche_correlation` (per-cluster means, noise exclusion), `GeneTrajectoryLogger` speciation integration (trajectory field, `cluster_lineage.jsonl`, stable caching between snapshot steps), `plot_chromosome_space_clusters` (2-gene, 1-gene, 3-gene/PCA, DBSCAN, custom filename).

--- a/docs/experiments/intrinsic_evolution.md
+++ b/docs/experiments/intrinsic_evolution.md
@@ -415,9 +415,8 @@ The `farm.analysis.speciation` module detects and tracks this structure.
 
 ### Enabling speciation tracking at run time
 
-Pass `enable_speciation=True` to `GeneTrajectoryLogger` (or the corresponding
-`IntrinsicEvolutionExperimentConfig` knob) to activate per-snapshot cluster
-detection:
+Pass `enable_speciation=True` to `GeneTrajectoryLogger` to activate
+per-snapshot cluster detection:
 
 ```python
 from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger

--- a/farm/analysis/speciation/__init__.py
+++ b/farm/analysis/speciation/__init__.py
@@ -15,7 +15,7 @@ Features
 - **Speciation index**: silhouette-based scalar in ``[0, 1]`` collapsed from
   a :class:`~farm.analysis.speciation.compute.ClusterResult`.
 - **Niche correlation**: per-cluster mean spatial position, energy, and
-  reproduction rate.
+  reproduction cost.
 - **Plot helper**: PCA/scatter of agents in chromosome space coloured by
   detected cluster.
 

--- a/farm/analysis/speciation/__init__.py
+++ b/farm/analysis/speciation/__init__.py
@@ -1,0 +1,68 @@
+"""Speciation and niche-detection analysis for intrinsic-evolution runs.
+
+Detects population sub-structure (speciation) from per-snapshot chromosome
+vectors, tracks cluster identity across time steps, and computes a scalar
+*speciation index* for time-series plots.
+
+Features
+--------
+- **GMM-BIC** cluster detection: Gaussian Mixture Model with ``k`` selected
+  by minimising BIC.  Fully deterministic given a ``seed``.
+- **DBSCAN** cluster detection (baseline): density-based; does not require a
+  pre-specified ``k``.
+- **Cluster persistence**: greedy centroid-distance matcher that assigns
+  stable string IDs across consecutive snapshots.
+- **Speciation index**: silhouette-based scalar in ``[0, 1]`` collapsed from
+  a :class:`~farm.analysis.speciation.compute.ClusterResult`.
+- **Niche correlation**: per-cluster mean spatial position, energy, and
+  reproduction rate.
+- **Plot helper**: PCA/scatter of agents in chromosome space coloured by
+  detected cluster.
+
+Quick start::
+
+    >>> from farm.analysis.speciation import (
+    ...     detect_clusters_gmm,
+    ...     detect_clusters_dbscan,
+    ...     match_clusters_greedy,
+    ...     compute_speciation_index,
+    ...     compute_niche_correlation,
+    ...     ClusterResult,
+    ...     ClusterLineageRecord,
+    ...     plot_chromosome_space_clusters,
+    ... )
+    >>> chromosomes = [{"lr": 0.01, "gamma": 0.99}, {"lr": 0.1, "gamma": 0.5}]
+    >>> result = detect_clusters_gmm(chromosomes, max_k=3, seed=42)
+    >>> index = compute_speciation_index(result)
+
+See ``tests/analysis/test_speciation.py`` for examples with known cluster
+fixtures and persistence across snapshots.
+"""
+
+from farm.analysis.speciation.compute import (
+    ClusterResult,
+    ClusterLineageRecord,
+    detect_clusters_gmm,
+    detect_clusters_dbscan,
+    match_clusters_greedy,
+    compute_speciation_index,
+    compute_niche_correlation,
+)
+from farm.analysis.speciation.plot import plot_chromosome_space_clusters
+
+__all__ = [
+    # Data structures
+    "ClusterResult",
+    "ClusterLineageRecord",
+    # Cluster detection
+    "detect_clusters_gmm",
+    "detect_clusters_dbscan",
+    # Cluster persistence
+    "match_clusters_greedy",
+    # Scalar metrics
+    "compute_speciation_index",
+    # Niche analysis
+    "compute_niche_correlation",
+    # Visualisation
+    "plot_chromosome_space_clusters",
+]

--- a/farm/analysis/speciation/compute.py
+++ b/farm/analysis/speciation/compute.py
@@ -44,7 +44,6 @@ those fields are present in the agent records.
 from __future__ import annotations
 
 import math
-import uuid
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 

--- a/farm/analysis/speciation/compute.py
+++ b/farm/analysis/speciation/compute.py
@@ -1,0 +1,639 @@
+"""Speciation and niche-detection analysis for intrinsic-evolution runs.
+
+Provides algorithms to detect population sub-structure (speciation) from
+per-snapshot chromosome vectors, to track cluster identity across time steps,
+and to compute a scalar *speciation index* suitable for time-series plots.
+
+Algorithms
+----------
+- **GMM-BIC** (primary): Gaussian Mixture Model with k selected by minimising
+  the Bayesian Information Criterion over ``k = 1 … max_k``.  Fully
+  deterministic given ``seed``.
+- **DBSCAN** (baseline): Density-Based Spatial Clustering; does not require
+  a pre-specified ``k``; noisy agents are assigned label ``-1``.
+
+Both functions consume a sequence of chromosome dicts (``{gene: value}``) and
+return a :class:`ClusterResult` describing the detected structure.
+
+Cluster persistence
+-------------------
+:func:`match_clusters_greedy` greedily assigns stable string IDs to the
+clusters found at each consecutive snapshot by matching new centroids to
+previous ones at minimum Euclidean distance.  New clusters that have no
+close predecessor receive a fresh monotonically-increasing ID (``"c0"``,
+``"c1"``, …).
+
+Speciation index
+----------------
+:func:`compute_speciation_index` collapses a :class:`ClusterResult` into a
+single scalar in ``[0.0, 1.0]``:
+
+- When ``k == 1`` (or all agents are noise): ``0.0``.
+- Otherwise: the *silhouette score* of the detected cluster assignment
+  (bounded to ``[0.0, 1.0]``).
+
+Niche correlation
+-----------------
+:func:`compute_niche_correlation` accepts the per-snapshot agent list (as
+emitted by :class:`~farm.runners.gene_trajectory_logger.GeneTrajectoryLogger`)
+together with a :class:`ClusterResult` and returns per-cluster summary dicts
+containing mean spatial position, mean energy, and mean reproduction rate when
+those fields are present in the agent records.
+"""
+
+from __future__ import annotations
+
+import math
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ClusterResult:
+    """Output of a single cluster-detection run.
+
+    Attributes
+    ----------
+    algorithm:
+        Either ``"gmm"`` or ``"dbscan"``.
+    k:
+        Number of detected clusters.  For DBSCAN this excludes the noise
+        pseudo-cluster (label ``-1``).
+    labels:
+        Per-agent integer cluster label.  DBSCAN noise agents have label
+        ``-1``.  Length equals the number of input chromosomes.
+    centroids:
+        Per-cluster centroid as a ``{gene_name: value}`` dict.  For DBSCAN
+        the centroid is the mean of member agents (noise cluster excluded).
+    sizes:
+        Number of agents in each cluster (noise excluded for DBSCAN).
+    gene_names:
+        Ordered list of gene names used for clustering (the columns of the
+        feature matrix).
+    silhouette_score:
+        Silhouette score over all labelled agents in ``[-1, 1]``.
+        ``0.0`` when ``k == 1`` or when fewer than 2 labelled agents exist.
+    bic_scores:
+        Mapping ``{k: bic_value}`` for each ``k`` tried during GMM search.
+        ``None`` for DBSCAN.
+    """
+
+    algorithm: str
+    k: int
+    labels: List[int]
+    centroids: List[Dict[str, float]]
+    sizes: List[int]
+    gene_names: List[str]
+    silhouette_score: float
+    bic_scores: Optional[Dict[int, float]]
+
+
+@dataclass
+class ClusterLineageRecord:
+    """One entry in the cluster-lineage history for a single snapshot step.
+
+    Attributes
+    ----------
+    step:
+        Simulation step at which this cluster was detected.
+    cluster_id:
+        Stable string identifier for this cluster across snapshots (e.g.
+        ``"c0"``).
+    centroid:
+        Gene-name → centroid-value mapping for this cluster at this step.
+    size:
+        Number of agents assigned to this cluster.
+    parent_cluster_id:
+        The ``cluster_id`` of the closest-matching cluster at the previous
+        snapshot, or ``None`` for founding clusters at the first snapshot.
+    gene_stats:
+        Optional per-gene statistics dict (``{gene: {mean, std, …}}``) for
+        agents in this cluster, populated by callers that request it.
+    """
+
+    step: int
+    cluster_id: str
+    centroid: Dict[str, float]
+    size: int
+    parent_cluster_id: Optional[str]
+    gene_stats: Optional[Dict[str, Dict[str, float]]] = field(default=None)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _chromosomes_to_matrix(
+    chromosomes: Sequence[Dict[str, float]],
+    gene_names: Optional[List[str]] = None,
+) -> Tuple[np.ndarray, List[str]]:
+    """Convert a sequence of chromosome dicts to a (N, D) float matrix.
+
+    Parameters
+    ----------
+    chromosomes:
+        Sequence of ``{gene_name: value}`` dicts; all dicts must share the
+        same set of keys.
+    gene_names:
+        Ordered list of gene names to use as columns.  When ``None`` the
+        union of all keys across all dicts is used (sorted deterministically).
+
+    Returns
+    -------
+    matrix : np.ndarray, shape (N, D)
+    gene_names : list[str]
+        Column labels corresponding to matrix columns.
+    """
+    if not chromosomes:
+        return np.empty((0, 0), dtype=float), gene_names or []
+
+    if gene_names is None:
+        # Use sorted union for determinism
+        all_keys: set = set()
+        for c in chromosomes:
+            all_keys.update(c.keys())
+        gene_names = sorted(all_keys)
+
+    matrix = np.array(
+        [[c.get(g, 0.0) for g in gene_names] for c in chromosomes],
+        dtype=float,
+    )
+    return matrix, gene_names
+
+
+def _centroid_to_dict(centroid_vec: np.ndarray, gene_names: List[str]) -> Dict[str, float]:
+    return {g: float(centroid_vec[i]) for i, g in enumerate(gene_names)}
+
+
+def _silhouette(X: np.ndarray, labels: np.ndarray) -> float:
+    """Compute silhouette score, returning 0.0 on any failure."""
+    unique = np.unique(labels[labels >= 0])
+    if len(unique) < 2 or X.shape[0] < 2:
+        return 0.0
+    # Only consider labelled agents (DBSCAN may have noise = -1)
+    mask = labels >= 0
+    if mask.sum() < 2:
+        return 0.0
+    try:
+        from sklearn.metrics import silhouette_score as _sk_silhouette
+        score = float(_sk_silhouette(X[mask], labels[mask]))
+        return max(0.0, score)
+    except Exception as exc:
+        logger.debug("_silhouette: failed to compute silhouette score: %s", exc)
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Cluster detection – GMM-BIC
+# ---------------------------------------------------------------------------
+
+
+def detect_clusters_gmm(
+    chromosomes: Sequence[Dict[str, float]],
+    *,
+    max_k: int = 5,
+    seed: int = 0,
+    gene_names: Optional[List[str]] = None,
+) -> ClusterResult:
+    """Detect population clusters using Gaussian Mixture Models with BIC selection.
+
+    Tries ``k = 1 … max_k`` components and picks the ``k`` that minimises the
+    Bayesian Information Criterion.  The result is fully deterministic given
+    the same ``seed``.
+
+    When fewer than ``max_k`` distinct chromosomes are present, ``max_k`` is
+    capped automatically.  When zero chromosomes are provided a single-cluster
+    trivial result is returned.
+
+    Parameters
+    ----------
+    chromosomes:
+        Sequence of chromosome dicts (``{gene_name: value}``).
+    max_k:
+        Maximum number of Gaussian components to try.  Default 5.
+    seed:
+        Random seed for reproducibility.  Default 0.
+    gene_names:
+        Ordered subset of genes to use.  When ``None`` all genes present in
+        the chromosomes are used (sorted).
+
+    Returns
+    -------
+    ClusterResult
+    """
+    from sklearn.mixture import GaussianMixture
+
+    X, gnames = _chromosomes_to_matrix(chromosomes, gene_names)
+    n_agents = X.shape[0]
+
+    if n_agents == 0:
+        return ClusterResult(
+            algorithm="gmm",
+            k=0,
+            labels=[],
+            centroids=[],
+            sizes=[],
+            gene_names=gnames,
+            silhouette_score=0.0,
+            bic_scores={},
+        )
+
+    # Cap max_k to number of distinct agents to avoid degenerate GMM fits
+    effective_max_k = min(max_k, n_agents)
+
+    bic_scores: Dict[int, float] = {}
+    best_k = 1
+    best_bic = math.inf
+    best_gmm = None
+
+    for k in range(1, effective_max_k + 1):
+        try:
+            gmm = GaussianMixture(
+                n_components=k,
+                covariance_type="full",
+                random_state=seed,
+                max_iter=200,
+                n_init=3,
+            )
+            gmm.fit(X)
+            bic = float(gmm.bic(X))
+            bic_scores[k] = bic
+            if bic < best_bic:
+                best_bic = bic
+                best_k = k
+                best_gmm = gmm
+        except Exception as exc:
+            logger.debug("detect_clusters_gmm: GMM fit failed for k=%d: %s", k, exc)
+
+    if best_gmm is None:
+        # All fits failed; return trivial single-cluster result
+        centroid = _centroid_to_dict(X.mean(axis=0), gnames)
+        return ClusterResult(
+            algorithm="gmm",
+            k=1,
+            labels=[0] * n_agents,
+            centroids=[centroid],
+            sizes=[n_agents],
+            gene_names=gnames,
+            silhouette_score=0.0,
+            bic_scores=bic_scores,
+        )
+
+    labels: np.ndarray = best_gmm.predict(X).astype(int)
+
+    centroids = [
+        _centroid_to_dict(best_gmm.means_[i], gnames)
+        for i in range(best_k)
+    ]
+    sizes = [int((labels == i).sum()) for i in range(best_k)]
+    sil = _silhouette(X, labels)
+
+    return ClusterResult(
+        algorithm="gmm",
+        k=best_k,
+        labels=labels.tolist(),
+        centroids=centroids,
+        sizes=sizes,
+        gene_names=gnames,
+        silhouette_score=sil,
+        bic_scores=bic_scores,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cluster detection – DBSCAN
+# ---------------------------------------------------------------------------
+
+
+def detect_clusters_dbscan(
+    chromosomes: Sequence[Dict[str, float]],
+    *,
+    eps: float = 0.1,
+    min_samples: int = 2,
+    gene_names: Optional[List[str]] = None,
+) -> ClusterResult:
+    """Detect population clusters using DBSCAN.
+
+    DBSCAN does not require a pre-specified number of clusters.  Agents that
+    do not belong to any dense region receive label ``-1`` (noise).
+
+    Parameters
+    ----------
+    chromosomes:
+        Sequence of chromosome dicts (``{gene_name: value}``).
+    eps:
+        Maximum distance between two samples to be considered in the same
+        neighbourhood.  Default ``0.1`` (gene values are typically in
+        ``[0, 1]`` after normalisation).
+    min_samples:
+        Minimum number of samples in a neighbourhood to form a core point.
+        Default 2.
+    gene_names:
+        Ordered subset of genes to use.  When ``None`` all present genes are
+        used (sorted).
+
+    Returns
+    -------
+    ClusterResult
+    """
+    from sklearn.cluster import DBSCAN
+
+    X, gnames = _chromosomes_to_matrix(chromosomes, gene_names)
+    n_agents = X.shape[0]
+
+    if n_agents == 0:
+        return ClusterResult(
+            algorithm="dbscan",
+            k=0,
+            labels=[],
+            centroids=[],
+            sizes=[],
+            gene_names=gnames,
+            silhouette_score=0.0,
+            bic_scores=None,
+        )
+
+    db = DBSCAN(eps=eps, min_samples=min_samples)
+    raw_labels: np.ndarray = db.fit_predict(X).astype(int)
+
+    unique_labels = [lbl for lbl in sorted(set(raw_labels.tolist())) if lbl >= 0]
+    k = len(unique_labels)
+
+    centroids: List[Dict[str, float]] = []
+    sizes: List[int] = []
+    for lbl in unique_labels:
+        mask = raw_labels == lbl
+        centroids.append(_centroid_to_dict(X[mask].mean(axis=0), gnames))
+        sizes.append(int(mask.sum()))
+
+    # Re-index labels so they run 0..k-1 for labelled agents; noise stays -1
+    label_map = {lbl: i for i, lbl in enumerate(unique_labels)}
+    remapped = np.array(
+        [label_map.get(lbl, -1) for lbl in raw_labels.tolist()],
+        dtype=int,
+    )
+    sil = _silhouette(X, remapped)
+
+    return ClusterResult(
+        algorithm="dbscan",
+        k=k,
+        labels=remapped.tolist(),
+        centroids=centroids,
+        sizes=sizes,
+        gene_names=gnames,
+        silhouette_score=sil,
+        bic_scores=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cluster persistence
+# ---------------------------------------------------------------------------
+
+
+def match_clusters_greedy(
+    prev_records: List[ClusterLineageRecord],
+    new_centroids: List[Dict[str, float]],
+    new_sizes: List[int],
+    gene_names: List[str],
+    step: int,
+    *,
+    max_distance: float = float("inf"),
+    id_counter_start: int = 0,
+) -> Tuple[List[ClusterLineageRecord], int]:
+    """Greedily assign stable cluster IDs by matching centroids across snapshots.
+
+    Each new cluster centroid is matched to the closest unmatched previous
+    cluster centroid.  When the minimum distance exceeds ``max_distance`` (or
+    there are no previous clusters), a fresh ID is allocated instead.
+
+    Parameters
+    ----------
+    prev_records:
+        :class:`ClusterLineageRecord` list from the previous snapshot
+        (may be empty for the first snapshot).
+    new_centroids:
+        List of per-cluster centroid dicts for the current snapshot.
+    new_sizes:
+        Corresponding per-cluster sizes.
+    gene_names:
+        Ordered list of gene names used to build centroid vectors.
+    step:
+        Current snapshot step (used to populate the new records).
+    max_distance:
+        Maximum Euclidean centroid distance for a match to be accepted.
+        Default: unlimited.
+    id_counter_start:
+        Counter used to generate new IDs (``"c{counter}"``).  The returned
+        second element is the next counter value after allocating all new IDs
+        in this call.
+
+    Returns
+    -------
+    records : list[ClusterLineageRecord]
+        One record per new cluster.
+    next_id_counter : int
+        Updated counter for subsequent calls.
+    """
+
+    import re as _re
+
+    def _centroid_vec(d: Dict[str, float]) -> np.ndarray:
+        return np.array([d.get(g, 0.0) for g in gene_names], dtype=float)
+
+    # Build vectors for new and previous centroids
+    new_vecs = [_centroid_vec(c) for c in new_centroids]
+    prev_vecs = [_centroid_vec(r.centroid) for r in prev_records]
+    prev_ids = [r.cluster_id for r in prev_records]
+
+    # Auto-advance id_counter past any IDs already used in prev_records so new
+    # IDs never collide with existing lineage IDs regardless of what the caller
+    # passes for id_counter_start.
+    id_counter = id_counter_start
+    for r in prev_records:
+        m = _re.match(r"^c(\d+)$", r.cluster_id)
+        if m:
+            id_counter = max(id_counter, int(m.group(1)) + 1)
+
+    used_prev: set = set()
+    records: List[ClusterLineageRecord] = []
+
+    for i, (centroid, size) in enumerate(zip(new_centroids, new_sizes)):
+        best_j: Optional[int] = None
+        best_dist = math.inf
+
+        for j, pv in enumerate(prev_vecs):
+            if j in used_prev:
+                continue
+            dist = float(np.linalg.norm(new_vecs[i] - pv))
+            if dist < best_dist and dist <= max_distance:
+                best_dist = dist
+                best_j = j
+
+        if best_j is not None:
+            cluster_id = prev_ids[best_j]
+            parent_cluster_id = prev_ids[best_j]
+            used_prev.add(best_j)
+        else:
+            cluster_id = f"c{id_counter}"
+            id_counter += 1
+            parent_cluster_id = None
+
+        records.append(
+            ClusterLineageRecord(
+                step=step,
+                cluster_id=cluster_id,
+                centroid=centroid,
+                size=size,
+                parent_cluster_id=parent_cluster_id,
+            )
+        )
+
+    return records, id_counter
+
+
+# ---------------------------------------------------------------------------
+# Speciation index
+# ---------------------------------------------------------------------------
+
+
+def compute_speciation_index(cluster_result: ClusterResult) -> float:
+    """Collapse a :class:`ClusterResult` into a single scalar speciation metric.
+
+    Returns a value in ``[0.0, 1.0]`` where:
+
+    - ``0.0`` means the population is a single undivided cluster (or too small
+      to cluster).
+    - Values approaching ``1.0`` indicate well-separated, evenly-sized
+      sub-populations.
+
+    The metric is the **silhouette score** of the cluster assignment when
+    ``k ≥ 2``; ``0.0`` when ``k ≤ 1``.
+
+    Parameters
+    ----------
+    cluster_result:
+        A :class:`ClusterResult` from :func:`detect_clusters_gmm` or
+        :func:`detect_clusters_dbscan`.
+
+    Returns
+    -------
+    float
+        Speciation index in ``[0.0, 1.0]``.
+    """
+    if cluster_result.k <= 1:
+        return 0.0
+    return max(0.0, min(1.0, cluster_result.silhouette_score))
+
+
+# ---------------------------------------------------------------------------
+# Niche correlation
+# ---------------------------------------------------------------------------
+
+
+def compute_niche_correlation(
+    cluster_result: ClusterResult,
+    agents: Sequence[Any],
+    *,
+    agent_id_key: str = "agent_id",
+    x_key: str = "x",
+    y_key: str = "y",
+    energy_key: str = "energy",
+    reproduction_cost_key: str = "reproduction_cost",
+) -> List[Dict[str, Any]]:
+    """Compute per-cluster spatial and behavioural niche statistics.
+
+    For each cluster identified in ``cluster_result``, this function computes
+    the mean spatial position (``mean_x``, ``mean_y``), mean energy, and mean
+    reproduction cost for the agents assigned to that cluster.
+
+    Agents must appear in the same order as the ``chromosomes`` that were
+    passed to the cluster-detection function.  Fields that are absent from an
+    agent record are silently skipped; the mean is computed only over agents
+    where the field is present.
+
+    Parameters
+    ----------
+    cluster_result:
+        A :class:`ClusterResult` from :func:`detect_clusters_gmm` or
+        :func:`detect_clusters_dbscan`.
+    agents:
+        Sequence of agent dicts (or objects with attribute access) in the
+        same order as the chromosomes used for clustering.
+    agent_id_key:
+        Key / attribute name for the agent identifier field.
+    x_key, y_key:
+        Spatial coordinate field names.
+    energy_key:
+        Agent energy field name.
+    reproduction_cost_key:
+        Reproduction cost field name.
+
+    Returns
+    -------
+    list of dict
+        One dict per cluster with keys: ``cluster_id`` (int index),
+        ``size``, ``mean_x``, ``mean_y``, ``mean_energy``,
+        ``mean_reproduction_cost``, ``agent_ids``.  Fields that cannot be
+        computed are set to ``None``.
+    """
+
+    def _get(obj: Any, key: str) -> Any:
+        if isinstance(obj, dict):
+            return obj.get(key)
+        return getattr(obj, key, None)
+
+    labels = cluster_result.labels
+    k = cluster_result.k
+    if k == 0 or len(labels) == 0:
+        return []
+
+    # Bucket agents by cluster index
+    buckets: Dict[int, List[Any]] = {i: [] for i in range(k)}
+    for idx, lbl in enumerate(labels):
+        if lbl >= 0 and idx < len(agents):
+            buckets[lbl].append(agents[idx])
+
+    niche_records: List[Dict[str, Any]] = []
+    for i in range(k):
+        members = buckets[i]
+        n = len(members)
+
+        def _mean_field(fkey: str) -> Optional[float]:
+            vals = []
+            for a in members:
+                v = _get(a, fkey)
+                if v is not None:
+                    try:
+                        vals.append(float(v))
+                    except (TypeError, ValueError):
+                        pass
+            return float(sum(vals) / len(vals)) if vals else None
+
+        agent_ids = [_get(a, agent_id_key) for a in members]
+
+        niche_records.append(
+            {
+                "cluster_id": i,
+                "size": n,
+                "mean_x": _mean_field(x_key),
+                "mean_y": _mean_field(y_key),
+                "mean_energy": _mean_field(energy_key),
+                "mean_reproduction_cost": _mean_field(reproduction_cost_key),
+                "agent_ids": agent_ids,
+            }
+        )
+
+    return niche_records

--- a/farm/analysis/speciation/compute.py
+++ b/farm/analysis/speciation/compute.py
@@ -37,7 +37,7 @@ Niche correlation
 :func:`compute_niche_correlation` accepts the per-snapshot agent list (as
 emitted by :class:`~farm.runners.gene_trajectory_logger.GeneTrajectoryLogger`)
 together with a :class:`ClusterResult` and returns per-cluster summary dicts
-containing mean spatial position, mean energy, and mean reproduction rate when
+containing mean spatial position, mean energy, and mean reproduction cost when
 those fields are present in the agent records.
 """
 
@@ -213,8 +213,8 @@ def detect_clusters_gmm(
     the same ``seed``.
 
     When fewer than ``max_k`` distinct chromosomes are present, ``max_k`` is
-    capped automatically.  When zero chromosomes are provided a single-cluster
-    trivial result is returned.
+    capped automatically.  When zero chromosomes are provided an empty
+    (``k=0``) trivial result with no labels or centroids is returned.
 
     Parameters
     ----------
@@ -249,7 +249,7 @@ def detect_clusters_gmm(
             bic_scores={},
         )
 
-    # Cap max_k to number of distinct agents to avoid degenerate GMM fits
+    # Cap max_k to the total number of agents to avoid degenerate GMM fits
     effective_max_k = min(max_k, n_agents)
 
     bic_scores: Dict[int, float] = {}

--- a/farm/analysis/speciation/compute.py
+++ b/farm/analysis/speciation/compute.py
@@ -618,7 +618,9 @@ def compute_niche_correlation(
                     try:
                         vals.append(float(v))
                     except (TypeError, ValueError):
-                        pass
+                        # Non-numeric values are intentionally ignored when
+                        # computing per-field means for heterogeneous records.
+                        continue
             return float(sum(vals) / len(vals)) if vals else None
 
         agent_ids = [_get(a, agent_id_key) for a in members]

--- a/farm/analysis/speciation/plot.py
+++ b/farm/analysis/speciation/plot.py
@@ -1,0 +1,212 @@
+"""Speciation visualisation helpers.
+
+Provides a scatter / projection plot of agents in chromosome space coloured
+by their detected cluster assignment.  Dimensionality reduction (PCA) is
+applied automatically when the number of evolvable genes exceeds 2.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import matplotlib
+
+matplotlib.use("Agg")  # non-interactive backend before pyplot import
+import matplotlib.pyplot as plt  # noqa: E402 – must follow backend selection
+
+import numpy as np
+
+from farm.analysis.common.context import AnalysisContext
+from farm.analysis.speciation.compute import ClusterResult
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Palette for up to 12 distinct clusters; noise (label -1) gets a neutral grey
+_CLUSTER_COLORS = [
+    "#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd",
+    "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf",
+    "#aec7e8", "#ffbb78",
+]
+_NOISE_COLOR = "#cccccc"
+
+
+def plot_chromosome_space_clusters(
+    chromosomes: Sequence[Dict[str, float]],
+    cluster_result: ClusterResult,
+    ctx: AnalysisContext,
+    *,
+    step: Optional[int] = None,
+    projection: str = "pca",
+    output_filename: Optional[str] = None,
+    agent_ids: Optional[Sequence[Any]] = None,
+    title: Optional[str] = None,
+) -> Optional[Path]:
+    """Scatter agents in 2-D chromosome space coloured by detected cluster.
+
+    When the chromosome has more than 2 genes, PCA is used to project to 2
+    dimensions first.  When there are exactly 2 genes the raw gene values are
+    used directly.  With a single gene a 1-D strip plot is drawn instead.
+
+    Parameters
+    ----------
+    chromosomes:
+        Sequence of chromosome dicts in the same order as
+        ``cluster_result.labels``.  Must not be empty.
+    cluster_result:
+        A :class:`~farm.analysis.speciation.compute.ClusterResult` from
+        :func:`~farm.analysis.speciation.compute.detect_clusters_gmm` or
+        :func:`~farm.analysis.speciation.compute.detect_clusters_dbscan`.
+    ctx:
+        :class:`~farm.analysis.common.context.AnalysisContext` supplying the
+        output directory.
+    step:
+        Simulation step number used in the default output filename and plot
+        title.
+    projection:
+        Dimensionality reduction method.  Currently only ``"pca"`` is
+        supported.  Ignored when the number of genes is ≤ 2.
+    output_filename:
+        Custom output filename (without directory).  Defaults to
+        ``"speciation_clusters_step{step}.png"`` or
+        ``"speciation_clusters.png"`` when ``step`` is ``None``.
+    agent_ids:
+        Optional sequence of agent-ID labels to annotate points.  When
+        provided and the population is small (≤ 30 agents) IDs are drawn
+        next to each point.
+    title:
+        Custom title string.  Auto-generated when ``None``.
+
+    Returns
+    -------
+    Path or None
+        Absolute path to the saved PNG file, or ``None`` on failure.
+    """
+    if not chromosomes:
+        logger.warning("plot_chromosome_space_clusters: no chromosomes provided; skipping plot")
+        return None
+
+    # Build feature matrix
+    gene_names = cluster_result.gene_names
+    X = np.array(
+        [[c.get(g, 0.0) for g in gene_names] for c in chromosomes],
+        dtype=float,
+    )
+    labels = np.array(cluster_result.labels, dtype=int)
+
+    if len(labels) != X.shape[0]:
+        logger.warning(
+            "plot_chromosome_space_clusters: label count (%d) != chromosome count (%d); skipping",
+            len(labels),
+            X.shape[0],
+        )
+        return None
+
+    n_genes = X.shape[1]
+
+    # Dimensionality reduction when needed
+    if n_genes > 2:
+        try:
+            from sklearn.decomposition import PCA
+
+            n_components = 2
+            pca = PCA(n_components=n_components, random_state=0)
+            X_2d: np.ndarray = pca.fit_transform(X)
+            explained = pca.explained_variance_ratio_
+            xlabel = f"PC1 ({explained[0] * 100:.1f}% var)"
+            ylabel = f"PC2 ({explained[1] * 100:.1f}% var)"
+        except Exception as exc:
+            logger.warning("plot_chromosome_space_clusters: PCA failed (%s); using first 2 genes", exc)
+            X_2d = X[:, :2]
+            xlabel = gene_names[0] if len(gene_names) > 0 else "gene_0"
+            ylabel = gene_names[1] if len(gene_names) > 1 else "gene_1"
+    elif n_genes == 2:
+        X_2d = X
+        xlabel = gene_names[0]
+        ylabel = gene_names[1]
+    else:
+        # Single-gene strip plot: x = gene value, y = jittered 0
+        X_2d = np.column_stack([X[:, 0], np.zeros(X.shape[0])])
+        xlabel = gene_names[0] if gene_names else "gene"
+        ylabel = ""
+
+    try:
+        fig, ax = plt.subplots(figsize=(7, 5))
+
+        unique_labels = sorted(set(labels.tolist()))
+        for lbl in unique_labels:
+            mask = labels == lbl
+            if lbl == -1:
+                color = _NOISE_COLOR
+                label_str = "noise"
+                zorder = 1
+            else:
+                color = _CLUSTER_COLORS[lbl % len(_CLUSTER_COLORS)]
+                size = cluster_result.sizes[lbl] if lbl < len(cluster_result.sizes) else 0
+                label_str = f"cluster {lbl} (n={size})"
+                zorder = 2
+
+            ax.scatter(
+                X_2d[mask, 0],
+                X_2d[mask, 1],
+                c=color,
+                label=label_str,
+                s=40,
+                alpha=0.75,
+                edgecolors="none",
+                zorder=zorder,
+            )
+
+            # Mark centroid with a larger marker
+            if lbl >= 0 and lbl < len(cluster_result.centroids):
+                cx = cluster_result.centroids[lbl]
+                cx_vec = np.array([cx.get(g, 0.0) for g in gene_names], dtype=float)
+                if n_genes > 2:
+                    cx_2d = pca.transform(cx_vec.reshape(1, -1))[0]  # type: ignore[possibly-undefined]
+                elif n_genes == 2:
+                    cx_2d = cx_vec
+                else:
+                    cx_2d = np.array([cx_vec[0], 0.0])
+                ax.scatter(
+                    [cx_2d[0]], [cx_2d[1]],
+                    c=color, s=150, marker="*", edgecolors="black",
+                    linewidths=0.8, zorder=3,
+                )
+
+        # Optional agent-ID annotations for small populations
+        if agent_ids is not None and len(agent_ids) <= 30:
+            for idx, aid in enumerate(agent_ids):
+                ax.annotate(str(aid), (X_2d[idx, 0], X_2d[idx, 1]),
+                            fontsize=6, alpha=0.6, ha="left", va="bottom")
+
+        ax.set_xlabel(xlabel)
+        if ylabel:
+            ax.set_ylabel(ylabel)
+
+        if title is None:
+            algo = cluster_result.algorithm.upper()
+            k = cluster_result.k
+            sil = cluster_result.silhouette_score
+            step_str = f" @ step {step}" if step is not None else ""
+            title = f"Chromosome Space – {algo} k={k}, sil={sil:.3f}{step_str}"
+        ax.set_title(title)
+
+        if cluster_result.k > 1 or any(lbl == -1 for lbl in labels.tolist()):
+            ax.legend(fontsize=8, loc="best")
+
+        # Resolve output path
+        if output_filename is None:
+            step_tag = f"_step{step}" if step is not None else ""
+            output_filename = f"speciation_clusters{step_tag}.png"
+
+        output_file = ctx.get_output_file(output_filename)
+        fig.savefig(output_file, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        logger.info("plot_chromosome_space_clusters: saved to %s", output_file)
+        return Path(output_file)
+
+    except Exception as exc:
+        logger.warning("plot_chromosome_space_clusters: plot failed: %s", exc)
+        plt.close("all")
+        return None

--- a/farm/analysis/speciation/plot.py
+++ b/farm/analysis/speciation/plot.py
@@ -104,6 +104,8 @@ def plot_chromosome_space_clusters(
         return None
 
     n_genes = X.shape[1]
+    # Track whether a fitted PCA object is available for centroid projection
+    _pca = None
 
     # Dimensionality reduction when needed
     if n_genes > 2:
@@ -111,13 +113,14 @@ def plot_chromosome_space_clusters(
             from sklearn.decomposition import PCA
 
             n_components = 2
-            pca = PCA(n_components=n_components, random_state=0)
-            X_2d: np.ndarray = pca.fit_transform(X)
-            explained = pca.explained_variance_ratio_
+            _pca = PCA(n_components=n_components, random_state=0)
+            X_2d: np.ndarray = _pca.fit_transform(X)
+            explained = _pca.explained_variance_ratio_
             xlabel = f"PC1 ({explained[0] * 100:.1f}% var)"
             ylabel = f"PC2 ({explained[1] * 100:.1f}% var)"
         except Exception as exc:
             logger.warning("plot_chromosome_space_clusters: PCA failed (%s); using first 2 genes", exc)
+            _pca = None
             X_2d = X[:, :2]
             xlabel = gene_names[0] if len(gene_names) > 0 else "gene_0"
             ylabel = gene_names[1] if len(gene_names) > 1 else "gene_1"
@@ -162,8 +165,11 @@ def plot_chromosome_space_clusters(
             if lbl >= 0 and lbl < len(cluster_result.centroids):
                 cx = cluster_result.centroids[lbl]
                 cx_vec = np.array([cx.get(g, 0.0) for g in gene_names], dtype=float)
-                if n_genes > 2:
-                    cx_2d = pca.transform(cx_vec.reshape(1, -1))[0]  # type: ignore[possibly-undefined]
+                if n_genes > 2 and _pca is not None:
+                    cx_2d = _pca.transform(cx_vec.reshape(1, -1))[0]
+                elif n_genes > 2:
+                    # PCA failed during setup; fall back to first two genes
+                    cx_2d = cx_vec[:2]
                 elif n_genes == 2:
                     cx_2d = cx_vec
                 else:

--- a/farm/analysis/speciation/plot.py
+++ b/farm/analysis/speciation/plot.py
@@ -111,6 +111,12 @@ def plot_chromosome_space_clusters(
         return None
 
     n_genes = X.shape[1]
+    if n_genes == 0:
+        logger.warning(
+            "plot_chromosome_space_clusters: no gene dimensions available; skipping"
+        )
+        return None
+
     # Track whether a fitted PCA object is available for centroid projection
     _pca = None
 
@@ -188,7 +194,13 @@ def plot_chromosome_space_clusters(
                 )
 
         # Optional agent-ID annotations for small populations
-        if agent_ids is not None and len(agent_ids) <= 30:
+        if agent_ids is not None and len(agent_ids) != X_2d.shape[0]:
+            logger.warning(
+                "plot_chromosome_space_clusters: agent_ids length (%d) != population (%d); skipping annotations",
+                len(agent_ids),
+                X_2d.shape[0],
+            )
+        elif agent_ids is not None and len(agent_ids) <= 30:
             for idx, aid in enumerate(agent_ids):
                 ax.annotate(str(aid), (X_2d[idx, 0], X_2d[idx, 1]),
                             fontsize=6, alpha=0.6, ha="left", va="bottom")

--- a/farm/analysis/speciation/plot.py
+++ b/farm/analysis/speciation/plot.py
@@ -66,7 +66,8 @@ def plot_chromosome_space_clusters(
         title.
     projection:
         Dimensionality reduction method.  Currently only ``"pca"`` is
-        supported.  Ignored when the number of genes is ≤ 2.
+        supported; passing any other value raises :exc:`ValueError`.
+        Ignored when the number of genes is ≤ 2.
     output_filename:
         Custom output filename (without directory).  Defaults to
         ``"speciation_clusters_step{step}.png"`` or
@@ -86,6 +87,12 @@ def plot_chromosome_space_clusters(
     if not chromosomes:
         logger.warning("plot_chromosome_space_clusters: no chromosomes provided; skipping plot")
         return None
+
+    if projection != "pca":
+        raise ValueError(
+            f"plot_chromosome_space_clusters: unsupported projection {projection!r}. "
+            "Only 'pca' is currently supported."
+        )
 
     # Build feature matrix
     gene_names = cluster_result.gene_names

--- a/farm/analysis/speciation/plot.py
+++ b/farm/analysis/speciation/plot.py
@@ -8,7 +8,7 @@ applied automatically when the number of evolvable genes exceeds 2.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 import matplotlib
 

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -15,9 +15,9 @@ Writes append-only JSONL files alongside other run artifacts:
   snapshot step with fields ``step``, ``cluster_id``, ``centroid``, ``size``,
   and ``parent_cluster_id``.
 
-All three files are no-ops when ``output_dir`` is ``None``, allowing the
-logger to be used unconditionally inside the runner regardless of whether the
-user asked for persisted artifacts.
+When ``output_dir`` is ``None``, JSONL files are not written; speciation
+state is still updated in memory when ``enable_speciation=True``, allowing
+the runner to use the logger unconditionally regardless of persisted artifacts.
 """
 
 from __future__ import annotations
@@ -38,8 +38,9 @@ class GeneTrajectoryLogger:
     Parameters
     ----------
     output_dir:
-        Directory in which to write the JSONL files.  When ``None`` all I/O
-        is suppressed and the logger becomes a no-op.
+        Directory in which to write the JSONL files.  When ``None``, file
+        I/O is suppressed; ``snapshot`` still updates in-memory speciation
+        when ``enable_speciation=True``.
     snapshot_interval:
         Write a full per-agent snapshot every this many steps.  Step 0 is
         always captured.  Must be at least 1.
@@ -128,9 +129,6 @@ class GeneTrajectoryLogger:
                 runner such as ``mean_reproduction_cost`` or
                 ``realized_birth_rate``).
         """
-        if self._trajectory_handle is None:
-            return
-
         alive_agents = list(environment.alive_agent_objects)
         chromosomes: List[HyperparameterChromosome] = [
             agent.hyperparameter_chromosome
@@ -141,9 +139,12 @@ class GeneTrajectoryLogger:
 
         is_snapshot_step = step % self._snapshot_interval == 0
 
-        # Run speciation at snapshot steps when enabled
+        # Run speciation at snapshot steps when enabled (even if trajectory file I/O is off).
         if self._enable_speciation and is_snapshot_step:
             self._update_speciation(chromosomes, step)
+
+        if self._trajectory_handle is None:
+            return
 
         trajectory_record: Dict[str, Any] = {
             "step": step,
@@ -224,6 +225,8 @@ class GeneTrajectoryLogger:
 
         if not chromosomes:
             self._cached_speciation_index = 0.0
+            self._prev_cluster_records = []
+            self._cluster_id_counter = 0
             return
 
         # Extract evolvable gene dicts

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -1,18 +1,23 @@
 """Per-step chromosome telemetry for intrinsic-evolution simulations.
 
-Writes two append-only JSONL files alongside other run artifacts:
+Writes append-only JSONL files alongside other run artifacts:
 
 - ``intrinsic_gene_trajectory.jsonl`` -- one record per step containing
   aggregate per-gene statistics over alive agents.  Compact and cheap to
-  append every step.
+  append every step.  When speciation tracking is enabled, each record also
+  contains a ``speciation_index`` scalar.
 - ``intrinsic_gene_snapshots.jsonl`` -- one record every
   ``snapshot_interval`` steps containing each alive agent's full chromosome
   values.  Supports lineage analysis offline; bounded cost via the
   configurable cadence.
+- ``cluster_lineage.jsonl`` -- written only when speciation tracking is
+  enabled (``enable_speciation=True``).  One record per detected cluster per
+  snapshot step with fields ``step``, ``cluster_id``, ``centroid``, ``size``,
+  and ``parent_cluster_id``.
 
-Both files are no-ops when ``output_dir`` is ``None``, allowing the logger to
-be used unconditionally inside the runner regardless of whether the user asked
-for persisted artifacts.
+All three files are no-ops when ``output_dir`` is ``None``, allowing the
+logger to be used unconditionally inside the runner regardless of whether the
+user asked for persisted artifacts.
 """
 
 from __future__ import annotations
@@ -28,18 +33,65 @@ from farm.core.hyperparameter_chromosome import (
 
 
 class GeneTrajectoryLogger:
-    """Buffered JSONL logger for chromosome distributions and snapshots."""
+    """Buffered JSONL logger for chromosome distributions and snapshots.
+
+    Parameters
+    ----------
+    output_dir:
+        Directory in which to write the JSONL files.  When ``None`` all I/O
+        is suppressed and the logger becomes a no-op.
+    snapshot_interval:
+        Write a full per-agent snapshot every this many steps.  Step 0 is
+        always captured.  Must be at least 1.
+    enable_speciation:
+        When ``True``, run cluster detection at every snapshot step and
+        include a ``speciation_index`` field in every trajectory record.
+        Also writes ``cluster_lineage.jsonl``.  Default ``False``.
+    speciation_algorithm:
+        Which cluster-detection algorithm to use.  ``"gmm"`` (default) runs
+        Gaussian Mixture Models with BIC-selected ``k``; ``"dbscan"`` runs
+        density-based clustering.
+    speciation_max_k:
+        Maximum number of clusters to try when ``speciation_algorithm="gmm"``.
+        Default 5.
+    speciation_seed:
+        Integer random seed for reproducible cluster detection.  Default 0.
+    """
 
     TRAJECTORY_FILENAME = "intrinsic_gene_trajectory.jsonl"
     SNAPSHOT_FILENAME = "intrinsic_gene_snapshots.jsonl"
+    CLUSTER_LINEAGE_FILENAME = "cluster_lineage.jsonl"
 
-    def __init__(self, output_dir: Optional[str], snapshot_interval: int) -> None:
+    def __init__(
+        self,
+        output_dir: Optional[str],
+        snapshot_interval: int,
+        *,
+        enable_speciation: bool = False,
+        speciation_algorithm: str = "gmm",
+        speciation_max_k: int = 5,
+        speciation_seed: int = 0,
+    ) -> None:
         if snapshot_interval < 1:
             raise ValueError("snapshot_interval must be at least 1.")
+        if speciation_algorithm not in ("gmm", "dbscan"):
+            raise ValueError("speciation_algorithm must be 'gmm' or 'dbscan'.")
         self._output_dir = output_dir
         self._snapshot_interval = snapshot_interval
+        self._enable_speciation = enable_speciation
+        self._speciation_algorithm = speciation_algorithm
+        self._speciation_max_k = speciation_max_k
+        self._speciation_seed = speciation_seed
+
         self._trajectory_handle: Optional[TextIO] = None
         self._snapshot_handle: Optional[TextIO] = None
+        self._cluster_lineage_handle: Optional[TextIO] = None
+
+        # Cached speciation state between snapshot steps
+        self._cached_speciation_index: float = 0.0
+        self._prev_cluster_records: List[Any] = []  # List[ClusterLineageRecord]
+        self._cluster_id_counter: int = 0
+
         if output_dir:
             os.makedirs(output_dir, exist_ok=True)
             self._trajectory_handle = open(
@@ -52,11 +104,19 @@ class GeneTrajectoryLogger:
                 "w",
                 encoding="utf-8",
             )
+            if enable_speciation:
+                self._cluster_lineage_handle = open(
+                    os.path.join(output_dir, self.CLUSTER_LINEAGE_FILENAME),
+                    "w",
+                    encoding="utf-8",
+                )
 
     def snapshot(self, environment: Any, step: int, extra_fields: Optional[Dict[str, Any]] = None) -> None:
         """Record the chromosome distribution at ``step``.
 
         Always appends a one-line aggregate record to the trajectory file.
+        When speciation tracking is enabled the record includes a
+        ``speciation_index`` field updated at every snapshot step.
         Additionally appends a full per-agent snapshot when
         ``step % snapshot_interval == 0`` (so step 0 is always captured).
 
@@ -78,14 +138,27 @@ class GeneTrajectoryLogger:
             if getattr(agent, "hyperparameter_chromosome", None) is not None
         ]
         gene_stats = compute_gene_statistics(chromosomes, evolvable_only=True)
+
+        is_snapshot_step = step % self._snapshot_interval == 0
+
+        # Run speciation at snapshot steps when enabled
+        if self._enable_speciation and is_snapshot_step:
+            self._update_speciation(chromosomes, step)
+
         trajectory_record: Dict[str, Any] = {
             "step": step,
             "n_alive": len(alive_agents),
             "n_with_chromosome": len(chromosomes),
             "gene_stats": gene_stats,
         }
+        if self._enable_speciation:
+            trajectory_record["speciation_index"] = self._cached_speciation_index
+
         if extra_fields:
-            _RESERVED_TRAJECTORY_KEYS = {"step", "n_alive", "n_with_chromosome", "gene_stats"}
+            _RESERVED_TRAJECTORY_KEYS = {
+                "step", "n_alive", "n_with_chromosome", "gene_stats",
+                "speciation_index",
+            }
             collisions = _RESERVED_TRAJECTORY_KEYS & extra_fields.keys()
             if collisions:
                 raise ValueError(
@@ -95,7 +168,7 @@ class GeneTrajectoryLogger:
             trajectory_record.update(extra_fields)
         self._trajectory_handle.write(json.dumps(trajectory_record) + "\n")
 
-        if self._snapshot_handle is not None and step % self._snapshot_interval == 0:
+        if self._snapshot_handle is not None and is_snapshot_step:
             agents_payload: List[Dict[str, Any]] = []
             for agent in alive_agents:
                 chromosome = getattr(agent, "hyperparameter_chromosome", None)
@@ -115,9 +188,97 @@ class GeneTrajectoryLogger:
             snapshot_record = {"step": step, "agents": agents_payload}
             self._snapshot_handle.write(json.dumps(snapshot_record) + "\n")
 
+    # ------------------------------------------------------------------
+    # Speciation helpers
+    # ------------------------------------------------------------------
+
+    def _update_speciation(
+        self,
+        chromosomes: List[HyperparameterChromosome],
+        step: int,
+    ) -> None:
+        """Run cluster detection and update cached speciation state.
+
+        Called at every snapshot step when ``enable_speciation=True``.
+        Writes cluster lineage records to ``cluster_lineage.jsonl`` when an
+        output directory is configured.
+        """
+        try:
+            from farm.analysis.speciation.compute import (
+                ClusterLineageRecord,
+                compute_speciation_index,
+                detect_clusters_dbscan,
+                detect_clusters_gmm,
+                match_clusters_greedy,
+            )
+        except ImportError as exc:
+            # scikit-learn may not be installed; degrade gracefully
+            import warnings
+            warnings.warn(
+                f"GeneTrajectoryLogger: speciation disabled – could not import "
+                f"speciation module ({exc}). Install scikit-learn to enable it.",
+                RuntimeWarning,
+                stacklevel=4,
+            )
+            self._enable_speciation = False
+            return
+
+        if not chromosomes:
+            self._cached_speciation_index = 0.0
+            return
+
+        # Extract evolvable gene dicts
+        chrom_dicts = [
+            {gene.name: gene.value for gene in c.genes if gene.evolvable}
+            for c in chromosomes
+        ]
+
+        try:
+            if self._speciation_algorithm == "gmm":
+                result = detect_clusters_gmm(
+                    chrom_dicts,
+                    max_k=self._speciation_max_k,
+                    seed=self._speciation_seed,
+                )
+            else:
+                result = detect_clusters_dbscan(chrom_dicts)
+
+            self._cached_speciation_index = compute_speciation_index(result)
+
+            # Persist cluster lineage
+            if result.k > 0:
+                new_records, self._cluster_id_counter = match_clusters_greedy(
+                    self._prev_cluster_records,
+                    result.centroids,
+                    result.sizes,
+                    result.gene_names,
+                    step,
+                    id_counter_start=self._cluster_id_counter,
+                )
+                self._prev_cluster_records = new_records
+
+                if self._cluster_lineage_handle is not None:
+                    for rec in new_records:
+                        row: Dict[str, Any] = {
+                            "step": rec.step,
+                            "cluster_id": rec.cluster_id,
+                            "centroid": rec.centroid,
+                            "size": rec.size,
+                            "parent_cluster_id": rec.parent_cluster_id,
+                        }
+                        self._cluster_lineage_handle.write(json.dumps(row) + "\n")
+        except Exception as exc:
+            # Non-fatal: log and keep previous cached value
+            import warnings
+            warnings.warn(
+                f"GeneTrajectoryLogger: speciation update failed at step {step}: {exc}",
+                RuntimeWarning,
+                stacklevel=4,
+            )
+
     def close(self) -> None:
-        """Flush and close both file handles; safe to call multiple times."""
-        for attr in ("_trajectory_handle", "_snapshot_handle"):
+        """Flush and close all file handles; safe to call multiple times."""
+        for attr in ("_trajectory_handle", "_snapshot_handle", "_cluster_lineage_handle"):
             handle = getattr(self, attr)
             if handle is not None:
                 try:

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -77,6 +77,15 @@ class GeneTrajectoryLogger:
             raise ValueError("snapshot_interval must be at least 1.")
         if speciation_algorithm not in ("gmm", "dbscan"):
             raise ValueError("speciation_algorithm must be 'gmm' or 'dbscan'.")
+
+        if enable_speciation:
+            try:
+                import sklearn  # noqa: F401
+            except ImportError as exc:
+                raise ImportError(
+                    "GeneTrajectoryLogger: enable_speciation=True requires scikit-learn. "
+                    "Install it with: pip install scikit-learn"
+                ) from exc
         self._output_dir = output_dir
         self._snapshot_interval = snapshot_interval
         self._enable_speciation = enable_speciation
@@ -203,25 +212,12 @@ class GeneTrajectoryLogger:
         Writes cluster lineage records to ``cluster_lineage.jsonl`` when an
         output directory is configured.
         """
-        try:
-            from farm.analysis.speciation.compute import (
-                ClusterLineageRecord,
-                compute_speciation_index,
-                detect_clusters_dbscan,
-                detect_clusters_gmm,
-                match_clusters_greedy,
-            )
-        except ImportError as exc:
-            # scikit-learn may not be installed; degrade gracefully
-            import warnings
-            warnings.warn(
-                f"GeneTrajectoryLogger: speciation disabled – could not import "
-                f"speciation module ({exc}). Install scikit-learn to enable it.",
-                RuntimeWarning,
-                stacklevel=4,
-            )
-            self._enable_speciation = False
-            return
+        from farm.analysis.speciation.compute import (
+            compute_speciation_index,
+            detect_clusters_dbscan,
+            detect_clusters_gmm,
+            match_clusters_greedy,
+        )
 
         if not chromosomes:
             self._cached_speciation_index = 0.0

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -155,10 +155,9 @@ class GeneTrajectoryLogger:
             trajectory_record["speciation_index"] = self._cached_speciation_index
 
         if extra_fields:
-            _RESERVED_TRAJECTORY_KEYS = {
-                "step", "n_alive", "n_with_chromosome", "gene_stats",
-                "speciation_index",
-            }
+            _RESERVED_TRAJECTORY_KEYS = {"step", "n_alive", "n_with_chromosome", "gene_stats"}
+            if self._enable_speciation:
+                _RESERVED_TRAJECTORY_KEYS = _RESERVED_TRAJECTORY_KEYS | {"speciation_index"}
             collisions = _RESERVED_TRAJECTORY_KEYS & extra_fields.keys()
             if collisions:
                 raise ValueError(
@@ -271,7 +270,7 @@ class GeneTrajectoryLogger:
             # Non-fatal: log and keep previous cached value
             import warnings
             warnings.warn(
-                f"GeneTrajectoryLogger: speciation update failed at step {step}: {exc}",
+                f"GeneTrajectoryLogger: speciation update failed at step {step}: {exc!r}",
                 RuntimeWarning,
                 stacklevel=4,
             )

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -244,27 +244,33 @@ class GeneTrajectoryLogger:
             self._cached_speciation_index = compute_speciation_index(result)
 
             # Persist cluster lineage
-            if result.k > 0:
-                new_records, self._cluster_id_counter = match_clusters_greedy(
-                    self._prev_cluster_records,
-                    result.centroids,
-                    result.sizes,
-                    result.gene_names,
-                    step,
-                    id_counter_start=self._cluster_id_counter,
-                )
-                self._prev_cluster_records = new_records
+            if result.k == 0:
+                # No clusters (e.g. DBSCAN all-noise snapshot): reset lineage
+                # state so later clusters are treated as new founding lineages.
+                self._prev_cluster_records = []
+                self._cluster_id_counter = 0
+                return
 
-                if self._cluster_lineage_handle is not None:
-                    for rec in new_records:
-                        row: Dict[str, Any] = {
-                            "step": rec.step,
-                            "cluster_id": rec.cluster_id,
-                            "centroid": rec.centroid,
-                            "size": rec.size,
-                            "parent_cluster_id": rec.parent_cluster_id,
-                        }
-                        self._cluster_lineage_handle.write(json.dumps(row) + "\n")
+            new_records, self._cluster_id_counter = match_clusters_greedy(
+                self._prev_cluster_records,
+                result.centroids,
+                result.sizes,
+                result.gene_names,
+                step,
+                id_counter_start=self._cluster_id_counter,
+            )
+            self._prev_cluster_records = new_records
+
+            if self._cluster_lineage_handle is not None:
+                for rec in new_records:
+                    row: Dict[str, Any] = {
+                        "step": rec.step,
+                        "cluster_id": rec.cluster_id,
+                        "centroid": rec.centroid,
+                        "size": rec.size,
+                        "parent_cluster_id": rec.parent_cluster_id,
+                    }
+                    self._cluster_lineage_handle.write(json.dumps(row) + "\n")
         except Exception as exc:
             # Non-fatal: log and keep previous cached value
             import warnings

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -220,13 +220,13 @@ class TestMatchClustersGreedy:
     def test_known_fixture_split_across_snapshots(self):
         """Full persistence scenario: start with 1 cluster, split into 2."""
         # Snapshot 0: one cluster
-        r0, ctr = match_clusters_greedy([], [{"lr": 0.05}], [30], ["lr"], step=0)
+        r0, ctr0 = match_clusters_greedy([], [{"lr": 0.05}], [30], ["lr"], step=0)
         assert r0[0].cluster_id == "c0"
 
         # Snapshot 100: split into two distinct clusters
-        r1, ctr = match_clusters_greedy(
+        r1, _ctr1 = match_clusters_greedy(
             r0, [{"lr": 0.01}, {"lr": 0.1}], [15, 15], ["lr"], step=100,
-            id_counter_start=ctr
+            id_counter_start=ctr0,
         )
         ids_100 = {r.cluster_id for r in r1}
         # "c0" should match one of them (closest to old centroid 0.05);
@@ -510,7 +510,7 @@ class TestGeneTrajectoryLoggerSpeciation:
             GeneTrajectoryLogger(None, snapshot_interval=1, speciation_algorithm="bad")
 
     def test_speciation_index_reserved_key_in_extra_fields(self, tmp_path):
-        """Passing speciation_index via extra_fields should raise ValueError."""
+        """Passing speciation_index via extra_fields should raise ValueError when speciation enabled."""
         from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
 
         logger = GeneTrajectoryLogger(str(tmp_path), snapshot_interval=1, enable_speciation=True)
@@ -518,6 +518,20 @@ class TestGeneTrajectoryLoggerSpeciation:
         with pytest.raises(ValueError, match="speciation_index"):
             logger.snapshot(env, step=0, extra_fields={"speciation_index": 0.5})
         logger.close()
+
+    def test_speciation_index_not_reserved_when_disabled(self, tmp_path):
+        """When speciation is disabled, speciation_index can be used as a custom field."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        logger = GeneTrajectoryLogger(str(tmp_path), snapshot_interval=1, enable_speciation=False)
+        env = _FakeEnvironment([_make_fake_agent()])
+        # Should NOT raise – speciation_index is only reserved when enable_speciation=True
+        logger.snapshot(env, step=0, extra_fields={"speciation_index": 0.42})
+        logger.close()
+
+        traj_path = tmp_path / "intrinsic_gene_trajectory.jsonl"
+        rec = json.loads(traj_path.read_text().splitlines()[0])
+        assert rec["speciation_index"] == pytest.approx(0.42)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -13,7 +13,6 @@ Covers:
 from __future__ import annotations
 
 import json
-import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, List

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -13,7 +13,6 @@ Covers:
 from __future__ import annotations
 
 import json
-import os
 import tempfile
 import unittest
 from pathlib import Path

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -1,0 +1,584 @@
+"""Tests for the speciation / niche-detection analysis module.
+
+Covers:
+- detect_clusters_gmm: trivial (empty), single cluster, known two-cluster split
+- detect_clusters_dbscan: trivial, basic cluster detection
+- match_clusters_greedy: stable IDs across snapshots, new cluster allocation
+- compute_speciation_index: single cluster → 0, multi-cluster → silhouette
+- compute_niche_correlation: per-cluster spatial/resource means
+- GeneTrajectoryLogger: speciation_index in trajectory, cluster_lineage.jsonl output
+- plot_chromosome_space_clusters: smoke test (no file I/O error)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+import pytest
+
+from farm.analysis.speciation import (
+    ClusterLineageRecord,
+    ClusterResult,
+    compute_niche_correlation,
+    compute_speciation_index,
+    detect_clusters_dbscan,
+    detect_clusters_gmm,
+    match_clusters_greedy,
+    plot_chromosome_space_clusters,
+)
+from farm.analysis.common.context import AnalysisContext
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_chromosomes(values: List[Dict[str, float]]) -> List[Dict[str, float]]:
+    """Return chromosome dicts as-is (convenience alias for readability)."""
+    return list(values)
+
+
+def _bimodal_chromosomes(n_per_cluster: int = 20) -> List[Dict[str, float]]:
+    """Two well-separated clusters: low-LR exploiters + high-LR explorers."""
+    import random
+    rng = random.Random(42)
+    low_cluster = [
+        {"learning_rate": rng.gauss(0.01, 0.002), "gamma": rng.gauss(0.99, 0.005)}
+        for _ in range(n_per_cluster)
+    ]
+    high_cluster = [
+        {"learning_rate": rng.gauss(0.1, 0.002), "gamma": rng.gauss(0.5, 0.005)}
+        for _ in range(n_per_cluster)
+    ]
+    return low_cluster + high_cluster
+
+
+# ---------------------------------------------------------------------------
+# detect_clusters_gmm
+# ---------------------------------------------------------------------------
+
+
+class TestDetectClustersGMM:
+    def test_empty_input_returns_zero_clusters(self):
+        result = detect_clusters_gmm([], max_k=3, seed=0)
+        assert isinstance(result, ClusterResult)
+        assert result.k == 0
+        assert result.labels == []
+        assert result.centroids == []
+        assert result.algorithm == "gmm"
+
+    def test_single_agent_single_cluster(self):
+        chromosomes = [{"lr": 0.01, "gamma": 0.99}]
+        result = detect_clusters_gmm(chromosomes, max_k=3, seed=0)
+        assert result.k == 1
+        assert len(result.labels) == 1
+        assert len(result.centroids) == 1
+        assert result.silhouette_score == 0.0
+
+    def test_all_identical_agents_single_cluster(self):
+        chromosomes = [{"lr": 0.05, "gamma": 0.9}] * 10
+        result = detect_clusters_gmm(chromosomes, max_k=5, seed=0)
+        assert result.k == 1
+
+    def test_two_well_separated_clusters_detected(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=30)
+        result = detect_clusters_gmm(chromosomes, max_k=5, seed=42)
+        assert result.k == 2
+        assert len(result.labels) == 60
+        assert result.silhouette_score > 0.5
+
+    def test_labels_length_matches_input(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=15)
+        result = detect_clusters_gmm(chromosomes, max_k=4, seed=0)
+        assert len(result.labels) == len(chromosomes)
+
+    def test_gene_names_populated(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=10)
+        result = detect_clusters_gmm(chromosomes, max_k=3, seed=0)
+        assert set(result.gene_names) == {"learning_rate", "gamma"}
+
+    def test_bic_scores_populated_for_gmm(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=10)
+        result = detect_clusters_gmm(chromosomes, max_k=3, seed=0)
+        assert isinstance(result.bic_scores, dict)
+        assert len(result.bic_scores) >= 1
+
+    def test_deterministic_given_same_seed(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        r1 = detect_clusters_gmm(chromosomes, max_k=4, seed=7)
+        r2 = detect_clusters_gmm(chromosomes, max_k=4, seed=7)
+        assert r1.k == r2.k
+        assert r1.labels == r2.labels
+
+    def test_gene_names_override(self):
+        chromosomes = [{"lr": 0.01, "gamma": 0.99, "noise": 999.0}] * 10
+        result = detect_clusters_gmm(
+            chromosomes, max_k=2, seed=0, gene_names=["lr", "gamma"]
+        )
+        assert result.gene_names == ["lr", "gamma"]
+
+
+# ---------------------------------------------------------------------------
+# detect_clusters_dbscan
+# ---------------------------------------------------------------------------
+
+
+class TestDetectClustersDBSCAN:
+    def test_empty_input_returns_zero_clusters(self):
+        result = detect_clusters_dbscan([], eps=0.1, min_samples=2)
+        assert result.k == 0
+        assert result.bic_scores is None
+
+    def test_single_agent_returns_single_or_noise(self):
+        chromosomes = [{"lr": 0.01}]
+        result = detect_clusters_dbscan(chromosomes, eps=0.5, min_samples=1)
+        # With min_samples=1 a single agent should form a cluster
+        assert result.k >= 0
+
+    def test_two_clusters_detected_with_appropriate_eps(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        # Learning_rate values: low cluster ~0.01, high cluster ~0.1  → gap ~0.09
+        result = detect_clusters_dbscan(chromosomes, eps=0.03, min_samples=3)
+        # Should find 2 clusters (noise-free for well-separated data)
+        assert result.k >= 2
+
+    def test_bic_scores_none_for_dbscan(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=10)
+        result = detect_clusters_dbscan(chromosomes)
+        assert result.bic_scores is None
+
+    def test_algorithm_field_is_dbscan(self):
+        result = detect_clusters_dbscan([{"lr": 0.01}])
+        assert result.algorithm == "dbscan"
+
+
+# ---------------------------------------------------------------------------
+# match_clusters_greedy
+# ---------------------------------------------------------------------------
+
+
+class TestMatchClustersGreedy:
+    def _make_record(self, cluster_id: str, centroid: Dict[str, float], size: int = 10) -> ClusterLineageRecord:
+        return ClusterLineageRecord(
+            step=0,
+            cluster_id=cluster_id,
+            centroid=centroid,
+            size=size,
+            parent_cluster_id=None,
+        )
+
+    def test_empty_prev_allocates_new_ids(self):
+        centroids = [{"lr": 0.01}, {"lr": 0.1}]
+        sizes = [20, 20]
+        records, next_ctr = match_clusters_greedy([], centroids, sizes, ["lr"], step=100)
+        assert len(records) == 2
+        assert all(r.parent_cluster_id is None for r in records)
+        assert {r.cluster_id for r in records} == {"c0", "c1"}
+        assert next_ctr == 2
+
+    def test_stable_id_carries_over_when_close(self):
+        prev = [self._make_record("c0", {"lr": 0.01})]
+        centroids = [{"lr": 0.011}]  # very close to prev
+        records, _ = match_clusters_greedy(prev, centroids, [18], ["lr"], step=200)
+        assert records[0].cluster_id == "c0"
+        assert records[0].parent_cluster_id == "c0"
+
+    def test_new_id_when_no_close_predecessor(self):
+        prev = [self._make_record("c0", {"lr": 0.01})]
+        # New centroid far away, max_distance very small so no match
+        centroids = [{"lr": 0.5}]
+        records, ctr = match_clusters_greedy(
+            prev, centroids, [15], ["lr"], step=200, max_distance=0.05
+        )
+        assert records[0].cluster_id != "c0"
+        assert records[0].parent_cluster_id is None
+
+    def test_split_cluster_produces_new_id(self):
+        """One previous cluster splits into two → one inherits ID, one is new."""
+        prev = [self._make_record("c0", {"lr": 0.05})]
+        centroids = [{"lr": 0.01}, {"lr": 0.1}]  # two new clusters
+        records, ctr = match_clusters_greedy(prev, centroids, [10, 10], ["lr"], step=200)
+        cluster_ids = {r.cluster_id for r in records}
+        parent_ids = {r.parent_cluster_id for r in records}
+        # One should have inherited "c0", one should be fresh
+        assert "c0" in cluster_ids
+        assert None in parent_ids  # one is a new lineage
+
+    def test_step_field_populated_correctly(self):
+        centroids = [{"lr": 0.05}]
+        records, _ = match_clusters_greedy([], centroids, [5], ["lr"], step=999)
+        assert records[0].step == 999
+
+    def test_known_fixture_split_across_snapshots(self):
+        """Full persistence scenario: start with 1 cluster, split into 2."""
+        # Snapshot 0: one cluster
+        r0, ctr = match_clusters_greedy([], [{"lr": 0.05}], [30], ["lr"], step=0)
+        assert r0[0].cluster_id == "c0"
+
+        # Snapshot 100: split into two distinct clusters
+        r1, ctr = match_clusters_greedy(
+            r0, [{"lr": 0.01}, {"lr": 0.1}], [15, 15], ["lr"], step=100,
+            id_counter_start=ctr
+        )
+        ids_100 = {r.cluster_id for r in r1}
+        # "c0" should match one of them (closest to old centroid 0.05);
+        # the other should be a new "c1"
+        assert "c0" in ids_100
+        assert "c1" in ids_100
+
+
+# ---------------------------------------------------------------------------
+# compute_speciation_index
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSpeciationIndex:
+    def _make_result(self, k: int, sil: float) -> ClusterResult:
+        return ClusterResult(
+            algorithm="gmm",
+            k=k,
+            labels=[0] * 5,
+            centroids=[{"lr": 0.01}],
+            sizes=[5],
+            gene_names=["lr"],
+            silhouette_score=sil,
+            bic_scores=None,
+        )
+
+    def test_single_cluster_returns_zero(self):
+        result = self._make_result(k=1, sil=0.9)
+        assert compute_speciation_index(result) == 0.0
+
+    def test_zero_clusters_returns_zero(self):
+        result = self._make_result(k=0, sil=0.0)
+        assert compute_speciation_index(result) == 0.0
+
+    def test_two_clusters_returns_silhouette(self):
+        result = ClusterResult(
+            algorithm="gmm", k=2, labels=[0, 1],
+            centroids=[{"lr": 0.01}, {"lr": 0.1}],
+            sizes=[1, 1], gene_names=["lr"],
+            silhouette_score=0.75, bic_scores=None,
+        )
+        assert compute_speciation_index(result) == pytest.approx(0.75)
+
+    def test_clamped_to_zero_when_negative_silhouette(self):
+        result = ClusterResult(
+            algorithm="dbscan", k=2, labels=[0, 1],
+            centroids=[{"lr": 0.01}, {"lr": 0.02}],
+            sizes=[1, 1], gene_names=["lr"],
+            silhouette_score=-0.2, bic_scores=None,
+        )
+        assert compute_speciation_index(result) == 0.0
+
+    def test_value_in_unit_interval_for_well_separated_bimodal(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=30)
+        result = detect_clusters_gmm(chromosomes, max_k=3, seed=0)
+        index = compute_speciation_index(result)
+        assert 0.0 <= index <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# compute_niche_correlation
+# ---------------------------------------------------------------------------
+
+
+class TestComputeNicheCorrelation:
+    def _make_simple_result(self, labels: List[int]) -> ClusterResult:
+        k = max(labels) + 1 if labels else 0
+        return ClusterResult(
+            algorithm="gmm", k=k, labels=labels,
+            centroids=[{"lr": 0.01}] * k,
+            sizes=[labels.count(i) for i in range(k)],
+            gene_names=["lr"], silhouette_score=0.5, bic_scores=None,
+        )
+
+    def test_empty_agents_returns_empty(self):
+        result = self._make_simple_result([])
+        niche = compute_niche_correlation(result, [])
+        assert niche == []
+
+    def test_mean_x_y_computed_correctly(self):
+        labels = [0, 0, 1, 1]
+        agents = [
+            {"x": 1.0, "y": 2.0, "energy": 10.0},
+            {"x": 3.0, "y": 4.0, "energy": 20.0},
+            {"x": 5.0, "y": 6.0, "energy": 30.0},
+            {"x": 7.0, "y": 8.0, "energy": 40.0},
+        ]
+        result = self._make_simple_result(labels)
+        niche = compute_niche_correlation(result, agents)
+        assert len(niche) == 2
+
+        by_id = {n["cluster_id"]: n for n in niche}
+        assert by_id[0]["mean_x"] == pytest.approx(2.0)
+        assert by_id[0]["mean_y"] == pytest.approx(3.0)
+        assert by_id[0]["mean_energy"] == pytest.approx(15.0)
+        assert by_id[1]["mean_x"] == pytest.approx(6.0)
+        assert by_id[1]["mean_energy"] == pytest.approx(35.0)
+
+    def test_missing_field_returns_none(self):
+        labels = [0, 0]
+        agents = [{"x": 1.0}, {"x": 2.0}]  # no 'y' field
+        result = self._make_simple_result(labels)
+        niche = compute_niche_correlation(result, agents)
+        assert niche[0]["mean_y"] is None
+
+    def test_noise_agents_excluded(self):
+        """DBSCAN noise (label=-1) agents should not appear in any cluster."""
+        labels = [-1, 0, 0, -1]
+        agents = [
+            {"x": 99.0},
+            {"x": 1.0},
+            {"x": 3.0},
+            {"x": 99.0},
+        ]
+        result = ClusterResult(
+            algorithm="dbscan", k=1, labels=labels,
+            centroids=[{"lr": 0.01}],
+            sizes=[2], gene_names=["lr"],
+            silhouette_score=0.0, bic_scores=None,
+        )
+        niche = compute_niche_correlation(result, agents)
+        # Only one cluster; mean_x should be average of agents at index 1,2
+        assert len(niche) == 1
+        assert niche[0]["mean_x"] == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# GeneTrajectoryLogger with speciation
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_chromosome(lr: float = 0.01, gamma: float = 0.99):
+    """Build a minimal HyperparameterChromosome-like object."""
+    from farm.core.hyperparameter_chromosome import chromosome_from_values
+    return chromosome_from_values({"learning_rate": lr, "gamma": gamma})
+
+
+def _make_fake_agent(lr: float = 0.01, gamma: float = 0.99):
+    chromosome = _make_fake_chromosome(lr, gamma)
+    state_inner = SimpleNamespace(parent_ids=["seed"])
+    return SimpleNamespace(
+        agent_id=f"agent_{lr:.4f}",
+        agent_type="system",
+        generation=0,
+        alive=True,
+        hyperparameter_chromosome=chromosome,
+        state=SimpleNamespace(_state=state_inner),
+    )
+
+
+class _FakeEnvironment:
+    def __init__(self, agents):
+        self._agents = list(agents)
+
+    @property
+    def alive_agent_objects(self):
+        return list(self._agents)
+
+
+class TestGeneTrajectoryLoggerSpeciation:
+    def test_no_speciation_by_default(self, tmp_path):
+        """Without enable_speciation, trajectory records have no speciation_index."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        logger = GeneTrajectoryLogger(str(tmp_path), snapshot_interval=1)
+        agents = [_make_fake_agent(lr=0.01), _make_fake_agent(lr=0.1)]
+        env = _FakeEnvironment(agents)
+        logger.snapshot(env, step=0)
+        logger.close()
+
+        traj_path = tmp_path / "intrinsic_gene_trajectory.jsonl"
+        records = [json.loads(line) for line in traj_path.read_text().splitlines()]
+        assert len(records) == 1
+        assert "speciation_index" not in records[0]
+
+    def test_speciation_index_present_when_enabled(self, tmp_path):
+        """With enable_speciation=True, trajectory records include speciation_index."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        logger = GeneTrajectoryLogger(str(tmp_path), snapshot_interval=1, enable_speciation=True)
+        agents = [_make_fake_agent(lr=0.01), _make_fake_agent(lr=0.1)]
+        env = _FakeEnvironment(agents)
+        logger.snapshot(env, step=0)
+        logger.close()
+
+        traj_path = tmp_path / "intrinsic_gene_trajectory.jsonl"
+        records = [json.loads(line) for line in traj_path.read_text().splitlines()]
+        assert len(records) == 1
+        assert "speciation_index" in records[0]
+        assert 0.0 <= records[0]["speciation_index"] <= 1.0
+
+    def test_cluster_lineage_written_when_speciation_enabled(self, tmp_path):
+        """cluster_lineage.jsonl is created and populated with speciation enabled."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        # Create a clearly bimodal population
+        agents = (
+            [_make_fake_agent(lr=0.01, gamma=0.99)] * 10
+            + [_make_fake_agent(lr=0.5, gamma=0.4)] * 10
+        )
+        env = _FakeEnvironment(agents)
+
+        logger = GeneTrajectoryLogger(str(tmp_path), snapshot_interval=1, enable_speciation=True)
+        logger.snapshot(env, step=0)
+        logger.close()
+
+        lineage_path = tmp_path / "cluster_lineage.jsonl"
+        assert lineage_path.exists()
+        rows = [json.loads(line) for line in lineage_path.read_text().splitlines()]
+        assert len(rows) >= 1
+        # Verify schema
+        row = rows[0]
+        assert "step" in row
+        assert "cluster_id" in row
+        assert "centroid" in row
+        assert "size" in row
+        assert "parent_cluster_id" in row
+
+    def test_cluster_lineage_not_written_without_speciation(self, tmp_path):
+        """cluster_lineage.jsonl should not be created when speciation is off."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        agents = [_make_fake_agent()]
+        env = _FakeEnvironment(agents)
+        logger = GeneTrajectoryLogger(str(tmp_path), snapshot_interval=1)
+        logger.snapshot(env, step=0)
+        logger.close()
+
+        lineage_path = tmp_path / "cluster_lineage.jsonl"
+        assert not lineage_path.exists()
+
+    def test_speciation_index_stable_between_snapshot_steps(self, tmp_path):
+        """Between snapshot steps the speciation_index should remain the same value."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        agents = (
+            [_make_fake_agent(lr=0.01)] * 10
+            + [_make_fake_agent(lr=0.5)] * 10
+        )
+        env = _FakeEnvironment(agents)
+
+        # snapshot_interval=5 means cluster detection at step 0, 5, 10, ...
+        logger = GeneTrajectoryLogger(str(tmp_path), snapshot_interval=5, enable_speciation=True)
+        for step in range(6):  # steps 0..5
+            logger.snapshot(env, step=step)
+        logger.close()
+
+        traj_path = tmp_path / "intrinsic_gene_trajectory.jsonl"
+        records = [json.loads(line) for line in traj_path.read_text().splitlines()]
+        assert len(records) == 6
+        # steps 1..4 should have same speciation_index as step 0
+        idx_0 = records[0]["speciation_index"]
+        idx_5 = records[5]["speciation_index"]
+        for rec in records[1:5]:
+            assert rec["speciation_index"] == pytest.approx(idx_0)
+        # step 5 is a new snapshot step → may have updated value (possibly same)
+        assert 0.0 <= idx_5 <= 1.0
+
+    def test_speciation_index_bimodal_population_nonzero(self, tmp_path):
+        """A clearly bimodal population should produce a nonzero speciation index."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        # Build highly separated bimodal population
+        agents = (
+            [_make_fake_agent(lr=0.001, gamma=0.99)] * 20
+            + [_make_fake_agent(lr=0.9, gamma=0.1)] * 20
+        )
+        env = _FakeEnvironment(agents)
+        logger = GeneTrajectoryLogger(str(tmp_path), snapshot_interval=1, enable_speciation=True)
+        logger.snapshot(env, step=0)
+        logger.close()
+
+        traj_path = tmp_path / "intrinsic_gene_trajectory.jsonl"
+        rec = json.loads(traj_path.read_text().splitlines()[0])
+        assert rec["speciation_index"] > 0.0
+
+    def test_invalid_speciation_algorithm_raises(self):
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        with pytest.raises(ValueError, match="speciation_algorithm"):
+            GeneTrajectoryLogger(None, snapshot_interval=1, speciation_algorithm="bad")
+
+    def test_speciation_index_reserved_key_in_extra_fields(self, tmp_path):
+        """Passing speciation_index via extra_fields should raise ValueError."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        logger = GeneTrajectoryLogger(str(tmp_path), snapshot_interval=1, enable_speciation=True)
+        env = _FakeEnvironment([_make_fake_agent()])
+        with pytest.raises(ValueError, match="speciation_index"):
+            logger.snapshot(env, step=0, extra_fields={"speciation_index": 0.5})
+        logger.close()
+
+
+# ---------------------------------------------------------------------------
+# plot_chromosome_space_clusters
+# ---------------------------------------------------------------------------
+
+
+class TestPlotChromosomeSpaceClusters:
+    def _ctx(self, tmp_path) -> AnalysisContext:
+        return AnalysisContext(output_path=Path(tmp_path))
+
+    def test_smoke_two_gene_two_clusters(self, tmp_path):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=15)
+        result = detect_clusters_gmm(chromosomes, max_k=3, seed=0)
+        ctx = self._ctx(tmp_path)
+        out = plot_chromosome_space_clusters(chromosomes, result, ctx, step=0)
+        assert out is not None
+        assert Path(out).exists()
+
+    def test_empty_chromosomes_returns_none(self, tmp_path):
+        result = ClusterResult(
+            algorithm="gmm", k=0, labels=[], centroids=[],
+            sizes=[], gene_names=[], silhouette_score=0.0, bic_scores=None,
+        )
+        ctx = self._ctx(tmp_path)
+        out = plot_chromosome_space_clusters([], result, ctx)
+        assert out is None
+
+    def test_single_gene_strip_plot(self, tmp_path):
+        chromosomes = [{"lr": v} for v in [0.01, 0.02, 0.1, 0.11]]
+        result = detect_clusters_gmm(chromosomes, max_k=3, seed=0)
+        ctx = self._ctx(tmp_path)
+        out = plot_chromosome_space_clusters(chromosomes, result, ctx, step=5)
+        assert out is not None
+        assert Path(out).exists()
+
+    def test_three_genes_uses_pca(self, tmp_path):
+        import random
+        rng = random.Random(0)
+        chromosomes = [
+            {"lr": rng.random(), "gamma": rng.random(), "eps": rng.random()}
+            for _ in range(20)
+        ]
+        result = detect_clusters_gmm(chromosomes, max_k=3, seed=0)
+        ctx = self._ctx(tmp_path)
+        out = plot_chromosome_space_clusters(chromosomes, result, ctx)
+        assert out is not None
+
+    def test_custom_output_filename(self, tmp_path):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=10)
+        result = detect_clusters_gmm(chromosomes, max_k=3, seed=0)
+        ctx = self._ctx(tmp_path)
+        out = plot_chromosome_space_clusters(
+            chromosomes, result, ctx, output_filename="my_custom_plot.png"
+        )
+        assert out is not None
+        assert "my_custom_plot.png" in str(out)
+
+    def test_dbscan_result_plot(self, tmp_path):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=15)
+        result = detect_clusters_dbscan(chromosomes, eps=0.04, min_samples=3)
+        ctx = self._ctx(tmp_path)
+        out = plot_chromosome_space_clusters(chromosomes, result, ctx)
+        assert out is not None

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -529,6 +529,45 @@ class TestGeneTrajectoryLoggerSpeciation:
         rec = json.loads(traj_path.read_text().splitlines()[0])
         assert rec["speciation_index"] == pytest.approx(0.42)
 
+    def test_dbscan_all_noise_snapshot_resets_lineage(self, tmp_path):
+        """All-noise DBSCAN snapshots should reset lineage state."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        logger = GeneTrajectoryLogger(
+            str(tmp_path),
+            snapshot_interval=1,
+            enable_speciation=True,
+            speciation_algorithm="dbscan",
+        )
+
+        # Step 0: one dense cluster near lr ~= 0.01
+        env_cluster_1 = _FakeEnvironment(
+            [_make_fake_agent(lr=0.01), _make_fake_agent(lr=0.011), _make_fake_agent(lr=0.012)]
+        )
+        logger.snapshot(env_cluster_1, step=0)
+
+        # Step 1: spread-out points -> DBSCAN labels all as noise.
+        env_all_noise = _FakeEnvironment(
+            [_make_fake_agent(lr=0.001), _make_fake_agent(lr=0.3), _make_fake_agent(lr=0.9)]
+        )
+        logger.snapshot(env_all_noise, step=1)
+
+        # Step 2: cluster reappears; should be treated as a new founding lineage.
+        env_cluster_2 = _FakeEnvironment(
+            [_make_fake_agent(lr=0.01), _make_fake_agent(lr=0.011), _make_fake_agent(lr=0.012)]
+        )
+        logger.snapshot(env_cluster_2, step=2)
+        logger.close()
+
+        lineage_path = tmp_path / "cluster_lineage.jsonl"
+        rows = [json.loads(line) for line in lineage_path.read_text().splitlines()]
+
+        step_0_rows = [row for row in rows if row["step"] == 0]
+        step_2_rows = [row for row in rows if row["step"] == 2]
+        assert len(step_0_rows) == 1
+        assert len(step_2_rows) == 1
+        assert step_2_rows[0]["parent_cluster_id"] is None
+
 
 # ---------------------------------------------------------------------------
 # plot_chromosome_space_clusters
@@ -591,4 +630,26 @@ class TestPlotChromosomeSpaceClusters:
         result = detect_clusters_dbscan(chromosomes, eps=0.04, min_samples=3)
         ctx = self._ctx(tmp_path)
         out = plot_chromosome_space_clusters(chromosomes, result, ctx)
+        assert out is not None
+
+    def test_zero_gene_dimensions_returns_none(self, tmp_path):
+        result = ClusterResult(
+            algorithm="gmm",
+            k=1,
+            labels=[0],
+            centroids=[{}],
+            sizes=[1],
+            gene_names=[],
+            silhouette_score=0.0,
+            bic_scores={1: 0.0},
+        )
+        ctx = self._ctx(tmp_path)
+        out = plot_chromosome_space_clusters([{}], result, ctx)
+        assert out is None
+
+    def test_agent_id_annotation_length_mismatch_does_not_fail(self, tmp_path):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=10)
+        result = detect_clusters_gmm(chromosomes, max_k=3, seed=0)
+        ctx = self._ctx(tmp_path)
+        out = plot_chromosome_space_clusters(chromosomes, result, ctx, agent_ids=["a0"])
         assert out is not None

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -16,7 +16,7 @@ import json
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 from unittest.mock import patch
 
 import pytest

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -17,7 +17,6 @@ import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, List
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import json
 import tempfile
-import unittest
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional


### PR DESCRIPTION
This pull request introduces a comprehensive speciation and niche-detection analysis framework for intrinsic-evolution experiments. The main changes add new cluster detection, tracking, and visualization features, along with integration into the experiment logging and documentation. These updates enable the detection of population substructure, computation of a speciation index, and offline/online analysis and visualization of clusters.

**Speciation and Niche Detection Features**

* Added the `farm.analysis.speciation` module, which provides GMM-BIC and DBSCAN cluster detection, cluster lineage tracking, speciation index computation, niche correlation analysis, and PCA/scatterplot visualization (`plot_chromosome_space_clusters`). The API is documented and exposed via the package’s `__init__.py`. [[1]](diffhunk://#diff-6d39a86319290299f250dd43155bda7bc9d0b1c4e1cc6ca75a68419af2035b05R1-R68) [[2]](diffhunk://#diff-c4fec462200b2ae2e3673e526500cfa29fcea10e5c352da54feb18d5b6f7f2b5R1-R218)
* Updated the experiment documentation to describe speciation/niche detection, runtime configuration, offline analysis, and the new API, with code examples and symbol references. [[1]](diffhunk://#diff-f8f1cf3d39bba02a52815918226df4a0245877364494e01281b047791334226dL406-R533) [[2]](diffhunk://#diff-f8f1cf3d39bba02a52815918226df4a0245877364494e01281b047791334226dL84-R87)

**Logger and Data Pipeline Integration**

* Extended `GeneTrajectoryLogger` to support speciation tracking: new parameters enable cluster detection and logging, each trajectory record gains a `speciation_index` field, and a new `cluster_lineage.jsonl` artifact is written at each snapshot step. The logger now manages all three files and caches cluster state between snapshots. [[1]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70L3-R20) [[2]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70L31-R94) [[3]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R107-R119)

**Testing**

* Added `tests/analysis/test_speciation.py` to cover the new cluster detection, matching, index calculation, niche analysis, logger integration, and visualization.

**Summary of most important changes:**

**Speciation and Niche Detection Core**
- Added `farm/analysis/speciation/` with GMM-BIC and DBSCAN clustering, cluster lineage tracking, speciation index, niche correlation, and plotting helpers, all documented and exposed in the API. [[1]](diffhunk://#diff-6d39a86319290299f250dd43155bda7bc9d0b1c4e1cc6ca75a68419af2035b05R1-R68) [[2]](diffhunk://#diff-c4fec462200b2ae2e3673e526500cfa29fcea10e5c352da54feb18d5b6f7f2b5R1-R218)
- Updated documentation to explain and demonstrate the new speciation/niche detection features, including runtime and offline usage. [[1]](diffhunk://#diff-f8f1cf3d39bba02a52815918226df4a0245877364494e01281b047791334226dL406-R533) [[2]](diffhunk://#diff-f8f1cf3d39bba02a52815918226df4a0245877364494e01281b047791334226dL84-R87)

**Logger and Data Pipeline**
- Enhanced `GeneTrajectoryLogger` to support speciation tracking, including new configuration options, per-step `speciation_index`, and the `cluster_lineage.jsonl` artifact. [[1]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70L3-R20) [[2]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70L31-R94) [[3]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R107-R119)

**Testing**
- Added comprehensive tests for all new speciation features and their integration into the logging pipeline.

These changes enable robust detection and analysis of population structure in intrinsic-evolution experiments, both during and after runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new clustering/plotting code paths (scikit-learn/matplotlib) and extends `GeneTrajectoryLogger` to optionally compute and persist additional telemetry, which could affect runtime performance and output schemas when enabled.
> 
> **Overview**
> Adds a new `farm.analysis.speciation` module to detect and track chromosome-space clusters (GMM/BIC or DBSCAN), compute a silhouette-based `speciation_index`, summarize per-cluster niche statistics, and generate PCA/scatter plots.
> 
> Extends `GeneTrajectoryLogger` with optional speciation tracking: when enabled it recomputes/caches `speciation_index` at snapshot steps, appends it to every `intrinsic_gene_trajectory.jsonl` record, and writes a new `cluster_lineage.jsonl` artifact with stable cluster IDs across snapshots.
> 
> Updates intrinsic-evolution docs to cover runtime/offline speciation workflows and adds comprehensive tests for clustering, persistence, niche metrics, plotting, and logger integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7efeeeb1334aff13408eb7a91ee71444b0636bcb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->