### PR TITLE
Implement initial genotype diversity seeding and configuration enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This repository is being developed to support research in the [Dooders](https://
 - Create specialized agent behaviors and properties
 - Configure simulation parameters and conditions
 - Design custom experiments and scenarios
+- Opt-in [initial genotype diversity](docs/initial_diversity.md) for any simulation - seed the starting population with `independent_mutation`, `unique`, or `min_distance` modes via `SimulationConfig.initial_diversity`
 
 ### [AI & Machine Learning](docs/features/ai_machine_learning.md)
 - Reinforcement learning for agent adaptation

--- a/docs/experiments/intrinsic_evolution/intrinsic_evolution.md
+++ b/docs/experiments/intrinsic_evolution/intrinsic_evolution.md
@@ -78,9 +78,9 @@ environment.
 flowchart TD
     Run["IntrinsicEvolutionExperiment.run()"] --> Sim["run_simulation(..., on_environment_ready, on_step_end)"]
 
-    Sim --> Ready["on_environment_ready(env)"]
-    Ready --> Seed["seed_population_diversity(env, policy)<br/><i>initial diversity</i>"]
-    Seed --> Snap0["GeneTrajectoryLogger.snapshot(env, step=0)<br/><i>core fields only</i>"]
+    Sim --> Diversity["apply_initial_diversity(env, cfg.initial_diversity)<br/><i>platform-wide seeding</i>"]
+    Diversity --> Ready["on_environment_ready(env)"]
+    Ready --> Snap0["GeneTrajectoryLogger.snapshot(env, step=0)<br/><i>core fields only</i>"]
 
     Sim --> Loop["per-step simulation loop"]
     Loop --> Repro["AgentCore.reproduce()"]
@@ -137,7 +137,8 @@ crossover with a co-parent, then mutation, using the policy's knobs.
 
 | Module                                                                                                   | Purpose                                                                                                                                                                                                   |
 | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `[farm/runners/intrinsic_evolution_experiment.py](../../farm/runners/intrinsic_evolution_experiment.py)` | `IntrinsicEvolutionPolicy`, `IntrinsicEvolutionExperimentConfig`, `IntrinsicEvolutionResult`, `seed_population_diversity()`, `IntrinsicEvolutionExperiment`                                               |
+| `[farm/runners/intrinsic_evolution_experiment.py](../../farm/runners/intrinsic_evolution_experiment.py)` | `IntrinsicEvolutionPolicy`, `IntrinsicEvolutionExperimentConfig`, `IntrinsicEvolutionResult`, `IntrinsicEvolutionExperiment`                                                                              |
+| `[farm/core/initial_diversity.py](../../farm/core/initial_diversity.py)`                                | `InitialDiversityConfig`, `SeedingMode`, `apply_initial_diversity()`, `ChromosomeDiversitySource` (platform-wide initial-diversity seeding; runner installs `INDEPENDENT_MUTATION` as the default mode)   |
 | `[farm/runners/gene_trajectory_logger.py](../../farm/runners/gene_trajectory_logger.py)`                 | `GeneTrajectoryLogger`: writes per-step aggregates, periodic full snapshots, and (when `enable_speciation=True`) a cached `speciation_index` on every trajectory line plus a `cluster_lineage.jsonl` file |
 | `[farm/core/agent/core.py](../../farm/core/agent/core.py)`                                               | `AgentCore._derive_child_chromosome` and `_select_coparent` (called from `reproduce`)                                                                                                                     |
 | `[farm/core/simulation.py](../../farm/core/simulation.py)`                                               | `run_simulation(..., on_environment_ready, on_step_end)` callback hooks the runner uses                                                                                                                   |
@@ -163,9 +164,6 @@ base_config = SimulationConfig.from_centralized_config(environment="development"
 
 policy = IntrinsicEvolutionPolicy(
     enabled=True,
-    seed_initial_diversity=True,
-    seed_mutation_rate=1.0,
-    seed_mutation_scale=0.2,
     mutation_rate=0.1,
     mutation_scale=0.1,
     mutation_mode=MutationMode.GAUSSIAN,
@@ -175,6 +173,18 @@ policy = IntrinsicEvolutionPolicy(
     coparent_strategy="nearest_alive_same_type",
     coparent_max_radius=10.0,
 )
+
+# Initial-diversity seeding has been promoted to a platform-wide feature.
+# IntrinsicEvolutionExperiment installs INDEPENDENT_MUTATION as the default
+# when base_config.initial_diversity.mode is NONE.  Override here to opt
+# into a stricter mode (e.g. UNIQUE) for an intrinsic-evolution run.  See
+# docs/initial_diversity.md for the full reference.
+# from farm.core.initial_diversity import InitialDiversityConfig, SeedingMode
+# base_config.initial_diversity = InitialDiversityConfig(
+#     mode=SeedingMode.UNIQUE,
+#     mutation_rate=1.0,
+#     mutation_scale=0.2,
+# )
 
 config = IntrinsicEvolutionExperimentConfig(
     num_steps=2000,
@@ -195,9 +205,6 @@ print(f"Final mean LR: {result.final_gene_statistics['learning_rate']['mean']}")
 | Field                    | Default                        | Meaning                                                                                                                                                          |
 | ------------------------ | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `enabled`                | `True`                         | Master switch. When `False`, reproduction inherits chromosomes unchanged.                                                                                        |
-| `seed_initial_diversity` | `True`                         | Mutate every initial agent's chromosome once before the loop starts so the starting population is not a monoculture.                                             |
-| `seed_mutation_rate`     | `1.0`                          | Per-gene mutation probability for the seed pass.                                                                                                                 |
-| `seed_mutation_scale`    | `0.2`                          | Per-gene scale for the seed pass. Larger spreads the population further.                                                                                         |
 | `mutation_rate`          | `0.1`                          | Per-gene mutation probability at each reproduction event.                                                                                                        |
 | `mutation_scale`         | `0.1`                          | Per-gene scale at each reproduction event.                                                                                                                       |
 | `mutation_mode`          | `MutationMode.GAUSSIAN`        | `gaussian` or `multiplicative`. See `[HyperparameterChromosome` docs](../design/hyperparameter_chromosome.md).                                                   |
@@ -357,14 +364,16 @@ settings". Field meanings:
 are noisy. An agent might "win" because of position, lineage timing, or
 social context rather than its hyperparameters. Replicate runs across
 multiple seeds and look at distributions, not single trajectories.
-- **Sparse initial coverage of genotype space.** When
-`seed_initial_diversity=True` (the default), each starting agent's
-chromosome is mutated independently using `seed_mutation_rate=1.0` and
-`seed_mutation_scale=0.2`. This typically yields one distinct
-chromosome per agent in expectation, but exact uniqueness is not
-guaranteed (collisions are possible, especially with small populations
-or low scales). Statistical power per genotype is low until lineages
-expand.
+- **Sparse initial coverage of genotype space.** The runner installs
+`SimulationConfig.initial_diversity = InitialDiversityConfig(mode=independent_mutation,
+mutation_rate=1.0, mutation_scale=0.2)` by default, so each starting
+agent's chromosome is mutated independently. This typically yields one
+distinct chromosome per agent in expectation, but exact uniqueness is
+not guaranteed (collisions are possible, especially with small
+populations or low scales). Use `SeedingMode.UNIQUE` or
+`SeedingMode.MIN_DISTANCE` for stronger guarantees - see
+[`docs/initial_diversity.md`](../../initial_diversity.md). Statistical
+power per genotype is low until lineages expand.
 - **Crossover requires same `agent_type`.** Cross-type pollination is not
 supported. Co-parent selection always filters to identical
 `agent_type`.
@@ -689,7 +698,8 @@ for snap in snapshots:
 
 ## Testing
 
-- `[tests/runners/test_intrinsic_evolution_experiment.py](../../tests/runners/test_intrinsic_evolution_experiment.py)`: policy / config validation, `seed_population_diversity`, runner orchestration with mocked `run_simulation`, artifact persistence (including the `speciation` block in `intrinsic_evolution_metadata.json` for both default-disabled and explicitly-enabled logger configurations), `ReproductionPressureConfig` validation, `selection_pressure` presets (none/low/medium/high/float), `_compute_effective_reproduction_cost` unit tests, trajectory telemetry field presence, and zero birth/death rates for stable populations.
+- `[tests/runners/test_intrinsic_evolution_experiment.py](../../tests/runners/test_intrinsic_evolution_experiment.py)`: policy / config validation, runner-level installation of platform-wide initial-diversity defaults, runner orchestration with mocked `run_simulation`, artifact persistence (including the `speciation` and `initial_diversity` blocks in `intrinsic_evolution_metadata.json` for both default-disabled and explicitly-enabled logger configurations), `ReproductionPressureConfig` validation, `selection_pressure` presets (none/low/medium/high/float), `_compute_effective_reproduction_cost` unit tests, trajectory telemetry field presence, and zero birth/death rates for stable populations.
+- `[tests/core/test_initial_diversity.py](../../tests/core/test_initial_diversity.py)` and `[tests/core/test_simulation_initial_diversity.py](../../tests/core/test_simulation_initial_diversity.py)`: behavioural tests for the platform-wide seeding feature - mode validation, `INDEPENDENT_MUTATION` / `UNIQUE` / `MIN_DISTANCE` correctness, fallback semantics, determinism, decision-module reinitialization, and end-to-end wiring through `run_simulation`.
 - `[tests/core/agent/test_reproduce_chromosome_policy.py](../../tests/core/agent/test_reproduce_chromosome_policy.py)`: no-policy passthrough, mutation path, co-parent selection (nearest, random, radius, type-filter, alive-filter), crossover end-to-end.
 - `[tests/test_agent_reproduction_hyperparameters.py](../../tests/test_agent_reproduction_hyperparameters.py)`: updated to assert the new contract (no policy = inheritance unchanged).
 - `[tests/analysis/test_intrinsic_lineage.py](../../tests/analysis/test_intrinsic_lineage.py)`: `load_intrinsic_snapshots`, `flatten_snapshots_to_agent_records`, `build_intrinsic_lineage_dag`, `compute_surviving_lineage_count_over_time`, `compute_lineage_depth_over_time`, `extract_chromosomes_from_snapshots`, `plot_intrinsic_lineage_tree` (with and without gene colouring).

--- a/docs/initial_diversity.md
+++ b/docs/initial_diversity.md
@@ -1,0 +1,120 @@
+# Initial Genotype Diversity
+
+AgentFarm can seed each starting agent with a slightly different
+hyperparameter chromosome before the simulation loop begins. This produces a
+non-monoculture starting population so subsequent learning, reproduction, and
+selection have a richer search space to work with from step zero.
+
+This is a **platform-wide feature**: every simulation can opt in via a single
+config block; the intrinsic-evolution runner installs a non-trivial mode by
+default. Off by default for ordinary simulations so existing baselines remain
+behaviorally identical.
+
+## Configuration
+
+Driven by `SimulationConfig.initial_diversity`, which is an
+[`InitialDiversityConfig`](../farm/core/initial_diversity.py).
+
+```python
+from farm.config import SimulationConfig
+from farm.core.initial_diversity import InitialDiversityConfig, SeedingMode
+
+config = SimulationConfig.from_centralized_config(environment="development")
+config.initial_diversity = InitialDiversityConfig(
+    mode=SeedingMode.UNIQUE,
+    mutation_rate=1.0,
+    mutation_scale=0.2,
+    max_retries_per_agent=32,
+    seed=42,  # optional; defaults to the simulation seed
+)
+```
+
+You can also set the same fields from the CLI when running
+`python run_simulation.py`:
+
+```bash
+python run_simulation.py \
+  --initial-diversity-mode unique \
+  --initial-diversity-mutation-rate 1.0 \
+  --initial-diversity-mutation-scale 0.2 \
+  --initial-diversity-max-retries 32 \
+  --seed 42
+```
+
+## Modes
+
+| Mode | Behavior | Guarantees |
+|---|---|---|
+| `none` | Skip seeding; chromosomes stay at their config defaults. | Backwards compatible; zero-cost. |
+| `independent_mutation` | Mutate every agent independently using `mutation_rate` / `mutation_scale`. | Best-effort diversity; collisions possible at small populations. |
+| `unique` | Independent mutation with bounded retries until each chromosome is novel at the gene encoding precision. | Distinct chromosomes when `max_retries_per_agent` allows; otherwise records `fallbacks > 0`. |
+| `min_distance` | Independent mutation with bounded retries until each chromosome is at least `min_distance` away (normalized Euclidean over evolvable genes) from every previously accepted chromosome. | Pairwise distance lower bound when satisfiable; otherwise records `fallbacks > 0`. |
+
+Strict modes (`unique`, `min_distance`) **always terminate**: once
+`max_retries_per_agent` candidates have been drawn for an agent, the latest
+candidate is accepted and the metrics report a fallback. Choose
+`mutation_scale` and `min_distance` together to keep fallbacks low.
+
+## Telemetry
+
+Every seeding pass returns an
+[`InitialDiversityMetrics`](../farm/core/initial_diversity.py) instance,
+attached to the environment as `environment.initial_diversity_metrics`:
+
+| Field | Description |
+|---|---|
+| `mode` | Seeding mode that produced the report. |
+| `agents_processed` | Number of agents whose chromosomes were considered. |
+| `unique_count` | Distinct chromosome signatures observed (encoding precision). |
+| `collision_count` | Accepted chromosomes whose signature matched a prior accepted one. |
+| `retries_used` | Total failed candidate draws across all agents. |
+| `fallbacks` | Number of agents accepted under fallback (retries exhausted). |
+| `min_pairwise_distance` | Smallest normalized Euclidean distance between accepted chromosomes. |
+| `mean_pairwise_distance` | Mean normalized Euclidean distance across all accepted pairs. |
+| `notes` | Human-readable diagnostics surfaced during seeding. |
+
+When `mode != none`, `run_simulation` also:
+
+- Emits a structured `initial_diversity_seeded` log event carrying the same fields.
+- Writes `<output_dir>/initial_diversity_metadata.json` next to the simulation database.
+
+The intrinsic-evolution runner additionally embeds the metrics in
+`intrinsic_evolution_metadata.json` under the `initial_diversity_metrics` key
+and the resolved config under `initial_diversity`.
+
+## Determinism
+
+Seeding uses `random.Random(seed)` with `seed = cfg.seed if cfg.seed is not
+None else simulation_seed`. Two runs with the same simulation seed (and
+unchanged config) produce identical seeded chromosomes and identical metrics.
+
+## Intrinsic evolution defaults
+
+`IntrinsicEvolutionExperiment.run()` sets
+`base_config.initial_diversity = InitialDiversityConfig(mode=independent_mutation, mutation_rate=1.0, mutation_scale=0.2, ...)`
+when the caller leaves `mode=none`. Pass an explicit `InitialDiversityConfig`
+on `base_config` to opt into a stricter mode (e.g. `unique`) for an
+intrinsic-evolution run. See
+[`docs/experiments/intrinsic_evolution/intrinsic_evolution.md`](experiments/intrinsic_evolution/intrinsic_evolution.md)
+for runner-specific guidance.
+
+## Pluggable diversity sources
+
+`apply_initial_diversity(environment, cfg, rng, source=...)` accepts any
+implementation of the [`InitialDiversitySource`](../farm/core/initial_diversity.py)
+`Protocol`:
+
+```python
+class InitialDiversitySource(Protocol):
+    def seed(
+        self,
+        environment: Any,
+        cfg: InitialDiversityConfig,
+        rng: random.Random,
+    ) -> InitialDiversityMetrics: ...
+```
+
+The default implementation is `ChromosomeDiversitySource`, which mutates each
+agent's `hyperparameter_chromosome`. Future scopes (per-agent-type
+parameters, decision-module weights, spatial layouts) can ship as additional
+sources without changing the orchestration contract.

--- a/farm/config/config.py
+++ b/farm/config/config.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 
+from farm.core.initial_diversity import InitialDiversityConfig, SeedingMode
 from farm.core.observations import ObservationConfig
 
 
@@ -851,6 +852,10 @@ class SimulationConfig:
     observation: Optional[ObservationConfig] = None
     redis: RedisMemoryConfig = field(default_factory=RedisMemoryConfig)
 
+    # Platform-wide initial genotype diversity (off by default; opt in per
+    # simulation or via the intrinsic-evolution runner's defaults).
+    initial_diversity: InitialDiversityConfig = field(default_factory=InitialDiversityConfig)
+
     # Analysis configurations
     spatial_analysis: SpatialAnalysisConfig = field(default_factory=SpatialAnalysisConfig)
     genesis_analysis: GenesisAnalysisConfig = field(default_factory=GenesisAnalysisConfig)
@@ -879,6 +884,8 @@ class SimulationConfig:
                 config_dict[key] = self.visualization.to_dict()
             elif key == "redis":
                 config_dict[key] = self.redis.to_dict()
+            elif key == "initial_diversity":
+                config_dict[key] = self.initial_diversity.to_dict()
             elif key == "analysis_global":
                 config_dict[key] = self.analysis_global.to_dict()
             elif key in [
@@ -957,6 +964,16 @@ class SimulationConfig:
             nested_data["redis"] = redis_data
         else:
             nested_data["redis"] = RedisMemoryConfig(**redis_data)
+
+        # Handle initial_diversity config specially (frozen dataclass with
+        # enum-typed fields that the constructor coerces from strings).
+        diversity_data = nested_data.pop("initial_diversity", None)
+        if isinstance(diversity_data, InitialDiversityConfig):
+            nested_data["initial_diversity"] = diversity_data
+        elif diversity_data is None:
+            nested_data["initial_diversity"] = InitialDiversityConfig()
+        else:
+            nested_data["initial_diversity"] = InitialDiversityConfig(**diversity_data)
 
         # Handle analysis configs specially
         analysis_configs = {

--- a/farm/config/config.py
+++ b/farm/config/config.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 
-from farm.core.initial_diversity import InitialDiversityConfig, SeedingMode
+from farm.core.initial_diversity import InitialDiversityConfig
 from farm.core.observations import ObservationConfig
 
 

--- a/farm/core/initial_diversity.py
+++ b/farm/core/initial_diversity.py
@@ -41,7 +41,7 @@ import random
 import statistics
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Iterable, List, Mapping, Optional, Protocol, Tuple
+from typing import Any, List, Mapping, Optional, Protocol, Tuple
 
 from farm.core.hyperparameter_chromosome import (
     BoundaryMode,

--- a/farm/core/initial_diversity.py
+++ b/farm/core/initial_diversity.py
@@ -347,11 +347,10 @@ class ChromosomeDiversitySource:
             accepted_vectors.append(_normalized_gene_vector(chosen))
             _apply_chromosome_to_agent(agent, chosen)
 
-            # Late-binding sanity note: if the user asked for a minimum distance
-            # but we accepted under fallback, surface the violation.
-            if collided and cfg.mode is SeedingMode.UNIQUE and not fell_back:
-                # Unreachable in practice because we only mark `collided=True`
-                # when we exhausted retries; left as defensive bookkeeping.
+            # In UNIQUE mode, if retries were exhausted and we accepted a
+            # fallback candidate that duplicates an existing signature,
+            # surface the violation for downstream auditing.
+            if collided and cfg.mode is SeedingMode.UNIQUE and fell_back:
                 metrics.notes.append(
                     f"agent={getattr(agent, 'agent_id', '?')} accepted duplicate signature."
                 )

--- a/farm/core/initial_diversity.py
+++ b/farm/core/initial_diversity.py
@@ -1,0 +1,491 @@
+"""Platform-wide initial genotype diversity for simulation startup.
+
+This module implements the seeding feature originally introduced for the
+intrinsic-evolution runner as a first-class capability available to **every**
+simulation.  Callers opt in via :class:`InitialDiversityConfig` on
+:class:`farm.config.SimulationConfig`; :func:`apply_initial_diversity` is
+invoked from :func:`farm.core.simulation.run_simulation` immediately after the
+initial agent population is created and before any ``on_environment_ready``
+hook fires.
+
+Design notes (see ``docs/initial_diversity.md`` for user-facing docs):
+
+- :class:`InitialDiversitySource` is a narrow ``Protocol`` so additional
+  genotype scopes (per-agent type parameters, decision-module weights,
+  spatial layouts, etc.) can ship later without changing the orchestration
+  contract or :class:`InitialDiversityConfig`.
+- :class:`ChromosomeDiversitySource` is the default implementation and reuses
+  the existing :func:`farm.core.hyperparameter_chromosome.mutate_chromosome`
+  primitive.  It supports four modes:
+
+  - ``NONE``: no-op; callers receive zeroed metrics.
+  - ``INDEPENDENT_MUTATION``: matches the legacy intrinsic-evolution seeding.
+  - ``UNIQUE``: bounded retries until each accepted chromosome is novel
+    against all previously accepted ones at the gene encoding precision.
+  - ``MIN_DISTANCE``: bounded retries until each accepted chromosome is at
+    least ``cfg.min_distance`` away (normalized Euclidean over evolvable
+    genes) from every previously accepted chromosome.
+
+  Strict modes always accept the latest sample once retries are exhausted
+  and increment ``fallbacks`` so callers can audit how often the constraint
+  could not be satisfied.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import math
+import os
+import random
+import statistics
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Iterable, List, Mapping, Optional, Protocol, Tuple
+
+from farm.core.hyperparameter_chromosome import (
+    BoundaryMode,
+    GeneEncodingSpec,
+    HyperparameterChromosome,
+    MutationMode,
+    apply_chromosome_to_learning_config,
+    encode_chromosome_vector,
+    mutate_chromosome,
+)
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class SeedingMode(str, Enum):
+    """Strategies for seeding initial genotype diversity.
+
+    - ``NONE``: leave the starting population untouched.
+    - ``INDEPENDENT_MUTATION``: mutate each agent independently.  Matches the
+      legacy intrinsic-evolution seeding behaviour.
+    - ``UNIQUE``: independent mutation with bounded retries until each
+      chromosome is unique at the gene encoding precision.
+    - ``MIN_DISTANCE``: independent mutation with bounded retries until each
+      chromosome is at least ``min_distance`` away (normalized Euclidean
+      across evolvable genes) from all previously accepted chromosomes.
+    """
+
+    NONE = "none"
+    INDEPENDENT_MUTATION = "independent_mutation"
+    UNIQUE = "unique"
+    MIN_DISTANCE = "min_distance"
+
+
+@dataclass(frozen=True)
+class InitialDiversityConfig:
+    """Configuration for platform-wide initial genotype diversity seeding.
+
+    Attributes:
+        mode: Which seeding strategy to apply.  Default ``NONE`` keeps
+            existing simulations unchanged.
+        mutation_rate: Probability of mutating each evolvable gene per draw.
+            Must be in ``[0, 1]``.
+        mutation_scale: Perturbation scale passed to ``mutate_chromosome``.
+            Must be non-negative.
+        mutation_mode: Perturbation operator (``gaussian`` or
+            ``multiplicative``).
+        boundary_mode: Out-of-range handling for mutated values.
+        interior_bias_fraction: Inward nudge fraction used by
+            :attr:`BoundaryMode.INTERIOR_BIASED`.  Must be non-negative.
+        max_retries_per_agent: Upper bound on retries per agent in strict
+            modes (``UNIQUE`` / ``MIN_DISTANCE``).  Must be at least 1.
+        min_distance: Minimum normalized Euclidean distance between any two
+            accepted chromosomes in ``MIN_DISTANCE`` mode.  Must be
+            non-negative; values larger than ``sqrt(num_evolvable_genes)``
+            are unsatisfiable in the unit hypercube.
+        seed: Optional override for the seeding RNG; when ``None`` the
+            simulation seed is used so the same simulation seed yields the
+            same initial population.
+    """
+
+    mode: SeedingMode = SeedingMode.NONE
+    mutation_rate: float = 1.0
+    mutation_scale: float = 0.2
+    mutation_mode: MutationMode = MutationMode.GAUSSIAN
+    boundary_mode: BoundaryMode = BoundaryMode.CLAMP
+    interior_bias_fraction: float = 1e-3
+    max_retries_per_agent: int = 32
+    min_distance: float = 0.05
+    seed: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.mutation_rate <= 1.0:
+            raise ValueError("mutation_rate must be between 0 and 1.")
+        if self.mutation_scale < 0.0:
+            raise ValueError("mutation_scale must be non-negative.")
+        if self.interior_bias_fraction < 0.0:
+            raise ValueError("interior_bias_fraction must be non-negative.")
+        if self.max_retries_per_agent < 1:
+            raise ValueError("max_retries_per_agent must be at least 1.")
+        if self.min_distance < 0.0:
+            raise ValueError("min_distance must be non-negative.")
+        # Coerce string-friendly enum values to enum instances; raises for invalid values.
+        object.__setattr__(self, "mode", SeedingMode(self.mode))
+        object.__setattr__(self, "mutation_mode", MutationMode(self.mutation_mode))
+        object.__setattr__(self, "boundary_mode", BoundaryMode(self.boundary_mode))
+
+    def to_dict(self) -> dict:
+        """Render config as a JSON-friendly dict, coercing enums to their values."""
+        raw = dataclasses.asdict(self)
+        for key in ("mode", "mutation_mode", "boundary_mode"):
+            value = raw.get(key)
+            if hasattr(value, "value"):
+                raw[key] = value.value
+        return raw
+
+
+@dataclass
+class InitialDiversityMetrics:
+    """Outcome telemetry from an initial-diversity seeding pass.
+
+    Attributes:
+        mode: The seeding mode that produced this report.
+        agents_processed: Number of agents whose chromosomes were considered.
+        unique_count: Number of distinct chromosome signatures observed
+            after seeding (at gene encoding precision).
+        collision_count: Number of accepted chromosomes whose signature
+            matched a previously accepted one.  Always 0 in ``UNIQUE`` mode
+            unless retries were exhausted (``fallbacks > 0``).
+        retries_used: Total number of failed candidate draws across all
+            agents.  Zero for ``NONE`` and ``INDEPENDENT_MUTATION``.
+        fallbacks: Number of agents whose final chromosome had to be
+            accepted under fallback because retries were exhausted.
+        min_pairwise_distance: Smallest normalized Euclidean distance
+            between any two accepted chromosomes.  ``None`` when fewer
+            than 2 chromosomes were processed.
+        mean_pairwise_distance: Mean normalized Euclidean distance across
+            all accepted chromosome pairs.  ``None`` when fewer than 2
+            chromosomes were processed.
+        notes: Optional human-readable diagnostics surfaced during seeding.
+    """
+
+    mode: SeedingMode
+    agents_processed: int = 0
+    unique_count: int = 0
+    collision_count: int = 0
+    retries_used: int = 0
+    fallbacks: int = 0
+    min_pairwise_distance: Optional[float] = None
+    mean_pairwise_distance: Optional[float] = None
+    notes: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Render metrics as a JSON-friendly dict, coercing the mode enum."""
+        raw = dataclasses.asdict(self)
+        mode_value = raw.get("mode")
+        if hasattr(mode_value, "value"):
+            raw["mode"] = mode_value.value
+        return raw
+
+
+class InitialDiversitySource(Protocol):
+    """Pluggable strategy that seeds diversity into the starting population.
+
+    Implementations receive the live ``environment``, the user-supplied
+    :class:`InitialDiversityConfig`, and a seeded :class:`random.Random`.
+    They are expected to return :class:`InitialDiversityMetrics` describing
+    the outcome.  Implementations should treat the environment as live state:
+    they may mutate agent attributes in place, but should not rely on a
+    specific ``Environment`` class beyond the iteration contract documented
+    by ``ChromosomeDiversitySource``.
+    """
+
+    def seed(  # pragma: no cover - Protocol method
+        self,
+        environment: Any,
+        cfg: InitialDiversityConfig,
+        rng: random.Random,
+    ) -> InitialDiversityMetrics: ...
+
+
+def _chromosome_signature(
+    chromosome: HyperparameterChromosome,
+    *,
+    encoding_specs: Optional[Mapping[str, GeneEncodingSpec]] = None,
+) -> Tuple[float, ...]:
+    """Quantize a chromosome to its gene encoding precision.
+
+    Two chromosomes that differ only below the smallest encoding bucket map
+    to the same signature, so uniqueness is meaningful at the precision the
+    learning agents actually express.
+    """
+    return encode_chromosome_vector(
+        chromosome,
+        include_fixed=False,
+        encoding_specs=encoding_specs,
+    )
+
+
+def _normalized_gene_vector(chromosome: HyperparameterChromosome) -> Tuple[float, ...]:
+    """Project a chromosome's evolvable genes into the unit hypercube.
+
+    For ``min_value == max_value`` genes the projection is ``0.0`` so the
+    distance contribution is zero (the locus carries no diversity).
+    """
+    coords: List[float] = []
+    for gene in chromosome.genes:
+        if not gene.evolvable:
+            continue
+        span = gene.max_value - gene.min_value
+        if span == 0.0:
+            coords.append(0.0)
+            continue
+        coords.append((gene.value - gene.min_value) / span)
+    return tuple(coords)
+
+
+def _pairwise_distance(a: Tuple[float, ...], b: Tuple[float, ...]) -> float:
+    if len(a) != len(b):
+        raise ValueError("Chromosome vectors must have matching length.")
+    return math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b)))
+
+
+def _compute_pairwise_summary(
+    vectors: List[Tuple[float, ...]],
+) -> Tuple[Optional[float], Optional[float]]:
+    """Return (min_distance, mean_distance) over all unordered pairs.
+
+    Returns ``(None, None)`` for fewer than 2 vectors.  The cost is
+    O(n^2), which is acceptable because seeding runs once per simulation
+    over modest populations; if very large populations become routine this
+    can be replaced with a spatial structure without changing the public
+    metrics contract.
+    """
+    if len(vectors) < 2:
+        return None, None
+    distances: List[float] = []
+    for i in range(len(vectors)):
+        for j in range(i + 1, len(vectors)):
+            distances.append(_pairwise_distance(vectors[i], vectors[j]))
+    if not distances:
+        return None, None
+    return min(distances), statistics.fmean(distances)
+
+
+def _apply_chromosome_to_agent(agent: Any, chromosome: HyperparameterChromosome) -> None:
+    """Push a freshly seeded chromosome into the agent and any live module.
+
+    This preserves the two-stage update used by the legacy intrinsic-evolution
+    seeding: rewrite ``hyperparameter_chromosome``, recompute the learning
+    config, and reinitialize the decision module's algorithm when one already
+    exists so optimizer hyperparameters track the seeded values.
+    """
+    agent.hyperparameter_chromosome = chromosome
+    new_decision_config = apply_chromosome_to_learning_config(
+        agent.config.decision, chromosome
+    )
+    agent.config.decision = new_decision_config
+
+    behavior = getattr(agent, "behavior", None)
+    decision_module = getattr(behavior, "decision_module", None)
+    reinitialize = getattr(decision_module, "reinitialize_algorithm", None)
+    if callable(reinitialize):
+        reinitialize(new_decision_config)
+
+
+class ChromosomeDiversitySource:
+    """Default seeding source that mutates each agent's hyperparameter chromosome.
+
+    The source iterates ``environment.agent_objects`` in order, skipping any
+    agent without a ``hyperparameter_chromosome``.  For each agent it draws
+    candidate mutations via :func:`mutate_chromosome` and, depending on
+    ``cfg.mode``, either accepts the first draw or retries until uniqueness
+    or a minimum distance constraint is met.  Strict modes accept the last
+    drawn candidate when ``cfg.max_retries_per_agent`` is exhausted and
+    record a fallback.
+    """
+
+    def __init__(
+        self,
+        encoding_specs: Optional[Mapping[str, GeneEncodingSpec]] = None,
+    ) -> None:
+        self._encoding_specs = encoding_specs
+
+    def seed(
+        self,
+        environment: Any,
+        cfg: InitialDiversityConfig,
+        rng: random.Random,
+    ) -> InitialDiversityMetrics:
+        if cfg.mode is SeedingMode.NONE:
+            return InitialDiversityMetrics(mode=SeedingMode.NONE)
+
+        agents: List[Any] = [
+            agent
+            for agent in environment.agent_objects
+            if getattr(agent, "hyperparameter_chromosome", None) is not None
+        ]
+
+        metrics = InitialDiversityMetrics(mode=cfg.mode)
+        accepted_signatures: set = set()
+        accepted_vectors: List[Tuple[float, ...]] = []
+
+        for agent in agents:
+            chromosome = agent.hyperparameter_chromosome
+            chosen, attempts, fell_back, collided = self._draw_candidate(
+                chromosome=chromosome,
+                cfg=cfg,
+                rng=rng,
+                accepted_signatures=accepted_signatures,
+                accepted_vectors=accepted_vectors,
+            )
+
+            metrics.agents_processed += 1
+            metrics.retries_used += max(attempts - 1, 0)
+            if fell_back:
+                metrics.fallbacks += 1
+
+            signature = _chromosome_signature(chosen, encoding_specs=self._encoding_specs)
+            if signature in accepted_signatures:
+                metrics.collision_count += 1
+            accepted_signatures.add(signature)
+            accepted_vectors.append(_normalized_gene_vector(chosen))
+            _apply_chromosome_to_agent(agent, chosen)
+
+            # Late-binding sanity note: if the user asked for a minimum distance
+            # but we accepted under fallback, surface the violation.
+            if collided and cfg.mode is SeedingMode.UNIQUE and not fell_back:
+                # Unreachable in practice because we only mark `collided=True`
+                # when we exhausted retries; left as defensive bookkeeping.
+                metrics.notes.append(
+                    f"agent={getattr(agent, 'agent_id', '?')} accepted duplicate signature."
+                )
+
+        metrics.unique_count = len(accepted_signatures)
+        min_d, mean_d = _compute_pairwise_summary(accepted_vectors)
+        metrics.min_pairwise_distance = min_d
+        metrics.mean_pairwise_distance = mean_d
+        return metrics
+
+    def _draw_candidate(
+        self,
+        *,
+        chromosome: HyperparameterChromosome,
+        cfg: InitialDiversityConfig,
+        rng: random.Random,
+        accepted_signatures: set,
+        accepted_vectors: List[Tuple[float, ...]],
+    ) -> Tuple[HyperparameterChromosome, int, bool, bool]:
+        """Return ``(chromosome, attempts, fell_back, collided)``.
+
+        ``attempts`` is the number of mutate_chromosome calls made (>=1).
+        ``fell_back`` is True if a strict mode exhausted retries.
+        ``collided`` flags an accepted-with-collision in UNIQUE mode after fallback.
+        """
+        last_candidate: Optional[HyperparameterChromosome] = None
+        attempts = 0
+        retry_budget = cfg.max_retries_per_agent if cfg.mode in (
+            SeedingMode.UNIQUE,
+            SeedingMode.MIN_DISTANCE,
+        ) else 1
+
+        for _ in range(retry_budget):
+            attempts += 1
+            candidate = mutate_chromosome(
+                chromosome,
+                mutation_rate=cfg.mutation_rate,
+                mutation_scale=cfg.mutation_scale,
+                mutation_mode=cfg.mutation_mode,
+                boundary_mode=cfg.boundary_mode,
+                interior_bias_fraction=cfg.interior_bias_fraction,
+                rng=rng,
+            )
+            last_candidate = candidate
+
+            if cfg.mode is SeedingMode.INDEPENDENT_MUTATION:
+                return candidate, attempts, False, False
+
+            if cfg.mode is SeedingMode.UNIQUE:
+                signature = _chromosome_signature(candidate, encoding_specs=self._encoding_specs)
+                if signature not in accepted_signatures:
+                    return candidate, attempts, False, False
+                continue
+
+            # SeedingMode.MIN_DISTANCE
+            vector = _normalized_gene_vector(candidate)
+            ok = all(
+                _pairwise_distance(vector, prev) >= cfg.min_distance
+                for prev in accepted_vectors
+            )
+            if ok:
+                return candidate, attempts, False, False
+
+        # Fallback: strict mode exhausted retries; accept the last candidate
+        # so seeding is bounded and deterministic.
+        assert last_candidate is not None  # retry_budget >= 1 guarantees this
+        collided = False
+        if cfg.mode is SeedingMode.UNIQUE:
+            signature = _chromosome_signature(last_candidate, encoding_specs=self._encoding_specs)
+            collided = signature in accepted_signatures
+        return last_candidate, attempts, True, collided
+
+
+def apply_initial_diversity(
+    environment: Any,
+    cfg: InitialDiversityConfig,
+    rng: random.Random,
+    *,
+    source: Optional[InitialDiversitySource] = None,
+) -> InitialDiversityMetrics:
+    """Seed the population's initial genotype diversity.
+
+    Returns an :class:`InitialDiversityMetrics` describing the outcome.
+    When ``cfg.mode`` is :attr:`SeedingMode.NONE`, returns a zeroed report
+    and does not touch any agent.  Otherwise the work is delegated to
+    ``source`` (defaults to :class:`ChromosomeDiversitySource`).
+    """
+    if cfg.mode is SeedingMode.NONE:
+        return InitialDiversityMetrics(mode=SeedingMode.NONE)
+    seeder = source if source is not None else ChromosomeDiversitySource()
+    return seeder.seed(environment, cfg, rng)
+
+
+def persist_initial_diversity_metrics(
+    output_dir: str,
+    metrics: InitialDiversityMetrics,
+    *,
+    filename: str = "initial_diversity_metadata.json",
+) -> str:
+    """Write metrics to ``<output_dir>/<filename>`` and return the path.
+
+    Creates ``output_dir`` if it does not yet exist.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, filename)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(metrics.to_dict(), handle, indent=2)
+    return path
+
+
+def emit_initial_diversity_event(
+    metrics: InitialDiversityMetrics,
+    *,
+    event_logger=logger,
+) -> None:
+    """Emit a structlog event summarizing the seeding outcome.
+
+    Centralized here so callers (currently :func:`run_simulation`) get
+    consistent field names and downstream analysis tooling can rely on
+    them.
+    """
+    event_logger.info(
+        "initial_diversity_seeded",
+        **metrics.to_dict(),
+    )
+
+
+__all__ = [
+    "ChromosomeDiversitySource",
+    "InitialDiversityConfig",
+    "InitialDiversityMetrics",
+    "InitialDiversitySource",
+    "SeedingMode",
+    "apply_initial_diversity",
+    "emit_initial_diversity_event",
+    "persist_initial_diversity_metrics",
+]

--- a/farm/core/simulation.py
+++ b/farm/core/simulation.py
@@ -46,6 +46,12 @@ from tqdm import tqdm
 from farm.config import SimulationConfig
 from farm.core.agent import AgentFactory, AgentServices
 from farm.core.environment import Environment
+from farm.core.initial_diversity import (
+    SeedingMode,
+    apply_initial_diversity,
+    emit_initial_diversity_event,
+    persist_initial_diversity_metrics,
+)
 from farm.utils.identity import Identity
 from farm.utils.logging import configure_logging, get_logger, log_simulation, log_step
 
@@ -474,11 +480,24 @@ def run_simulation(
             config.population.chaos_agents,
         )
 
-        # Allow callers to attach per-environment policy / state, seed
-        # population diversity, etc., after agents exist but before the
-        # initial DB flush.  Mutations made here (e.g., chromosome seeding)
-        # will therefore be captured by the flush below and keep in-memory
-        # state in sync with persisted records.
+        # Apply platform-wide initial genotype diversity (off by default; opt
+        # in via config.initial_diversity).  Runs before any caller-supplied
+        # on_environment_ready hook so downstream policy attachment / step-0
+        # snapshots observe the seeded chromosomes.
+        diversity_cfg = config.initial_diversity
+        seeding_seed = diversity_cfg.seed if diversity_cfg.seed is not None else seed
+        seeding_rng = random.Random(seeding_seed)
+        diversity_metrics = apply_initial_diversity(environment, diversity_cfg, seeding_rng)
+        environment.initial_diversity_metrics = diversity_metrics
+        if diversity_cfg.mode is not SeedingMode.NONE:
+            emit_initial_diversity_event(diversity_metrics)
+            if path is not None:
+                persist_initial_diversity_metrics(path, diversity_metrics)
+
+        # Allow callers to attach per-environment policy / state, etc., after
+        # agents exist (and after diversity seeding) but before the initial
+        # DB flush.  Mutations made here will therefore be captured by the
+        # flush below and keep in-memory state in sync with persisted records.
         if on_environment_ready is not None:
             on_environment_ready(environment)
 

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -26,9 +26,11 @@ from farm.core.hyperparameter_chromosome import (
     CrossoverMode,
     HyperparameterChromosome,
     MutationMode,
-    apply_chromosome_to_learning_config,
     compute_gene_statistics,
-    mutate_chromosome,
+)
+from farm.core.initial_diversity import (
+    InitialDiversityConfig,
+    SeedingMode,
 )
 from farm.core.simulation import run_simulation
 from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger
@@ -127,12 +129,6 @@ class IntrinsicEvolutionPolicy:
 
     Attributes:
         enabled: Master switch for in-situ chromosome inheritance.
-        seed_initial_diversity: When ``True``, the runner mutates every
-            initial agent's chromosome once before the loop starts so the
-            starting population is not a monoculture.
-        seed_mutation_rate / seed_mutation_scale: Mutation knobs used **only**
-            for the initial diversity seed.  Defaults are intentionally larger
-            than per-reproduction values to spread the starting population.
         mutation_rate / mutation_scale / mutation_mode: Per-reproduction
             mutation parameters threaded through to
             :func:`mutate_chromosome`.
@@ -171,9 +167,6 @@ class IntrinsicEvolutionPolicy:
     """
 
     enabled: bool = True
-    seed_initial_diversity: bool = True
-    seed_mutation_rate: float = 1.0
-    seed_mutation_scale: float = 0.2
     mutation_rate: float = 0.1
     mutation_scale: float = 0.1
     mutation_mode: MutationMode = MutationMode.GAUSSIAN
@@ -197,10 +190,6 @@ class IntrinsicEvolutionPolicy:
             raise ValueError("mutation_rate must be between 0 and 1.")
         if self.mutation_scale < 0.0:
             raise ValueError("mutation_scale must be non-negative.")
-        if not 0.0 <= self.seed_mutation_rate <= 1.0:
-            raise ValueError("seed_mutation_rate must be between 0 and 1.")
-        if self.seed_mutation_scale < 0.0:
-            raise ValueError("seed_mutation_scale must be non-negative.")
         if self.interior_bias_fraction < 0.0:
             raise ValueError("interior_bias_fraction must be non-negative.")
         if self.blend_alpha < 0.0:
@@ -254,54 +243,6 @@ class IntrinsicEvolutionResult:
     final_gene_statistics: Dict[str, Dict[str, float]]
 
 
-def seed_population_diversity(
-    environment: Any,
-    policy: IntrinsicEvolutionPolicy,
-    rng: random.Random,
-) -> None:
-    """Mutate each initial agent's chromosome to spread the starting population.
-
-    When ``policy.seed_initial_diversity`` is ``False`` this is a no-op.
-    Both the agent's ``hyperparameter_chromosome`` attribute and its
-    ``config.decision`` are updated so subsequent decision-module construction
-    sees the seeded values.  If the agent already has a ``LearningAgentBehavior``
-    with a ``DecisionModule`` (i.e., the module was constructed before seeding),
-    the module's config is updated and its algorithm is reinitialized so that
-    optimizer hyper-parameters (LR, gamma, …) reflect the seeded chromosome.
-    """
-    if not policy.seed_initial_diversity:
-        return
-
-    for agent in list(environment.agent_objects):
-        chromosome = getattr(agent, "hyperparameter_chromosome", None)
-        if chromosome is None:
-            continue
-        mutated = mutate_chromosome(
-            chromosome,
-            mutation_rate=policy.seed_mutation_rate,
-            mutation_scale=policy.seed_mutation_scale,
-            mutation_mode=policy.mutation_mode,
-            boundary_mode=policy.boundary_mode,
-            interior_bias_fraction=policy.interior_bias_fraction,
-            rng=rng,
-        )
-        agent.hyperparameter_chromosome = mutated
-        new_decision_config = apply_chromosome_to_learning_config(
-            agent.config.decision, mutated
-        )
-        agent.config.decision = new_decision_config
-
-        # If a decision module was already constructed (common when
-        # on_environment_ready fires after create_initial_agents), update its
-        # config and reinitialize the algorithm so the optimizer reflects the
-        # seeded hyperparameters rather than the pre-seed defaults.
-        behavior = getattr(agent, "behavior", None)
-        decision_module = getattr(behavior, "decision_module", None)
-        reinitialize = getattr(decision_module, "reinitialize_algorithm", None)
-        if callable(reinitialize):
-            reinitialize(new_decision_config)
-
-
 class IntrinsicEvolutionExperiment:
     """Run a single simulation in which agents carry inheritable chromosomes."""
 
@@ -334,9 +275,28 @@ class IntrinsicEvolutionExperiment:
         )
 
         policy = self.config.policy
+
+        # The intrinsic-evolution runner relies on a non-monoculture starting
+        # population.  When the caller has not customized the platform-wide
+        # initial-diversity config, install the runner's defaults so seeding
+        # happens inside run_simulation.  Boundary handling mirrors the
+        # per-reproduction policy so seeded values respect the same invariants
+        # the policy enforces during the loop.
+        if self.base_config.initial_diversity.mode is SeedingMode.NONE:
+            self.base_config.initial_diversity = InitialDiversityConfig(
+                mode=SeedingMode.INDEPENDENT_MUTATION,
+                mutation_rate=1.0,
+                mutation_scale=0.2,
+                mutation_mode=policy.mutation_mode,
+                boundary_mode=policy.boundary_mode,
+                interior_bias_fraction=policy.interior_bias_fraction,
+                seed=seed,
+            )
+
         latest_step = 0
         latest_population = 0
         latest_gene_statistics: Dict[str, Dict[str, float]] = {}
+        latest_diversity_metrics: Optional[Any] = None
 
         # Track agent IDs from the previous step to compute birth/death rates.
         prev_agent_ids: set = set()
@@ -435,10 +395,15 @@ class IntrinsicEvolutionExperiment:
             }
 
         def _on_environment_ready(environment: Any) -> None:
