### PR TITLE
Enhance Hungarian cluster matching with transition types and validation

### DIFF
--- a/farm/analysis/speciation/__init__.py
+++ b/farm/analysis/speciation/__init__.py
@@ -43,10 +43,12 @@ from farm.analysis.speciation.compute import (
     ClusterResult,
     ClusterLineageRecord,
     VALID_SCALERS,
+    VALID_TRANSITION_TYPES,
     detect_clusters_gmm,
     detect_clusters_dbscan,
     suggest_dbscan_params,
     match_clusters_greedy,
+    match_clusters_hungarian,
     compute_speciation_index,
     compute_niche_correlation,
 )
@@ -58,12 +60,14 @@ __all__ = [
     "ClusterLineageRecord",
     # Configuration constants
     "VALID_SCALERS",
+    "VALID_TRANSITION_TYPES",
     # Cluster detection
     "detect_clusters_gmm",
     "detect_clusters_dbscan",
     "suggest_dbscan_params",
     # Cluster persistence
     "match_clusters_greedy",
+    "match_clusters_hungarian",
     # Scalar metrics
     "compute_speciation_index",
     # Niche analysis

--- a/farm/analysis/speciation/compute.py
+++ b/farm/analysis/speciation/compute.py
@@ -952,11 +952,18 @@ def match_clusters_hungarian(
 
     # -----------------------------------------------------------------------
     # Hungarian assignment on gated cost matrix.
-    # Pairs beyond max_distance get a very large penalty so the solver avoids
-    # them while keeping the matrix finite.
+    # Pairs beyond max_distance get a finite penalty that is strictly larger
+    # than any valid in-gate distance, so the solver will always prefer a
+    # within-gate assignment when one exists.
     # -----------------------------------------------------------------------
-    _HUNGARIAN_GATE_PENALTY = 1.0e15
-    cost = np.where(D <= max_distance, D, _HUNGARIAN_GATE_PENALTY)
+    gate_ceiling = max(float(max_distance), float(np.max(D)) if D.size else 0.0)
+    if not np.isfinite(gate_ceiling) or gate_ceiling >= np.finfo(float).max:
+        raise ValueError(
+            "max_distance and lineage-assignment distances must be finite "
+            "and smaller than the largest representable float"
+        )
+    hungarian_gate_penalty = np.nextafter(gate_ceiling, math.inf)
+    cost = np.where(D <= max_distance, D, hungarian_gate_penalty)
     row_ind, col_ind = _lsa(cost)
 
     # Accept only within-gate pairs
@@ -981,7 +988,8 @@ def match_clusters_hungarian(
                     best_j = j
             all_new_to_prev[i] = best_j
 
-    # Reverse mapping: prev_j → all new_i that claim it as primary parent
+    # Reverse mapping: prev_j → all new_i that point to it (primary Hungarian
+    # matches plus nearest-predecessor links for unmatched new clusters)
     prev_to_all_new: Dict[int, List[int]] = {}
     for ni, pj in all_new_to_prev.items():
         if pj is not None:

--- a/farm/analysis/speciation/compute.py
+++ b/farm/analysis/speciation/compute.py
@@ -956,12 +956,17 @@ def match_clusters_hungarian(
     # than any valid in-gate distance, so the solver will always prefer a
     # within-gate assignment when one exists.
     # -----------------------------------------------------------------------
-    gate_ceiling = max(float(max_distance), float(np.max(D)) if D.size else 0.0)
+    # n_new > 0 and n_prev > 0 are guaranteed by the early-return above,
+    # so D is non-empty here and np.max(D) is safe.
+    gate_ceiling = max(float(max_distance), float(np.max(D)))
     if not np.isfinite(gate_ceiling) or gate_ceiling >= np.finfo(float).max:
         raise ValueError(
             "max_distance and lineage-assignment distances must be finite "
             "and smaller than the largest representable float"
         )
+    # np.nextafter gives the smallest representable float strictly greater than
+    # gate_ceiling, ensuring out-of-gate pairs always cost more than any valid
+    # in-gate pair regardless of the magnitude of max_distance.
     hungarian_gate_penalty = np.nextafter(gate_ceiling, math.inf)
     cost = np.where(D <= max_distance, D, hungarian_gate_penalty)
     row_ind, col_ind = _lsa(cost)

--- a/farm/analysis/speciation/compute.py
+++ b/farm/analysis/speciation/compute.py
@@ -806,7 +806,7 @@ def match_clusters_hungarian(
     gene_names: List[str],
     step: int,
     *,
-    max_distance: float = float("inf"),
+    max_distance: float = 1.0,
     id_counter_start: int = 0,
 ) -> Tuple[List[ClusterLineageRecord], int]:
     """Assign stable cluster IDs using a globally optimal (Hungarian) matcher.
@@ -842,7 +842,8 @@ def match_clusters_hungarian(
     max_distance:
         Maximum Euclidean centroid distance for a match to be accepted.
         Pairs whose distance exceeds this threshold are never matched.
-        Default: unlimited.
+        Must be finite and > 0 to avoid pathological over-linking of
+        unrelated clusters.
     id_counter_start:
         Counter used to generate new IDs (``"c{counter}"``).  The returned
         second element is the next counter value after allocating all new IDs
@@ -862,6 +863,8 @@ def match_clusters_hungarian(
     ------
     ImportError
         When ``scipy`` is not installed.
+    ValueError
+        If ``max_distance`` is not finite and positive.
 
     Notes
     -----
@@ -880,7 +883,17 @@ def match_clusters_hungarian(
     - ``"merge"`` – multiple predecessors are within ``max_distance``
       (many-to-one).  The Hungarian-matched predecessor donates its ID;
       all contributors are listed in ``parent_cluster_ids``.
+
+    ``max_distance`` is intentionally required to be finite so merge/split
+    classification remains local rather than linking arbitrarily distant
+    centroids.
     """
+    if not math.isfinite(max_distance) or max_distance <= 0.0:
+        raise ValueError(
+            "match_clusters_hungarian requires max_distance to be finite and > 0; "
+            f"got {max_distance!r}."
+        )
+
     try:
         from scipy.optimize import linear_sum_assignment as _lsa
     except ImportError as exc:

--- a/farm/analysis/speciation/compute.py
+++ b/farm/analysis/speciation/compute.py
@@ -23,6 +23,14 @@ previous ones at minimum Euclidean distance.  New clusters that have no
 close predecessor receive a fresh monotonically-increasing ID (``"c0"``,
 ``"c1"``, …).
 
+:func:`match_clusters_hungarian` uses a globally optimal assignment
+(Hungarian / Kuhn–Munkres algorithm via
+``scipy.optimize.linear_sum_assignment``) under the same distance gate,
+then classifies each record as ``"founding"``, ``"continuation"``,
+``"split"`` (one-to-many), or ``"merge"`` (many-to-one).  The full set
+of predecessor IDs is stored in
+:attr:`ClusterLineageRecord.parent_cluster_ids`.
+
 Speciation index
 ----------------
 :func:`compute_speciation_index` collapses a :class:`ClusterResult` into a
@@ -84,6 +92,14 @@ def _require_sklearn() -> None:
 
 #: Valid choices for the ``scaler`` parameter in cluster-detection functions.
 VALID_SCALERS: Tuple[str, ...] = ("none", "standard", "robust")
+
+#: Valid ``transition_type`` values emitted by :func:`match_clusters_hungarian`.
+VALID_TRANSITION_TYPES: Tuple[str, ...] = (
+    "founding",
+    "continuation",
+    "split",
+    "merge",
+)
 
 # ---------------------------------------------------------------------------
 # Result dataclasses
@@ -158,6 +174,26 @@ class ClusterLineageRecord:
     parent_cluster_id:
         The ``cluster_id`` of the closest-matching cluster at the previous
         snapshot, or ``None`` for founding clusters at the first snapshot.
+        Backward-compatible single-parent field; use ``parent_cluster_ids``
+        for the full list when a merge has occurred.
+    transition_type:
+        How this cluster relates to the previous snapshot.  One of:
+
+        - ``"founding"`` – no predecessor within ``max_distance``; brand-new
+          lineage.
+        - ``"continuation"`` – one-to-one match with no split or merge.
+        - ``"split"`` – the predecessor also spawned at least one other new
+          cluster (one-to-many).
+        - ``"merge"`` – multiple predecessors are within ``max_distance`` of
+          this cluster (many-to-one).
+
+        ``None`` when populated by :func:`match_clusters_greedy` (legacy
+        matcher that does not classify transitions).
+    parent_cluster_ids:
+        All predecessor ``cluster_id`` values within ``max_distance``.  For a
+        continuation or split this is a single-element list; for a merge it
+        contains all contributing predecessors.  Empty list for founding
+        clusters or when populated by :func:`match_clusters_greedy`.
     gene_stats:
         Optional per-gene statistics dict (``{gene: {mean, std, …}}``) for
         agents in this cluster, populated by callers that request it.
@@ -168,6 +204,8 @@ class ClusterLineageRecord:
     centroid: Dict[str, float]
     size: int
     parent_cluster_id: Optional[str]
+    transition_type: Optional[str] = field(default=None)
+    parent_cluster_ids: List[str] = field(default_factory=list)
     gene_stats: Optional[Dict[str, Dict[str, float]]] = field(default=None)
 
 
@@ -750,6 +788,242 @@ def match_clusters_greedy(
                 centroid=centroid,
                 size=size,
                 parent_cluster_id=parent_cluster_id,
+            )
+        )
+
+    return records, id_counter
+
+
+def match_clusters_hungarian(
+    prev_records: List[ClusterLineageRecord],
+    new_centroids: List[Dict[str, float]],
+    new_sizes: List[int],
+    gene_names: List[str],
+    step: int,
+    *,
+    max_distance: float = float("inf"),
+    id_counter_start: int = 0,
+) -> Tuple[List[ClusterLineageRecord], int]:
+    """Assign stable cluster IDs using a globally optimal (Hungarian) matcher.
+
+    Unlike :func:`match_clusters_greedy`, which processes new clusters in
+    iteration order and makes locally-optimal nearest-centroid assignments,
+    this function solves the assignment problem globally via the Hungarian
+    algorithm (``scipy.optimize.linear_sum_assignment``).  Global
+    optimisation avoids order-dependence and gives better ID stability
+    during rapid topology shifts.
+
+    After the one-to-one global assignment, unmatched new clusters are
+    linked to their nearest predecessor within ``max_distance`` (split
+    children).  Every resulting record carries a
+    :attr:`ClusterLineageRecord.transition_type` (one of ``"founding"``,
+    ``"continuation"``, ``"split"``, or ``"merge"``) and a
+    :attr:`ClusterLineageRecord.parent_cluster_ids` list of all predecessor
+    IDs within ``max_distance``.
+
+    Parameters
+    ----------
+    prev_records:
+        :class:`ClusterLineageRecord` list from the previous snapshot
+        (may be empty for the first snapshot).
+    new_centroids:
+        List of per-cluster centroid dicts for the current snapshot.
+    new_sizes:
+        Corresponding per-cluster sizes.
+    gene_names:
+        Ordered list of gene names used to build centroid vectors.
+    step:
+        Current snapshot step (used to populate the new records).
+    max_distance:
+        Maximum Euclidean centroid distance for a match to be accepted.
+        Pairs whose distance exceeds this threshold are never matched.
+        Default: unlimited.
+    id_counter_start:
+        Counter used to generate new IDs (``"c{counter}"``).  The returned
+        second element is the next counter value after allocating all new IDs
+        in this call.
+
+    Returns
+    -------
+    records : list[ClusterLineageRecord]
+        One record per new cluster.  ``transition_type`` is one of
+        ``"founding"``, ``"continuation"``, ``"split"``, or ``"merge"``;
+        ``parent_cluster_ids`` lists every predecessor within
+        ``max_distance`` (empty for founding clusters).
+    next_id_counter : int
+        Updated counter for subsequent calls.
+
+    Raises
+    ------
+    ImportError
+        When ``scipy`` is not installed.
+
+    Notes
+    -----
+    **Determinism**: the Hungarian algorithm is deterministic for a fixed
+    cost matrix.  Tie-breaking follows
+    ``scipy.optimize.linear_sum_assignment``.
+
+    **Transition-type semantics**:
+
+    - ``"founding"`` – no predecessor within ``max_distance``; new lineage.
+    - ``"continuation"`` – one predecessor matched via global assignment,
+      no split or merge detected.
+    - ``"split"`` – the predecessor also produced at least one other new
+      cluster (one-to-many).  The Hungarian-matched cluster inherits the
+      predecessor ID; additional split children receive fresh IDs.
+    - ``"merge"`` – multiple predecessors are within ``max_distance``
+      (many-to-one).  The Hungarian-matched predecessor donates its ID;
+      all contributors are listed in ``parent_cluster_ids``.
+    """
+    try:
+        from scipy.optimize import linear_sum_assignment as _lsa
+    except ImportError as exc:
+        raise ImportError(
+            "match_clusters_hungarian requires scipy. "
+            "Install with: pip install scipy"
+        ) from exc
+
+    import re as _re
+
+    def _centroid_vec(d: Dict[str, float]) -> np.ndarray:
+        return np.array([d.get(g, 0.0) for g in gene_names], dtype=float)
+
+    n_new = len(new_centroids)
+    n_prev = len(prev_records)
+
+    new_vecs = [_centroid_vec(c) for c in new_centroids]
+    prev_vecs = [_centroid_vec(r.centroid) for r in prev_records]
+    prev_ids = [r.cluster_id for r in prev_records]
+
+    # Auto-advance id_counter past any IDs already used in prev_records
+    id_counter = id_counter_start
+    for r in prev_records:
+        m = _re.match(r"^c(\d+)$", r.cluster_id)
+        if m:
+            id_counter = max(id_counter, int(m.group(1)) + 1)
+
+    records: List[ClusterLineageRecord] = []
+
+    # -----------------------------------------------------------------------
+    # Edge cases: no previous clusters
+    # -----------------------------------------------------------------------
+    if n_prev == 0 or n_new == 0:
+        for centroid, size in zip(new_centroids, new_sizes):
+            records.append(
+                ClusterLineageRecord(
+                    step=step,
+                    cluster_id=f"c{id_counter}",
+                    centroid=centroid,
+                    size=size,
+                    parent_cluster_id=None,
+                    transition_type="founding",
+                    parent_cluster_ids=[],
+                )
+            )
+            id_counter += 1
+        return records, id_counter
+
+    # -----------------------------------------------------------------------
+    # Pairwise distance matrix  D[i, j] = dist(new_i, prev_j)
+    # -----------------------------------------------------------------------
+    D = np.zeros((n_new, n_prev), dtype=float)
+    for i, nv in enumerate(new_vecs):
+        for j, pv in enumerate(prev_vecs):
+            D[i, j] = float(np.linalg.norm(nv - pv))
+
+    # -----------------------------------------------------------------------
+    # Hungarian assignment on gated cost matrix.
+    # Pairs beyond max_distance get a very large penalty so the solver avoids
+    # them while keeping the matrix finite.
+    # -----------------------------------------------------------------------
+    _HUNGARIAN_GATE_PENALTY = 1.0e15
+    cost = np.where(D <= max_distance, D, _HUNGARIAN_GATE_PENALTY)
+    row_ind, col_ind = _lsa(cost)
+
+    # Accept only within-gate pairs
+    primary_matches: Dict[int, int] = {}  # new_i → prev_j
+    for ri, ci in zip(row_ind.tolist(), col_ind.tolist()):
+        if ri < n_new and ci < n_prev and D[ri, ci] <= max_distance:
+            primary_matches[ri] = ci
+
+    # -----------------------------------------------------------------------
+    # For unmatched new clusters find the nearest predecessor (split child)
+    # -----------------------------------------------------------------------
+    all_new_to_prev: Dict[int, Optional[int]] = {}
+    for i in range(n_new):
+        if i in primary_matches:
+            all_new_to_prev[i] = primary_matches[i]
+        else:
+            best_j: Optional[int] = None
+            best_d = math.inf
+            for j in range(n_prev):
+                if D[i, j] < best_d and D[i, j] <= max_distance:
+                    best_d = D[i, j]
+                    best_j = j
+            all_new_to_prev[i] = best_j
+
+    # Reverse mapping: prev_j → all new_i that claim it as primary parent
+    prev_to_all_new: Dict[int, List[int]] = {}
+    for ni, pj in all_new_to_prev.items():
+        if pj is not None:
+            prev_to_all_new.setdefault(pj, []).append(ni)
+
+    # Per new cluster: all prev clusters within max_distance (for merge check)
+    new_to_all_prev: Dict[int, List[int]] = {
+        i: [j for j in range(n_prev) if D[i, j] <= max_distance]
+        for i in range(n_new)
+    }
+
+    # -----------------------------------------------------------------------
+    # Build ClusterLineageRecord for each new cluster
+    # -----------------------------------------------------------------------
+    for i, (centroid, size) in enumerate(zip(new_centroids, new_sizes)):
+        primary_j: Optional[int] = all_new_to_prev[i]
+        all_prev_js: List[int] = new_to_all_prev[i]
+
+        if primary_j is None:
+            records.append(
+                ClusterLineageRecord(
+                    step=step,
+                    cluster_id=f"c{id_counter}",
+                    centroid=centroid,
+                    size=size,
+                    parent_cluster_id=None,
+                    transition_type="founding",
+                    parent_cluster_ids=[],
+                )
+            )
+            id_counter += 1
+            continue
+
+        is_merge = len(all_prev_js) > 1
+        is_split = len(prev_to_all_new.get(primary_j, [])) > 1
+
+        if is_merge:
+            transition_type = "merge"
+        elif is_split:
+            transition_type = "split"
+        else:
+            transition_type = "continuation"
+
+        # Hungarian-matched clusters inherit the predecessor ID;
+        # fallback-matched split children receive fresh IDs.
+        if i in primary_matches:
+            cluster_id = prev_ids[primary_j]
+        else:
+            cluster_id = f"c{id_counter}"
+            id_counter += 1
+
+        records.append(
+            ClusterLineageRecord(
+                step=step,
+                cluster_id=cluster_id,
+                centroid=centroid,
+                size=size,
+                parent_cluster_id=prev_ids[primary_j],
+                transition_type=transition_type,
+                parent_cluster_ids=[prev_ids[j] for j in all_prev_js],
             )
         )
 

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -306,6 +306,8 @@ class GeneTrajectoryLogger:
                         "centroid": rec.centroid,
                         "size": rec.size,
                         "parent_cluster_id": rec.parent_cluster_id,
+                        "transition_type": rec.transition_type,
+                        "parent_cluster_ids": rec.parent_cluster_ids,
                         "scaler": result.scaler,
                         "dbscan_params": result.dbscan_params,
                     }

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -87,9 +87,12 @@ class GeneTrajectoryLogger:
         ``"hungarian"`` (default) uses a globally optimal assignment and
         populates transition metadata; ``"greedy"`` preserves legacy behavior.
     speciation_lineage_max_distance:
-        Maximum centroid distance accepted by the lineage matcher. Must be
-        finite and > 0. Lower values are more conservative and will classify
-        distant clusters as founding.
+        Maximum centroid distance accepted by the lineage matcher. For
+        ``"hungarian"``, must be finite and > 0 (default ``1.0`` when omitted).
+        For ``"greedy"``, may be ``float("inf")`` for unlimited matching (the
+        historical default); when omitted, greedy uses unlimited distance.
+        Lower finite values are more conservative and classify distant clusters
+        as founding.
     """
 
     TRAJECTORY_FILENAME = "intrinsic_gene_trajectory.jsonl"
@@ -110,7 +113,7 @@ class GeneTrajectoryLogger:
         speciation_dbscan_auto_tune: bool = False,
         speciation_dbscan_auto_tune_percentile: float = 90.0,
         speciation_lineage_matcher: str = "hungarian",
-        speciation_lineage_max_distance: float = 1.0,
+        speciation_lineage_max_distance: Optional[float] = None,
     ) -> None:
         if snapshot_interval < 1:
             raise ValueError("snapshot_interval must be at least 1.")
@@ -121,11 +124,26 @@ class GeneTrajectoryLogger:
                 "speciation_lineage_matcher must be one of "
                 f"{self.VALID_LINEAGE_MATCHERS!r}; got {speciation_lineage_matcher!r}."
             )
-        if not math.isfinite(speciation_lineage_max_distance) or speciation_lineage_max_distance <= 0.0:
-            raise ValueError(
-                "speciation_lineage_max_distance must be finite and > 0; "
-                f"got {speciation_lineage_max_distance!r}."
+        if speciation_lineage_max_distance is None:
+            resolved_max_distance = (
+                float("inf") if speciation_lineage_matcher == "greedy" else 1.0
             )
+        elif speciation_lineage_matcher == "hungarian":
+            if not math.isfinite(speciation_lineage_max_distance) or speciation_lineage_max_distance <= 0.0:
+                raise ValueError(
+                    "speciation_lineage_max_distance must be finite and > 0 for "
+                    f"speciation_lineage_matcher='hungarian'; got {speciation_lineage_max_distance!r}."
+                )
+            resolved_max_distance = speciation_lineage_max_distance
+        else:
+            # greedy: unlimited (inf) or any positive finite distance
+            d = speciation_lineage_max_distance
+            if d != float("inf") and (not math.isfinite(d) or d <= 0.0):
+                raise ValueError(
+                    "speciation_lineage_max_distance must be float('inf') or finite and > 0 for "
+                    f"speciation_lineage_matcher='greedy'; got {d!r}."
+                )
+            resolved_max_distance = d
         if speciation_scaler not in VALID_SCALERS:
             raise ValueError(
                 f"speciation_scaler must be one of {VALID_SCALERS!r}; "
@@ -145,6 +163,14 @@ class GeneTrajectoryLogger:
                     "GeneTrajectoryLogger: enable_speciation=True requires scikit-learn. "
                     "Install it with: pip install scikit-learn"
                 ) from exc
+            if speciation_lineage_matcher == "hungarian":
+                try:
+                    import scipy  # noqa: F401
+                except ImportError as exc:
+                    raise ImportError(
+                        "GeneTrajectoryLogger: speciation_lineage_matcher='hungarian' requires scipy. "
+                        "Install it with: pip install scipy"
+                    ) from exc
         self._output_dir = output_dir
         self._snapshot_interval = snapshot_interval
         self._enable_speciation = enable_speciation
@@ -155,7 +181,7 @@ class GeneTrajectoryLogger:
         self._speciation_dbscan_auto_tune = speciation_dbscan_auto_tune
         self._speciation_dbscan_auto_tune_percentile = speciation_dbscan_auto_tune_percentile
         self._speciation_lineage_matcher = speciation_lineage_matcher
-        self._speciation_lineage_max_distance = speciation_lineage_max_distance
+        self._speciation_lineage_max_distance = resolved_max_distance
 
         self._trajectory_handle: Optional[TextIO] = None
         self._snapshot_handle: Optional[TextIO] = None

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -13,7 +13,8 @@ Writes append-only JSONL files alongside other run artifacts:
 - ``cluster_lineage.jsonl`` -- written only when speciation tracking is
   enabled (``enable_speciation=True``).  One record per detected cluster per
   snapshot step with fields ``step``, ``cluster_id``, ``centroid``, ``size``,
-  and ``parent_cluster_id``.
+  ``parent_cluster_id``, ``transition_type``, ``parent_cluster_ids``,
+  ``lineage_matcher``, and ``lineage_max_distance``.
 
 When ``output_dir`` is ``None``, JSONL files are not written; speciation
 state is still updated in memory when ``enable_speciation=True``, allowing
@@ -23,6 +24,7 @@ the runner to use the logger unconditionally regardless of persisted artifacts.
 from __future__ import annotations
 
 import json
+import math
 import os
 import warnings
 from typing import Any, Dict, List, Optional, TextIO
@@ -33,6 +35,7 @@ from farm.analysis.speciation.compute import (
     detect_clusters_dbscan,
     detect_clusters_gmm,
     match_clusters_greedy,
+    match_clusters_hungarian,
 )
 from farm.core.hyperparameter_chromosome import (
     HyperparameterChromosome,
@@ -79,11 +82,20 @@ class GeneTrajectoryLogger:
     speciation_dbscan_auto_tune_percentile:
         Percentile (0–100) of the k-NN distance distribution used to estimate
         ``eps`` when ``speciation_dbscan_auto_tune=True``.  Default 90.
+    speciation_lineage_matcher:
+        Cluster-lineage matcher used to persist stable IDs across snapshots.
+        ``"hungarian"`` (default) uses a globally optimal assignment and
+        populates transition metadata; ``"greedy"`` preserves legacy behavior.
+    speciation_lineage_max_distance:
+        Maximum centroid distance accepted by the lineage matcher. Must be
+        finite and > 0. Lower values are more conservative and will classify
+        distant clusters as founding.
     """
 
     TRAJECTORY_FILENAME = "intrinsic_gene_trajectory.jsonl"
     SNAPSHOT_FILENAME = "intrinsic_gene_snapshots.jsonl"
     CLUSTER_LINEAGE_FILENAME = "cluster_lineage.jsonl"
+    VALID_LINEAGE_MATCHERS = ("hungarian", "greedy")
 
     def __init__(
         self,
@@ -97,11 +109,23 @@ class GeneTrajectoryLogger:
         speciation_scaler: str = "none",
         speciation_dbscan_auto_tune: bool = False,
         speciation_dbscan_auto_tune_percentile: float = 90.0,
+        speciation_lineage_matcher: str = "hungarian",
+        speciation_lineage_max_distance: float = 1.0,
     ) -> None:
         if snapshot_interval < 1:
             raise ValueError("snapshot_interval must be at least 1.")
         if speciation_algorithm not in ("gmm", "dbscan"):
             raise ValueError("speciation_algorithm must be 'gmm' or 'dbscan'.")
+        if speciation_lineage_matcher not in self.VALID_LINEAGE_MATCHERS:
+            raise ValueError(
+                "speciation_lineage_matcher must be one of "
+                f"{self.VALID_LINEAGE_MATCHERS!r}; got {speciation_lineage_matcher!r}."
+            )
+        if not math.isfinite(speciation_lineage_max_distance) or speciation_lineage_max_distance <= 0.0:
+            raise ValueError(
+                "speciation_lineage_max_distance must be finite and > 0; "
+                f"got {speciation_lineage_max_distance!r}."
+            )
         if speciation_scaler not in VALID_SCALERS:
             raise ValueError(
                 f"speciation_scaler must be one of {VALID_SCALERS!r}; "
@@ -130,6 +154,8 @@ class GeneTrajectoryLogger:
         self._speciation_scaler = speciation_scaler
         self._speciation_dbscan_auto_tune = speciation_dbscan_auto_tune
         self._speciation_dbscan_auto_tune_percentile = speciation_dbscan_auto_tune_percentile
+        self._speciation_lineage_matcher = speciation_lineage_matcher
+        self._speciation_lineage_max_distance = speciation_lineage_max_distance
 
         self._trajectory_handle: Optional[TextIO] = None
         self._snapshot_handle: Optional[TextIO] = None
@@ -288,14 +314,26 @@ class GeneTrajectoryLogger:
                 self._cluster_id_counter = 0
                 return
 
-            new_records, self._cluster_id_counter = match_clusters_greedy(
-                self._prev_cluster_records,
-                result.centroids,
-                result.sizes,
-                result.gene_names,
-                step,
-                id_counter_start=self._cluster_id_counter,
-            )
+            if self._speciation_lineage_matcher == "hungarian":
+                new_records, self._cluster_id_counter = match_clusters_hungarian(
+                    self._prev_cluster_records,
+                    result.centroids,
+                    result.sizes,
+                    result.gene_names,
+                    step,
+                    max_distance=self._speciation_lineage_max_distance,
+                    id_counter_start=self._cluster_id_counter,
+                )
+            else:
+                new_records, self._cluster_id_counter = match_clusters_greedy(
+                    self._prev_cluster_records,
+                    result.centroids,
+                    result.sizes,
+                    result.gene_names,
+                    step,
+                    max_distance=self._speciation_lineage_max_distance,
+                    id_counter_start=self._cluster_id_counter,
+                )
             self._prev_cluster_records = new_records
 
             if self._cluster_lineage_handle is not None:
@@ -308,6 +346,8 @@ class GeneTrajectoryLogger:
                         "parent_cluster_id": rec.parent_cluster_id,
                         "transition_type": rec.transition_type,
                         "parent_cluster_ids": rec.parent_cluster_ids,
+                        "lineage_matcher": self._speciation_lineage_matcher,
+                        "lineage_max_distance": self._speciation_lineage_max_distance,
                         "scaler": result.scaler,
                         "dbscan_params": result.dbscan_params,
                     }

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -390,11 +390,18 @@ class TestMatchClustersHungarian:
             self._make_record("c1", {"lr": 5.0}),
         ]
         records, _ = match_clusters_hungarian(
-            prev, [{"lr": 4.0}, {"lr": 6.0}], [10, 10], ["lr"], step=1
+            prev, [{"lr": 4.0}, {"lr": 6.0}], [10, 10], ["lr"], step=1, max_distance=10.0
         )
         id_map = {r.centroid["lr"]: r.cluster_id for r in records}
         assert id_map[4.0] == "c0"
         assert id_map[6.0] == "c1"
+
+    def test_invalid_max_distance_raises(self):
+        prev = [self._make_record("c0", {"lr": 0.01})]
+        with pytest.raises(ValueError, match="finite and > 0"):
+            match_clusters_hungarian(
+                prev, [{"lr": 0.011}], [18], ["lr"], step=1, max_distance=float("inf")
+            )
 
     # --- determinism ---------------------------------------------------------
 
@@ -491,6 +498,9 @@ class TestClusterLineageJsonlTransitionFields:
             assert "transition_type" in row
             assert "parent_cluster_ids" in row
             assert isinstance(row["parent_cluster_ids"], list)
+            assert row["transition_type"] in VALID_TRANSITION_TYPES
+            assert row["lineage_matcher"] == "hungarian"
+            assert row["lineage_max_distance"] == pytest.approx(1.0)
             # Backward-compatible fields still present
             assert "parent_cluster_id" in row
             assert "step" in row
@@ -770,6 +780,45 @@ class TestGeneTrajectoryLoggerSpeciation:
 
         with pytest.raises(ValueError, match="speciation_algorithm"):
             GeneTrajectoryLogger(None, snapshot_interval=1, speciation_algorithm="bad")
+
+    def test_invalid_lineage_matcher_raises(self):
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        with pytest.raises(ValueError, match="speciation_lineage_matcher"):
+            GeneTrajectoryLogger(None, snapshot_interval=1, speciation_lineage_matcher="bad")
+
+    def test_invalid_lineage_max_distance_raises(self):
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        with pytest.raises(ValueError, match="speciation_lineage_max_distance"):
+            GeneTrajectoryLogger(
+                None,
+                snapshot_interval=1,
+                speciation_lineage_max_distance=float("inf"),
+            )
+
+    def test_greedy_lineage_matcher_keeps_legacy_transition_fields(self, tmp_path):
+        """Greedy matcher keeps transition_type unset for backward compatibility."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        agents = [_make_fake_agent(lr=0.01), _make_fake_agent(lr=0.1)]
+        env = _FakeEnvironment(agents)
+        logger = GeneTrajectoryLogger(
+            str(tmp_path),
+            snapshot_interval=1,
+            enable_speciation=True,
+            speciation_lineage_matcher="greedy",
+        )
+        logger.snapshot(env, step=0)
+        logger.close()
+
+        lineage_path = tmp_path / "cluster_lineage.jsonl"
+        rows = [json.loads(line) for line in lineage_path.read_text().splitlines()]
+        assert len(rows) >= 1
+        for row in rows:
+            assert row["lineage_matcher"] == "greedy"
+            assert row["transition_type"] is None
+            assert row["parent_cluster_ids"] == []
 
     def test_speciation_index_reserved_key_in_extra_fields(self, tmp_path):
         """Passing speciation_index via extra_fields should raise ValueError when speciation enabled."""

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -787,15 +787,26 @@ class TestGeneTrajectoryLoggerSpeciation:
         with pytest.raises(ValueError, match="speciation_lineage_matcher"):
             GeneTrajectoryLogger(None, snapshot_interval=1, speciation_lineage_matcher="bad")
 
-    def test_invalid_lineage_max_distance_raises(self):
+    def test_invalid_lineage_max_distance_raises_for_hungarian(self):
         from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
 
         with pytest.raises(ValueError, match="speciation_lineage_max_distance"):
             GeneTrajectoryLogger(
                 None,
                 snapshot_interval=1,
+                speciation_lineage_matcher="hungarian",
                 speciation_lineage_max_distance=float("inf"),
             )
+
+    def test_greedy_lineage_max_distance_inf_allowed(self):
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        GeneTrajectoryLogger(
+            None,
+            snapshot_interval=1,
+            speciation_lineage_matcher="greedy",
+            speciation_lineage_max_distance=float("inf"),
+        )
 
     def test_greedy_lineage_matcher_keeps_legacy_transition_fields(self, tmp_path):
         """Greedy matcher keeps transition_type unset for backward compatibility."""

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -23,11 +23,13 @@ import pytest
 from farm.analysis.speciation import (
     ClusterLineageRecord,
     ClusterResult,
+    VALID_TRANSITION_TYPES,
     compute_niche_correlation,
     compute_speciation_index,
     detect_clusters_dbscan,
     detect_clusters_gmm,
     match_clusters_greedy,
+    match_clusters_hungarian,
     plot_chromosome_space_clusters,
     suggest_dbscan_params,
 )
@@ -230,6 +232,269 @@ class TestMatchClustersGreedy:
         # the other should be a new "c1"
         assert "c0" in ids_100
         assert "c1" in ids_100
+
+
+# ---------------------------------------------------------------------------
+# match_clusters_hungarian
+# ---------------------------------------------------------------------------
+
+
+class TestMatchClustersHungarian:
+    """Tests for the Hungarian-algorithm-based cluster matcher."""
+
+    def _make_record(
+        self, cluster_id: str, centroid: Dict[str, float], size: int = 10
+    ) -> ClusterLineageRecord:
+        return ClusterLineageRecord(
+            step=0,
+            cluster_id=cluster_id,
+            centroid=centroid,
+            size=size,
+            parent_cluster_id=None,
+        )
+
+    # --- basic correctness ---------------------------------------------------
+
+    def test_empty_prev_all_founding(self):
+        """With no previous clusters every new cluster is a founding."""
+        centroids = [{"lr": 0.01}, {"lr": 0.1}]
+        records, next_ctr = match_clusters_hungarian([], centroids, [20, 20], ["lr"], step=0)
+        assert len(records) == 2
+        assert all(r.transition_type == "founding" for r in records)
+        assert all(r.parent_cluster_id is None for r in records)
+        assert all(r.parent_cluster_ids == [] for r in records)
+        assert next_ctr == 2
+
+    def test_stable_id_continuation(self):
+        """A closely-matching 1:1 pair gets transition_type 'continuation'."""
+        prev = [self._make_record("c0", {"lr": 0.01})]
+        records, _ = match_clusters_hungarian(prev, [{"lr": 0.011}], [18], ["lr"], step=1)
+        assert records[0].cluster_id == "c0"
+        assert records[0].parent_cluster_id == "c0"
+        assert records[0].transition_type == "continuation"
+        assert records[0].parent_cluster_ids == ["c0"]
+
+    def test_founding_when_beyond_max_distance(self):
+        """New cluster exceeding max_distance gets a fresh founding ID."""
+        prev = [self._make_record("c0", {"lr": 0.01})]
+        records, _ = match_clusters_hungarian(
+            prev, [{"lr": 0.5}], [15], ["lr"], step=1, max_distance=0.05
+        )
+        assert records[0].cluster_id != "c0"
+        assert records[0].parent_cluster_id is None
+        assert records[0].transition_type == "founding"
+        assert records[0].parent_cluster_ids == []
+
+    def test_step_field_populated_correctly(self):
+        records, _ = match_clusters_hungarian([], [{"lr": 0.05}], [5], ["lr"], step=999)
+        assert records[0].step == 999
+
+    def test_id_counter_auto_advances(self):
+        """Counter skips over IDs already used in prev_records."""
+        prev = [
+            self._make_record("c0", {"lr": 0.01}),
+            self._make_record("c3", {"lr": 0.9}),  # non-contiguous
+        ]
+        records, ctr = match_clusters_hungarian(
+            prev, [{"lr": 0.5}], [10], ["lr"], step=1, max_distance=0.05
+        )
+        assert records[0].cluster_id == "c4"  # skips c0..c3
+        assert ctr == 5
+
+    # --- split detection -----------------------------------------------------
+
+    def test_split_transition_type_detected(self):
+        """One prev cluster splits into two new ones → both get 'split'."""
+        prev = [self._make_record("c0", {"lr": 0.05})]
+        records, _ = match_clusters_hungarian(
+            prev, [{"lr": 0.01}, {"lr": 0.09}], [10, 10], ["lr"], step=1
+        )
+        assert "split" in {r.transition_type for r in records}
+
+    def test_split_inheritor_keeps_prev_id(self):
+        """The Hungarian-matched split child inherits the predecessor ID."""
+        prev = [self._make_record("c0", {"lr": 0.05})]
+        records, _ = match_clusters_hungarian(
+            prev, [{"lr": 0.04}, {"lr": 0.08}], [10, 10], ["lr"], step=1, max_distance=0.5
+        )
+        assert "c0" in {r.cluster_id for r in records}
+
+    def test_split_fixture_across_snapshots(self):
+        """Full scenario: single cluster at step 0, splits at step 1."""
+        r0, ctr0 = match_clusters_hungarian([], [{"lr": 0.05}], [30], ["lr"], step=0)
+        assert r0[0].cluster_id == "c0"
+        assert r0[0].transition_type == "founding"
+
+        r1, _ = match_clusters_hungarian(
+            r0, [{"lr": 0.01}, {"lr": 0.09}], [15, 15], ["lr"], step=1,
+            id_counter_start=ctr0,
+        )
+        ids = {rec.cluster_id for rec in r1}
+        types = {rec.transition_type for rec in r1}
+        assert "c0" in ids
+        assert "split" in types
+
+    # --- merge detection -----------------------------------------------------
+
+    def test_merge_transition_type_detected(self):
+        """Two prev clusters converging into one → transition 'merge'."""
+        prev = [
+            self._make_record("c0", {"lr": 0.01}),
+            self._make_record("c1", {"lr": 0.02}),
+        ]
+        records, _ = match_clusters_hungarian(
+            prev, [{"lr": 0.015}], [20], ["lr"], step=1, max_distance=1.0
+        )
+        assert len(records) == 1
+        assert records[0].transition_type == "merge"
+
+    def test_merge_parent_cluster_ids_contains_all_parents(self):
+        """Merged cluster lists all contributing predecessors."""
+        prev = [
+            self._make_record("c0", {"lr": 0.01}),
+            self._make_record("c1", {"lr": 0.02}),
+        ]
+        records, _ = match_clusters_hungarian(
+            prev, [{"lr": 0.015}], [20], ["lr"], step=1, max_distance=1.0
+        )
+        assert set(records[0].parent_cluster_ids) == {"c0", "c1"}
+
+    def test_merge_fixture_across_snapshots(self):
+        """Full scenario: two clusters at step 0, merge at step 1."""
+        r0, ctr0 = match_clusters_hungarian(
+            [], [{"lr": 0.01}, {"lr": 0.09}], [10, 10], ["lr"], step=0
+        )
+        assert {r.cluster_id for r in r0} == {"c0", "c1"}
+
+        r1, _ = match_clusters_hungarian(
+            r0, [{"lr": 0.05}], [20], ["lr"], step=1,
+            id_counter_start=ctr0, max_distance=1.0,
+        )
+        assert len(r1) == 1
+        assert r1[0].transition_type == "merge"
+        assert set(r1[0].parent_cluster_ids) == {"c0", "c1"}
+
+    # --- global optimality ---------------------------------------------------
+
+    def test_hungarian_global_optimum(self):
+        """Skewed layout where Hungarian gives lower total cost than greedy.
+
+        prev: c0 at 0.0, c1 at 5.0
+        new:  A at 4.0,  B at 6.0
+
+        Greedy (A first): A→c1 (dist 1), B→c0 (dist 6), total 7
+        Hungarian:        A→c0 (dist 4), B→c1 (dist 1), total 5 ← better
+        """
+        prev = [
+            self._make_record("c0", {"lr": 0.0}),
+            self._make_record("c1", {"lr": 5.0}),
+        ]
+        records, _ = match_clusters_hungarian(
+            prev, [{"lr": 4.0}, {"lr": 6.0}], [10, 10], ["lr"], step=1
+        )
+        id_map = {r.centroid["lr"]: r.cluster_id for r in records}
+        assert id_map[4.0] == "c0"
+        assert id_map[6.0] == "c1"
+
+    # --- determinism ---------------------------------------------------------
+
+    def test_deterministic_on_repeated_calls(self):
+        """Repeated calls with identical input give identical output."""
+        prev = [
+            self._make_record("c0", {"lr": 0.01, "gamma": 0.9}),
+            self._make_record("c1", {"lr": 0.1, "gamma": 0.5}),
+        ]
+        centroids = [{"lr": 0.015, "gamma": 0.88}, {"lr": 0.09, "gamma": 0.52}]
+        r1, ctr1 = match_clusters_hungarian(prev, centroids, [10, 10], ["lr", "gamma"], step=5)
+        r2, ctr2 = match_clusters_hungarian(prev, centroids, [10, 10], ["lr", "gamma"], step=5)
+        assert ctr1 == ctr2
+        assert [(r.cluster_id, r.transition_type) for r in r1] == [
+            (r.cluster_id, r.transition_type) for r in r2
+        ]
+
+    # --- transition type validity --------------------------------------------
+
+    def test_all_transition_types_are_valid(self):
+        """All emitted transition_type values are in VALID_TRANSITION_TYPES."""
+        prev = [
+            self._make_record("c0", {"lr": 0.05}),
+            self._make_record("c1", {"lr": 0.5}),
+        ]
+        centroids = [{"lr": 0.01}, {"lr": 0.1}, {"lr": 0.49}]
+        records, _ = match_clusters_hungarian(
+            prev, centroids, [10, 10, 10], ["lr"], step=1, max_distance=1.0
+        )
+        for r in records:
+            assert r.transition_type in VALID_TRANSITION_TYPES
+
+
+# ---------------------------------------------------------------------------
+# ClusterLineageRecord new fields (backward compatibility)
+# ---------------------------------------------------------------------------
+
+
+class TestClusterLineageRecordNewFields:
+    """Backward-compatible new fields on ClusterLineageRecord."""
+
+    def test_transition_type_defaults_to_none(self):
+        rec = ClusterLineageRecord(
+            step=0, cluster_id="c0", centroid={"lr": 0.01}, size=5,
+            parent_cluster_id=None,
+        )
+        assert rec.transition_type is None
+
+    def test_parent_cluster_ids_defaults_to_empty_list(self):
+        rec = ClusterLineageRecord(
+            step=0, cluster_id="c0", centroid={"lr": 0.01}, size=5,
+            parent_cluster_id=None,
+        )
+        assert rec.parent_cluster_ids == []
+
+    def test_greedy_records_have_none_transition_type(self):
+        """match_clusters_greedy leaves transition_type as None."""
+        records, _ = match_clusters_greedy([], [{"lr": 0.01}], [10], ["lr"], step=0)
+        assert records[0].transition_type is None
+        assert records[0].parent_cluster_ids == []
+
+    def test_hungarian_records_have_valid_transition_type(self):
+        records, _ = match_clusters_hungarian([], [{"lr": 0.01}], [10], ["lr"], step=0)
+        assert records[0].transition_type == "founding"
+        assert records[0].parent_cluster_ids == []
+
+
+# ---------------------------------------------------------------------------
+# cluster_lineage.jsonl – new transition fields
+# ---------------------------------------------------------------------------
+
+
+class TestClusterLineageJsonlTransitionFields:
+    """Verify transition_type and parent_cluster_ids appear in cluster_lineage.jsonl."""
+
+    def test_cluster_lineage_contains_transition_fields(self, tmp_path):
+        """cluster_lineage.jsonl rows include transition_type and parent_cluster_ids."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        agents = (
+            [_make_fake_agent(lr=0.001, gamma=0.99)] * 10
+            + [_make_fake_agent(lr=0.9, gamma=0.1)] * 10
+        )
+        env = _FakeEnvironment(agents)
+
+        logger = GeneTrajectoryLogger(str(tmp_path), snapshot_interval=1, enable_speciation=True)
+        logger.snapshot(env, step=0)
+        logger.close()
+
+        lineage_path = tmp_path / "cluster_lineage.jsonl"
+        rows = [json.loads(line) for line in lineage_path.read_text().splitlines()]
+        assert len(rows) >= 1
+        for row in rows:
+            assert "transition_type" in row
+            assert "parent_cluster_ids" in row
+            assert isinstance(row["parent_cluster_ids"], list)
+            # Backward-compatible fields still present
+            assert "parent_cluster_id" in row
+            assert "step" in row
+            assert "cluster_id" in row
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces a new globally optimal cluster-lineage matching algorithm using the Hungarian method, enhances cluster lineage tracking with detailed transition metadata, and updates the speciation pipeline and logging to support these new features. The changes improve the accuracy and interpretability of cluster tracking across snapshots, and provide more detailed output for downstream analysis.

