### PR TITLE
Add SpeciationQualityBundle and compute speciation quality metrics

### DIFF
--- a/farm/analysis/speciation/__init__.py
+++ b/farm/analysis/speciation/__init__.py
@@ -14,6 +14,9 @@ Features
   stable string IDs across consecutive snapshots.
 - **Speciation index**: silhouette-based scalar in ``[0, 1]`` collapsed from
   a :class:`~farm.analysis.speciation.compute.ClusterResult`.
+- **Quality bundle**: richer diagnostics via
+  :func:`compute_speciation_quality_bundle` including raw (unclipped)
+  silhouette, noise fraction, cluster-size entropy, and cluster count.
 - **Niche correlation**: per-cluster mean spatial position, energy, and
   reproduction cost.
 - **Plot helper**: PCA/scatter of agents in chromosome space coloured by
@@ -26,14 +29,17 @@ Quick start::
     ...     detect_clusters_dbscan,
     ...     match_clusters_greedy,
     ...     compute_speciation_index,
+    ...     compute_speciation_quality_bundle,
     ...     compute_niche_correlation,
     ...     ClusterResult,
     ...     ClusterLineageRecord,
+    ...     SpeciationQualityBundle,
     ...     plot_chromosome_space_clusters,
     ... )
     >>> chromosomes = [{"lr": 0.01, "gamma": 0.99}, {"lr": 0.1, "gamma": 0.5}]
     >>> result = detect_clusters_gmm(chromosomes, max_k=3, seed=42)
     >>> index = compute_speciation_index(result)
+    >>> bundle = compute_speciation_quality_bundle(result)
 
 See ``tests/analysis/test_speciation.py`` for examples with known cluster
 fixtures and persistence across snapshots.