-            nonlocal prev_agent_ids
+            nonlocal prev_agent_ids, latest_diversity_metrics
             environment.intrinsic_evolution_policy = policy
             environment.intrinsic_evolution_rng = rng
-            seed_population_diversity(environment, policy, rng)
+            # Initial diversity seeding now happens inside run_simulation
+            # before this hook fires; capture the metrics so they can be
+            # included in the persisted experiment metadata.
+            latest_diversity_metrics = getattr(
+                environment, "initial_diversity_metrics", None
+            )
             # At step 0 there is no previous step, so birth/death rates are 0.
             alive_agents = list(environment.alive_agent_objects)
             prev_agent_ids = {_agent_telemetry_key(a) for a in alive_agents}
@@ -479,7 +444,7 @@ class IntrinsicEvolutionExperiment:
             final_population=latest_population,
             final_gene_statistics=latest_gene_statistics,
         )
-        self._persist(result)
+        self._persist(result, initial_diversity_metrics=latest_diversity_metrics)
         logger.info(
             "intrinsic_evolution_completed",
             output_dir=self.config.output_dir,
@@ -488,7 +453,12 @@ class IntrinsicEvolutionExperiment:
         )
         return result
 
-    def _persist(self, result: IntrinsicEvolutionResult) -> None:
+    def _persist(
+        self,
+        result: IntrinsicEvolutionResult,
+        *,
+        initial_diversity_metrics: Optional[Any] = None,
+    ) -> None:
         if not self.config.output_dir:
             return
         metadata_path = os.path.join(
@@ -501,6 +471,14 @@ class IntrinsicEvolutionExperiment:
             "final_population": result.final_population,
             "final_gene_statistics": result.final_gene_statistics,
             "policy": _serialize_policy(self.config.policy),
+            "initial_diversity": (
+                self.base_config.initial_diversity.to_dict()
+            ),
+            "initial_diversity_metrics": (
+                initial_diversity_metrics.to_dict()
+                if initial_diversity_metrics is not None
+                else None
+            ),
             "speciation": dict(self._last_speciation_config),
             "seed": self.config.seed,
         }

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -214,10 +214,17 @@ class IntrinsicEvolutionPolicy:
 
 @dataclass(frozen=True)
 class IntrinsicEvolutionExperimentConfig:
-    """Top-level config for the intrinsic evolution runner."""
+    """Top-level config for the intrinsic evolution runner.
+
+    ``install_default_initial_diversity`` keeps historical behavior by
+    installing the runner's independent-mutation defaults when the provided
+    base config still has ``initial_diversity.mode=none``. Set it to ``False``
+    to preserve an explicit ``none`` mode (monoculture start) unchanged.
+    """
 
     num_steps: int = 2000
     snapshot_interval: int = 100
+    install_default_initial_diversity: bool = True
     policy: IntrinsicEvolutionPolicy = field(default_factory=IntrinsicEvolutionPolicy)
     output_dir: Optional[str] = None
     seed: Optional[int] = None
@@ -265,6 +272,7 @@ class IntrinsicEvolutionExperiment:
         """Execute the configured number of steps and persist artifacts."""
         seed = self.config.seed if self.config.policy.seed is None else self.config.policy.seed
         rng = random.Random(seed)
+        run_config = self.base_config.copy()
 
         if self.config.output_dir:
             os.makedirs(self.config.output_dir, exist_ok=True)
@@ -282,8 +290,11 @@ class IntrinsicEvolutionExperiment:
         # happens inside run_simulation.  Boundary handling mirrors the
         # per-reproduction policy so seeded values respect the same invariants
         # the policy enforces during the loop.