**Cluster lineage tracking improvements:**

* Added the `match_clusters_hungarian` function, which uses the Hungarian (Kuhn–Munkres) algorithm for globally optimal cluster assignment across snapshots. This method classifies transitions as "founding", "continuation", "split", or "merge", and tracks all predecessor clusters for each new cluster. (`farm/analysis/speciation/compute.py`, [farm/analysis/speciation/compute.pyR802-R1050](diffhunk://#diff-b156f055aa6a9132d524472b587703fedb67934ba8b5b3e030831d8692fb97b8R802-R1050))
* Extended `ClusterLineageRecord` to include `transition_type` (the type of lineage transition) and `parent_cluster_ids` (all matched predecessor IDs), and updated documentation to describe these fields and their semantics. (`farm/analysis/speciation/compute.py`, [[1]](diffhunk://#diff-b156f055aa6a9132d524472b587703fedb67934ba8b5b3e030831d8692fb97b8R177-R196) [[2]](diffhunk://#diff-b156f055aa6a9132d524472b587703fedb67934ba8b5b3e030831d8692fb97b8R207-R208)

**Configuration and interface updates:**

* Added `VALID_TRANSITION_TYPES` and `match_clusters_hungarian` to the module exports, and updated relevant imports in both the core and test code. (`farm/analysis/speciation/__init__.py`, [[1]](diffhunk://#diff-6d39a86319290299f250dd43155bda7bc9d0b1c4e1cc6ca75a68419af2035b05R46-R51) [[2]](diffhunk://#diff-6d39a86319290299f250dd43155bda7bc9d0b1c4e1cc6ca75a68419af2035b05R63-R70); `tests/analysis/test_speciation.py`, [[3]](diffhunk://#diff-1f115c5d91d0105b737c836e1ec29f2d12b123e6fe3b5c046c01e8b278526088R26-R32)
* Updated `GeneTrajectoryLogger` to support a new `speciation_lineage_matcher` option ("hungarian" or "greedy", default "hungarian") and a configurable `speciation_lineage_max_distance` parameter, with validation for both. (`farm/runners/gene_trajectory_logger.py`, [[1]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R85-R98) [[2]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R112-R128) [[3]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R157-R158)

**Output and logging enhancements:**

* The `cluster_lineage.jsonl` output now includes `transition_type`, `parent_cluster_ids`, `lineage_matcher`, and `lineage_max_distance` fields for each cluster, providing richer metadata for downstream analysis. (`farm/runners/gene_trajectory_logger.py`, [[1]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70L16-R17) [[2]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R347-R350)
* The speciation update logic now uses the selected matcher and passes the configured maximum distance to both greedy and Hungarian algorithms. (`farm/runners/gene_trajectory_logger.py`, [farm/runners/gene_trajectory_logger.pyR317-R334](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R317-R334))

**Constants and validation:**

* Added `VALID_TRANSITION_TYPES` as a configuration constant for valid transition types. (`farm/analysis/speciation/compute.py`, [farm/analysis/speciation/compute.pyR96-R103](diffhunk://#diff-b156f055aa6a9132d524472b587703fedb67934ba8b5b3e030831d8692fb97b8R96-R103))
* Added input validation for the new matcher and max distance parameters. (`farm/runners/gene_trajectory_logger.py`, [farm/runners/gene_trajectory_logger.pyR112-R128](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R112-R128))

These changes collectively improve the robustness, flexibility, and transparency of cluster lineage tracking in the speciation analysis pipeline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster lineage ID assignment and the `cluster_lineage.jsonl` schema, and introduces an optional runtime dependency on `scipy` for the new matcher; downstream analysis relying on prior matching or fields may need updates.
> 
> **Overview**
> Adds `match_clusters_hungarian` for cluster lineage persistence, using Hungarian assignment with a `max_distance` gate and emitting per-cluster transition metadata (`founding`/`continuation`/`split`/`merge`) plus full predecessor lists.
> 
> Extends `ClusterLineageRecord` with `transition_type` and `parent_cluster_ids` (keeping `parent_cluster_id` for compatibility), exports new APIs/constants (`VALID_TRANSITION_TYPES`, `match_clusters_hungarian`), and updates `GeneTrajectoryLogger` to default to the Hungarian matcher while allowing opt-out to legacy greedy matching and persisting the new fields (plus matcher/max-distance) into `cluster_lineage.jsonl`. Tests are expanded to cover the new matcher behavior, validations, and output schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c050a6a405c7d8b4a6fb6d89df49a189cb198c89. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->