### PR TITLE
Implement auto-tuning for DBSCAN parameters in speciation

### DIFF
--- a/farm/analysis/speciation/__init__.py
+++ b/farm/analysis/speciation/__init__.py
@@ -45,6 +45,7 @@ from farm.analysis.speciation.compute import (
     VALID_SCALERS,
     detect_clusters_gmm,
     detect_clusters_dbscan,
+    suggest_dbscan_params,
     match_clusters_greedy,
     compute_speciation_index,
     compute_niche_correlation,
@@ -60,6 +61,7 @@ __all__ = [
     # Cluster detection
     "detect_clusters_gmm",
     "detect_clusters_dbscan",
+    "suggest_dbscan_params",
     # Cluster persistence
     "match_clusters_greedy",
     # Scalar metrics

--- a/farm/analysis/speciation/compute.py
+++ b/farm/analysis/speciation/compute.py
@@ -582,6 +582,11 @@ def detect_clusters_dbscan(
         the chosen ``eps``, ``min_samples``, ``method``, and ``k_percentile``.
     """
     _validate_scaler(scaler)
+    if auto_tune and not 0.0 <= auto_tune_percentile <= 100.0:
+        raise ValueError(
+            "auto_tune_percentile must be in [0, 100] when auto_tune=True; "
+            f"got {auto_tune_percentile!r}."
+        )
     _require_sklearn()
     X, gnames = _chromosomes_to_matrix(chromosomes, gene_names)
     n_agents = X.shape[0]

--- a/farm/analysis/speciation/compute.py
+++ b/farm/analysis/speciation/compute.py
@@ -118,6 +118,14 @@ class ClusterResult:
     bic_scores:
         Mapping ``{k: bic_value}`` for each ``k`` tried during GMM search.
         ``None`` for DBSCAN.
+    scaler:
+        Feature scaling applied before clustering.  One of ``"none"``,
+        ``"standard"``, or ``"robust"``.
+    dbscan_params:
+        When DBSCAN was run with ``auto_tune=True``, a dict containing the
+        chosen ``eps``, ``min_samples``, ``method``, and ``k_percentile`` for
+        reproducibility.  ``None`` when parameters were supplied explicitly or
+        the algorithm is GMM.
     """
 
     algorithm: str
@@ -129,6 +137,7 @@ class ClusterResult:
     silhouette_score: float
     bic_scores: Optional[Dict[int, float]]
     scaler: str = "none"
+    dbscan_params: Optional[Dict[str, Any]] = field(default=None)
 
 
 @dataclass
@@ -409,6 +418,117 @@ def detect_clusters_gmm(
 # ---------------------------------------------------------------------------
 
 
+def suggest_dbscan_params(
+    chromosomes: Sequence[Dict[str, float]],
+    *,
+    gene_names: Optional[List[str]] = None,
+    k_percentile: float = 90.0,
+    scaler: str = "none",
+) -> Dict[str, Any]:
+    """Suggest DBSCAN ``eps`` and ``min_samples`` from data statistics.
+
+    Uses the *k-NN distance percentile* heuristic:
+
+    1. ``min_samples`` is set to ``max(2, n_dims + 1)`` — a common rule of
+       thumb that scales with chromosome dimensionality.
+    2. For each point the distance to its ``min_samples``-th nearest neighbour
+       is computed.  ``eps`` is the ``k_percentile``-th percentile of those
+       sorted distances.
+
+    The returned dict can be unpacked directly into :func:`detect_clusters_dbscan`::
+
+        params = suggest_dbscan_params(chromosomes, k_percentile=90)
+        result = detect_clusters_dbscan(chromosomes, **params)
+
+    Parameters
+    ----------
+    chromosomes:
+        Sequence of chromosome dicts used to estimate parameters.
+    gene_names:
+        Ordered subset of genes to use.  When ``None`` all present genes are
+        used (sorted).
+    k_percentile:
+        Percentile (0–100) of the sorted k-NN distance distribution used to
+        estimate ``eps``.  Higher values produce a more inclusive neighbourhood
+        and tend to merge smaller clusters.  Default 90.
+    scaler:
+        Feature scaling applied before computing distances.  Same options as
+        :func:`detect_clusters_dbscan`.  Use the same value you intend to pass
+        to :func:`detect_clusters_dbscan` so the suggested ``eps`` is valid in
+        the same scaled space.
+
+    Returns
+    -------
+    dict
+        ``{"eps": float, "min_samples": int, "method": str, "k_percentile": float}``
+        where ``method`` is always ``"k_distance_percentile"``.
+
+    Raises
+    ------
+    ValueError
+        When ``k_percentile`` is outside ``[0, 100]`` or ``scaler`` is invalid.
+    ImportError
+        When scikit-learn is not installed.
+    """
+    if not 0.0 <= k_percentile <= 100.0:
+        raise ValueError(f"k_percentile must be in [0, 100]; got {k_percentile!r}.")
+    _validate_scaler(scaler)
+    _require_sklearn()
+
+    from sklearn.neighbors import NearestNeighbors
+
+    X, gnames = _chromosomes_to_matrix(chromosomes, gene_names)
+    n_agents, n_dims = X.shape
+
+    min_samples: int = max(2, n_dims + 1)
+
+    fallback: Dict[str, Any] = {
+        "eps": 0.5,
+        "min_samples": min_samples,
+        "method": "k_distance_percentile",
+        "k_percentile": k_percentile,
+    }
+
+    if n_agents <= min_samples:
+        # Too few points to fit NearestNeighbors reliably; return safe defaults.
+        logger.info(
+            "suggest_dbscan_params: insufficient data for k-NN estimation; using fallback",
+            n_agents=n_agents,
+            n_dims=n_dims,
+            min_samples=min_samples,
+        )
+        return fallback
+
+    X_scaled, _ = _apply_scaler(X, scaler)
+
+    nbrs = NearestNeighbors(n_neighbors=min_samples).fit(X_scaled)
+    distances, _ = nbrs.kneighbors(X_scaled)
+    # distances[:, -1] is the distance to the min_samples-th nearest neighbour
+    kth_distances = distances[:, -1]
+    eps = float(np.percentile(kth_distances, k_percentile))
+
+    # Guard against degenerate case where all points are identical (eps == 0).
+    if eps <= 0.0:
+        eps = float(np.percentile(kth_distances, min(k_percentile + 5.0, 100.0)))
+    if eps <= 0.0:
+        eps = 1e-6  # absolute fallback to avoid DBSCAN running with eps=0
+
+    logger.info(
+        "suggest_dbscan_params",
+        n_agents=n_agents,
+        n_dims=n_dims,
+        suggested_eps=round(eps, 6),
+        suggested_min_samples=min_samples,
+        k_percentile=k_percentile,
+    )
+    return {
+        "eps": eps,
+        "min_samples": min_samples,
+        "method": "k_distance_percentile",
+        "k_percentile": k_percentile,
+    }
+
+
 def detect_clusters_dbscan(
     chromosomes: Sequence[Dict[str, float]],
     *,
@@ -416,6 +536,8 @@ def detect_clusters_dbscan(
     min_samples: int = 2,
     gene_names: Optional[List[str]] = None,
     scaler: str = "none",
+    auto_tune: bool = False,
+    auto_tune_percentile: float = 90.0,
 ) -> ClusterResult:
     """Detect population clusters using DBSCAN.
 
@@ -429,10 +551,10 @@ def detect_clusters_dbscan(
     eps:
         Maximum distance between two samples to be considered in the same
         neighbourhood.  Default ``0.1`` (gene values are typically in
-        ``[0, 1]`` after normalisation).
+        ``[0, 1]`` after normalisation).  Ignored when ``auto_tune=True``.
     min_samples:
         Minimum number of samples in a neighbourhood to form a core point.
-        Default 2.
+        Default 2.  Ignored when ``auto_tune=True``.
     gene_names:
         Ordered subset of genes to use.  When ``None`` all present genes are
         used (sorted).
@@ -442,15 +564,38 @@ def detect_clusters_dbscan(
         (z-score), or ``"robust"`` (median/IQR).  When genes have widely
         different numeric ranges scaling is strongly recommended, as DBSCAN's
         ``eps`` threshold is applied in the scaled space.
+    auto_tune:
+        When ``True``, ``eps`` and ``min_samples`` are estimated automatically
+        from the chromosome distribution using :func:`suggest_dbscan_params`
+        (k-NN distance percentile heuristic).  The chosen parameters are
+        recorded in :attr:`ClusterResult.dbscan_params` for reproducibility.
+        Default ``False``.
+    auto_tune_percentile:
+        Percentile (0–100) of the k-NN distance distribution used to estimate
+        ``eps`` when ``auto_tune=True``.  Higher values produce a larger, more
+        inclusive neighbourhood.  Default 90.
 
     Returns
     -------
     ClusterResult
+        ``dbscan_params`` is populated when ``auto_tune=True`` and contains
+        the chosen ``eps``, ``min_samples``, ``method``, and ``k_percentile``.
     """
     _validate_scaler(scaler)
     _require_sklearn()
     X, gnames = _chromosomes_to_matrix(chromosomes, gene_names)
     n_agents = X.shape[0]
+
+    chosen_params: Optional[Dict[str, Any]] = None
+    if auto_tune and n_agents > 0:
+        chosen_params = suggest_dbscan_params(
+            chromosomes,
+            gene_names=gnames,
+            k_percentile=auto_tune_percentile,
+            scaler=scaler,
+        )
+        eps = chosen_params["eps"]
+        min_samples = chosen_params["min_samples"]
 
     if n_agents == 0:
         return ClusterResult(
@@ -463,6 +608,7 @@ def detect_clusters_dbscan(
             silhouette_score=0.0,
             bic_scores=None,
             scaler=scaler,
+            dbscan_params=chosen_params,
         )
 
     X_scaled, inverse_transform = _apply_scaler(X, scaler)
@@ -500,6 +646,7 @@ def detect_clusters_dbscan(
         silhouette_score=sil,
         bic_scores=None,
         scaler=scaler,
+        dbscan_params=chosen_params,
     )
 
 

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -70,6 +70,15 @@ class GeneTrajectoryLogger:
         clustering.  One of ``"none"`` (default, no scaling), ``"standard"``
         (z-score), or ``"robust"`` (median/IQR).  Scaling is recommended when
         genes have widely different numeric ranges.
+    speciation_dbscan_auto_tune:
+        When ``True`` and ``speciation_algorithm="dbscan"``, ``eps`` and
+        ``min_samples`` are estimated automatically from each snapshot's
+        chromosome distribution using the k-NN distance percentile heuristic.
+        The chosen parameters are recorded in ``cluster_lineage.jsonl`` rows
+        under the ``"dbscan_params"`` key for reproducibility.  Default ``False``.
+    speciation_dbscan_auto_tune_percentile:
+        Percentile (0–100) of the k-NN distance distribution used to estimate
+        ``eps`` when ``speciation_dbscan_auto_tune=True``.  Default 90.
     """
 
     TRAJECTORY_FILENAME = "intrinsic_gene_trajectory.jsonl"
@@ -86,6 +95,8 @@ class GeneTrajectoryLogger:
         speciation_max_k: int = 5,
         speciation_seed: int = 0,
         speciation_scaler: str = "none",
+        speciation_dbscan_auto_tune: bool = False,
+        speciation_dbscan_auto_tune_percentile: float = 90.0,
     ) -> None:
         if snapshot_interval < 1:
             raise ValueError("snapshot_interval must be at least 1.")
@@ -95,6 +106,11 @@ class GeneTrajectoryLogger:
             raise ValueError(
                 f"speciation_scaler must be one of {VALID_SCALERS!r}; "
                 f"got {speciation_scaler!r}."
+            )
+        if not 0.0 <= speciation_dbscan_auto_tune_percentile <= 100.0:
+            raise ValueError(
+                "speciation_dbscan_auto_tune_percentile must be in [0, 100]; "
+                f"got {speciation_dbscan_auto_tune_percentile!r}."
             )
 
         if enable_speciation:
@@ -112,6 +128,8 @@ class GeneTrajectoryLogger:
         self._speciation_max_k = speciation_max_k
         self._speciation_seed = speciation_seed
         self._speciation_scaler = speciation_scaler
+        self._speciation_dbscan_auto_tune = speciation_dbscan_auto_tune
+        self._speciation_dbscan_auto_tune_percentile = speciation_dbscan_auto_tune_percentile
 
         self._trajectory_handle: Optional[TextIO] = None
         self._snapshot_handle: Optional[TextIO] = None
@@ -256,6 +274,8 @@ class GeneTrajectoryLogger:
                 result = detect_clusters_dbscan(
                     chrom_dicts,
                     scaler=self._speciation_scaler,
+                    auto_tune=self._speciation_dbscan_auto_tune,
+                    auto_tune_percentile=self._speciation_dbscan_auto_tune_percentile,
                 )
 
             self._cached_speciation_index = compute_speciation_index(result)
@@ -287,6 +307,7 @@ class GeneTrajectoryLogger:
                         "size": rec.size,
                         "parent_cluster_id": rec.parent_cluster_id,
                         "scaler": result.scaler,
+                        "dbscan_params": result.dbscan_params,
                     }
                     self._cluster_lineage_handle.write(json.dumps(row) + "\n")
         except Exception as exc:

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -1137,9 +1137,10 @@ class TestGeneTrajectoryLoggerAutoTune:
         """Agents with two well-separated clusters where auto_tune finds structure."""
         import itertools
 
-        # Two 3×3 grids of agents separated by a large gap in lr/gamma space.
-        # Spacing within each cluster is 0.15, so eps=0.1 gives k=0 (all noise).
-        # auto_tune estimates eps ~0.3 and correctly recovers at least one cluster.
+        # Two 5×5 grids of agents separated by a large gap in lr/gamma space.
+        # Spacing within each cluster is 0.02 (between adjacent grid points).
+        # auto_tune estimates eps from the actual k-NN distances and recovers
+        # at least one cluster; dbscan_params is then persisted in lineage rows.
         low = [
             _make_fake_agent(lr=0.1 + i * 0.02, gamma=0.1 + j * 0.02)
             for i, j in itertools.product(range(5), range(5))

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -1099,6 +1099,10 @@ class TestDBSCANAutoTune:
         # dbscan_params is None for empty input (no data to estimate from)
         assert result.dbscan_params is None
 
+    def test_auto_tune_invalid_percentile_raises_on_empty_input(self):
+        with pytest.raises(ValueError, match="auto_tune_percentile"):
+            detect_clusters_dbscan([], auto_tune=True, auto_tune_percentile=120.0)
+
     def test_auto_tune_bimodal_finds_clusters(self):
         """auto_tune should also work on normal-range bimodal data."""
         chromosomes = _bimodal_chromosomes(n_per_cluster=20)
@@ -1235,10 +1239,10 @@ class TestGeneTrajectoryLoggerAutoTune:
         log.close()
 
         lineage_path = tmp_path / "cluster_lineage.jsonl"
-        if lineage_path.exists():
-            rows = [json.loads(line) for line in lineage_path.read_text().splitlines()]
-            for row in rows:
-                # dbscan_params key should exist but be null (no auto_tune)
-                assert "dbscan_params" in row
-                assert row["dbscan_params"] is None
+        assert lineage_path.exists(), "cluster_lineage.jsonl should be written"
+        rows = [json.loads(line) for line in lineage_path.read_text().splitlines()]
+        for row in rows:
+            # dbscan_params key should exist but be null (no auto_tune)
+            assert "dbscan_params" in row
+            assert row["dbscan_params"] is None
 

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -29,6 +29,7 @@ from farm.analysis.speciation import (
     detect_clusters_gmm,
     match_clusters_greedy,
     plot_chromosome_space_clusters,
+    suggest_dbscan_params,
 )
 from farm.analysis.common.context import AnalysisContext
 
@@ -906,4 +907,337 @@ class TestGeneTrajectoryLoggerScaler:
         rec = json.loads(traj_path.read_text().splitlines()[0])
         assert "speciation_index" in rec
         assert 0.0 <= rec["speciation_index"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Wide-range fixture: fixed defaults fail but auto_tune succeeds
+# ---------------------------------------------------------------------------
+
+
+def _wide_range_bimodal_chromosomes(n_per_cluster: int = 25) -> List[Dict[str, float]]:
+    """Two well-separated clusters on a regular grid with spacing > 0.1.
+
+    Points within each cluster are placed on a 5x5 grid with 0.5-unit spacing,
+    so the minimum inter-point distance is 0.5.  With fixed ``eps=0.1`` DBSCAN
+    treats every agent as noise (k=0) because no two agents are within 0.1 of
+    each other.  Auto-tuning estimates ``eps`` from the actual k-NN distances
+    (~0.5) and correctly recovers both clusters.
+
+    The ``n_per_cluster`` argument is accepted for API compatibility but the
+    fixture always returns 50 points (two 5×5 grids).
+    """
+    import itertools
+
+    cluster1 = [
+        {"lr": float(i) * 0.5, "gamma": float(j) * 0.5}
+        for i, j in itertools.product(range(5), range(5))
+    ]
+    cluster2 = [
+        {"lr": 8.0 + float(i) * 0.5, "gamma": 8.0 + float(j) * 0.5}
+        for i, j in itertools.product(range(5), range(5))
+    ]
+    return cluster1 + cluster2
+
+
+# ---------------------------------------------------------------------------
+# suggest_dbscan_params
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestDBSCANParams:
+    """Tests for the parameter-estimation helper."""
+
+    def test_returns_dict_with_required_keys(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        params = suggest_dbscan_params(chromosomes)
+        assert set(params.keys()) >= {"eps", "min_samples", "method", "k_percentile"}
+
+    def test_eps_is_positive(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        params = suggest_dbscan_params(chromosomes)
+        assert params["eps"] > 0.0
+
+    def test_min_samples_at_least_two(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        params = suggest_dbscan_params(chromosomes)
+        assert params["min_samples"] >= 2
+
+    def test_min_samples_scales_with_dimensionality(self):
+        """min_samples should be >= n_dims + 1 for n_dims >= 1."""
+        chromosomes = [{"a": 0.1, "b": 0.2, "c": 0.3, "d": 0.4}] * 30
+        params = suggest_dbscan_params(chromosomes)
+        # 4 dims → min_samples >= 5
+        assert params["min_samples"] >= 5
+
+    def test_method_field_is_k_distance_percentile(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        params = suggest_dbscan_params(chromosomes)
+        assert params["method"] == "k_distance_percentile"
+
+    def test_k_percentile_stored_in_result(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        params = suggest_dbscan_params(chromosomes, k_percentile=75.0)
+        assert params["k_percentile"] == 75.0
+
+    def test_invalid_k_percentile_raises(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=10)
+        with pytest.raises(ValueError, match="k_percentile"):
+            suggest_dbscan_params(chromosomes, k_percentile=110.0)
+
+    def test_invalid_scaler_raises(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=10)
+        with pytest.raises(ValueError, match="scaler"):
+            suggest_dbscan_params(chromosomes, scaler="minmax")
+
+    def test_empty_chromosomes_returns_fallback(self):
+        """Empty input should not raise; returns a safe fallback dict."""
+        params = suggest_dbscan_params([])
+        assert params["eps"] > 0.0
+        assert params["min_samples"] >= 2
+
+    def test_single_chromosome_returns_fallback(self):
+        """Single point → not enough for k-NN; safe fallback returned."""
+        params = suggest_dbscan_params([{"lr": 0.5}])
+        assert params["eps"] > 0.0
+        assert params["min_samples"] >= 2
+
+    def test_wide_range_eps_larger_than_default(self):
+        """For wide-range data (grid spacing 0.5), suggested eps should exceed the fixed default 0.1."""
+        chromosomes = _wide_range_bimodal_chromosomes()
+        params = suggest_dbscan_params(chromosomes)
+        assert params["eps"] > 0.1
+
+    def test_gene_names_override_respected(self):
+        """Supplying gene_names restricts the genes used for estimation."""
+        chromosomes = [{"lr": 0.01, "gamma": 0.99, "noise": 999.0}] * 20
+        params = suggest_dbscan_params(chromosomes, gene_names=["lr", "gamma"])
+        assert params["min_samples"] >= 3  # 2 dims + 1
+
+    def test_can_unpack_into_detect_clusters_dbscan(self):
+        """Returned dict can be passed directly as kwargs to detect_clusters_dbscan."""
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        params = suggest_dbscan_params(chromosomes)
+        # Should not raise; eps and min_samples are valid positives.
+        result = detect_clusters_dbscan(chromosomes, **{
+            k: v for k, v in params.items() if k in ("eps", "min_samples")
+        })
+        assert isinstance(result, ClusterResult)
+
+    def test_scaler_parameter_used_in_distance_computation(self):
+        """With standard scaler, suggested eps differs from 'none'."""
+        chromosomes = _wide_range_bimodal_chromosomes()
+        params_none = suggest_dbscan_params(chromosomes, scaler="none")
+        params_std = suggest_dbscan_params(chromosomes, scaler="standard")
+        # eps in standardised space should be much smaller than in raw space
+        assert params_std["eps"] < params_none["eps"]
+
+
+# ---------------------------------------------------------------------------
+# DBSCAN auto_tune parameter
+# ---------------------------------------------------------------------------
+
+
+class TestDBSCANAutoTune:
+    """Tests for the ``auto_tune`` parameter of detect_clusters_dbscan."""
+
+    # ---- Acceptance: auto_tune=False (default) leaves dbscan_params None ----
+
+    def test_default_dbscan_params_is_none(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=10)
+        result = detect_clusters_dbscan(chromosomes)
+        assert result.dbscan_params is None
+
+    def test_explicit_auto_tune_false_dbscan_params_is_none(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=10)
+        result = detect_clusters_dbscan(chromosomes, auto_tune=False)
+        assert result.dbscan_params is None
+
+    # ---- auto_tune=True populates dbscan_params ----
+
+    def test_auto_tune_populates_dbscan_params(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        result = detect_clusters_dbscan(chromosomes, auto_tune=True)
+        assert result.dbscan_params is not None
+        assert "eps" in result.dbscan_params
+        assert "min_samples" in result.dbscan_params
+        assert "method" in result.dbscan_params
+        assert "k_percentile" in result.dbscan_params
+
+    def test_auto_tune_eps_is_positive(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        result = detect_clusters_dbscan(chromosomes, auto_tune=True)
+        assert result.dbscan_params["eps"] > 0.0
+
+    def test_auto_tune_min_samples_at_least_two(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        result = detect_clusters_dbscan(chromosomes, auto_tune=True)
+        assert result.dbscan_params["min_samples"] >= 2
+
+    def test_auto_tune_percentile_stored(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        result = detect_clusters_dbscan(chromosomes, auto_tune=True, auto_tune_percentile=80.0)
+        assert result.dbscan_params["k_percentile"] == 80.0
+
+    # ---- Key acceptance criterion: fixed defaults fail, auto_tune succeeds ----
+
+    def test_fixed_defaults_fail_on_wide_range_data(self):
+        """Verify the premise: default eps=0.1 labels all wide-range (grid) agents as noise."""
+        chromosomes = _wide_range_bimodal_chromosomes()
+        result_default = detect_clusters_dbscan(chromosomes, eps=0.1, min_samples=2)
+        # With eps=0.1 and grid spacing 0.5, every agent is isolated → all noise
+        assert result_default.k == 0
+
+    def test_auto_tune_finds_clusters_on_wide_range_data(self):
+        """auto_tune=True should find at least 2 clusters where defaults find none."""
+        chromosomes = _wide_range_bimodal_chromosomes()
+        result_auto = detect_clusters_dbscan(chromosomes, auto_tune=True)
+        assert result_auto.k >= 2
+
+    def test_auto_tune_empty_input_still_returns_zero_clusters(self):
+        result = detect_clusters_dbscan([], auto_tune=True)
+        assert result.k == 0
+        # dbscan_params is None for empty input (no data to estimate from)
+        assert result.dbscan_params is None
+
+    def test_auto_tune_bimodal_finds_clusters(self):
+        """auto_tune should also work on normal-range bimodal data."""
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        result = detect_clusters_dbscan(chromosomes, auto_tune=True)
+        assert result.k >= 2
+
+    def test_auto_tune_with_scaler_wide_range(self):
+        """auto_tune + standard scaler on wide-range data should find clusters."""
+        chromosomes = _wide_range_bimodal_chromosomes()
+        result = detect_clusters_dbscan(
+            chromosomes, auto_tune=True, scaler="standard"
+        )
+        assert result.k >= 2
+        assert result.dbscan_params is not None
+
+    def test_auto_tune_labels_length_matches_input(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=15)
+        result = detect_clusters_dbscan(chromosomes, auto_tune=True)
+        assert len(result.labels) == len(chromosomes)
+
+    def test_auto_tune_algorithm_field_is_dbscan(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=10)
+        result = detect_clusters_dbscan(chromosomes, auto_tune=True)
+        assert result.algorithm == "dbscan"
+
+
+# ---------------------------------------------------------------------------
+# GeneTrajectoryLogger: auto_tune integration
+# ---------------------------------------------------------------------------
+
+
+class TestGeneTrajectoryLoggerAutoTune:
+    """Tests for speciation_dbscan_auto_tune in GeneTrajectoryLogger."""
+
+    def _make_wide_range_agents(self) -> List[Any]:
+        """Agents with two well-separated clusters where auto_tune finds structure."""
+        import itertools
+
+        # Two 3×3 grids of agents separated by a large gap in lr/gamma space.
+        # Spacing within each cluster is 0.15, so eps=0.1 gives k=0 (all noise).
+        # auto_tune estimates eps ~0.3 and correctly recovers at least one cluster.
+        low = [
+            _make_fake_agent(lr=0.1 + i * 0.02, gamma=0.1 + j * 0.02)
+            for i, j in itertools.product(range(5), range(5))
+        ]
+        high = [
+            _make_fake_agent(lr=0.7 + i * 0.02, gamma=0.7 + j * 0.02)
+            for i, j in itertools.product(range(5), range(5))
+        ]
+        return low + high
+
+    def test_default_auto_tune_is_false(self, tmp_path):
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+        log = GeneTrajectoryLogger(
+            str(tmp_path), snapshot_interval=1,
+            enable_speciation=True, speciation_algorithm="dbscan",
+        )
+        assert log._speciation_dbscan_auto_tune is False
+        log.close()
+
+    def test_auto_tune_flag_stored(self, tmp_path):
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+        log = GeneTrajectoryLogger(
+            str(tmp_path), snapshot_interval=1,
+            enable_speciation=True, speciation_algorithm="dbscan",
+            speciation_dbscan_auto_tune=True,
+        )
+        assert log._speciation_dbscan_auto_tune is True
+        log.close()
+
+    def test_auto_tune_percentile_stored(self, tmp_path):
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+        log = GeneTrajectoryLogger(
+            str(tmp_path), snapshot_interval=1,
+            enable_speciation=True, speciation_algorithm="dbscan",
+            speciation_dbscan_auto_tune=True,
+            speciation_dbscan_auto_tune_percentile=75.0,
+        )
+        assert log._speciation_dbscan_auto_tune_percentile == 75.0
+        log.close()
+
+    def test_invalid_percentile_raises(self):
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+        with pytest.raises(ValueError, match="speciation_dbscan_auto_tune_percentile"):
+            GeneTrajectoryLogger(
+                None, snapshot_interval=1,
+                speciation_dbscan_auto_tune_percentile=150.0,
+            )
+
+    def test_auto_tune_persists_dbscan_params_in_lineage(self, tmp_path):
+        """cluster_lineage.jsonl rows include 'dbscan_params' when auto_tune=True."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        agents = self._make_wide_range_agents()
+        env = _FakeEnvironment(agents)
+        log = GeneTrajectoryLogger(
+            str(tmp_path), snapshot_interval=1,
+            enable_speciation=True, speciation_algorithm="dbscan",
+            speciation_dbscan_auto_tune=True,
+        )
+        log.snapshot(env, step=0)
+        log.close()
+
+        lineage_path = tmp_path / "cluster_lineage.jsonl"
+        assert lineage_path.exists(), "cluster_lineage.jsonl should be written"
+        rows = [json.loads(line) for line in lineage_path.read_text().splitlines()]
+        assert len(rows) >= 1, "Should have detected at least one cluster"
+        for row in rows:
+            assert "dbscan_params" in row
+            params = row["dbscan_params"]
+            assert params is not None
+            assert "eps" in params
+            assert "min_samples" in params
+
+    def test_no_auto_tune_dbscan_params_is_none_in_lineage(self, tmp_path):
+        """Without auto_tune, dbscan_params in lineage rows should be null."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        agents = (
+            [_make_fake_agent(lr=0.001, gamma=0.99)] * 15
+            + [_make_fake_agent(lr=0.9, gamma=0.1)] * 15
+        )
+        env = _FakeEnvironment(agents)
+        log = GeneTrajectoryLogger(
+            str(tmp_path), snapshot_interval=1,
+            enable_speciation=True, speciation_algorithm="dbscan",
+            speciation_dbscan_auto_tune=False,
+            speciation_scaler="standard",
+        )
+        # Use eps wide enough to find clusters so we actually get lineage rows
+        # We rely on the standard scaler to find clusters
+        log.snapshot(env, step=0)
+        log.close()
+
+        lineage_path = tmp_path / "cluster_lineage.jsonl"
+        if lineage_path.exists():
+            rows = [json.loads(line) for line in lineage_path.read_text().splitlines()]
+            for row in rows:
+                # dbscan_params key should exist but be null (no auto_tune)
+                assert "dbscan_params" in row
+                assert row["dbscan_params"] is None
 


### PR DESCRIPTION
This pull request adds automatic parameter tuning for DBSCAN clustering and improves reproducibility and configuration options for speciation analysis. The main changes include a new function to suggest DBSCAN parameters, support for auto-tuning in the DBSCAN clustering workflow, and new options for controlling this behavior in the gene trajectory logger. Additionally, results now include the chosen DBSCAN parameters for traceability.

**DBSCAN auto-tuning and parameter tracking:**

* Added `suggest_dbscan_params` function to automatically estimate suitable `eps` and `min_samples` for DBSCAN using the k-NN distance percentile heuristic. This function is now part of the public API. [[1]](diffhunk://#diff-b156f055aa6a9132d524472b587703fedb67934ba8b5b3e030831d8692fb97b8R421-R540) [[2]](diffhunk://#diff-6d39a86319290299f250dd43155bda7bc9d0b1c4e1cc6ca75a68419af2035b05R48) [[3]](diffhunk://#diff-6d39a86319290299f250dd43155bda7bc9d0b1c4e1cc6ca75a68419af2035b05R64) [[4]](diffhunk://#diff-1f115c5d91d0105b737c836e1ec29f2d12b123e6fe3b5c046c01e8b278526088R32)
* Enhanced `detect_clusters_dbscan` to support an `auto_tune` mode, which uses `suggest_dbscan_params` to select parameters, and records them in the `ClusterResult` for reproducibility. New parameters `auto_tune` and `auto_tune_percentile` were added. [[1]](diffhunk://#diff-b156f055aa6a9132d524472b587703fedb67934ba8b5b3e030831d8692fb97b8L432-R557) [[2]](diffhunk://#diff-b156f055aa6a9132d524472b587703fedb67934ba8b5b3e030831d8692fb97b8R567-R599) [[3]](diffhunk://#diff-b156f055aa6a9132d524472b587703fedb67934ba8b5b3e030831d8692fb97b8R611) [[4]](diffhunk://#diff-b156f055aa6a9132d524472b587703fedb67934ba8b5b3e030831d8692fb97b8R649)

**Result and API improvements:**

* `ClusterResult` now includes a `dbscan_params` field to store the parameters used when DBSCAN auto-tuning is enabled, and improved docstrings to reflect this. [[1]](diffhunk://#diff-b156f055aa6a9132d524472b587703fedb67934ba8b5b3e030831d8692fb97b8R121-R128) [[2]](diffhunk://#diff-b156f055aa6a9132d524472b587703fedb67934ba8b5b3e030831d8692fb97b8R140)

**GeneTrajectoryLogger enhancements:**

* Added `speciation_dbscan_auto_tune` and `speciation_dbscan_auto_tune_percentile` options to the `GeneTrajectoryLogger` for controlling DBSCAN parameter auto-tuning, with validation and documentation. [[1]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R73-R81) [[2]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R98-R99) [[3]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R110-R114) [[4]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R131-R132)
* Updated the speciation update logic to pass the new auto-tuning options to DBSCAN, and to write the chosen parameters to the cluster lineage output for reproducibility. [[1]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R277-R278) [[2]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R310)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes DBSCAN clustering behavior when enabled and expands persisted `cluster_lineage.jsonl` schema, which can affect downstream analyses expecting fixed parameters or older output format.
> 
> **Overview**
> **DBSCAN speciation can now auto-tune `eps`/`min_samples` per snapshot** via a new public `suggest_dbscan_params` helper (k-NN distance percentile heuristic) and new `detect_clusters_dbscan(auto_tune, auto_tune_percentile)` options.
> 
> `ClusterResult` now carries optional `dbscan_params` for traceability, and `GeneTrajectoryLogger` adds `speciation_dbscan_auto_tune`/`speciation_dbscan_auto_tune_percentile` wiring plus persistence of `dbscan_params` into `cluster_lineage.jsonl`. Tests were expanded to cover parameter suggestion, wide-range fixtures where defaults fail, and logger integration/persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b9c5556c0728b223ca7f4420f63536b261de517. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->