-        if self.base_config.initial_diversity.mode is SeedingMode.NONE:
-            self.base_config.initial_diversity = InitialDiversityConfig(
+        if (
+            self.config.install_default_initial_diversity
+            and run_config.initial_diversity.mode is SeedingMode.NONE
+        ):
+            run_config.initial_diversity = InitialDiversityConfig(
                 mode=SeedingMode.INDEPENDENT_MUTATION,
                 mutation_rate=1.0,
                 mutation_scale=0.2,
@@ -422,7 +433,7 @@ class IntrinsicEvolutionExperiment:
         try:
             run_simulation(
                 num_steps=self.config.num_steps,
-                config=self.base_config,
+                config=run_config,
                 path=self.config.output_dir,
                 save_config=False,
                 seed=self.config.seed,
@@ -444,7 +455,11 @@ class IntrinsicEvolutionExperiment:
             final_population=latest_population,
             final_gene_statistics=latest_gene_statistics,
         )
-        self._persist(result, initial_diversity_metrics=latest_diversity_metrics)
+        self._persist(
+            result,
+            initial_diversity_config=run_config.initial_diversity,
+            initial_diversity_metrics=latest_diversity_metrics,
+        )
         logger.info(
             "intrinsic_evolution_completed",
             output_dir=self.config.output_dir,
@@ -457,6 +472,7 @@ class IntrinsicEvolutionExperiment:
         self,
         result: IntrinsicEvolutionResult,
         *,
+        initial_diversity_config: InitialDiversityConfig,
         initial_diversity_metrics: Optional[Any] = None,
     ) -> None:
         if not self.config.output_dir:
@@ -471,9 +487,7 @@ class IntrinsicEvolutionExperiment:
             "final_population": result.final_population,
             "final_gene_statistics": result.final_gene_statistics,
             "policy": _serialize_policy(self.config.policy),
-            "initial_diversity": (
-                self.base_config.initial_diversity.to_dict()
-            ),
+            "initial_diversity": initial_diversity_config.to_dict(),
             "initial_diversity_metrics": (
                 initial_diversity_metrics.to_dict()
                 if initial_diversity_metrics is not None

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -15,6 +15,8 @@ from io import StringIO
 
 # Local imports
 from farm.config import SimulationConfig
+from farm.core.hyperparameter_chromosome import BoundaryMode, MutationMode
+from farm.core.initial_diversity import InitialDiversityConfig, SeedingMode
 from farm.core.simulation import run_simulation
 from farm.utils.logging import configure_logging, get_logger
 
@@ -203,6 +205,54 @@ def main():
         action="store_true",
         help="Skip database validation after simulation completes",
     )
+
+    # Initial genotype diversity (off by default; see farm/core/initial_diversity.py).
+    parser.add_argument(
+        "--initial-diversity-mode",
+        type=str,
+        default=SeedingMode.NONE.value,
+        choices=[m.value for m in SeedingMode],
+        help="Initial genotype diversity strategy applied before the loop starts.",
+    )
+    parser.add_argument(
+        "--initial-diversity-mutation-rate",
+        type=float,
+        default=1.0,
+        help="Per-gene mutation probability used when seeding initial diversity.",
+    )
+    parser.add_argument(
+        "--initial-diversity-mutation-scale",
+        type=float,
+        default=0.2,
+        help="Mutation scale used when seeding initial diversity.",
+    )
+    parser.add_argument(
+        "--initial-diversity-mutation-mode",
+        type=str,
+        default=MutationMode.GAUSSIAN.value,
+        choices=[m.value for m in MutationMode],
+        help="Mutation operator used when seeding initial diversity.",
+    )
+    parser.add_argument(
+        "--initial-diversity-boundary-mode",
+        type=str,
+        default=BoundaryMode.CLAMP.value,
+        choices=[m.value for m in BoundaryMode],
+        help="Boundary handling for mutated values when seeding initial diversity.",
+    )
+    parser.add_argument(
+        "--initial-diversity-min-distance",
+        type=float,
+        default=0.05,
+        help="Minimum normalized pairwise distance for MIN_DISTANCE seeding mode.",
+    )
+    parser.add_argument(
+        "--initial-diversity-max-retries",
+        type=int,
+        default=32,
+        help="Maximum candidate draws per agent in strict seeding modes.",
+    )
+
     args = parser.parse_args()
 
     # Ensure simulations directory exists
@@ -241,6 +291,19 @@ def main():
             )
             if args.no_persist:
                 logger.warning("in_memory_db_no_persist", message="Database will not be persisted to disk")
+
+        # Apply initial-diversity overrides from CLI.  Always assigning here
+        # makes the CLI flags authoritative over any baked-in config defaults.
+        config.initial_diversity = InitialDiversityConfig(
+            mode=SeedingMode(args.initial_diversity_mode),
+            mutation_rate=args.initial_diversity_mutation_rate,
+            mutation_scale=args.initial_diversity_mutation_scale,
+            mutation_mode=MutationMode(args.initial_diversity_mutation_mode),
+            boundary_mode=BoundaryMode(args.initial_diversity_boundary_mode),
+            max_retries_per_agent=args.initial_diversity_max_retries,
+            min_distance=args.initial_diversity_min_distance,
+            seed=args.seed,
+        )
 
         # Apply seed override if provided
         if args.seed is not None:

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -305,7 +305,6 @@ def main():
                 args.initial_diversity_boundary_mode,
                 args.initial_diversity_min_distance,
                 args.initial_diversity_max_retries,
-                args.seed,
             )
         ):
             base_diversity = config.initial_diversity

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -210,47 +210,47 @@ def main():
     parser.add_argument(
         "--initial-diversity-mode",
         type=str,
-        default=SeedingMode.NONE.value,
+        default=None,
         choices=[m.value for m in SeedingMode],
-        help="Initial genotype diversity strategy applied before the loop starts.",
+        help="Override initial genotype diversity strategy applied before the loop starts.",
     )
     parser.add_argument(
         "--initial-diversity-mutation-rate",
         type=float,
-        default=1.0,
-        help="Per-gene mutation probability used when seeding initial diversity.",
+        default=None,
+        help="Override per-gene mutation probability used when seeding initial diversity.",
     )
     parser.add_argument(
         "--initial-diversity-mutation-scale",
         type=float,
-        default=0.2,
-        help="Mutation scale used when seeding initial diversity.",
+        default=None,
+        help="Override mutation scale used when seeding initial diversity.",
     )
     parser.add_argument(
         "--initial-diversity-mutation-mode",
         type=str,
-        default=MutationMode.GAUSSIAN.value,
+        default=None,
         choices=[m.value for m in MutationMode],
-        help="Mutation operator used when seeding initial diversity.",
+        help="Override mutation operator used when seeding initial diversity.",
     )
     parser.add_argument(
         "--initial-diversity-boundary-mode",
         type=str,
-        default=BoundaryMode.CLAMP.value,
+        default=None,
         choices=[m.value for m in BoundaryMode],
-        help="Boundary handling for mutated values when seeding initial diversity.",
+        help="Override boundary handling for mutated values when seeding initial diversity.",
     )
     parser.add_argument(
         "--initial-diversity-min-distance",
         type=float,
-        default=0.05,
-        help="Minimum normalized pairwise distance for MIN_DISTANCE seeding mode.",
+        default=None,
+        help="Override minimum normalized pairwise distance for MIN_DISTANCE seeding mode.",
     )
     parser.add_argument(
         "--initial-diversity-max-retries",
         type=int,
-        default=32,
-        help="Maximum candidate draws per agent in strict seeding modes.",
+        default=None,
+        help="Override maximum candidate draws per agent in strict seeding modes.",
     )
 
     args = parser.parse_args()