@@ -42,6 +48,7 @@ fixtures and persistence across snapshots.
 from farm.analysis.speciation.compute import (
     ClusterResult,
     ClusterLineageRecord,
+    SpeciationQualityBundle,
     VALID_SCALERS,
     VALID_TRANSITION_TYPES,
     detect_clusters_gmm,
@@ -50,6 +57,7 @@ from farm.analysis.speciation.compute import (
     match_clusters_greedy,
     match_clusters_hungarian,
     compute_speciation_index,
+    compute_speciation_quality_bundle,
     compute_niche_correlation,
 )
 from farm.analysis.speciation.plot import plot_chromosome_space_clusters
@@ -58,6 +66,7 @@ __all__ = [
     # Data structures
     "ClusterResult",
     "ClusterLineageRecord",
+    "SpeciationQualityBundle",
     # Configuration constants
     "VALID_SCALERS",
     "VALID_TRANSITION_TYPES",
@@ -70,6 +79,7 @@ __all__ = [
     "match_clusters_hungarian",
     # Scalar metrics
     "compute_speciation_index",
+    "compute_speciation_quality_bundle",
     # Niche analysis
     "compute_niche_correlation",
     # Visualisation

--- a/farm/analysis/speciation/__init__.py
+++ b/farm/analysis/speciation/__init__.py
@@ -16,7 +16,8 @@ Features
   a :class:`~farm.analysis.speciation.compute.ClusterResult`.
 - **Quality bundle**: richer diagnostics via
   :func:`compute_speciation_quality_bundle` including raw (unclipped)
-  silhouette, noise fraction, cluster-size entropy, and cluster count.
+  silhouette, noise fraction, cluster-size entropy, and cluster count, with
+  optional ``stability_score`` from perturbation analysis.
 - **Niche correlation**: per-cluster mean spatial position, energy, and
   reproduction cost.
 - **Plot helper**: PCA/scatter of agents in chromosome space coloured by
@@ -29,6 +30,7 @@ Quick start::
     ...     detect_clusters_dbscan,
     ...     match_clusters_greedy,
     ...     compute_speciation_index,
+    ...     compute_speciation_stability_score,
     ...     compute_speciation_quality_bundle,
     ...     compute_niche_correlation,
     ...     ClusterResult,
@@ -39,6 +41,7 @@ Quick start::
     >>> chromosomes = [{"lr": 0.01, "gamma": 0.99}, {"lr": 0.1, "gamma": 0.5}]
     >>> result = detect_clusters_gmm(chromosomes, max_k=3, seed=42)
     >>> index = compute_speciation_index(result)
+    >>> stability = compute_speciation_stability_score(chromosomes)
     >>> bundle = compute_speciation_quality_bundle(result)
 
 See ``tests/analysis/test_speciation.py`` for examples with known cluster
@@ -57,6 +60,7 @@ from farm.analysis.speciation.compute import (
     match_clusters_greedy,
     match_clusters_hungarian,
     compute_speciation_index,
+    compute_speciation_stability_score,
     compute_speciation_quality_bundle,
     compute_niche_correlation,
 )
@@ -79,6 +83,7 @@ __all__ = [
     "match_clusters_hungarian",
     # Scalar metrics
     "compute_speciation_index",
+    "compute_speciation_stability_score",
     "compute_speciation_quality_bundle",
     # Niche analysis
     "compute_niche_correlation",

--- a/farm/analysis/speciation/compute.py
+++ b/farm/analysis/speciation/compute.py
@@ -52,6 +52,8 @@ Quality bundle
 - ``cluster_size_entropy``: Shannon entropy (nats) of cluster-size
   distribution; ``0.0`` when ``k ≤ 1``; higher means more balanced clusters.
 - ``n_clusters``: number of detected clusters.
+- ``stability_score`` (optional): mean agreement under small perturbations of
+  chromosome values, normalised to ``[0, 1]``.
 
 Niche correlation
 -----------------
@@ -72,11 +74,13 @@ import numpy as np
 
 try:
     from sklearn.cluster import DBSCAN
+    from sklearn.metrics import adjusted_rand_score as _sk_adjusted_rand
     from sklearn.metrics import silhouette_score as _sk_silhouette
     from sklearn.mixture import GaussianMixture
     from sklearn.preprocessing import RobustScaler, StandardScaler
 except ImportError:
     DBSCAN = None  # type: ignore[assignment]
+    _sk_adjusted_rand = None  # type: ignore[assignment]
     _sk_silhouette = None  # type: ignore[assignment]
     GaussianMixture = None  # type: ignore[assignment]
     RobustScaler = None  # type: ignore[assignment]
@@ -89,6 +93,7 @@ logger = get_logger(__name__)
 def _require_sklearn() -> None:
     if (
         DBSCAN is None
+        or _sk_adjusted_rand is None
         or _sk_silhouette is None
         or GaussianMixture is None
         or RobustScaler is None
@@ -249,6 +254,10 @@ class SpeciationQualityBundle:
         indicate more balanced clusters; maximum is ``ln(k)``.
     n_clusters:
         Number of detected clusters (``ClusterResult.k``).
+    stability_score:
+        Optional robustness metric in ``[0.0, 1.0]`` measuring assignment
+        agreement under small feature-space perturbations. ``None`` when not
+        computed by the caller.
     """
 
     speciation_index: float
@@ -256,6 +265,7 @@ class SpeciationQualityBundle:
     noise_fraction: float
     cluster_size_entropy: float
     n_clusters: int
+    stability_score: Optional[float] = None
 
 
 # ---------------------------------------------------------------------------
@@ -299,6 +309,16 @@ def _chromosomes_to_matrix(
         dtype=float,
     )
     return matrix, gene_names
+
+
+def _matrix_to_chromosomes(X: np.ndarray, gene_names: List[str]) -> List[Dict[str, float]]:
+    """Convert a (N, D) matrix back to chromosome dicts."""
+    if X.shape[0] == 0:
+        return []
+    return [
+        {g: float(X[i, j]) for j, g in enumerate(gene_names)}
+        for i in range(X.shape[0])
+    ]
 
 
 def _centroid_to_dict(centroid_vec: np.ndarray, gene_names: List[str]) -> Dict[str, float]:
@@ -1148,8 +1168,99 @@ def compute_speciation_index(cluster_result: ClusterResult) -> float:
     return max(0.0, min(1.0, cluster_result.silhouette_score))
 
 
+def compute_speciation_stability_score(
+    chromosomes: Sequence[Dict[str, float]],
+    *,
+    algorithm: str = "gmm",
+    gene_names: Optional[List[str]] = None,
+    scaler: str = "none",
+    gmm_max_k: int = 5,
+    gmm_seed: int = 0,
+    dbscan_eps: float = 0.1,
+    dbscan_min_samples: int = 2,
+    dbscan_auto_tune: bool = False,
+    dbscan_auto_tune_percentile: float = 90.0,
+    n_perturbations: int = 5,
+    noise_std: float = 0.005,
+    random_seed: int = 0,
+) -> float:
+    """Estimate clustering robustness under small feature perturbations.
+
+    The baseline cluster assignment is compared against assignments from
+    ``n_perturbations`` noisy replicas using adjusted Rand index (ARI).  ARI is
+    mapped from ``[-1, 1]`` to ``[0, 1]`` and averaged.
+    """
+    if algorithm not in ("gmm", "dbscan"):
+        raise ValueError(f"algorithm must be 'gmm' or 'dbscan'; got {algorithm!r}.")
+    if n_perturbations < 1:
+        raise ValueError(
+            f"n_perturbations must be at least 1; got {n_perturbations!r}."
+        )
+    if noise_std < 0.0:
+        raise ValueError(f"noise_std must be non-negative; got {noise_std!r}.")
+    _validate_scaler(scaler)
+    _require_sklearn()
+
+    X, gnames = _chromosomes_to_matrix(chromosomes, gene_names)
+    if X.shape[0] < 2:
+        return 0.0
+
+    if algorithm == "gmm":
+        baseline = detect_clusters_gmm(
+            chromosomes,
+            max_k=gmm_max_k,
+            seed=gmm_seed,
+            gene_names=gnames,
+            scaler=scaler,
+        )
+    else:
+        baseline = detect_clusters_dbscan(
+            chromosomes,
+            eps=dbscan_eps,
+            min_samples=dbscan_min_samples,
+            gene_names=gnames,
+            scaler=scaler,
+            auto_tune=dbscan_auto_tune,
+            auto_tune_percentile=dbscan_auto_tune_percentile,
+        )
+
+    baseline_labels = np.array(baseline.labels, dtype=int)
+    rng = np.random.default_rng(random_seed)
+    scores: List[float] = []
+
+    for _ in range(n_perturbations):
+        X_perturbed = X + rng.normal(loc=0.0, scale=noise_std, size=X.shape)
+        perturbed_chromosomes = _matrix_to_chromosomes(X_perturbed, gnames)
+        if algorithm == "gmm":
+            perturbed = detect_clusters_gmm(
+                perturbed_chromosomes,
+                max_k=gmm_max_k,
+                seed=gmm_seed,
+                gene_names=gnames,
+                scaler=scaler,
+            )
+        else:
+            perturbed = detect_clusters_dbscan(
+                perturbed_chromosomes,
+                eps=dbscan_eps,
+                min_samples=dbscan_min_samples,
+                gene_names=gnames,
+                scaler=scaler,
+                auto_tune=dbscan_auto_tune,
+                auto_tune_percentile=dbscan_auto_tune_percentile,
+            )
+        ari = float(_sk_adjusted_rand(baseline_labels, np.array(perturbed.labels, dtype=int)))
+        scores.append((ari + 1.0) / 2.0)
+
+    if not scores:
+        return 0.0
+    return max(0.0, min(1.0, float(sum(scores) / len(scores))))
+
+
 def compute_speciation_quality_bundle(
     cluster_result: ClusterResult,
+    *,
+    stability_score: Optional[float] = None,
 ) -> SpeciationQualityBundle:
     """Compute a rich set of quality metrics for a cluster-detection result.
 
@@ -1176,11 +1287,13 @@ def compute_speciation_quality_bundle(
         - ``cluster_size_entropy`` – Shannon entropy (nats) of the
           cluster-size distribution; ``0.0`` when ``k ≤ 1``.
         - ``n_clusters`` – number of detected clusters.
+        - ``stability_score`` – optional robustness estimate in ``[0.0, 1.0]``
+          from :func:`compute_speciation_stability_score`.
     """
     n_total = len(cluster_result.labels)
 
     # Noise fraction (DBSCAN label -1; always 0 for GMM)
-    if n_total > 0:
+    if cluster_result.algorithm == "dbscan" and n_total > 0:
         n_noise = sum(1 for lbl in cluster_result.labels if lbl < 0)
         noise_fraction = float(n_noise) / float(n_total)
     else:
@@ -1206,6 +1319,7 @@ def compute_speciation_quality_bundle(
         noise_fraction=noise_fraction,
         cluster_size_entropy=entropy,
         n_clusters=cluster_result.k,
+        stability_score=stability_score,
     )
 
 

--- a/farm/analysis/speciation/compute.py
+++ b/farm/analysis/speciation/compute.py
@@ -40,6 +40,19 @@ single scalar in ``[0.0, 1.0]``:
 - Otherwise: the *silhouette score* of the detected cluster assignment
   (bounded to ``[0.0, 1.0]``).
 
+Quality bundle
+--------------
+:func:`compute_speciation_quality_bundle` returns a
+:class:`SpeciationQualityBundle` with richer diagnostics alongside
+``speciation_index``:
+
+- ``raw_silhouette``: unclipped silhouette in ``[-1, 1]`` (negative values
+  signal overlapping clusters).
+- ``noise_fraction``: fraction of DBSCAN noise agents (``0.0`` for GMM).
+- ``cluster_size_entropy``: Shannon entropy (nats) of cluster-size
+  distribution; ``0.0`` when ``k ≤ 1``; higher means more balanced clusters.
+- ``n_clusters``: number of detected clusters.
+
 Niche correlation
 -----------------
 :func:`compute_niche_correlation` accepts the per-snapshot agent list (as
@@ -209,6 +222,42 @@ class ClusterLineageRecord:
     gene_stats: Optional[Dict[str, Dict[str, float]]] = field(default=None)
 
 
+@dataclass
+class SpeciationQualityBundle:
+    """Rich quality metrics for a single cluster-detection result.
+
+    This bundle supplements the scalar :func:`compute_speciation_index` with
+    additional diagnostics that expose signal which the clipped scalar loses
+    (e.g. negative silhouette) and that characterise noise prevalence and
+    cluster balance.
+
+    Attributes
+    ----------
+    speciation_index:
+        Normalised speciation index in ``[0.0, 1.0]``, identical to the
+        value returned by :func:`compute_speciation_index`.
+    raw_silhouette:
+        Unclipped silhouette score in ``[-1.0, 1.0]``.  ``0.0`` when
+        ``k ≤ 1`` or when fewer than two labelled agents exist.  Negative
+        values indicate overlapping or misassigned clusters.
+    noise_fraction:
+        Fraction of all input agents labelled as noise (label ``-1``) by
+        DBSCAN.  Always ``0.0`` for GMM results.
+    cluster_size_entropy:
+        Shannon entropy (nats) of the cluster-size distribution, computed
+        over labelled agents only.  ``0.0`` when ``k ≤ 1``.  Higher values
+        indicate more balanced clusters; maximum is ``ln(k)``.
+    n_clusters:
+        Number of detected clusters (``ClusterResult.k``).
+    """
+
+    speciation_index: float
+    raw_silhouette: float
+    noise_fraction: float
+    cluster_size_entropy: float
+    n_clusters: int
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
@@ -257,7 +306,12 @@ def _centroid_to_dict(centroid_vec: np.ndarray, gene_names: List[str]) -> Dict[s
 
 
 def _silhouette(X: np.ndarray, labels: np.ndarray) -> float:
-    """Compute silhouette score, returning 0.0 on any failure."""
+    """Compute raw silhouette score in ``[-1, 1]``, returning ``0.0`` on failure.
+
+    Unlike the previous behaviour this function no longer clips negative
+    scores; callers that need a non-negative value apply ``max(0.0, …)``
+    themselves (see :func:`compute_speciation_index`).
+    """
     unique = np.unique(labels[labels >= 0])
     if len(unique) < 2 or X.shape[0] < 2:
         return 0.0
@@ -266,8 +320,7 @@ def _silhouette(X: np.ndarray, labels: np.ndarray) -> float:
     if mask.sum() < 2:
         return 0.0
     try:
-        score = float(_sk_silhouette(X[mask], labels[mask]))
-        return max(0.0, score)
+        return float(_sk_silhouette(X[mask], labels[mask]))
     except Exception as exc:
         logger.debug("_silhouette: failed to compute silhouette score: %s", exc)
         return 0.0
@@ -1080,6 +1133,67 @@ def compute_speciation_index(cluster_result: ClusterResult) -> float:
     if cluster_result.k <= 1:
         return 0.0
     return max(0.0, min(1.0, cluster_result.silhouette_score))
+
+
+def compute_speciation_quality_bundle(
+    cluster_result: ClusterResult,
+) -> SpeciationQualityBundle:
+    """Compute a rich set of quality metrics for a cluster-detection result.
+
+    Returns a :class:`SpeciationQualityBundle` that supplements the scalar
+    :func:`compute_speciation_index` with diagnostics for noise prevalence
+    and cluster balance.
+
+    Parameters
+    ----------
+    cluster_result:
+        A :class:`ClusterResult` from :func:`detect_clusters_gmm` or
+        :func:`detect_clusters_dbscan`.
+
+    Returns
+    -------
+    SpeciationQualityBundle
+        Bundle with the following fields:
+
+        - ``speciation_index`` – normalised index in ``[0.0, 1.0]``
+          (same as :func:`compute_speciation_index`).
+        - ``raw_silhouette`` – unclipped silhouette in ``[-1.0, 1.0]``.
+        - ``noise_fraction`` – fraction of DBSCAN noise agents; ``0.0``
+          for GMM.
+        - ``cluster_size_entropy`` – Shannon entropy (nats) of the
+          cluster-size distribution; ``0.0`` when ``k ≤ 1``.
+        - ``n_clusters`` – number of detected clusters.
+    """
+    n_total = len(cluster_result.labels)
+
+    # Noise fraction (DBSCAN label -1; always 0 for GMM)
+    if n_total > 0:
+        n_noise = sum(1 for lbl in cluster_result.labels if lbl < 0)
+        noise_fraction = float(n_noise) / float(n_total)
+    else:
+        noise_fraction = 0.0
+
+    # Cluster-size Shannon entropy (nats)
+    if cluster_result.k >= 2 and cluster_result.sizes:
+        total_labelled = float(sum(cluster_result.sizes))
+        if total_labelled > 0.0:
+            entropy = 0.0
+            for sz in cluster_result.sizes:
+                p = sz / total_labelled
+                if p > 0.0:
+                    entropy -= p * math.log(p)
+        else:
+            entropy = 0.0
+    else:
+        entropy = 0.0
+
+    return SpeciationQualityBundle(
+        speciation_index=compute_speciation_index(cluster_result),
+        raw_silhouette=cluster_result.silhouette_score if cluster_result.k >= 2 else 0.0,
+        noise_fraction=noise_fraction,
+        cluster_size_entropy=entropy,
+        n_clusters=cluster_result.k,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -31,7 +31,6 @@ from typing import Any, Dict, List, Optional, TextIO
 
 from farm.analysis.speciation.compute import (
     VALID_SCALERS,
-    compute_speciation_index,
     compute_speciation_quality_bundle,
     detect_clusters_dbscan,
     detect_clusters_gmm,
@@ -337,8 +336,8 @@ class GeneTrajectoryLogger:
                     auto_tune_percentile=self._speciation_dbscan_auto_tune_percentile,
                 )
 
-            self._cached_speciation_index = compute_speciation_index(result)
             bundle = compute_speciation_quality_bundle(result)
+            self._cached_speciation_index = bundle.speciation_index
             self._cached_speciation_quality = {
                 "speciation_index": bundle.speciation_index,
                 "raw_silhouette": bundle.raw_silhouette,

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -32,6 +32,7 @@ from typing import Any, Dict, List, Optional, TextIO
 from farm.analysis.speciation.compute import (
     VALID_SCALERS,
     compute_speciation_index,
+    compute_speciation_quality_bundle,
     detect_clusters_dbscan,
     detect_clusters_gmm,
     match_clusters_greedy,
@@ -163,6 +164,7 @@ class GeneTrajectoryLogger:
 
         # Cached speciation state between snapshot steps
         self._cached_speciation_index: float = 0.0
+        self._cached_speciation_quality: Optional[Dict[str, Any]] = None
         self._prev_cluster_records: List[Any] = []  # List[ClusterLineageRecord]
         self._cluster_id_counter: int = 0
 
@@ -227,11 +229,15 @@ class GeneTrajectoryLogger:
         }
         if self._enable_speciation:
             trajectory_record["speciation_index"] = self._cached_speciation_index
+            if self._cached_speciation_quality is not None:
+                trajectory_record["speciation_quality"] = self._cached_speciation_quality
 
         if extra_fields:
             _RESERVED_TRAJECTORY_KEYS = {"step", "n_alive", "n_with_chromosome", "gene_stats"}
             if self._enable_speciation:
-                _RESERVED_TRAJECTORY_KEYS = _RESERVED_TRAJECTORY_KEYS | {"speciation_index"}
+                _RESERVED_TRAJECTORY_KEYS = _RESERVED_TRAJECTORY_KEYS | {
+                    "speciation_index", "speciation_quality"
+                }
             collisions = _RESERVED_TRAJECTORY_KEYS & extra_fields.keys()
             if collisions:
                 raise ValueError(
@@ -278,6 +284,7 @@ class GeneTrajectoryLogger:
         """
         if not chromosomes:
             self._cached_speciation_index = 0.0
+            self._cached_speciation_quality = None
             self._prev_cluster_records = []
             self._cluster_id_counter = 0
             return
@@ -305,6 +312,14 @@ class GeneTrajectoryLogger:
                 )
 
             self._cached_speciation_index = compute_speciation_index(result)
+            bundle = compute_speciation_quality_bundle(result)
+            self._cached_speciation_quality = {
+                "speciation_index": bundle.speciation_index,
+                "raw_silhouette": bundle.raw_silhouette,
+                "noise_fraction": bundle.noise_fraction,
+                "cluster_size_entropy": bundle.cluster_size_entropy,
+                "n_clusters": bundle.n_clusters,
+            }
 
             # Persist cluster lineage
             if result.k == 0:

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -32,6 +32,7 @@ from typing import Any, Dict, List, Optional, TextIO
 from farm.analysis.speciation.compute import (
     VALID_SCALERS,
     compute_speciation_quality_bundle,
+    compute_speciation_stability_score,
     detect_clusters_dbscan,
     detect_clusters_gmm,
     match_clusters_greedy,
@@ -93,6 +94,19 @@ class GeneTrajectoryLogger:
         historical default); when omitted, greedy uses unlimited distance.
         Lower finite values are more conservative and classify distant clusters
         as founding.
+    speciation_include_stability:
+        When ``True``, compute and include an optional ``stability_score`` in
+        ``speciation_quality`` using perturbation-based robustness checks.
+        Default ``False``.
+    speciation_stability_perturbations:
+        Number of perturbation replicas used for stability estimation.
+        Must be at least 1. Default 5.
+    speciation_stability_noise_std:
+        Standard deviation of additive Gaussian noise in chromosome space for
+        each perturbation replica. Must be non-negative. Default 0.005.
+    speciation_stability_seed:
+        Integer random seed used for deterministic perturbation sampling.
+        Default 0.
     """
 
     TRAJECTORY_FILENAME = "intrinsic_gene_trajectory.jsonl"
@@ -114,6 +128,10 @@ class GeneTrajectoryLogger:
         speciation_dbscan_auto_tune_percentile: float = 90.0,
         speciation_lineage_matcher: str = "hungarian",
         speciation_lineage_max_distance: Optional[float] = None,
+        speciation_include_stability: bool = False,
+        speciation_stability_perturbations: int = 5,
+        speciation_stability_noise_std: float = 0.005,
+        speciation_stability_seed: int = 0,
     ) -> None:
         if snapshot_interval < 1:
             raise ValueError("snapshot_interval must be at least 1.")
@@ -154,6 +172,16 @@ class GeneTrajectoryLogger:
                 "speciation_dbscan_auto_tune_percentile must be in [0, 100]; "
                 f"got {speciation_dbscan_auto_tune_percentile!r}."
             )
+        if speciation_stability_perturbations < 1:
+            raise ValueError(
+                "speciation_stability_perturbations must be at least 1; "
+                f"got {speciation_stability_perturbations!r}."
+            )
+        if speciation_stability_noise_std < 0.0:
+            raise ValueError(
+                "speciation_stability_noise_std must be non-negative; "
+                f"got {speciation_stability_noise_std!r}."
+            )
 
         if enable_speciation:
             try:
@@ -182,6 +210,10 @@ class GeneTrajectoryLogger:
         self._speciation_dbscan_auto_tune_percentile = speciation_dbscan_auto_tune_percentile
         self._speciation_lineage_matcher = speciation_lineage_matcher
         self._speciation_lineage_max_distance = resolved_max_distance
+        self._speciation_include_stability = speciation_include_stability
+        self._speciation_stability_perturbations = speciation_stability_perturbations
+        self._speciation_stability_noise_std = speciation_stability_noise_std
+        self._speciation_stability_seed = speciation_stability_seed
 
         self._trajectory_handle: Optional[TextIO] = None
         self._snapshot_handle: Optional[TextIO] = None
@@ -221,6 +253,8 @@ class GeneTrajectoryLogger:
         present at the snapshot step, a ``speciation_quality`` dict
         containing ``speciation_index``, ``raw_silhouette``,
         ``noise_fraction``, ``cluster_size_entropy``, and ``n_clusters``.
+        When ``speciation_include_stability=True``, ``speciation_quality``
+        also includes ``stability_score`` in ``[0, 1]``.
         Both fields are updated at every snapshot step; ``speciation_quality``
         is absent from non-snapshot steps and from snapshot steps where there
         are no chromosomes.
@@ -260,7 +294,7 @@ class GeneTrajectoryLogger:
         }
         if self._enable_speciation:
             trajectory_record["speciation_index"] = self._cached_speciation_index
-            if self._cached_speciation_quality is not None:
+            if is_snapshot_step and self._cached_speciation_quality is not None:
                 trajectory_record["speciation_quality"] = self._cached_speciation_quality
 
         if extra_fields:
@@ -342,7 +376,25 @@ class GeneTrajectoryLogger:
                     auto_tune_percentile=self._speciation_dbscan_auto_tune_percentile,
                 )
 
-            bundle = compute_speciation_quality_bundle(result)
+            stability_score = None
+            if self._speciation_include_stability:
+                stability_score = compute_speciation_stability_score(
+                    chrom_dicts,
+                    algorithm=self._speciation_algorithm,
+                    scaler=self._speciation_scaler,
+                    gmm_max_k=self._speciation_max_k,
+                    gmm_seed=self._speciation_seed,
+                    dbscan_auto_tune=self._speciation_dbscan_auto_tune,
+                    dbscan_auto_tune_percentile=self._speciation_dbscan_auto_tune_percentile,
+                    n_perturbations=self._speciation_stability_perturbations,
+                    noise_std=self._speciation_stability_noise_std,
+                    random_seed=self._speciation_stability_seed,
+                )
+
+            bundle = compute_speciation_quality_bundle(
+                result,
+                stability_score=stability_score,
+            )
             self._cached_speciation_index = bundle.speciation_index
             self._cached_speciation_quality = {
                 "speciation_index": bundle.speciation_index,
@@ -351,6 +403,8 @@ class GeneTrajectoryLogger:
                 "cluster_size_entropy": bundle.cluster_size_entropy,
                 "n_clusters": bundle.n_clusters,
             }
+            if bundle.stability_score is not None:
+                self._cached_speciation_quality["stability_score"] = bundle.stability_score
 
             # Persist cluster lineage
             if result.k == 0:

--- a/farm/runners/gene_trajectory_logger.py
+++ b/farm/runners/gene_trajectory_logger.py
@@ -217,7 +217,13 @@ class GeneTrajectoryLogger:
 
         Always appends a one-line aggregate record to the trajectory file.
         When speciation tracking is enabled the record includes a
-        ``speciation_index`` field updated at every snapshot step.
+        ``speciation_index`` field and, when at least one chromosome is
+        present at the snapshot step, a ``speciation_quality`` dict
+        containing ``speciation_index``, ``raw_silhouette``,
+        ``noise_fraction``, ``cluster_size_entropy``, and ``n_clusters``.
+        Both fields are updated at every snapshot step; ``speciation_quality``
+        is absent from non-snapshot steps and from snapshot steps where there
+        are no chromosomes.
         Additionally appends a full per-agent snapshot when
         ``step % snapshot_interval == 0`` (so step 0 is always captured).
 

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -6,6 +6,7 @@ Covers:
 - match_clusters_greedy: stable IDs across snapshots, new cluster allocation
 - compute_speciation_index: single cluster → 0, multi-cluster → silhouette
 - compute_speciation_quality_bundle: full quality bundle validation
+- compute_speciation_stability_score: perturbation robustness score in [0, 1]
 - compute_niche_correlation: per-cluster spatial/resource means
 - GeneTrajectoryLogger: speciation_index in trajectory, cluster_lineage.jsonl output
 - plot_chromosome_space_clusters: smoke test (no file I/O error)
@@ -29,6 +30,7 @@ from farm.analysis.speciation import (
     compute_niche_correlation,
     compute_speciation_index,
     compute_speciation_quality_bundle,
+    compute_speciation_stability_score,
     detect_clusters_dbscan,
     detect_clusters_gmm,
     match_clusters_greedy,
@@ -603,8 +605,13 @@ class TestComputeSpeciationQualityBundle:
         result = self._make_result(k=1, sil=0.5)
         bundle = compute_speciation_quality_bundle(result)
         for attr in ("speciation_index", "raw_silhouette", "noise_fraction",
-                     "cluster_size_entropy", "n_clusters"):
+                     "cluster_size_entropy", "n_clusters", "stability_score"):
             assert hasattr(bundle, attr)
+
+    def test_bundle_can_include_stability_score(self):
+        result = self._make_result(k=2, sil=0.5, labels=[0, 1], sizes=[1, 1])
+        bundle = compute_speciation_quality_bundle(result, stability_score=0.9)
+        assert bundle.stability_score == pytest.approx(0.9)
 
     # --- speciation_index consistency ---
 
@@ -654,6 +661,21 @@ class TestComputeSpeciationQualityBundle:
     def test_noise_fraction_zero_for_gmm(self):
         chromosomes = _bimodal_chromosomes(n_per_cluster=20)
         result = detect_clusters_gmm(chromosomes, max_k=3, seed=0)
+        bundle = compute_speciation_quality_bundle(result)
+        assert bundle.noise_fraction == pytest.approx(0.0)
+
+    def test_noise_fraction_zero_for_gmm_even_with_negative_labels(self):
+        """GMM results must report zero noise even for malformed labels."""
+        result = ClusterResult(
+            algorithm="gmm",
+            k=2,
+            labels=[-1, 0, 1, -1],
+            centroids=[{"lr": 0.01}, {"lr": 0.1}],
+            sizes=[1, 1],
+            gene_names=["lr"],
+            silhouette_score=0.2,
+            bic_scores={1: 10.0, 2: 9.0},
+        )
         bundle = compute_speciation_quality_bundle(result)
         assert bundle.noise_fraction == pytest.approx(0.0)
 
@@ -761,6 +783,47 @@ class TestComputeSpeciationQualityBundle:
         assert bundle.noise_fraction == pytest.approx(0.0)
         assert bundle.cluster_size_entropy > 0.0
         assert bundle.n_clusters == 2
+
+
+# ---------------------------------------------------------------------------
+# compute_speciation_stability_score
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSpeciationStabilityScore:
+    def test_returns_unit_interval_for_gmm(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        score = compute_speciation_stability_score(
+            chromosomes,
+            algorithm="gmm",
+            gmm_max_k=3,
+            gmm_seed=0,
+            n_perturbations=3,
+            noise_std=0.002,
+            random_seed=0,
+        )
+        assert 0.0 <= score <= 1.0
+
+    def test_returns_unit_interval_for_dbscan(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        score = compute_speciation_stability_score(
+            chromosomes,
+            algorithm="dbscan",
+            dbscan_eps=0.04,
+            dbscan_min_samples=3,
+            n_perturbations=3,
+            noise_std=0.002,
+            random_seed=0,
+        )
+        assert 0.0 <= score <= 1.0
+
+    def test_invalid_perturbation_count_raises(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=5)
+        with pytest.raises(ValueError, match="n_perturbations"):
+            compute_speciation_stability_score(
+                chromosomes,
+                n_perturbations=0,
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -962,6 +1025,26 @@ class TestGeneTrajectoryLoggerSpeciation:
         # step 5 is a new snapshot step → may have updated value (possibly same)
         assert 0.0 <= idx_5 <= 1.0
 
+    def test_quality_bundle_absent_between_snapshot_steps(self, tmp_path):
+        """speciation_quality should only be emitted at snapshot steps."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        agents = (
+            [_make_fake_agent(lr=0.001)] * 10
+            + [_make_fake_agent(lr=0.9)] * 10
+        )
+        env = _FakeEnvironment(agents)
+        logger = GeneTrajectoryLogger(str(tmp_path), snapshot_interval=5, enable_speciation=True)
+        for step in range(3):  # steps 0..2 (only step 0 is snapshot step)
+            logger.snapshot(env, step=step)
+        logger.close()
+
+        traj_path = tmp_path / "intrinsic_gene_trajectory.jsonl"
+        records = [json.loads(line) for line in traj_path.read_text().splitlines()]
+        assert "speciation_quality" in records[0]
+        assert "speciation_quality" not in records[1]
+        assert "speciation_quality" not in records[2]
+
     def test_speciation_index_bimodal_population_nonzero(self, tmp_path):
         """A clearly bimodal population should produce a nonzero speciation index."""
         from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
@@ -1012,6 +1095,28 @@ class TestGeneTrajectoryLoggerSpeciation:
             speciation_lineage_matcher="greedy",
             speciation_lineage_max_distance=float("inf"),
         )
+
+    def test_invalid_stability_perturbations_raises(self):
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        with pytest.raises(ValueError, match="speciation_stability_perturbations"):
+            GeneTrajectoryLogger(
+                None,
+                snapshot_interval=1,
+                speciation_include_stability=True,
+                speciation_stability_perturbations=0,
+            )
+
+    def test_invalid_stability_noise_std_raises(self):
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        with pytest.raises(ValueError, match="speciation_stability_noise_std"):
+            GeneTrajectoryLogger(
+                None,
+                snapshot_interval=1,
+                speciation_include_stability=True,
+                speciation_stability_noise_std=-0.1,
+            )
 
     def test_greedy_lineage_matcher_keeps_legacy_transition_fields(self, tmp_path):
         """Greedy matcher keeps transition_type unset for backward compatibility."""
@@ -1142,6 +1247,32 @@ class TestGeneTrajectoryLoggerSpeciation:
         assert 0.0 <= q["noise_fraction"] <= 1.0
         assert q["cluster_size_entropy"] >= 0.0
         assert isinstance(q["n_clusters"], int) and q["n_clusters"] >= 0
+
+    def test_quality_bundle_includes_stability_when_enabled(self, tmp_path):
+        """With speciation_include_stability=True, quality includes stability_score."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        agents = (
+            [_make_fake_agent(lr=0.001, gamma=0.99)] * 20
+            + [_make_fake_agent(lr=0.9, gamma=0.1)] * 20
+        )
+        env = _FakeEnvironment(agents)
+        logger = GeneTrajectoryLogger(
+            str(tmp_path),
+            snapshot_interval=1,
+            enable_speciation=True,
+            speciation_include_stability=True,
+            speciation_stability_perturbations=3,
+            speciation_stability_noise_std=0.002,
+            speciation_stability_seed=0,
+        )
+        logger.snapshot(env, step=0)
+        logger.close()
+
+        traj_path = tmp_path / "intrinsic_gene_trajectory.jsonl"
+        q = json.loads(traj_path.read_text().splitlines()[0])["speciation_quality"]
+        assert "stability_score" in q
+        assert 0.0 <= q["stability_score"] <= 1.0
 
     def test_quality_bundle_absent_when_speciation_disabled(self, tmp_path):
         """Without enable_speciation, trajectory records have no speciation_quality."""

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -5,6 +5,7 @@ Covers:
 - detect_clusters_dbscan: trivial, basic cluster detection
 - match_clusters_greedy: stable IDs across snapshots, new cluster allocation
 - compute_speciation_index: single cluster → 0, multi-cluster → silhouette
+- compute_speciation_quality_bundle: full quality bundle validation
 - compute_niche_correlation: per-cluster spatial/resource means
 - GeneTrajectoryLogger: speciation_index in trajectory, cluster_lineage.jsonl output
 - plot_chromosome_space_clusters: smoke test (no file I/O error)
@@ -16,16 +17,18 @@ import json
 import random
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import pytest
 
 from farm.analysis.speciation import (
     ClusterLineageRecord,
     ClusterResult,
+    SpeciationQualityBundle,
     VALID_TRANSITION_TYPES,
     compute_niche_correlation,
     compute_speciation_index,
+    compute_speciation_quality_bundle,
     detect_clusters_dbscan,
     detect_clusters_gmm,
     match_clusters_greedy,
@@ -559,6 +562,208 @@ class TestComputeSpeciationIndex:
 
 
 # ---------------------------------------------------------------------------
+# compute_speciation_quality_bundle
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSpeciationQualityBundle:
+    """Tests for the richer quality-metrics bundle."""
+
+    def _make_result(
+        self,
+        k: int,
+        sil: float,
+        labels: Optional[List[int]] = None,
+        sizes: Optional[List[int]] = None,
+        algorithm: str = "gmm",
+    ) -> ClusterResult:
+        if labels is None:
+            labels = [0] * 5
+        if sizes is None:
+            sizes = [5] if k >= 1 else []
+        return ClusterResult(
+            algorithm=algorithm,
+            k=k,
+            labels=labels,
+            centroids=[{"lr": 0.01}] * k,
+            sizes=sizes,
+            gene_names=["lr"],
+            silhouette_score=sil,
+            bic_scores=None,
+        )
+
+    # --- return type ---
+
+    def test_returns_speciation_quality_bundle_instance(self):
+        result = self._make_result(k=1, sil=0.5)
+        bundle = compute_speciation_quality_bundle(result)
+        assert isinstance(bundle, SpeciationQualityBundle)
+
+    def test_bundle_has_expected_fields(self):
+        result = self._make_result(k=1, sil=0.5)
+        bundle = compute_speciation_quality_bundle(result)
+        for attr in ("speciation_index", "raw_silhouette", "noise_fraction",
+                     "cluster_size_entropy", "n_clusters"):
+            assert hasattr(bundle, attr)
+
+    # --- speciation_index consistency ---
+
+    def test_speciation_index_matches_scalar_function(self):
+        result = self._make_result(k=2, sil=0.75, labels=[0, 1], sizes=[1, 1])
+        bundle = compute_speciation_quality_bundle(result)
+        assert bundle.speciation_index == pytest.approx(compute_speciation_index(result))
+
+    def test_speciation_index_zero_for_single_cluster(self):
+        result = self._make_result(k=1, sil=0.9)
+        bundle = compute_speciation_quality_bundle(result)
+        assert bundle.speciation_index == 0.0
+
+    def test_speciation_index_in_unit_interval(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=30)
+        result = detect_clusters_gmm(chromosomes, max_k=3, seed=0)
+        bundle = compute_speciation_quality_bundle(result)
+        assert 0.0 <= bundle.speciation_index <= 1.0
+
+    # --- raw_silhouette ---
+
+    def test_raw_silhouette_zero_for_single_cluster(self):
+        result = self._make_result(k=1, sil=0.9)
+        bundle = compute_speciation_quality_bundle(result)
+        assert bundle.raw_silhouette == 0.0
+
+    def test_raw_silhouette_preserves_negative_value(self):
+        """Negative silhouette must NOT be clipped to 0."""
+        result = self._make_result(k=2, sil=-0.3, labels=[0, 1], sizes=[1, 1])
+        bundle = compute_speciation_quality_bundle(result)
+        assert bundle.raw_silhouette == pytest.approx(-0.3)
+
+    def test_raw_silhouette_in_minus1_to_1_range_for_bimodal(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=30)
+        result = detect_clusters_gmm(chromosomes, max_k=3, seed=0)
+        bundle = compute_speciation_quality_bundle(result)
+        assert -1.0 <= bundle.raw_silhouette <= 1.0
+
+    def test_raw_silhouette_positive_for_well_separated_clusters(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=30)
+        result = detect_clusters_gmm(chromosomes, max_k=3, seed=0)
+        bundle = compute_speciation_quality_bundle(result)
+        assert bundle.raw_silhouette > 0.0
+
+    # --- noise_fraction ---
+
+    def test_noise_fraction_zero_for_gmm(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        result = detect_clusters_gmm(chromosomes, max_k=3, seed=0)
+        bundle = compute_speciation_quality_bundle(result)
+        assert bundle.noise_fraction == pytest.approx(0.0)
+
+    def test_noise_fraction_computed_correctly(self):
+        """2 noise, 2 labelled → fraction = 0.5."""
+        result = ClusterResult(
+            algorithm="dbscan",
+            k=1,
+            labels=[-1, 0, 0, -1],
+            centroids=[{"lr": 0.01}],
+            sizes=[2],
+            gene_names=["lr"],
+            silhouette_score=0.0,
+            bic_scores=None,
+        )
+        bundle = compute_speciation_quality_bundle(result)
+        assert bundle.noise_fraction == pytest.approx(0.5)
+
+    def test_noise_fraction_zero_when_no_noise(self):
+        result = ClusterResult(
+            algorithm="dbscan", k=2, labels=[0, 0, 1, 1],
+            centroids=[{"lr": 0.01}, {"lr": 0.1}],
+            sizes=[2, 2], gene_names=["lr"],
+            silhouette_score=0.8, bic_scores=None,
+        )
+        bundle = compute_speciation_quality_bundle(result)
+        assert bundle.noise_fraction == pytest.approx(0.0)
+
+    def test_noise_fraction_in_unit_interval(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=20)
+        result = detect_clusters_dbscan(chromosomes, eps=0.04, min_samples=3)
+        bundle = compute_speciation_quality_bundle(result)
+        assert 0.0 <= bundle.noise_fraction <= 1.0
+
+    # --- cluster_size_entropy ---
+
+    def test_entropy_zero_for_single_cluster(self):
+        result = self._make_result(k=1, sil=0.5)
+        bundle = compute_speciation_quality_bundle(result)
+        assert bundle.cluster_size_entropy == pytest.approx(0.0)
+
+    def test_entropy_zero_for_no_clusters(self):
+        result = self._make_result(k=0, sil=0.0, labels=[], sizes=[])
+        bundle = compute_speciation_quality_bundle(result)
+        assert bundle.cluster_size_entropy == pytest.approx(0.0)
+
+    def test_entropy_maximised_for_equal_sizes(self):
+        """Two equal clusters → entropy = ln(2)."""
+        import math as _math
+        result = ClusterResult(
+            algorithm="gmm", k=2, labels=[0, 0, 1, 1],
+            centroids=[{"lr": 0.01}, {"lr": 0.1}],
+            sizes=[2, 2], gene_names=["lr"],
+            silhouette_score=0.8, bic_scores=None,
+        )
+        bundle = compute_speciation_quality_bundle(result)
+        assert bundle.cluster_size_entropy == pytest.approx(_math.log(2))
+
+    def test_entropy_lower_for_imbalanced_split(self):
+        balanced = ClusterResult(
+            algorithm="gmm", k=2, labels=[0] * 10 + [1] * 10,
+            centroids=[{"lr": 0.01}, {"lr": 0.1}],
+            sizes=[10, 10], gene_names=["lr"],
+            silhouette_score=0.8, bic_scores=None,
+        )
+        imbalanced = ClusterResult(
+            algorithm="gmm", k=2, labels=[0] * 18 + [1] * 2,
+            centroids=[{"lr": 0.01}, {"lr": 0.1}],
+            sizes=[18, 2], gene_names=["lr"],
+            silhouette_score=0.5, bic_scores=None,
+        )
+        assert (compute_speciation_quality_bundle(balanced).cluster_size_entropy
+                > compute_speciation_quality_bundle(imbalanced).cluster_size_entropy)
+
+    def test_entropy_non_negative(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=30)
+        result = detect_clusters_gmm(chromosomes, max_k=3, seed=0)
+        assert compute_speciation_quality_bundle(result).cluster_size_entropy >= 0.0
+
+    # --- n_clusters ---
+
+    def test_n_clusters_matches_result_k(self):
+        for k in (0, 1, 2, 3):
+            sizes = [5] * k
+            labels: List[int] = []
+            for i in range(k):
+                labels.extend([i] * 5)
+            result = ClusterResult(
+                algorithm="gmm", k=k, labels=labels,
+                centroids=[{"lr": 0.01}] * k,
+                sizes=sizes, gene_names=["lr"],
+                silhouette_score=0.5 if k >= 2 else 0.0,
+                bic_scores=None,
+            )
+            assert compute_speciation_quality_bundle(result).n_clusters == k
+
+    # --- end-to-end with real clustering ---
+
+    def test_bimodal_gmm_bundle_sensible_values(self):
+        chromosomes = _bimodal_chromosomes(n_per_cluster=30)
+        result = detect_clusters_gmm(chromosomes, max_k=3, seed=0)
+        bundle = compute_speciation_quality_bundle(result)
+        assert bundle.speciation_index > 0.5
+        assert bundle.raw_silhouette > 0.5
+        assert bundle.noise_fraction == pytest.approx(0.0)
+        assert bundle.cluster_size_entropy > 0.0
+        assert bundle.n_clusters == 2
+
+
+# ---------------------------------------------------------------------------
 # compute_niche_correlation
 # ---------------------------------------------------------------------------
 
@@ -882,6 +1087,82 @@ class TestGeneTrajectoryLoggerSpeciation:
         assert len(step_0_rows) == 1
         assert len(step_2_rows) == 1
         assert step_2_rows[0]["parent_cluster_id"] is None
+
+    def test_quality_bundle_emitted_in_trajectory(self, tmp_path):
+        """With enable_speciation=True, trajectory includes speciation_quality dict."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        agents = (
+            [_make_fake_agent(lr=0.001, gamma=0.99)] * 20
+            + [_make_fake_agent(lr=0.9, gamma=0.1)] * 20
+        )
+        env = _FakeEnvironment(agents)
+        logger = GeneTrajectoryLogger(str(tmp_path), snapshot_interval=1, enable_speciation=True)
+        logger.snapshot(env, step=0)
+        logger.close()
+
+        traj_path = tmp_path / "intrinsic_gene_trajectory.jsonl"
+        rec = json.loads(traj_path.read_text().splitlines()[0])
+        assert "speciation_quality" in rec
+        q = rec["speciation_quality"]
+        assert isinstance(q, dict)
+        assert set(q.keys()) >= {
+            "speciation_index", "raw_silhouette", "noise_fraction",
+            "cluster_size_entropy", "n_clusters",
+        }
+
+    def test_quality_bundle_field_bounds(self, tmp_path):
+        """All quality bundle fields are within their documented bounds."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        agents = (
+            [_make_fake_agent(lr=0.001, gamma=0.99)] * 20
+            + [_make_fake_agent(lr=0.9, gamma=0.1)] * 20
+        )
+        env = _FakeEnvironment(agents)
+        logger = GeneTrajectoryLogger(str(tmp_path), snapshot_interval=1, enable_speciation=True)
+        logger.snapshot(env, step=0)
+        logger.close()
+
+        traj_path = tmp_path / "intrinsic_gene_trajectory.jsonl"
+        q = json.loads(traj_path.read_text().splitlines()[0])["speciation_quality"]
+        assert 0.0 <= q["speciation_index"] <= 1.0
+        assert -1.0 <= q["raw_silhouette"] <= 1.0
+        assert 0.0 <= q["noise_fraction"] <= 1.0
+        assert q["cluster_size_entropy"] >= 0.0
+        assert isinstance(q["n_clusters"], int) and q["n_clusters"] >= 0
+
+    def test_quality_bundle_absent_when_speciation_disabled(self, tmp_path):
+        """Without enable_speciation, trajectory records have no speciation_quality."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        logger = GeneTrajectoryLogger(str(tmp_path), snapshot_interval=1)
+        env = _FakeEnvironment([_make_fake_agent(lr=0.01), _make_fake_agent(lr=0.1)])
+        logger.snapshot(env, step=0)
+        logger.close()
+
+        traj_path = tmp_path / "intrinsic_gene_trajectory.jsonl"
+        rec = json.loads(traj_path.read_text().splitlines()[0])
+        assert "speciation_quality" not in rec
+
+    def test_quality_bundle_speciation_index_matches_top_level(self, tmp_path):
+        """quality bundle's speciation_index must equal the top-level field."""
+        from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
+
+        agents = (
+            [_make_fake_agent(lr=0.001, gamma=0.99)] * 20
+            + [_make_fake_agent(lr=0.9, gamma=0.1)] * 20
+        )
+        env = _FakeEnvironment(agents)
+        logger = GeneTrajectoryLogger(str(tmp_path), snapshot_interval=1, enable_speciation=True)
+        logger.snapshot(env, step=0)
+        logger.close()
+
+        traj_path = tmp_path / "intrinsic_gene_trajectory.jsonl"
+        rec = json.loads(traj_path.read_text().splitlines()[0])
+        assert rec["speciation_quality"]["speciation_index"] == pytest.approx(
+            rec["speciation_index"]
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request adds a new "quality bundle" for speciation analysis, providing richer diagnostics alongside the existing scalar speciation index. It introduces the `SpeciationQualityBundle` dataclass and the `compute_speciation_quality_bundle` function, which together deliver additional metrics such as raw silhouette score, noise fraction, cluster-size entropy, and cluster count. The changes are integrated throughout the speciation analysis API, the gene trajectory logger, and the test suite.

**Enhancements to Speciation Analysis:**

* Added the `SpeciationQualityBundle` dataclass and the `compute_speciation_quality_bundle` function, which returns a bundle of diagnostics including unclipped silhouette score, noise fraction, cluster-size entropy, and number of clusters, supplementing the scalar speciation index. [[1]](diffhunk://#diff-b156f055aa6a9132d524472b587703fedb67934ba8b5b3e030831d8692fb97b8R225-R260) [[2]](diffhunk://#diff-b156f055aa6a9132d524472b587703fedb67934ba8b5b3e030831d8692fb97b8R1151-R1211)
* Updated the public API in `farm/analysis/speciation/__init__.py` to expose `SpeciationQualityBundle` and `compute_speciation_quality_bundle`, and documented their usage in the module docstring. [[1]](diffhunk://#diff-6d39a86319290299f250dd43155bda7bc9d0b1c4e1cc6ca75a68419af2035b05R17-R19) [[2]](diffhunk://#diff-6d39a86319290299f250dd43155bda7bc9d0b1c4e1cc6ca75a68419af2035b05R32-R42) [[3]](diffhunk://#diff-6d39a86319290299f250dd43155bda7bc9d0b1c4e1cc6ca75a68419af2035b05R51) [[4]](diffhunk://#diff-6d39a86319290299f250dd43155bda7bc9d0b1c4e1cc6ca75a68419af2035b05R60) [[5]](diffhunk://#diff-6d39a86319290299f250dd43155bda7bc9d0b1c4e1cc6ca75a68419af2035b05R69) [[6]](diffhunk://#diff-6d39a86319290299f250dd43155bda7bc9d0b1c4e1cc6ca75a68419af2035b05R82)
* Improved the `_silhouette` helper to return the raw silhouette score (possibly negative), rather than clipping to [0, 1], so downstream consumers can access the true signal. [[1]](diffhunk://#diff-b156f055aa6a9132d524472b587703fedb67934ba8b5b3e030831d8692fb97b8L260-R314) [[2]](diffhunk://#diff-b156f055aa6a9132d524472b587703fedb67934ba8b5b3e030831d8692fb97b8L269-R323)

**Integration with Logging and Downstream Consumers:**

* Extended `GeneTrajectoryLogger` to cache and emit the full speciation quality bundle in each trajectory record, and to handle the new field in reserved key collision checks. [[1]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R35) [[2]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R193) [[3]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R258-R266) [[4]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R313) [[5]](diffhunk://#diff-f88bb525481f7bdce646eb9ce70b0b74580f6708f66b6e5e01ebc09043248f70R341-R348)

**Testing and Validation:**

* Updated the test suite to validate the new `compute_speciation_quality_bundle` functionality and import the relevant symbols. [[1]](diffhunk://#diff-1f115c5d91d0105b737c836e1ec29f2d12b123e6fe3b5c046c01e8b278526088R8) [[2]](diffhunk://#diff-1f115c5d91d0105b737c836e1ec29f2d12b123e6fe3b5c046c01e8b278526088L19-R31)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e7e95e9494824b7c44dc91ae3e719e45767b69be. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->