@@ -292,18 +292,66 @@ def main():
             if args.no_persist:
                 logger.warning("in_memory_db_no_persist", message="Database will not be persisted to disk")
 
-        # Apply initial-diversity overrides from CLI.  Always assigning here
-        # makes the CLI flags authoritative over any baked-in config defaults.
-        config.initial_diversity = InitialDiversityConfig(
-            mode=SeedingMode(args.initial_diversity_mode),
-            mutation_rate=args.initial_diversity_mutation_rate,
-            mutation_scale=args.initial_diversity_mutation_scale,
-            mutation_mode=MutationMode(args.initial_diversity_mutation_mode),
-            boundary_mode=BoundaryMode(args.initial_diversity_boundary_mode),
-            max_retries_per_agent=args.initial_diversity_max_retries,
-            min_distance=args.initial_diversity_min_distance,
-            seed=args.seed,
-        )
+        # Apply initial-diversity overrides only for fields explicitly
+        # provided on the CLI. This preserves profile/config values unless
+        # the caller intentionally overrides them.
+        if any(
+            value is not None
+            for value in (
+                args.initial_diversity_mode,
+                args.initial_diversity_mutation_rate,
+                args.initial_diversity_mutation_scale,
+                args.initial_diversity_mutation_mode,
+                args.initial_diversity_boundary_mode,
+                args.initial_diversity_min_distance,
+                args.initial_diversity_max_retries,
+                args.seed,
+            )
+        ):
+            base_diversity = config.initial_diversity
+            config.initial_diversity = InitialDiversityConfig(
+                mode=(
+                    SeedingMode(args.initial_diversity_mode)
+                    if args.initial_diversity_mode is not None
+                    else base_diversity.mode
+                ),
+                mutation_rate=(
+                    args.initial_diversity_mutation_rate
+                    if args.initial_diversity_mutation_rate is not None
+                    else base_diversity.mutation_rate
+                ),
+                mutation_scale=(
+                    args.initial_diversity_mutation_scale
+                    if args.initial_diversity_mutation_scale is not None
+                    else base_diversity.mutation_scale
+                ),
+                mutation_mode=(
+                    MutationMode(args.initial_diversity_mutation_mode)
+                    if args.initial_diversity_mutation_mode is not None
+                    else base_diversity.mutation_mode
+                ),
+                boundary_mode=(
+                    BoundaryMode(args.initial_diversity_boundary_mode)
+                    if args.initial_diversity_boundary_mode is not None
+                    else base_diversity.boundary_mode
+                ),
+                interior_bias_fraction=base_diversity.interior_bias_fraction,
+                max_retries_per_agent=(
+                    args.initial_diversity_max_retries
+                    if args.initial_diversity_max_retries is not None
+                    else base_diversity.max_retries_per_agent
+                ),
+                min_distance=(
+                    args.initial_diversity_min_distance
+                    if args.initial_diversity_min_distance is not None
+                    else base_diversity.min_distance
+                ),
+                seed=(
+                    args.seed
+                    if args.seed is not None
+                    else base_diversity.seed
+                ),
+            )
 
         # Apply seed override if provided
         if args.seed is not None:

--- a/scripts/run_intrinsic_evolution_experiment.py
+++ b/scripts/run_intrinsic_evolution_experiment.py
@@ -219,6 +219,9 @@ def _build_run(args: argparse.Namespace) -> IntrinsicEvolutionExperiment:
     config = IntrinsicEvolutionExperimentConfig(
         num_steps=args.num_steps,
         snapshot_interval=args.snapshot_interval,
+        install_default_initial_diversity=(
+            SeedingMode(args.initial_diversity_mode) is not SeedingMode.NONE
+        ),
         policy=policy,
         output_dir=args.output_dir,
         seed=args.seed,

--- a/scripts/run_intrinsic_evolution_experiment.py
+++ b/scripts/run_intrinsic_evolution_experiment.py
@@ -41,6 +41,10 @@ from farm.core.hyperparameter_chromosome import (  # noqa: E402
     CrossoverMode,
     MutationMode,
 )
+from farm.core.initial_diversity import (  # noqa: E402
+    InitialDiversityConfig,
+    SeedingMode,
+)
 from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger  # noqa: E402
 from farm.runners.intrinsic_evolution_experiment import (  # noqa: E402
     IntrinsicEvolutionExperiment,
@@ -90,10 +94,21 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--interior-bias-fraction", type=float, default=1e-3)
 
-    # Initial diversity seeding
-    parser.add_argument("--no-seed-diversity", action="store_true")
-    parser.add_argument("--seed-mutation-rate", type=float, default=1.0)
-    parser.add_argument("--seed-mutation-scale", type=float, default=0.25)
+    # Initial diversity seeding (platform-wide; see farm/core/initial_diversity.py).
+    # The intrinsic-evolution runner installs INDEPENDENT_MUTATION as the default
+    # when --initial-diversity-mode is left at "independent_mutation"; explicitly
+    # passing "none" disables seeding so the starting population is a monoculture.
+    parser.add_argument(
+        "--initial-diversity-mode",
+        type=str,
+        default=SeedingMode.INDEPENDENT_MUTATION.value,
+        choices=[m.value for m in SeedingMode],
+        help="Initial genotype diversity strategy applied before the loop starts.",
+    )
+    parser.add_argument("--initial-diversity-mutation-rate", type=float, default=1.0)
+    parser.add_argument("--initial-diversity-mutation-scale", type=float, default=0.25)
+    parser.add_argument("--initial-diversity-min-distance", type=float, default=0.05)
+    parser.add_argument("--initial-diversity-max-retries", type=int, default=32)
 
     # Crossover
     parser.add_argument(
@@ -172,11 +187,20 @@ def _build_run(args: argparse.Namespace) -> IntrinsicEvolutionExperiment:
         profile=args.profile,
     )
 
+    base_config.initial_diversity = InitialDiversityConfig(
+        mode=SeedingMode(args.initial_diversity_mode),
+        mutation_rate=args.initial_diversity_mutation_rate,
+        mutation_scale=args.initial_diversity_mutation_scale,
+        mutation_mode=MutationMode(args.mutation_mode),
+        boundary_mode=BoundaryMode(args.boundary_mode),
+        interior_bias_fraction=args.interior_bias_fraction,
+        max_retries_per_agent=args.initial_diversity_max_retries,
+        min_distance=args.initial_diversity_min_distance,
+        seed=args.seed,
+    )
+
     policy = IntrinsicEvolutionPolicy(
         enabled=True,
-        seed_initial_diversity=not args.no_seed_diversity,
-        seed_mutation_rate=args.seed_mutation_rate,
-        seed_mutation_scale=args.seed_mutation_scale,
         mutation_rate=args.mutation_rate,
         mutation_scale=args.mutation_scale,
         mutation_mode=MutationMode(args.mutation_mode),

--- a/scripts/run_intrinsic_evolution_experiment.py
+++ b/scripts/run_intrinsic_evolution_experiment.py
@@ -95,9 +95,9 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--interior-bias-fraction", type=float, default=1e-3)
 
     # Initial diversity seeding (platform-wide; see farm/core/initial_diversity.py).
-    # The intrinsic-evolution runner installs INDEPENDENT_MUTATION as the default
-    # when --initial-diversity-mode is left at "independent_mutation"; explicitly
-    # passing "none" disables seeding so the starting population is a monoculture.
+    # The CLI default for --initial-diversity-mode is "independent_mutation".
+    # Explicitly passing "none" disables seeding, so no default initial-diversity
+    # configuration is installed and the starting population is a monoculture.
     parser.add_argument(
         "--initial-diversity-mode",
         type=str,

--- a/tests/core/test_initial_diversity.py
+++ b/tests/core/test_initial_diversity.py
@@ -1,0 +1,350 @@
+"""Tests for the platform-wide initial genotype diversity seeding feature.
+
+Mirrors the structure of ``tests/runners/test_intrinsic_evolution_experiment.py``
+but exercises the new shared module rather than the now-deleted
+``seed_population_diversity`` helper.
+"""
+
+from __future__ import annotations
+
+import random
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from farm.core.hyperparameter_chromosome import (
+    BoundaryMode,
+    MutationMode,
+    chromosome_from_learning_config,
+)
+from farm.core.initial_diversity import (
+    ChromosomeDiversitySource,
+    InitialDiversityConfig,
+    InitialDiversityMetrics,
+    SeedingMode,
+    apply_initial_diversity,
+    persist_initial_diversity_metrics,
+)
+
+
+def _make_fake_agent(learning_rate: float = 0.01, agent_id: str = "a"):
+    """Lightweight stand-in carrying the attributes the seeder reads/writes."""
+    config = SimpleNamespace(decision=SimpleNamespace(learning_rate=learning_rate))
+    chromosome = chromosome_from_learning_config(config.decision)
+    return SimpleNamespace(
+        agent_id=agent_id,
+        agent_type="system",
+        alive=True,
+        config=config,
+        hyperparameter_chromosome=chromosome,
+    )
+
+
+class _FakeEnvironment:
+    """Minimal environment compatible with the seeder iteration contract."""
+
+    def __init__(self, agents):
+        self._agents = list(agents)
+
+    @property
+    def agent_objects(self):
+        return list(self._agents)
+
+    @property
+    def alive_agent_objects(self):
+        return [a for a in self._agents if a.alive]
+
+
+class TestInitialDiversityConfig(unittest.TestCase):
+    def test_defaults_are_off(self):
+        cfg = InitialDiversityConfig()
+        self.assertEqual(cfg.mode, SeedingMode.NONE)
+        self.assertEqual(cfg.mutation_mode, MutationMode.GAUSSIAN)
+        self.assertEqual(cfg.boundary_mode, BoundaryMode.CLAMP)
+
+    def test_rejects_invalid_mutation_rate(self):
+        with self.assertRaises(ValueError):
+            InitialDiversityConfig(mutation_rate=1.5)
+
+    def test_rejects_negative_mutation_scale(self):
+        with self.assertRaises(ValueError):
+            InitialDiversityConfig(mutation_scale=-0.1)
+
+    def test_rejects_zero_max_retries(self):
+        with self.assertRaises(ValueError):
+            InitialDiversityConfig(max_retries_per_agent=0)
+
+    def test_rejects_negative_min_distance(self):
+        with self.assertRaises(ValueError):
+            InitialDiversityConfig(min_distance=-0.01)
+
+    def test_string_enums_coerced(self):
+        cfg = InitialDiversityConfig(
+            mode="independent_mutation",  # type: ignore[arg-type]
+            mutation_mode="multiplicative",  # type: ignore[arg-type]
+            boundary_mode="reflect",  # type: ignore[arg-type]
+        )
+        self.assertIs(cfg.mode, SeedingMode.INDEPENDENT_MUTATION)
+        self.assertIs(cfg.mutation_mode, MutationMode.MULTIPLICATIVE)
+        self.assertIs(cfg.boundary_mode, BoundaryMode.REFLECT)
+
+    def test_invalid_string_enum_raises(self):
+        with self.assertRaises(ValueError):
+            InitialDiversityConfig(mode="bogus")  # type: ignore[arg-type]
+
+    def test_to_dict_serializes_enums_as_strings(self):
+        cfg = InitialDiversityConfig(mode=SeedingMode.UNIQUE)
+        raw = cfg.to_dict()
+        self.assertEqual(raw["mode"], "unique")
+        self.assertEqual(raw["mutation_mode"], "gaussian")
+        self.assertEqual(raw["boundary_mode"], "clamp")
+
+
+class TestApplyInitialDiversityNoneMode(unittest.TestCase):
+    def test_none_mode_does_not_touch_agents_or_call_source(self):
+        agents = [_make_fake_agent(0.01, agent_id=f"a{i}") for i in range(3)]
+        env = _FakeEnvironment(agents)
+        original_lrs = [
+            a.hyperparameter_chromosome.get_value("learning_rate") for a in agents
+        ]
+        sentinel_source = MagicMock()
+        metrics = apply_initial_diversity(
+            env, InitialDiversityConfig(mode=SeedingMode.NONE), random.Random(0),
+            source=sentinel_source,
+        )
+        new_lrs = [
+            a.hyperparameter_chromosome.get_value("learning_rate") for a in agents
+        ]
+        self.assertEqual(original_lrs, new_lrs)
+        self.assertEqual(metrics.mode, SeedingMode.NONE)
+        self.assertEqual(metrics.agents_processed, 0)
+        sentinel_source.seed.assert_not_called()
+
+
+class TestChromosomeDiversitySourceIndependentMutation(unittest.TestCase):
+    def test_mutates_each_agent(self):
+        agents = [_make_fake_agent(0.01, agent_id=f"a{i}") for i in range(5)]
+        env = _FakeEnvironment(agents)
+        cfg = InitialDiversityConfig(
+            mode=SeedingMode.INDEPENDENT_MUTATION,
+            mutation_rate=1.0,
+            mutation_scale=0.3,
+        )
+        metrics = apply_initial_diversity(env, cfg, random.Random(0))
+        new_lrs = [
+            a.hyperparameter_chromosome.get_value("learning_rate") for a in agents
+        ]
+        self.assertTrue(any(lr != 0.01 for lr in new_lrs))
+        self.assertEqual(metrics.agents_processed, 5)
+        self.assertEqual(metrics.retries_used, 0)
+        self.assertEqual(metrics.fallbacks, 0)
+        # Decision config tracks the chromosome in lock-step.
+        for agent, lr in zip(agents, new_lrs):
+            self.assertEqual(agent.config.decision.learning_rate, lr)
+
+    def test_decision_module_reinitialized_when_present(self):
+        dm = MagicMock()
+        behavior = SimpleNamespace(decision_module=dm)
+        config = SimpleNamespace(decision=SimpleNamespace(learning_rate=0.01))
+        chromosome = chromosome_from_learning_config(config.decision)
+        agent = SimpleNamespace(
+            agent_id="agent_with_module",
+            agent_type="system",
+            alive=True,
+            config=config,
+            hyperparameter_chromosome=chromosome,
+            behavior=behavior,
+        )
+        env = _FakeEnvironment([agent])
+        cfg = InitialDiversityConfig(
+            mode=SeedingMode.INDEPENDENT_MUTATION,
+            mutation_rate=1.0,
+            mutation_scale=0.5,
+        )
+        apply_initial_diversity(env, cfg, random.Random(42))
+        dm.reinitialize_algorithm.assert_called_once_with(agent.config.decision)
+
+    def test_skips_agents_without_chromosome(self):
+        agent_with = _make_fake_agent(0.02, agent_id="ok")
+        agent_without = SimpleNamespace(
+            agent_id="x",
+            agent_type="system",
+            alive=True,
+            config=SimpleNamespace(decision=SimpleNamespace(learning_rate=0.02)),
+            hyperparameter_chromosome=None,
+        )
+        env = _FakeEnvironment([agent_with, agent_without])
+        cfg = InitialDiversityConfig(
+            mode=SeedingMode.INDEPENDENT_MUTATION,
+            mutation_rate=1.0,
+            mutation_scale=0.2,
+        )
+        metrics = apply_initial_diversity(env, cfg, random.Random(0))
+        self.assertEqual(metrics.agents_processed, 1)
+
+
+class TestChromosomeDiversitySourceUnique(unittest.TestCase):
+    def test_unique_mode_produces_distinct_signatures(self):
+        agents = [_make_fake_agent(0.01, agent_id=f"a{i}") for i in range(8)]
+        env = _FakeEnvironment(agents)
+        cfg = InitialDiversityConfig(
+            mode=SeedingMode.UNIQUE,
+            mutation_rate=1.0,
+            mutation_scale=0.4,
+            max_retries_per_agent=64,
+        )
+        metrics = apply_initial_diversity(env, cfg, random.Random(0))
+        # All accepted chromosomes should be distinct.
+        self.assertEqual(metrics.unique_count, 8)
+        # No fallbacks expected for this generous configuration.
+        self.assertEqual(metrics.fallbacks, 0)
+        self.assertEqual(metrics.collision_count, 0)
+
+    def test_unique_mode_falls_back_under_tight_budget(self):
+        # mutation_scale=0 + UNIQUE => every draw is identical, triggering fallback.
+        agents = [_make_fake_agent(0.01, agent_id=f"a{i}") for i in range(4)]
+        env = _FakeEnvironment(agents)
+        cfg = InitialDiversityConfig(
+            mode=SeedingMode.UNIQUE,
+            mutation_rate=1.0,
+            mutation_scale=0.0,
+            max_retries_per_agent=2,
+        )
+        metrics = apply_initial_diversity(env, cfg, random.Random(0))
+        # Agent 0 always succeeds, agents 1-3 must fall back.
+        self.assertEqual(metrics.fallbacks, 3)
+        self.assertEqual(metrics.agents_processed, 4)
+        # retries_used = (max_retries - 1) per fallback.
+        self.assertEqual(metrics.retries_used, 3 * (2 - 1))
+
+
+class TestChromosomeDiversitySourceMinDistance(unittest.TestCase):
+    def test_min_distance_satisfied_for_loose_constraint(self):
+        agents = [_make_fake_agent(0.01, agent_id=f"a{i}") for i in range(6)]
+        env = _FakeEnvironment(agents)
+        cfg = InitialDiversityConfig(
+            mode=SeedingMode.MIN_DISTANCE,
+            mutation_rate=1.0,
+            mutation_scale=0.4,
+            min_distance=0.01,
+            max_retries_per_agent=64,
+        )
+        metrics = apply_initial_diversity(env, cfg, random.Random(0))
+        self.assertEqual(metrics.fallbacks, 0)
+        self.assertIsNotNone(metrics.min_pairwise_distance)
+        assert metrics.min_pairwise_distance is not None  # for type narrowing
+        self.assertGreaterEqual(metrics.min_pairwise_distance, 0.01)
+
+    def test_min_distance_falls_back_for_unsatisfiable_constraint(self):
+        agents = [_make_fake_agent(0.01, agent_id=f"a{i}") for i in range(5)]
+        env = _FakeEnvironment(agents)
+        # min_distance >> achievable in unit hypercube => guaranteed fallback after 1st.
+        cfg = InitialDiversityConfig(
+            mode=SeedingMode.MIN_DISTANCE,
+            mutation_rate=1.0,
+            mutation_scale=0.1,
+            min_distance=10.0,
+            max_retries_per_agent=3,
+        )
+        metrics = apply_initial_diversity(env, cfg, random.Random(0))
+        self.assertEqual(metrics.fallbacks, 4)
+        self.assertEqual(metrics.agents_processed, 5)
+
+
+class TestDeterminism(unittest.TestCase):
+    def _seed_run(self, mode: SeedingMode, seed: int):
+        agents = [_make_fake_agent(0.01, agent_id=f"a{i}") for i in range(6)]
+        env = _FakeEnvironment(agents)
+        cfg = InitialDiversityConfig(
+            mode=mode,
+            mutation_rate=1.0,
+            mutation_scale=0.3,
+            min_distance=0.02,
+            max_retries_per_agent=32,
+        )
+        metrics = apply_initial_diversity(env, cfg, random.Random(seed))
+        chromosome_values = [
+            tuple((g.name, g.value) for g in a.hyperparameter_chromosome.genes)
+            for a in agents
+        ]
+        return chromosome_values, metrics
+
+    def test_independent_mutation_is_deterministic(self):
+        a, m_a = self._seed_run(SeedingMode.INDEPENDENT_MUTATION, seed=1234)
+        b, m_b = self._seed_run(SeedingMode.INDEPENDENT_MUTATION, seed=1234)
+        self.assertEqual(a, b)
+        self.assertEqual(m_a.to_dict(), m_b.to_dict())
+
+    def test_unique_mode_is_deterministic(self):
+        a, m_a = self._seed_run(SeedingMode.UNIQUE, seed=1234)
+        b, m_b = self._seed_run(SeedingMode.UNIQUE, seed=1234)
+        self.assertEqual(a, b)
+        self.assertEqual(m_a.to_dict(), m_b.to_dict())
+
+    def test_min_distance_is_deterministic(self):
+        a, m_a = self._seed_run(SeedingMode.MIN_DISTANCE, seed=1234)
+        b, m_b = self._seed_run(SeedingMode.MIN_DISTANCE, seed=1234)
+        self.assertEqual(a, b)
+        self.assertEqual(m_a.to_dict(), m_b.to_dict())
+
+
+class TestInitialDiversityMetricsSerialization(unittest.TestCase):
+    def test_to_dict_round_trips_via_persistence_helper(self):
+        import json
+        import os
+        import tempfile
+
+        metrics = InitialDiversityMetrics(
+            mode=SeedingMode.UNIQUE,
+            agents_processed=4,
+            unique_count=4,
+            collision_count=0,
+            retries_used=7,
+            fallbacks=0,
+            min_pairwise_distance=0.12,
+            mean_pairwise_distance=0.34,
+            notes=["ok"],
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = persist_initial_diversity_metrics(tmp, metrics)
+            self.assertTrue(os.path.exists(path))
+            with open(path, encoding="utf-8") as fh:
+                payload = json.load(fh)
+        self.assertEqual(payload["mode"], "unique")
+        self.assertEqual(payload["agents_processed"], 4)
+        self.assertEqual(payload["unique_count"], 4)
+        self.assertEqual(payload["retries_used"], 7)
+        self.assertEqual(payload["min_pairwise_distance"], 0.12)
+
+
+class TestChromosomeDiversitySourceCustomEncodings(unittest.TestCase):
+    def test_source_accepts_custom_encoding_specs(self):
+        # Smoke test: providing encoding specs should not raise and should
+        # still produce metrics with the expected mode.  Behaviour parity with
+        # the default encoding is asserted indirectly through other tests.
+        from farm.core.hyperparameter_chromosome import (
+            GeneEncodingScale,
+            GeneEncodingSpec,
+        )
+
+        agents = [_make_fake_agent(0.01, agent_id=f"a{i}") for i in range(3)]
+        env = _FakeEnvironment(agents)
+        source = ChromosomeDiversitySource(
+            encoding_specs={
+                "learning_rate": GeneEncodingSpec(
+                    scale=GeneEncodingScale.LOG, bit_width=6
+                )
+            }
+        )
+        cfg = InitialDiversityConfig(
+            mode=SeedingMode.UNIQUE,
+            mutation_rate=1.0,
+            mutation_scale=0.3,
+        )
+        metrics = source.seed(env, cfg, random.Random(0))
+        self.assertEqual(metrics.mode, SeedingMode.UNIQUE)
+        self.assertEqual(metrics.agents_processed, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/test_simulation_initial_diversity.py
+++ b/tests/core/test_simulation_initial_diversity.py
@@ -1,0 +1,144 @@
+"""End-to-end tests that initial-diversity seeding fires from run_simulation.
+
+These exercise the wiring between :class:`SimulationConfig.initial_diversity`
+and :func:`farm.core.simulation.run_simulation` via a small in-process run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+
+from farm.config import SimulationConfig
+from farm.core.initial_diversity import (
+    InitialDiversityConfig,
+    InitialDiversityMetrics,
+    SeedingMode,
+)
+from farm.core.simulation import run_simulation
+
+
+def _tiny_config(initial_diversity: InitialDiversityConfig) -> SimulationConfig:
+    """Build a deterministic, minimal config that produces real agents."""
+    cfg = SimulationConfig.from_centralized_config(environment="testing")
+    cfg.simulation_steps = 1
+    cfg.max_steps = 1
+    cfg.population.system_agents = 3
+    cfg.population.independent_agents = 2
+    cfg.population.control_agents = 0
+    cfg.population.order_agents = 0
+    cfg.population.chaos_agents = 0
+    cfg.environment.width = 20
+    cfg.environment.height = 20
+    cfg.database.use_in_memory_db = True
+    cfg.database.persist_db_on_completion = False
+    cfg.initial_diversity = initial_diversity
+    return cfg
+
+
+class TestRunSimulationInitialDiversity(unittest.TestCase):
+    def test_none_mode_attaches_zeroed_metrics_and_no_sidecar(self):
+        cfg = _tiny_config(InitialDiversityConfig(mode=SeedingMode.NONE))
+        with tempfile.TemporaryDirectory() as out:
+            env = run_simulation(num_steps=1, config=cfg, path=out, save_config=False, seed=7)
+            metrics = getattr(env, "initial_diversity_metrics", None)
+            self.assertIsInstance(metrics, InitialDiversityMetrics)
+            assert metrics is not None  # for type narrowing
+            self.assertIs(metrics.mode, SeedingMode.NONE)
+            self.assertEqual(metrics.agents_processed, 0)
+            sidecar = os.path.join(out, "initial_diversity_metadata.json")
+            self.assertFalse(os.path.exists(sidecar))
+
+    def test_independent_mutation_writes_sidecar_and_processes_agents(self):
+        cfg = _tiny_config(
+            InitialDiversityConfig(
+                mode=SeedingMode.INDEPENDENT_MUTATION,
+                mutation_rate=1.0,
+                mutation_scale=0.2,
+                seed=11,
+            )
+        )
+        with tempfile.TemporaryDirectory() as out:
+            env = run_simulation(num_steps=1, config=cfg, path=out, save_config=False, seed=11)
+            metrics = env.initial_diversity_metrics
+            self.assertIs(metrics.mode, SeedingMode.INDEPENDENT_MUTATION)
+            # System (3) + independent (2) learning agents.
+            self.assertEqual(metrics.agents_processed, 5)
+            sidecar = os.path.join(out, "initial_diversity_metadata.json")
+            self.assertTrue(os.path.exists(sidecar))
+            with open(sidecar, encoding="utf-8") as fh:
+                payload = json.load(fh)
+            self.assertEqual(payload["mode"], "independent_mutation")
+            self.assertEqual(payload["agents_processed"], 5)
+
+    def test_unique_mode_yields_distinct_chromosomes(self):
+        cfg = _tiny_config(
+            InitialDiversityConfig(
+                mode=SeedingMode.UNIQUE,
+                mutation_rate=1.0,
+                mutation_scale=0.4,
+                max_retries_per_agent=64,
+                seed=23,
+            )
+        )
+        with tempfile.TemporaryDirectory() as out:
+            env = run_simulation(num_steps=1, config=cfg, path=out, save_config=False, seed=23)
+            metrics = env.initial_diversity_metrics
+            self.assertIs(metrics.mode, SeedingMode.UNIQUE)
+            self.assertEqual(metrics.agents_processed, 5)
+            self.assertEqual(metrics.unique_count, 5)
+            self.assertEqual(metrics.fallbacks, 0)
+
+    def test_min_distance_mode_records_pairwise_distance(self):
+        cfg = _tiny_config(
+            InitialDiversityConfig(
+                mode=SeedingMode.MIN_DISTANCE,
+                mutation_rate=1.0,
+                mutation_scale=0.4,
+                min_distance=0.01,
+                max_retries_per_agent=64,
+                seed=37,
+            )
+        )
+        with tempfile.TemporaryDirectory() as out:
+            env = run_simulation(num_steps=1, config=cfg, path=out, save_config=False, seed=37)
+            metrics = env.initial_diversity_metrics
+            self.assertIs(metrics.mode, SeedingMode.MIN_DISTANCE)
+            self.assertEqual(metrics.fallbacks, 0)
+            self.assertIsNotNone(metrics.min_pairwise_distance)
+            assert metrics.min_pairwise_distance is not None  # type narrowing
+            self.assertGreaterEqual(metrics.min_pairwise_distance, 0.01)
+
+    def test_seeding_runs_before_on_environment_ready_hook(self):
+        """The hook must observe the seeded chromosomes (post-seed state)."""
+        seen_metrics = {}
+
+        def _hook(environment):
+            seen_metrics["mode"] = environment.initial_diversity_metrics.mode
+            seen_metrics["count"] = environment.initial_diversity_metrics.agents_processed
+
+        cfg = _tiny_config(
+            InitialDiversityConfig(
+                mode=SeedingMode.INDEPENDENT_MUTATION,
+                mutation_rate=1.0,
+                mutation_scale=0.1,
+                seed=51,
+            )
+        )
+        with tempfile.TemporaryDirectory() as out:
+            run_simulation(
+                num_steps=1,
+                config=cfg,
+                path=out,
+                save_config=False,
+                seed=51,
+                on_environment_ready=_hook,
+            )
+        self.assertIs(seen_metrics["mode"], SeedingMode.INDEPENDENT_MUTATION)
+        self.assertEqual(seen_metrics["count"], 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -1,8 +1,9 @@
 """Tests for the intrinsic evolution runner.
 
 The runner drives a single simulation and patches `run_simulation` so we can
-exercise the orchestration (policy attachment, seed diversity, per-step
-logger snapshots, artifact persistence) without the cost of a full sim.
+exercise the orchestration (policy attachment, default initial-diversity
+config installation, per-step logger snapshots, artifact persistence) without
+the cost of a full sim.
 """
 
 from __future__ import annotations
@@ -22,12 +23,16 @@ from farm.core.hyperparameter_chromosome import (
     MutationMode,
     chromosome_from_learning_config,
 )
+from farm.core.initial_diversity import (
+    InitialDiversityConfig,
+    InitialDiversityMetrics,
+    SeedingMode,
+)
 from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger as RealGeneTrajectoryLogger
 from farm.runners.intrinsic_evolution_experiment import (
     IntrinsicEvolutionExperiment,
     IntrinsicEvolutionExperimentConfig,
     IntrinsicEvolutionPolicy,
-    seed_population_diversity,
 )
 
 
@@ -124,86 +129,45 @@ class TestIntrinsicEvolutionExperimentConfig(unittest.TestCase):
             IntrinsicEvolutionExperimentConfig(snapshot_interval=0)
 
 
-class TestSeedPopulationDiversity(unittest.TestCase):
-    def test_no_op_when_disabled(self):
-        agents = [_make_fake_agent(0.01) for _ in range(3)]
-        env = _FakeEnvironment(agents)
-        original_lrs = [a.hyperparameter_chromosome.get_value("learning_rate") for a in agents]
-        policy = IntrinsicEvolutionPolicy(seed_initial_diversity=False)
-        seed_population_diversity(env, policy, random.Random(0))
-        new_lrs = [a.hyperparameter_chromosome.get_value("learning_rate") for a in agents]
-        self.assertEqual(original_lrs, new_lrs)
+class TestRunnerInitialDiversityIntegration(unittest.TestCase):
+    """The runner must install its own initial-diversity defaults when the
+    base config has not opted in, so the starting population is not a
+    monoculture by default.  Detailed behavioral tests for the seeding
+    primitive itself live in tests/core/test_initial_diversity.py.
+    """
 
-    def test_seeds_each_agent_with_distinct_chromosome(self):
-        agents = [_make_fake_agent(0.01) for _ in range(5)]
-        env = _FakeEnvironment(agents)
-        policy = IntrinsicEvolutionPolicy(
-            seed_initial_diversity=True,
-            seed_mutation_rate=1.0,
-            seed_mutation_scale=0.3,
+    def test_runner_installs_independent_mutation_default_when_unset(self):
+        base_config = SimulationConfig()
+        self.assertIs(base_config.initial_diversity.mode, SeedingMode.NONE)
+
+        # Stub run_simulation so we only care about the side effect of mutating
+        # base_config.initial_diversity inside .run().
+        with patch("farm.runners.intrinsic_evolution_experiment.run_simulation"):
+            cfg = IntrinsicEvolutionExperimentConfig(num_steps=1, snapshot_interval=1, seed=99)
+            IntrinsicEvolutionExperiment(base_config, cfg).run()
+
+        self.assertIs(base_config.initial_diversity.mode, SeedingMode.INDEPENDENT_MUTATION)
+        self.assertEqual(base_config.initial_diversity.mutation_rate, 1.0)
+        self.assertEqual(base_config.initial_diversity.mutation_scale, 0.2)
+        self.assertEqual(base_config.initial_diversity.seed, 99)
+
+    def test_runner_respects_caller_supplied_initial_diversity(self):
+        custom = InitialDiversityConfig(
+            mode=SeedingMode.UNIQUE,
+            mutation_rate=0.5,
+            mutation_scale=0.05,
+            seed=777,
         )
-        seed_population_diversity(env, policy, random.Random(0))
-        new_lrs = [a.hyperparameter_chromosome.get_value("learning_rate") for a in agents]
-        # With mutation_rate=1.0 and a non-zero scale, at least one value should differ.
-        self.assertTrue(any(lr != 0.01 for lr in new_lrs))
-        # Decision config is updated alongside the chromosome.
-        for agent, lr in zip(agents, new_lrs):
-            self.assertEqual(agent.config.decision.learning_rate, lr)
+        base_config = SimulationConfig()
+        base_config.initial_diversity = custom
 
-    def test_reinitializes_decision_module_when_behavior_present(self):
-        """DecisionModule config and algorithm are updated when already constructed."""
-        from unittest.mock import MagicMock
+        with patch("farm.runners.intrinsic_evolution_experiment.run_simulation"):
+            cfg = IntrinsicEvolutionExperimentConfig(num_steps=1, snapshot_interval=1, seed=42)
+            IntrinsicEvolutionExperiment(base_config, cfg).run()
 
-        from farm.core.agent.behaviors.learning import LearningAgentBehavior
-
-        dm = MagicMock()
-        behavior = LearningAgentBehavior(dm)
-        config = SimpleNamespace(decision=SimpleNamespace(learning_rate=0.01))
-        chromosome = chromosome_from_learning_config(config.decision)
-        agent = SimpleNamespace(
-            agent_id="dm_agent",
-            agent_type="system",
-            alive=True,
-            config=config,
-            hyperparameter_chromosome=chromosome,
-            behavior=behavior,
-        )
-        env = _FakeEnvironment([agent])
-        policy = IntrinsicEvolutionPolicy(
-            seed_initial_diversity=True,
-            seed_mutation_rate=1.0,
-            seed_mutation_scale=0.5,
-        )
-        seed_population_diversity(env, policy, random.Random(42))
-
-        # DecisionModule must be reinitialized via the public reinitialize_algorithm method.
-        dm.reinitialize_algorithm.assert_called_once_with(agent.config.decision)
-
-    def test_reinitializes_any_behavior_with_compatible_decision_module(self):
-        """Reinitialization is capability-based, not tied to one behavior class."""
-        from unittest.mock import MagicMock
-
-        dm = MagicMock()
-        behavior = SimpleNamespace(decision_module=dm)
-        config = SimpleNamespace(decision=SimpleNamespace(learning_rate=0.01))
-        chromosome = chromosome_from_learning_config(config.decision)
-        agent = SimpleNamespace(
-            agent_id="generic_behavior_agent",
-            agent_type="system",
-            alive=True,
-            config=config,
-            hyperparameter_chromosome=chromosome,
-            behavior=behavior,
-        )
-        env = _FakeEnvironment([agent])
-        policy = IntrinsicEvolutionPolicy(
-            seed_initial_diversity=True,
-            seed_mutation_rate=1.0,
-            seed_mutation_scale=0.5,
-        )
-        seed_population_diversity(env, policy, random.Random(42))
-
-        dm.reinitialize_algorithm.assert_called_once_with(agent.config.decision)
+        # Should be left untouched because the caller already opted in.
+        self.assertIs(base_config.initial_diversity, custom)
+        self.assertIs(base_config.initial_diversity.mode, SeedingMode.UNIQUE)
 
 
 class TestRunnerOrchestration(unittest.TestCase):
@@ -215,6 +179,14 @@ class TestRunnerOrchestration(unittest.TestCase):
         def _side_effect(*args, **kwargs):
             on_environment_ready = kwargs.get("on_environment_ready")
             on_step_end = kwargs.get("on_step_end")
+            # Real run_simulation attaches initial_diversity_metrics to the env
+            # before invoking the hook; mimic that contract for the runner's
+            # _on_environment_ready capture path.
+            env.initial_diversity_metrics = InitialDiversityMetrics(
+                mode=SeedingMode.INDEPENDENT_MUTATION,
+                agents_processed=num_agents,
+                unique_count=num_agents,
+            )
             if on_environment_ready is not None:
                 on_environment_ready(env)
             for step in range(num_steps):
@@ -297,6 +269,14 @@ class TestRunnerOrchestration(unittest.TestCase):
             self.assertEqual(metadata["speciation"]["scaler"], "none")
             # Enums in the policy must serialize to plain string values.
             self.assertEqual(metadata["policy"]["mutation_mode"], "gaussian")
+            # Initial-diversity defaults installed by the runner are
+            # surfaced in the metadata for reproducibility.
+            self.assertIn("initial_diversity", metadata)
+            self.assertEqual(metadata["initial_diversity"]["mode"], "independent_mutation")
+            self.assertIn("initial_diversity_metrics", metadata)
+            self.assertEqual(
+                metadata["initial_diversity_metrics"]["mode"], "independent_mutation"
+            )
 
     def test_runner_persists_speciation_settings_when_logger_enables_it(self):
         side_effect, _env = self._stub_run_simulation(num_agents=2, num_steps=2)

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -140,16 +140,18 @@ class TestRunnerInitialDiversityIntegration(unittest.TestCase):
         base_config = SimulationConfig()
         self.assertIs(base_config.initial_diversity.mode, SeedingMode.NONE)
 
-        # Stub run_simulation so we only care about the side effect of mutating
-        # base_config.initial_diversity inside .run().
-        with patch("farm.runners.intrinsic_evolution_experiment.run_simulation"):
+        with patch("farm.runners.intrinsic_evolution_experiment.run_simulation") as run_mock:
             cfg = IntrinsicEvolutionExperimentConfig(num_steps=1, snapshot_interval=1, seed=99)
             IntrinsicEvolutionExperiment(base_config, cfg).run()
 
-        self.assertIs(base_config.initial_diversity.mode, SeedingMode.INDEPENDENT_MUTATION)
-        self.assertEqual(base_config.initial_diversity.mutation_rate, 1.0)
-        self.assertEqual(base_config.initial_diversity.mutation_scale, 0.2)
-        self.assertEqual(base_config.initial_diversity.seed, 99)
+        # Caller-owned config remains unchanged; runner operates on a per-run copy.
+        self.assertIs(base_config.initial_diversity.mode, SeedingMode.NONE)
+        passed_config = run_mock.call_args.kwargs["config"]
+        self.assertIsNot(passed_config, base_config)
+        self.assertIs(passed_config.initial_diversity.mode, SeedingMode.INDEPENDENT_MUTATION)
+        self.assertEqual(passed_config.initial_diversity.mutation_rate, 1.0)
+        self.assertEqual(passed_config.initial_diversity.mutation_scale, 0.2)
+        self.assertEqual(passed_config.initial_diversity.seed, 99)
 
     def test_runner_respects_caller_supplied_initial_diversity(self):
         custom = InitialDiversityConfig(
@@ -161,13 +163,30 @@ class TestRunnerInitialDiversityIntegration(unittest.TestCase):
         base_config = SimulationConfig()
         base_config.initial_diversity = custom
 
-        with patch("farm.runners.intrinsic_evolution_experiment.run_simulation"):
+        with patch("farm.runners.intrinsic_evolution_experiment.run_simulation") as run_mock:
             cfg = IntrinsicEvolutionExperimentConfig(num_steps=1, snapshot_interval=1, seed=42)
             IntrinsicEvolutionExperiment(base_config, cfg).run()
 
         # Should be left untouched because the caller already opted in.
         self.assertIs(base_config.initial_diversity, custom)
         self.assertIs(base_config.initial_diversity.mode, SeedingMode.UNIQUE)
+        self.assertEqual(run_mock.call_args.kwargs["config"].initial_diversity, custom)
+
+    def test_runner_can_preserve_explicit_none_when_default_install_disabled(self):
+        base_config = SimulationConfig()
+        self.assertIs(base_config.initial_diversity.mode, SeedingMode.NONE)
+
+        with patch("farm.runners.intrinsic_evolution_experiment.run_simulation") as run_mock:
+            cfg = IntrinsicEvolutionExperimentConfig(
+                num_steps=1,
+                snapshot_interval=1,
+                seed=21,
+                install_default_initial_diversity=False,
+            )
+            IntrinsicEvolutionExperiment(base_config, cfg).run()
+
+        passed_config = run_mock.call_args.kwargs["config"]
+        self.assertIs(passed_config.initial_diversity.mode, SeedingMode.NONE)
 
 
 class TestRunnerOrchestration(unittest.TestCase):


### PR DESCRIPTION
This pull request introduces a new platform-wide feature for initial genotype diversity seeding in simulations, making it easy to start with a genetically diverse agent population. The feature is configurable via `SimulationConfig.initial_diversity`, supports several seeding modes, and integrates with both the simulation core and the intrinsic-evolution runner. The documentation and tests have been updated to reflect and validate this new functionality.

**Platform-wide initial genotype diversity seeding:**
- Added `InitialDiversityConfig` to `SimulationConfig`, allowing any simulation to opt in to initial genotype diversity seeding with configurable modes (`independent_mutation`, `unique`, `min_distance`, or `none`). [[1]](diffhunk://#diff-4b2fc3c00fa9df153de28d46f1d13e4a6d9eede8ef44d3b56f6aea46238defc4R12) [[2]](diffhunk://#diff-4b2fc3c00fa9df153de28d46f1d13e4a6d9eede8ef44d3b56f6aea46238defc4R855-R858)
- Implemented seeding logic in `run_simulation`, applying diversity before any environment hooks and persisting telemetry and metrics.
- Updated serialization and deserialization in `SimulationConfig` to support the new config field. [[1]](diffhunk://#diff-4b2fc3c00fa9df153de28d46f1d13e4a6d9eede8ef44d3b56f6aea46238defc4R887-R888) [[2]](diffhunk://#diff-4b2fc3c00fa9df153de28d46f1d13e4a6d9eede8ef44d3b56f6aea46238defc4R968-R977)

**Documentation updates:**
- Added `docs/initial_diversity.md` with a full reference on configuration, modes, telemetry, determinism, and extensibility for initial genotype diversity.
- Updated `README.md` and intrinsic evolution experiment documentation to describe the new feature, its configuration, and its default behavior in the intrinsic-evolution runner. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24) [[2]](diffhunk://#diff-ce900449bd53bd4ee7c0c4e1ffe5de7519bc7cd66001bc3493cf24bab8351535L81-R83) [[3]](diffhunk://#diff-ce900449bd53bd4ee7c0c4e1ffe5de7519bc7cd66001bc3493cf24bab8351535L140-R141) [[4]](diffhunk://#diff-ce900449bd53bd4ee7c0c4e1ffe5de7519bc7cd66001bc3493cf24bab8351535R177-R188) [[5]](diffhunk://#diff-ce900449bd53bd4ee7c0c4e1ffe5de7519bc7cd66001bc3493cf24bab8351535L198-L200) [[6]](diffhunk://#diff-ce900449bd53bd4ee7c0c4e1ffe5de7519bc7cd66001bc3493cf24bab8351535L360-R376)

**Testing improvements:**
- Added and updated tests to cover platform-wide initial diversity seeding, including behavioral tests for all seeding modes and integration with the simulation runner.

**References:** [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24) [[2]](diffhunk://#diff-ce900449bd53bd4ee7c0c4e1ffe5de7519bc7cd66001bc3493cf24bab8351535L81-R83) [[3]](diffhunk://#diff-ce900449bd53bd4ee7c0c4e1ffe5de7519bc7cd66001bc3493cf24bab8351535L140-R141) [[4]](diffhunk://#diff-ce900449bd53bd4ee7c0c4e1ffe5de7519bc7cd66001bc3493cf24bab8351535R177-R188) [[5]](diffhunk://#diff-ce900449bd53bd4ee7c0c4e1ffe5de7519bc7cd66001bc3493cf24bab8351535L198-L200) [[6]](diffhunk://#diff-ce900449bd53bd4ee7c0c4e1ffe5de7519bc7cd66001bc3493cf24bab8351535L360-R376) [[7]](diffhunk://#diff-ce900449bd53bd4ee7c0c4e1ffe5de7519bc7cd66001bc3493cf24bab8351535L692-R702) [[8]](diffhunk://#diff-58d65728e1e9676365f02e101c19fa7ece6d2f93db6cbbc24c9b8db5fa637a1aR1-R120) [[9]](diffhunk://#diff-4b2fc3c00fa9df153de28d46f1d13e4a6d9eede8ef44d3b56f6aea46238defc4R12) [[10]](diffhunk://#diff-4b2fc3c00fa9df153de28d46f1d13e4a6d9eede8ef44d3b56f6aea46238defc4R855-R858) [[11]](diffhunk://#diff-4b2fc3c00fa9df153de28d46f1d13e4a6d9eede8ef44d3b56f6aea46238defc4R887-R888) [[12]](diffhunk://#diff-4b2fc3c00fa9df153de28d46f1d13e4a6d9eede8ef44d3b56f6aea46238defc4R968-R977) [[13]](diffhunk://#diff-ff06a5cb09730a065f7613b2ba815c4602c7f5e7b7ce98b3a346e0c9fc3b0786R49-R54) [[14]](diffhunk://#diff-ff06a5cb09730a065f7613b2ba815c4602c7f5e7b7ce98b3a346e0c9fc3b0786L477-R500)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `run_simulation` startup flow and config serialization, which could subtly affect determinism, initial agent state, and persisted artifacts; default remains `none` to minimize impact but runner/CLI opt-ins widen surface area.
> 
> **Overview**
> Introduces a platform-wide **initial genotype diversity** feature via `SimulationConfig.initial_diversity`, with a new `farm/core/initial_diversity.py` module implementing `none`, `independent_mutation`, `unique`, and `min_distance` seeding plus metrics/telemetry.
> 
> `run_simulation` now applies seeding immediately after initial agent creation (before `on_environment_ready`), attaches `environment.initial_diversity_metrics`, emits a structured `initial_diversity_seeded` log event, and persists `initial_diversity_metadata.json` when an output path is provided.
> 
> The intrinsic-evolution runner is updated to rely on the shared seeding path: it removes runner-specific `seed_population_diversity`, optionally installs default `INDEPENDENT_MUTATION` seeding via `install_default_initial_diversity`, and persists both the resolved initial-diversity config and metrics into `intrinsic_evolution_metadata.json`. CLI drivers (`run_simulation.py` and `scripts/run_intrinsic_evolution_experiment.py`) add flags to configure/override initial-diversity settings, and docs/tests are added/updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6590efba83cfefa3663cb23ec967179db1e4d55. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->