### PR TITLE
Enhance intrinsic evolution with initial conditions and GPU acceleration

### DIFF
--- a/docs/experiments/intrinsic_evolution/intrinsic_evolution.md
+++ b/docs/experiments/intrinsic_evolution/intrinsic_evolution.md
@@ -365,7 +365,7 @@ enums serialized to plain strings so it round-trips cleanly, and a
   "initial_conditions": {
     "profile": "stable",
     "resolved": {
-      "initial_agent_resource_level": 20.0,
+      "initial_agent_resource_level": 20,
       "initial_resource_count": 30,
       "resource_regen_rate": 0.15,
       "resource_regen_amount": 3
@@ -378,7 +378,7 @@ enums serialized to plain strings so it round-trips cleanly, and a
     "transient_window": 50
   },
   "resolved_initial_conditions": {
-    "initial_agent_resource_level": 20.0,
+    "initial_agent_resource_level": 20,
     "initial_resource_count": 30,
     "resource_regen_rate": 0.15,
     "resource_regen_amount": 3,

--- a/docs/experiments/intrinsic_evolution/intrinsic_evolution.md
+++ b/docs/experiments/intrinsic_evolution/intrinsic_evolution.md
@@ -238,6 +238,37 @@ crossover can become asexual at runtime; everything else is policy-driven.
 | `seed`              | `None`                       | Top-level RNG seed propagated to `run_simulation` and the policy if the policy seed is unset.                                                    |
 
 
+## Initial conditions profiles and legacy parity
+
+Intrinsic runs now include an explicit startup-conditions layer via
+`InitialConditionsConfig` (`IntrinsicEvolutionExperimentConfig.initial_conditions`).
+
+- Default profile is `stable`, tuned to reduce the first-steps boom-bust wave.
+- `legacy` preserves pre-profile startup behavior (no startup overrides).
+- `stress` and `exploratory` provide alternative preset regimes.
+- Manual per-field overrides always win over profile defaults.
+
+Use `legacy` when you need apples-to-apples comparisons with older runs:
+
+```python
+from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+config = IntrinsicEvolutionExperimentConfig(
+    # ...
+    initial_conditions=InitialConditionsConfig(profile="legacy"),
+)
+```
+
+CLI equivalent:
+
+```bash
+python scripts/run_intrinsic_evolution_experiment.py \
+  --initial-conditions-profile legacy
+```
+
+If the CLI profile is omitted, it defaults to `stable` and emits a warning so
+the behavior shift is visible in logs and manifests.
+
 ## Output artifacts
 
 When `output_dir` is set, three new files are written alongside whatever
@@ -324,6 +355,36 @@ enums serialized to plain strings so it round-trips cleanly, and a
   "snapshot_interval": 100,
   "final_population": 47,
   "final_gene_statistics": { ... },
+  "startup_transient_metrics": {
+    "peak_birth_rate": 0.23,
+    "peak_death_rate": 0.11,
+    "oscillation_amplitude": 12,
+    "n_steps_observed": 50,
+    "transient_window": 50
+  },
+  "initial_conditions": {
+    "profile": "stable",
+    "resolved": {
+      "initial_agent_resource_level": 20.0,
+      "initial_resource_count": 30,
+      "resource_regen_rate": 0.15,
+      "resource_regen_amount": 3
+    },
+    "initial_agent_resource_level": null,
+    "initial_resource_count": null,
+    "resource_regen_rate": null,
+    "resource_regen_amount": null,
+    "warmup_steps": 0,
+    "transient_window": 50
+  },
+  "resolved_initial_conditions": {
+    "initial_agent_resource_level": 20.0,
+    "initial_resource_count": 30,
+    "resource_regen_rate": 0.15,
+    "resource_regen_amount": 3,
+    "warmup_steps": 0,
+    "transient_window": 50
+  },
   "policy": {
     "enabled": true,
     "mutation_mode": "gaussian",
@@ -698,7 +759,7 @@ for snap in snapshots:
 
 ## Testing
 
-- `[tests/runners/test_intrinsic_evolution_experiment.py](../../tests/runners/test_intrinsic_evolution_experiment.py)`: policy / config validation, runner-level installation of platform-wide initial-diversity defaults, runner orchestration with mocked `run_simulation`, artifact persistence (including the `speciation` and `initial_diversity` blocks in `intrinsic_evolution_metadata.json` for both default-disabled and explicitly-enabled logger configurations), `ReproductionPressureConfig` validation, `selection_pressure` presets (none/low/medium/high/float), `_compute_effective_reproduction_cost` unit tests, trajectory telemetry field presence, and zero birth/death rates for stable populations.
+- `[tests/runners/test_intrinsic_evolution_experiment.py](../../tests/runners/test_intrinsic_evolution_experiment.py)`: policy / config validation, runner-level installation of platform-wide initial-diversity defaults, runner orchestration with mocked `run_simulation`, artifact persistence (including the `speciation` and `initial_diversity` blocks in `intrinsic_evolution_metadata.json` for both default-disabled and explicitly-enabled logger configurations), `ReproductionPressureConfig` validation, `selection_pressure` presets (none/low/medium/high/float), `_compute_effective_reproduction_cost` unit tests, trajectory telemetry field presence, startup-transient metrics (including stable-vs-legacy benchmark assertions on representative seeds), and zero birth/death rates for stable populations.
 - `[tests/core/test_initial_diversity.py](../../tests/core/test_initial_diversity.py)` and `[tests/core/test_simulation_initial_diversity.py](../../tests/core/test_simulation_initial_diversity.py)`: behavioural tests for the platform-wide seeding feature - mode validation, `INDEPENDENT_MUTATION` / `UNIQUE` / `MIN_DISTANCE` correctness, fallback semantics, determinism, decision-module reinitialization, and end-to-end wiring through `run_simulation`.
 - `[tests/core/agent/test_reproduce_chromosome_policy.py](../../tests/core/agent/test_reproduce_chromosome_policy.py)`: no-policy passthrough, mutation path, co-parent selection (nearest, random, radius, type-filter, alive-filter), crossover end-to-end.
 - `[tests/test_agent_reproduction_hyperparameters.py](../../tests/test_agent_reproduction_hyperparameters.py)`: updated to assert the new contract (no policy = inheritance unchanged).

--- a/farm/core/spatial/__init__.py
+++ b/farm/core/spatial/__init__.py
@@ -6,9 +6,11 @@ This package contains:
 - Quadtree for hierarchical partitioning
 - SpatialIndex orchestrating KD-tree, Quadtree, and Spatial Hash indices
 - Priority constants for batch update ordering
+- GPU-accelerated spatial kernels (SpatialGpuKernels, is_gpu_available)
 """
 
 from .dirty_regions import DirtyRegion, DirtyRegionTracker
+from .gpu_kernels import SpatialGpuKernels, get_spatial_device, is_gpu_available
 from .hash_grid import SpatialHashGrid
 from .index import (
     PRIORITY_CRITICAL,
@@ -30,4 +32,7 @@ __all__ = [
     "PRIORITY_NORMAL",
     "PRIORITY_HIGH",
     "PRIORITY_CRITICAL",
+    "SpatialGpuKernels",
+    "is_gpu_available",
+    "get_spatial_device",
 ]

--- a/farm/core/spatial/gpu_kernels.py
+++ b/farm/core/spatial/gpu_kernels.py
@@ -252,8 +252,8 @@ class SpatialGpuKernels:
         if n_entities == 0 or m_queries == 0:
             return [[] for _ in range(m_queries)]
 
-        # ------ GPU / torch path ------
-        if _TORCH_AVAILABLE and self._device is not None:
+        # ------ GPU / torch path (only for large entity counts) ------
+        if _TORCH_AVAILABLE and self._device is not None and n_entities >= self.gpu_threshold:
             pos_t = torch.as_tensor(positions, dtype=torch.float64, device=self._device)
             qpt_t = torch.as_tensor(query_points, dtype=torch.float64, device=self._device)
             # torch.cdist: (M, N) pairwise L2 distances
@@ -265,7 +265,7 @@ class SpatialGpuKernels:
                 for i in range(m_queries)
             ]
 
-        # ------ NumPy CPU fallback ------
+        # ------ NumPy CPU fallback (also used when n_entities < gpu_threshold) ------
         dists = _np_pairwise_distances(positions, query_points)  # (M, N)
         mask = dists <= radius
         return [list(np.where(mask[i])[0]) for i in range(m_queries)]
@@ -302,15 +302,15 @@ class SpatialGpuKernels:
         if m_queries == 0:
             return np.empty(0, dtype=np.int64)
 
-        # ------ GPU / torch path ------
-        if _TORCH_AVAILABLE and self._device is not None:
+        # ------ GPU / torch path (only for large entity counts) ------
+        if _TORCH_AVAILABLE and self._device is not None and n_entities >= self.gpu_threshold:
             pos_t = torch.as_tensor(positions, dtype=torch.float64, device=self._device)
             qpt_t = torch.as_tensor(query_points, dtype=torch.float64, device=self._device)
             dist_t = torch.cdist(qpt_t, pos_t)   # (M, N)
             idx_t = dist_t.argmin(dim=1)          # (M,)
             return idx_t.cpu().numpy().astype(np.int64)
 
-        # ------ NumPy CPU fallback ------
+        # ------ NumPy CPU fallback (also used when n_entities < gpu_threshold) ------
         dists = _np_pairwise_distances(positions, query_points)  # (M, N)
         return dists.argmin(axis=1).astype(np.int64)
 

--- a/farm/core/spatial/gpu_kernels.py
+++ b/farm/core/spatial/gpu_kernels.py
@@ -1,0 +1,349 @@
+"""GPU-accelerated spatial computation kernels using PyTorch.
+
+These kernels accelerate common spatial queries (radius search, nearest
+neighbour) via vectorised distance-matrix operations.  When a CUDA device is
+available the work is dispatched there; otherwise the same tensor code runs on
+CPU, still benefiting from vectorised parallelism over a pure-Python loop.
+
+Typical usage
+-------------
+>>> from farm.core.spatial.gpu_kernels import SpatialGpuKernels
+>>> kernels = SpatialGpuKernels()          # auto-detect GPU
+>>> indices = kernels.radius_query(positions, query_point, radius=20.0)
+>>> nearest_idx = kernels.nearest_query(positions, query_point)
+
+For bulk / batch queries (many query points at once):
+>>> results = kernels.batch_radius_query(positions, query_points, radius=20.0)
+>>> results = kernels.batch_nearest_query(positions, query_points)
+
+Notes
+-----
+- Import of ``torch`` is deferred so that the rest of the spatial package
+  continues to work on environments that do not have PyTorch installed.
+- GPU acceleration is most beneficial when *N* (number of candidate positions)
+  is large.  For small entity counts the per-call tensor-setup overhead
+  exceeds the saving; the ``gpu_threshold`` parameter in :class:`SpatialGpuKernels`
+  controls the cross-over point.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from farm.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Optional torch import
+# ---------------------------------------------------------------------------
+try:
+    import torch
+
+    _TORCH_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    torch = None  # type: ignore[assignment]
+    _TORCH_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def is_gpu_available() -> bool:
+    """Return ``True`` if a CUDA GPU is available via PyTorch."""
+    return _TORCH_AVAILABLE and torch.cuda.is_available()
+
+
+def get_spatial_device(prefer_gpu: bool = True) -> "Optional[torch.device]":
+    """Return the best device for spatial tensor operations.
+
+    Parameters
+    ----------
+    prefer_gpu:
+        When *True*, try to return a CUDA device; fall back to CPU if CUDA is
+        not available.  When *False*, always returns a CPU device.
+
+    Returns
+    -------
+    torch.device or None
+        ``None`` only when PyTorch is not installed at all.
+    """
+    if not _TORCH_AVAILABLE:
+        return None  # type: ignore[return-value]
+    if prefer_gpu and torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
+# ---------------------------------------------------------------------------
+# Low-level numpy fallbacks (no torch required)
+# ---------------------------------------------------------------------------
+
+
+def _np_pairwise_distances(
+    positions: np.ndarray, query_points: np.ndarray
+) -> np.ndarray:
+    """Pure-NumPy pairwise Euclidean distances, shape ``(M, N)``."""
+    # positions: (N, 2),  query_points: (M, 2)
+    diff = query_points[:, np.newaxis, :] - positions[np.newaxis, :, :]  # (M, N, 2)
+    return np.sqrt((diff**2).sum(axis=-1))  # (M, N)
+
+
+# ---------------------------------------------------------------------------
+# Main class
+# ---------------------------------------------------------------------------
+
+
+class SpatialGpuKernels:
+    """GPU-accelerated (or vectorised-CPU) spatial kernels.
+
+    Parameters
+    ----------
+    use_gpu:
+        Whether to prefer GPU execution.  When *True* and no CUDA device is
+        found, falls back to CPU tensors transparently.
+    gpu_threshold:
+        Minimum number of candidate entities before the GPU/tensor path is
+        preferred over a direct call.  Below this count the tensor-setup
+        overhead is not worthwhile.  Default 256.
+    device:
+        Explicit ``torch.device`` to use.  Auto-selected when ``None``.
+    """
+
+    def __init__(
+        self,
+        use_gpu: bool = True,
+        gpu_threshold: int = 256,
+        device: "Optional[torch.device]" = None,
+    ) -> None:
+        self.use_gpu = use_gpu
+        self.gpu_threshold = gpu_threshold
+
+        if device is not None:
+            self._device = device
+        elif _TORCH_AVAILABLE:
+            self._device = get_spatial_device(prefer_gpu=use_gpu)
+        else:
+            self._device = None
+
+        self._on_gpu: bool = (
+            self._device is not None and self._device.type == "cuda"
+        )
+
+        logger.debug(
+            "spatial_gpu_kernels_init",
+            device=str(self._device),
+            on_gpu=self._on_gpu,
+            torch_available=_TORCH_AVAILABLE,
+        )
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def device(self) -> "Optional[torch.device]":
+        """The active compute device (``None`` when torch is unavailable)."""
+        return self._device
+
+    @property
+    def on_gpu(self) -> bool:
+        """``True`` when computations will run on a CUDA device."""
+        return self._on_gpu
+
+    # ------------------------------------------------------------------
+    # Single-query helpers
+    # ------------------------------------------------------------------
+
+    def radius_query(
+        self,
+        positions: np.ndarray,
+        query_point: Tuple[float, float],
+        radius: float,
+    ) -> List[int]:
+        """Return indices of *positions* within *radius* of *query_point*.
+
+        Parameters
+        ----------
+        positions:
+            Candidate entity positions, shape ``(N, 2)``.
+        query_point:
+            Query ``(x, y)`` tuple.
+        radius:
+            Search radius (same units as positions).
+
+        Returns
+        -------
+        list of int
+            Indices into *positions* whose distance to *query_point* is ``<= radius``.
+        """
+        if len(positions) == 0:
+            return []
+        qp = np.asarray(query_point, dtype=np.float64).reshape(1, 2)
+        results = self.batch_radius_query(positions, qp, radius)
+        return results[0]
+
+    def nearest_query(
+        self,
+        positions: np.ndarray,
+        query_point: Tuple[float, float],
+    ) -> int:
+        """Return index of the nearest position to *query_point*.
+
+        Parameters
+        ----------
+        positions:
+            Candidate entity positions, shape ``(N, 2)``.
+        query_point:
+            Query ``(x, y)`` tuple.
+
+        Returns
+        -------
+        int
+            Index into *positions* of the nearest entity, or ``-1`` if
+            *positions* is empty.
+        """
+        if len(positions) == 0:
+            return -1
+        qp = np.asarray(query_point, dtype=np.float64).reshape(1, 2)
+        indices = self.batch_nearest_query(positions, qp)
+        return int(indices[0])
+
+    # ------------------------------------------------------------------
+    # Batch query methods (primary GPU-accelerated paths)
+    # ------------------------------------------------------------------
+
+    def batch_radius_query(
+        self,
+        positions: np.ndarray,
+        query_points: np.ndarray,
+        radius: float,
+    ) -> List[List[int]]:
+        """Return neighbour indices for every query point in *query_points*.
+
+        This is the primary GPU-accelerated path.  The full ``(M, N)``
+        distance matrix is computed in a single batched operation.
+
+        Parameters
+        ----------
+        positions:
+            Candidate entity positions, shape ``(N, 2)``.
+        query_points:
+            Query positions, shape ``(M, 2)``.
+        radius:
+            Search radius.
+
+        Returns
+        -------
+        list of lists of int
+            ``results[i]`` contains the indices of all positions within
+            *radius* of ``query_points[i]``.
+        """
+        positions = np.asarray(positions, dtype=np.float64)
+        query_points = np.asarray(query_points, dtype=np.float64)
+
+        n_entities = len(positions)
+        m_queries = len(query_points)
+
+        if n_entities == 0 or m_queries == 0:
+            return [[] for _ in range(m_queries)]
+
+        # ------ GPU / torch path ------
+        if _TORCH_AVAILABLE and self._device is not None:
+            pos_t = torch.as_tensor(positions, dtype=torch.float32, device=self._device)
+            qpt_t = torch.as_tensor(query_points, dtype=torch.float32, device=self._device)
+            # torch.cdist: (M, N) pairwise L2 distances
+            dist_t = torch.cdist(qpt_t, pos_t)  # (M, N)
+            mask = dist_t <= float(radius)       # (M, N) bool
+            mask_cpu = mask.cpu()
+            return [
+                mask_cpu[i].nonzero(as_tuple=False).squeeze(1).tolist()
+                for i in range(m_queries)
+            ]
+
+        # ------ NumPy CPU fallback ------
+        dists = _np_pairwise_distances(positions, query_points)  # (M, N)
+        mask = dists <= radius
+        return [list(np.where(mask[i])[0]) for i in range(m_queries)]
+
+    def batch_nearest_query(
+        self,
+        positions: np.ndarray,
+        query_points: np.ndarray,
+    ) -> np.ndarray:
+        """Return the nearest-position index for every query point.
+
+        Parameters
+        ----------
+        positions:
+            Candidate entity positions, shape ``(N, 2)``.
+        query_points:
+            Query positions, shape ``(M, 2)``.
+
+        Returns
+        -------
+        ndarray, shape ``(M,)``
+            Each element is the index into *positions* of the nearest entity
+            for the corresponding query point.  Values are ``-1`` for any
+            query point when *positions* is empty.
+        """
+        positions = np.asarray(positions, dtype=np.float64)
+        query_points = np.asarray(query_points, dtype=np.float64)
+
+        n_entities = len(positions)
+        m_queries = len(query_points)
+
+        if n_entities == 0:
+            return np.full(m_queries, -1, dtype=np.int64)
+        if m_queries == 0:
+            return np.empty(0, dtype=np.int64)
+
+        # ------ GPU / torch path ------
+        if _TORCH_AVAILABLE and self._device is not None:
+            pos_t = torch.as_tensor(positions, dtype=torch.float32, device=self._device)
+            qpt_t = torch.as_tensor(query_points, dtype=torch.float32, device=self._device)
+            dist_t = torch.cdist(qpt_t, pos_t)   # (M, N)
+            idx_t = dist_t.argmin(dim=1)          # (M,)
+            return idx_t.cpu().numpy().astype(np.int64)
+
+        # ------ NumPy CPU fallback ------
+        dists = _np_pairwise_distances(positions, query_points)  # (M, N)
+        return dists.argmin(axis=1).astype(np.int64)
+
+    def pairwise_distances(
+        self,
+        positions: np.ndarray,
+        query_points: np.ndarray,
+    ) -> np.ndarray:
+        """Compute the full pairwise distance matrix.
+
+        Parameters
+        ----------
+        positions:
+            Candidate positions, shape ``(N, 2)``.
+        query_points:
+            Query positions, shape ``(M, 2)``.
+
+        Returns
+        -------
+        ndarray, shape ``(M, N)``
+            ``distances[i, j]`` is the Euclidean distance between
+            ``query_points[i]`` and ``positions[j]``.
+        """
+        positions = np.asarray(positions, dtype=np.float64)
+        query_points = np.asarray(query_points, dtype=np.float64)
+
+        if len(positions) == 0 or len(query_points) == 0:
+            return np.empty((len(query_points), len(positions)), dtype=np.float64)
+
+        if _TORCH_AVAILABLE and self._device is not None:
+            pos_t = torch.as_tensor(positions, dtype=torch.float32, device=self._device)
+            qpt_t = torch.as_tensor(query_points, dtype=torch.float32, device=self._device)
+            dist_t = torch.cdist(qpt_t, pos_t)
+            return dist_t.cpu().numpy().astype(np.float64)
+
+        return _np_pairwise_distances(positions, query_points)

--- a/farm/core/spatial/gpu_kernels.py
+++ b/farm/core/spatial/gpu_kernels.py
@@ -254,8 +254,8 @@ class SpatialGpuKernels:
 
         # ------ GPU / torch path ------
         if _TORCH_AVAILABLE and self._device is not None:
-            pos_t = torch.as_tensor(positions, dtype=torch.float32, device=self._device)
-            qpt_t = torch.as_tensor(query_points, dtype=torch.float32, device=self._device)
+            pos_t = torch.as_tensor(positions, dtype=torch.float64, device=self._device)
+            qpt_t = torch.as_tensor(query_points, dtype=torch.float64, device=self._device)
             # torch.cdist: (M, N) pairwise L2 distances
             dist_t = torch.cdist(qpt_t, pos_t)  # (M, N)
             mask = dist_t <= float(radius)       # (M, N) bool
@@ -304,8 +304,8 @@ class SpatialGpuKernels:
 
         # ------ GPU / torch path ------
         if _TORCH_AVAILABLE and self._device is not None:
-            pos_t = torch.as_tensor(positions, dtype=torch.float32, device=self._device)
-            qpt_t = torch.as_tensor(query_points, dtype=torch.float32, device=self._device)
+            pos_t = torch.as_tensor(positions, dtype=torch.float64, device=self._device)
+            qpt_t = torch.as_tensor(query_points, dtype=torch.float64, device=self._device)
             dist_t = torch.cdist(qpt_t, pos_t)   # (M, N)
             idx_t = dist_t.argmin(dim=1)          # (M,)
             return idx_t.cpu().numpy().astype(np.int64)
@@ -341,9 +341,9 @@ class SpatialGpuKernels:
             return np.empty((len(query_points), len(positions)), dtype=np.float64)
 
         if _TORCH_AVAILABLE and self._device is not None:
-            pos_t = torch.as_tensor(positions, dtype=torch.float32, device=self._device)
-            qpt_t = torch.as_tensor(query_points, dtype=torch.float32, device=self._device)
+            pos_t = torch.as_tensor(positions, dtype=torch.float64, device=self._device)
+            qpt_t = torch.as_tensor(query_points, dtype=torch.float64, device=self._device)
             dist_t = torch.cdist(qpt_t, pos_t)
-            return dist_t.cpu().numpy().astype(np.float64)
+            return dist_t.cpu().numpy()
 
         return _np_pairwise_distances(positions, query_points)

--- a/farm/core/spatial/index.py
+++ b/farm/core/spatial/index.py
@@ -36,7 +36,7 @@ import numpy as np
 from scipy.spatial import cKDTree
 
 from .dirty_regions import DirtyRegionTracker
-from .gpu_kernels import SpatialGpuKernels, is_gpu_available
+from .gpu_kernels import SpatialGpuKernels
 from .hash_grid import SpatialHashGrid
 from .quadtree import Quadtree, QuadtreeNode
 

--- a/farm/core/spatial/index.py
+++ b/farm/core/spatial/index.py
@@ -1107,7 +1107,7 @@ class SpatialIndex:
         """GPU-accelerated batch radius query for multiple query positions.
 
         Computes, in a single vectorised operation, which entities lie within
-        *radius* of **every** position in *query_positions*.  This is far more
+        *radius* for each position in *query_positions*.  This is far more
         efficient than calling :meth:`get_nearby` in a loop when there are many
         query positions because the full ``(M, N)`` distance matrix is computed
         on the GPU (or vectorised CPU) in one shot.

--- a/farm/core/spatial/index.py
+++ b/farm/core/spatial/index.py
@@ -152,6 +152,14 @@ class SpatialIndex:
                 gpu_threshold=gpu_threshold,
             )
 
+        # CPU-only fallback kernels used by batch methods when GPU is disabled.
+        # Created once and reused to avoid repeated instantiation overhead.
+        self._cpu_kernels: SpatialGpuKernels = (
+            self._gpu_kernels
+            if self._gpu_kernels is not None
+            else SpatialGpuKernels(use_gpu=False)
+        )
+
         # Flush policy settings
         self.flush_interval_seconds = flush_interval_seconds
         self.max_pending_updates_before_flush = max_pending_updates_before_flush
@@ -1130,7 +1138,7 @@ class SpatialIndex:
         qp_array = np.asarray(query_positions, dtype=np.float64)
         results: Dict[str, List[List[Any]]] = {}
 
-        kernels = self._gpu_kernels or SpatialGpuKernels(use_gpu=False)
+        kernels = self._cpu_kernels
 
         for name in names:
             state = self._named_indices.get(name)
@@ -1184,7 +1192,7 @@ class SpatialIndex:
         qp_array = np.asarray(query_positions, dtype=np.float64)
         results: Dict[str, List[Optional[Any]]] = {}
 
-        kernels = self._gpu_kernels or SpatialGpuKernels(use_gpu=False)
+        kernels = self._cpu_kernels
 
         for name in names:
             state = self._named_indices.get(name)

--- a/farm/core/spatial/index.py
+++ b/farm/core/spatial/index.py
@@ -36,6 +36,7 @@ import numpy as np
 from scipy.spatial import cKDTree
 
 from .dirty_regions import DirtyRegionTracker
+from .gpu_kernels import SpatialGpuKernels, is_gpu_available
 from .hash_grid import SpatialHashGrid
 from .quadtree import Quadtree, QuadtreeNode
 
@@ -90,6 +91,8 @@ class SpatialIndex:
         flush_interval_seconds: float = 1.0,
         max_pending_updates_before_flush: int = 50,
         dirty_region_batch_size: int = 10,
+        use_gpu: bool = False,
+        gpu_threshold: int = 256,
     ):
         """
         Initialize the SpatialIndex.
@@ -116,12 +119,38 @@ class SpatialIndex:
             Size-based flush policy: automatically flush when this many updates are pending
         dirty_region_batch_size : int, default 10
             Number of dirty regions to process per batch
+        use_gpu : bool, default False
+            Whether to use GPU acceleration for spatial queries when available.
+            Falls back to CPU-based tensor operations when no CUDA device is
+            detected.  For small entity counts (below ``gpu_threshold``) the
+            existing scipy cKDTree path is used regardless of this setting to
+            avoid tensor-setup overhead.
+        gpu_threshold : int, default 256
+            Minimum number of candidate entities before the GPU/tensor path is
+            preferred over the scipy cKDTree for individual queries.  Batch
+            query methods always use the GPU/tensor path when ``use_gpu=True``.
         """
         self.width = width
         self.height = height
         self._initial_batch_updates_enabled = enable_batch_updates
         self.max_batch_size = max_batch_size
         self._dirty_region_batch_size = dirty_region_batch_size
+
+        # GPU acceleration
+        self._use_gpu = use_gpu
+        self._gpu_threshold = gpu_threshold
+        self._gpu_kernels: Optional[SpatialGpuKernels] = None
+        if use_gpu:
+            self._gpu_kernels = SpatialGpuKernels(
+                use_gpu=use_gpu,
+                gpu_threshold=gpu_threshold,
+            )
+            logger.info(
+                "spatial_index_gpu_enabled",
+                on_gpu=self._gpu_kernels.on_gpu,
+                device=str(self._gpu_kernels.device),
+                gpu_threshold=gpu_threshold,
+            )
 
         # Flush policy settings
         self.flush_interval_seconds = flush_interval_seconds
@@ -960,9 +989,20 @@ class SpatialIndex:
                 if state["kdtree"] is None:
                     results[name] = []
                     continue
-                indices = state["kdtree"].query_ball_point(position, radius)
                 cached_items = state["cached_items"] or []
-                results[name] = [cached_items[i] for i in indices]
+                # GPU-accelerated path: use when enabled and entity count meets threshold
+                if (
+                    self._gpu_kernels is not None
+                    and len(cached_items) >= self._gpu_threshold
+                    and state["positions"] is not None
+                ):
+                    hit_indices = self._gpu_kernels.radius_query(
+                        state["positions"], position, radius
+                    )
+                    results[name] = [cached_items[i] for i in hit_indices]
+                else:
+                    indices = state["kdtree"].query_ball_point(position, radius)
+                    results[name] = [cached_items[i] for i in indices]
             elif index_type == "quadtree":
                 if state["quadtree"] is None:
                     results[name] = []
@@ -1023,8 +1063,18 @@ class SpatialIndex:
                 if state["kdtree"] is None or not state["cached_items"]:
                     results[name] = None
                     continue
-                _, idx = state["kdtree"].query(position)
-                results[name] = state["cached_items"][idx]
+                cached_items = state["cached_items"]
+                # GPU-accelerated path: use when enabled and entity count meets threshold
+                if (
+                    self._gpu_kernels is not None
+                    and len(cached_items) >= self._gpu_threshold
+                    and state["positions"] is not None
+                ):
+                    idx = self._gpu_kernels.nearest_query(state["positions"], position)
+                    results[name] = cached_items[idx] if idx >= 0 else None
+                else:
+                    _, idx = state["kdtree"].query(position)
+                    results[name] = cached_items[idx]
             elif index_type == "quadtree":
                 if state["quadtree"] is None or not state["cached_items"]:
                     results[name] = None
@@ -1038,6 +1088,131 @@ class SpatialIndex:
             else:
                 results[name] = None
         return results
+
+    def batch_radius_query(
+        self,
+        query_positions: List[Tuple[float, float]],
+        radius: float,
+        index_names: Optional[List[str]] = None,
+        allow_stale_reads: bool = False,
+    ) -> Dict[str, List[List[Any]]]:
+        """GPU-accelerated batch radius query for multiple query positions.
+
+        Computes, in a single vectorised operation, which entities lie within
+        *radius* of **every** position in *query_positions*.  This is far more
+        efficient than calling :meth:`get_nearby` in a loop when there are many
+        query positions because the full ``(M, N)`` distance matrix is computed
+        on the GPU (or vectorised CPU) in one shot.
+
+        Parameters
+        ----------
+        query_positions : list of (x, y) tuples
+            Positions to query from.
+        radius : float
+            Search radius.
+        index_names : list of str, optional
+            Named indices to query.  Defaults to all registered indices.
+        allow_stale_reads : bool, default False
+            If *True*, skip flushing pending batch updates first.
+
+        Returns
+        -------
+        dict
+            ``results[index_name][i]`` is the list of entities within *radius*
+            of ``query_positions[i]``.
+        """
+        if not allow_stale_reads:
+            self.update()
+        if not query_positions or radius <= 0:
+            return {}
+
+        names = index_names or list(self._named_indices.keys())
+        qp_array = np.asarray(query_positions, dtype=np.float64)
+        results: Dict[str, List[List[Any]]] = {}
+
+        kernels = self._gpu_kernels or SpatialGpuKernels(use_gpu=False)
+
+        for name in names:
+            state = self._named_indices.get(name)
+            if state is None or state.get("positions") is None:
+                results[name] = [[] for _ in query_positions]
+                continue
+            cached_items = state["cached_items"] or []
+            positions = state["positions"]
+            if len(positions) == 0:
+                results[name] = [[] for _ in query_positions]
+                continue
+            hit_index_lists = kernels.batch_radius_query(positions, qp_array, radius)
+            results[name] = [
+                [cached_items[i] for i in idx_list] for idx_list in hit_index_lists
+            ]
+
+        return results
+
+    def batch_nearest_query(
+        self,
+        query_positions: List[Tuple[float, float]],
+        index_names: Optional[List[str]] = None,
+        allow_stale_reads: bool = False,
+    ) -> Dict[str, List[Optional[Any]]]:
+        """GPU-accelerated batch nearest-neighbour query.
+
+        Finds the nearest entity for each position in *query_positions* using a
+        single batched distance-matrix computation.
+
+        Parameters
+        ----------
+        query_positions : list of (x, y) tuples
+            Positions to query from.
+        index_names : list of str, optional
+            Named indices to query.  Defaults to all registered indices.
+        allow_stale_reads : bool, default False
+            If *True*, skip flushing pending batch updates first.
+
+        Returns
+        -------
+        dict
+            ``results[index_name][i]`` is the nearest entity to
+            ``query_positions[i]``, or ``None`` if no entities exist.
+        """
+        if not allow_stale_reads:
+            self.update()
+        if not query_positions:
+            return {}
+
+        names = index_names or list(self._named_indices.keys())
+        qp_array = np.asarray(query_positions, dtype=np.float64)
+        results: Dict[str, List[Optional[Any]]] = {}
+
+        kernels = self._gpu_kernels or SpatialGpuKernels(use_gpu=False)
+
+        for name in names:
+            state = self._named_indices.get(name)
+            if state is None or state.get("positions") is None:
+                results[name] = [None] * len(query_positions)
+                continue
+            cached_items = state["cached_items"] or []
+            positions = state["positions"]
+            if len(positions) == 0:
+                results[name] = [None] * len(query_positions)
+                continue
+            nearest_indices = kernels.batch_nearest_query(positions, qp_array)
+            results[name] = [
+                cached_items[int(idx)] if idx >= 0 else None
+                for idx in nearest_indices
+            ]
+
+        return results
+
+    @property
+    def gpu_enabled(self) -> bool:
+        """Whether GPU acceleration is active for this index."""
+        return self._gpu_kernels is not None
+
+    @property
+    def gpu_on_device(self) -> bool:
+        """Whether GPU computations run on a CUDA device (vs CPU tensors)."""
+        return self._gpu_kernels is not None and self._gpu_kernels.on_gpu
 
     def _quadtree_nearest(
         self, quadtree: Quadtree, position: Tuple[float, float]

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -129,7 +129,7 @@ def _preset_or_scale_to_pressure_config(
 class _InitialConditionsPreset:
     """Internal container for the values that an initial-conditions preset sets."""
 
-    initial_agent_resource_level: Optional[float]
+    initial_agent_resource_level: Optional[int]
     """Starting resource level for each newly-spawned agent (``None`` = no override)."""
     initial_resource_count: Optional[int]
     """Number of resource nodes placed at simulation start (``None`` = no override)."""
@@ -144,8 +144,8 @@ _INITIAL_CONDITIONS_PRESETS: Dict[str, _InitialConditionsPreset] = {
     # reproduce sooner, and the population stabilizes without a sharp spike/crash.
     #
     # Rationale for specific values:
-    #   initial_agent_resource_level=20.0: agents start with ~2–4× the default
-    #     fallback level (5.0) so they can gather and meet the default
+    #   initial_agent_resource_level=20: agents start with ~2–4× the default
+    #     fallback level (5) so they can gather and meet the default
     #     min_reproduction_resources threshold (8) within the first few steps
     #     rather than starving before they find food.
     #   initial_resource_count=30: 50% more resource nodes than the default (20)
@@ -155,7 +155,7 @@ _INITIAL_CONDITIONS_PRESETS: Dict[str, _InitialConditionsPreset] = {
     #   resource_regen_amount=3: slightly above the default (2) to keep per-node
     #     regeneration meaningful while not making resources unlimited.
     "stable": _InitialConditionsPreset(
-        initial_agent_resource_level=20.0,
+        initial_agent_resource_level=20,
         initial_resource_count=30,
         resource_regen_rate=0.15,
         resource_regen_amount=3,
@@ -164,7 +164,7 @@ _INITIAL_CONDITIONS_PRESETS: Dict[str, _InitialConditionsPreset] = {
     # how quickly adaptive traits emerge under pressure.
     #
     # Rationale:
-    #   initial_agent_resource_level=3.0: well below the default, forcing
+    #   initial_agent_resource_level=3: well below the default, forcing
     #     immediate resource-seeking and creating strong early mortality.
     #   initial_resource_count=10: half the default node count; food scarcity
     #     is the dominant selection pressure from step 1.
@@ -172,7 +172,7 @@ _INITIAL_CONDITIONS_PRESETS: Dict[str, _InitialConditionsPreset] = {
     #     building up; only the most efficient foragers survive.
     #   resource_regen_amount=1: minimal per-node yield amplifies scarcity.
     "stress": _InitialConditionsPreset(
-        initial_agent_resource_level=3.0,
+        initial_agent_resource_level=3,
         initial_resource_count=10,
         resource_regen_rate=0.05,
         resource_regen_amount=1,
@@ -182,10 +182,10 @@ _INITIAL_CONDITIONS_PRESETS: Dict[str, _InitialConditionsPreset] = {
     #
     # Rationale: values match the SimulationConfig defaults (resource_regen_rate=0.1,
     # resource_regen_amount=2, initial_resources=20) with a modest agent resource
-    # bump (12.0 vs the fallback 5.0) so agents are not immediately at risk
+    # bump (12 vs the fallback 5) so agents are not immediately at risk
     # while still experiencing meaningful selection.
     "exploratory": _InitialConditionsPreset(
-        initial_agent_resource_level=12.0,
+        initial_agent_resource_level=12,
         initial_resource_count=20,
         resource_regen_rate=0.1,
         resource_regen_amount=2,
@@ -248,7 +248,7 @@ class InitialConditionsConfig:
 
     profile: Optional[InitialConditionsProfileName] = "stable"
     # Per-field manual overrides (win over preset when set)
-    initial_agent_resource_level: Optional[float] = None
+    initial_agent_resource_level: Optional[int] = None
     initial_resource_count: Optional[int] = None
     resource_regen_rate: Optional[float] = None
     resource_regen_amount: Optional[int] = None
@@ -262,12 +262,9 @@ class InitialConditionsConfig:
                 f"got {self.profile!r}."
             )
         if self.initial_agent_resource_level is not None:
-            if (
-                not math.isfinite(self.initial_agent_resource_level)
-                or self.initial_agent_resource_level < 0.0
-            ):
+            if self.initial_agent_resource_level < 0:
                 raise ValueError(
-                    "initial_agent_resource_level must be a finite, non-negative number when set."
+                    "initial_agent_resource_level must be a non-negative integer when set."
                 )
         if self.initial_resource_count is not None and self.initial_resource_count < 0:
             raise ValueError("initial_resource_count must be non-negative when set.")
@@ -579,21 +576,33 @@ class IntrinsicEvolutionExperiment:
             )
         resolved_ic = self.config.initial_conditions.resolve()
         if resolved_ic.get("initial_agent_resource_level") is not None:
-            run_config.agent_behavior.initial_resource_level = round(
+            resolved_ic["initial_agent_resource_level"] = int(
                 resolved_ic["initial_agent_resource_level"]
             )
+            run_config.agent_behavior.initial_resource_level = resolved_ic[
+                "initial_agent_resource_level"
+            ]
         if resolved_ic.get("initial_resource_count") is not None:
-            run_config.resources.initial_resources = int(
+            resolved_ic["initial_resource_count"] = int(
                 resolved_ic["initial_resource_count"]
             )
+            run_config.resources.initial_resources = resolved_ic[
+                "initial_resource_count"
+            ]
         if resolved_ic.get("resource_regen_rate") is not None:
-            run_config.resources.resource_regen_rate = float(
+            resolved_ic["resource_regen_rate"] = float(
                 resolved_ic["resource_regen_rate"]
             )
+            run_config.resources.resource_regen_rate = resolved_ic[
+                "resource_regen_rate"
+            ]
         if resolved_ic.get("resource_regen_amount") is not None:
-            run_config.resources.resource_regen_amount = int(
+            resolved_ic["resource_regen_amount"] = int(
                 resolved_ic["resource_regen_amount"]
             )
+            run_config.resources.resource_regen_amount = resolved_ic[
+                "resource_regen_amount"
+            ]
 
         effective_warmup: int = int(resolved_ic.get("warmup_steps", 0))
         transient_window: int = int(resolved_ic.get("transient_window", 50))

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -579,7 +579,7 @@ class IntrinsicEvolutionExperiment:
             )
         resolved_ic = self.config.initial_conditions.resolve()
         if resolved_ic.get("initial_agent_resource_level") is not None:
-            run_config.agent_behavior.initial_resource_level = int(
+            run_config.agent_behavior.initial_resource_level = round(
                 resolved_ic["initial_agent_resource_level"]
             )
         if resolved_ic.get("initial_resource_count") is not None:

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -41,8 +41,9 @@ logger = get_logger(__name__)
 
 CoparentStrategy = Literal["nearest_alive_same_type", "random_alive_same_type"]
 SelectionPressurePreset = Literal["none", "low", "medium", "high"]
+InitialConditionsProfileName = Literal["stable", "stress", "exploratory", "legacy"]
 
-# ── Preset definitions ────────────────────────────────────────────────────────
+# ── Selection-pressure preset definitions ─────────────────────────────────────
 # Each preset maps to a ReproductionPressureConfig with sensible defaults that
 # give progressively stronger selection without requiring the user to tune raw
 # coefficients.  "none" is the identity (no density cost).
@@ -115,6 +116,226 @@ def _preset_or_scale_to_pressure_config(
         f"selection_pressure must be a str preset or float in [0, 1]; "
         f"got {type(selection_pressure).__name__!r}."
     )
+
+
+# ── Initial-conditions preset definitions ─────────────────────────────────────
+# Each preset bundles overrides for agent starting resources, environmental
+# resource count, and regeneration rates.  "stable" is the default and is
+# tuned to reduce the early boom-bust transient common in fresh simulations.
+# "legacy" applies no overrides and reproduces the pre-feature behavior.
+
+@dataclass(frozen=True)
+class _InitialConditionsPreset:
+    """Internal container for the values that an initial-conditions preset sets."""
+
+    initial_agent_resource_level: Optional[float]
+    """Starting resource level for each newly-spawned agent (``None`` = no override)."""
+    initial_resource_count: Optional[int]
+    """Number of resource nodes placed at simulation start (``None`` = no override)."""
+    resource_regen_rate: Optional[float]
+    """Per-step probability of a resource node regenerating (``None`` = no override)."""
+    resource_regen_amount: Optional[int]
+    """Amount regenerated per node per step when regeneration fires (``None`` = no override)."""
+
+
+_INITIAL_CONDITIONS_PRESETS: Dict[str, _InitialConditionsPreset] = {
+    # stable: higher agent and environment resources → agents survive early steps,
+    # reproduce sooner, and the population stabilises without a sharp spike/crash.
+    "stable": _InitialConditionsPreset(
+        initial_agent_resource_level=20.0,
+        initial_resource_count=30,
+        resource_regen_rate=0.15,
+        resource_regen_amount=3,
+    ),
+    # stress: scarce resources → intense early selection; use when studying
+    # how quickly adaptive traits emerge under pressure.
+    "stress": _InitialConditionsPreset(
+        initial_agent_resource_level=3.0,
+        initial_resource_count=10,
+        resource_regen_rate=0.05,
+        resource_regen_amount=1,
+    ),
+    # exploratory: moderate resources similar to defaults; intended for runs
+    # focused on genetic diversity rather than survival pressure.
+    "exploratory": _InitialConditionsPreset(
+        initial_agent_resource_level=12.0,
+        initial_resource_count=20,
+        resource_regen_rate=0.1,
+        resource_regen_amount=2,
+    ),
+    # legacy: no overrides; reproduces pre-InitialConditionsConfig behavior
+    # exactly so existing benchmarks and comparisons remain valid.
+    "legacy": _InitialConditionsPreset(
+        initial_agent_resource_level=None,
+        initial_resource_count=None,
+        resource_regen_rate=None,
+        resource_regen_amount=None,
+    ),
+}
+
+
+@dataclass(frozen=True)
+class InitialConditionsConfig:
+    """Initial-conditions configuration for an intrinsic evolution run.
+
+    Controls the starting state of the simulation (agent resources, environmental
+    resources, and regeneration rates) to reduce or shape early boom-bust dynamics.
+
+    Profiles
+    --------
+    ``profile`` selects a named preset:
+
+    - ``"stable"`` *(default)*: Higher agent and environment resources reduce the
+      early growth/death wave while preserving normal adaptive dynamics thereafter.
+    - ``"stress"``: Scarce resources amplify early selection pressure; useful for
+      studying rapid adaptation.
+    - ``"exploratory"``: Moderate resources with default regeneration; a neutral
+      baseline for genetic-diversity research.
+    - ``"legacy"``: No overrides; exactly reproduces behavior from before this
+      feature was introduced.  Use to run apples-to-apples comparisons with older
+      runs.
+    - ``None``: Skip preset application entirely; only explicit manual overrides
+      below are applied (all default to ``None``, i.e., no override).
+
+    Manual overrides
+    ----------------
+    All override fields default to ``None`` (meaning "use the preset value or
+    leave the base config unchanged").  Non-``None`` values always win over the
+    preset.
+
+    ``warmup_steps``
+    ----------------
+    When > 0 the simulation runs for ``warmup_steps`` extra steps *before* the
+    main telemetry window.  Gene-trajectory snapshots are suppressed during the
+    warmup phase so the persistent artifacts reflect only the stabilised
+    population.  The ``startup_transient_metrics`` in
+    :class:`IntrinsicEvolutionResult` are still computed from the very first
+    ``transient_window`` steps regardless of warmup.
+
+    ``transient_window``
+    --------------------
+    Number of *post-environment-ready* steps used to derive startup-transient
+    metrics (peak birth rate, peak death rate, oscillation amplitude).  Defaults
+    to 50.  Does not affect the total number of steps run.
+    """
+
+    profile: Optional[str] = "stable"
+    # Per-field manual overrides (win over preset when set)
+    initial_agent_resource_level: Optional[float] = None
+    initial_resource_count: Optional[int] = None
+    resource_regen_rate: Optional[float] = None
+    resource_regen_amount: Optional[int] = None
+    warmup_steps: int = 0
+    transient_window: int = 50
+
+    def __post_init__(self) -> None:
+        if self.profile is not None and self.profile not in _INITIAL_CONDITIONS_PRESETS:
+            raise ValueError(
+                f"profile must be one of {list(_INITIAL_CONDITIONS_PRESETS)} or None; "
+                f"got {self.profile!r}."
+            )
+        if self.warmup_steps < 0:
+            raise ValueError("warmup_steps must be non-negative.")
+        if self.transient_window < 1:
+            raise ValueError("transient_window must be at least 1.")
+
+    def resolve(self) -> Dict[str, Any]:
+        """Return the effective settings after merging preset defaults with manual overrides.
+
+        The returned dict always contains the following keys:
+        ``initial_agent_resource_level``, ``initial_resource_count``,
+        ``resource_regen_rate``, ``resource_regen_amount``,
+        ``warmup_steps``, ``transient_window``.
+        Values may be ``None`` when neither a preset nor a manual override supplies them.
+        """
+        if self.profile is not None:
+            preset = _INITIAL_CONDITIONS_PRESETS[self.profile]
+            resolved: Dict[str, Any] = {
+                "initial_agent_resource_level": preset.initial_agent_resource_level,
+                "initial_resource_count": preset.initial_resource_count,
+                "resource_regen_rate": preset.resource_regen_rate,
+                "resource_regen_amount": preset.resource_regen_amount,
+            }
+        else:
+            resolved = {
+                "initial_agent_resource_level": None,
+                "initial_resource_count": None,
+                "resource_regen_rate": None,
+                "resource_regen_amount": None,
+            }
+
+        # Manual overrides win over preset defaults.
+        if self.initial_agent_resource_level is not None:
+            resolved["initial_agent_resource_level"] = self.initial_agent_resource_level
+        if self.initial_resource_count is not None:
+            resolved["initial_resource_count"] = self.initial_resource_count
+        if self.resource_regen_rate is not None:
+            resolved["resource_regen_rate"] = self.resource_regen_rate
+        if self.resource_regen_amount is not None:
+            resolved["resource_regen_amount"] = self.resource_regen_amount
+
+        resolved["warmup_steps"] = self.warmup_steps
+        resolved["transient_window"] = self.transient_window
+        return resolved
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a JSON-friendly dict including the resolved effective values."""
+        resolved = self.resolve()
+        return {
+            "profile": self.profile,
+            "resolved": {
+                k: v for k, v in resolved.items()
+                if k not in ("warmup_steps", "transient_window")
+            },
+            "initial_agent_resource_level": self.initial_agent_resource_level,
+            "initial_resource_count": self.initial_resource_count,
+            "resource_regen_rate": self.resource_regen_rate,
+            "resource_regen_amount": self.resource_regen_amount,
+            "warmup_steps": self.warmup_steps,
+            "transient_window": self.transient_window,
+        }
+
+
+def _compute_startup_transient_metrics(
+    birth_rates: List[float],
+    death_rates: List[float],
+    populations: List[int],
+    transient_window: int,
+) -> Dict[str, Any]:
+    """Compute startup-transient summary statistics from per-step series.
+
+    Parameters
+    ----------
+    birth_rates:
+        Realized birth rates for the first N steps.
+    death_rates:
+        Realized death rates for the first N steps.
+    populations:
+        Alive-agent counts for the first N steps.
+    transient_window:
+        Configured window size (recorded even when fewer steps were observed).
+
+    Returns
+    -------
+    Dict with keys ``peak_birth_rate``, ``peak_death_rate``,
+    ``oscillation_amplitude``, ``n_steps_observed``, and ``transient_window``.
+    """
+    n = len(birth_rates)
+    if n == 0:
+        return {
+            "peak_birth_rate": 0.0,
+            "peak_death_rate": 0.0,
+            "oscillation_amplitude": 0,
+            "n_steps_observed": 0,
+            "transient_window": transient_window,
+        }
+    return {
+        "peak_birth_rate": max(birth_rates),
+        "peak_death_rate": max(death_rates),
+        "oscillation_amplitude": max(populations) - min(populations) if populations else 0,
+        "n_steps_observed": n,
+        "transient_window": transient_window,
+    }
 
 
 @dataclass(frozen=True)
@@ -220,11 +441,19 @@ class IntrinsicEvolutionExperimentConfig:
     installing the runner's independent-mutation defaults when the provided
     base config still has ``initial_diversity.mode=none``. Set it to ``False``
     to preserve an explicit ``none`` mode (monoculture start) unchanged.
+
+    ``initial_conditions`` controls the starting state of the simulation to
+    reduce early boom-bust dynamics.  Defaults to the ``"stable"`` profile;
+    use ``InitialConditionsConfig(profile="legacy")`` to reproduce the
+    pre-feature behavior exactly.
     """
 
     num_steps: int = 2000
     snapshot_interval: int = 100
     install_default_initial_diversity: bool = True
+    initial_conditions: InitialConditionsConfig = field(
+        default_factory=InitialConditionsConfig
+    )
     policy: IntrinsicEvolutionPolicy = field(default_factory=IntrinsicEvolutionPolicy)
     output_dir: Optional[str] = None
     seed: Optional[int] = None
@@ -243,11 +472,15 @@ class IntrinsicEvolutionResult:
     ``num_steps_completed`` may be smaller than ``config.num_steps`` if the
     population went extinct early (mirroring ``run_simulation`` semantics).
     ``final_gene_statistics`` is empty when the final population is empty.
+    ``startup_transient_metrics`` summarises the early boom-bust characteristics
+    of the run; keys: ``peak_birth_rate``, ``peak_death_rate``,
+    ``oscillation_amplitude``, ``n_steps_observed``, ``transient_window``.
     """
 
     num_steps_completed: int
     final_population: int
     final_gene_statistics: Dict[str, Dict[str, float]]
+    startup_transient_metrics: Dict[str, Any] = field(default_factory=dict)
 
 
 class IntrinsicEvolutionExperiment:
@@ -284,6 +517,31 @@ class IntrinsicEvolutionExperiment:
 
         policy = self.config.policy
 
+        # ── Apply initial-conditions overrides ───────────────────────────────
+        # Resolve the effective initial-condition settings by merging the
+        # selected profile defaults with any explicit per-field overrides.
+        resolved_ic = self.config.initial_conditions.resolve()
+        if resolved_ic.get("initial_agent_resource_level") is not None:
+            run_config.agent_behavior.initial_resource_level = int(
+                resolved_ic["initial_agent_resource_level"]
+            )
+        if resolved_ic.get("initial_resource_count") is not None:
+            run_config.resources.initial_resources = int(
+                resolved_ic["initial_resource_count"]
+            )
+        if resolved_ic.get("resource_regen_rate") is not None:
+            run_config.resources.resource_regen_rate = float(
+                resolved_ic["resource_regen_rate"]
+            )
+        if resolved_ic.get("resource_regen_amount") is not None:
+            run_config.resources.resource_regen_amount = int(
+                resolved_ic["resource_regen_amount"]
+            )
+
+        effective_warmup: int = int(resolved_ic.get("warmup_steps", 0))
+        transient_window: int = int(resolved_ic.get("transient_window", 50))
+        total_sim_steps = self.config.num_steps + effective_warmup
+
         # The intrinsic-evolution runner relies on a non-monoculture starting
         # population.  When the caller has not customized the platform-wide
         # initial-diversity config, install the runner's defaults so seeding
@@ -308,6 +566,12 @@ class IntrinsicEvolutionExperiment:
         latest_population = 0
         latest_gene_statistics: Dict[str, Dict[str, float]] = {}
         latest_diversity_metrics: Optional[Any] = None
+
+        # Startup-transient metric accumulators (filled for the first
+        # transient_window post-environment-ready steps).
+        _transient_birth_rates: List[float] = []
+        _transient_death_rates: List[float] = []
+        _transient_populations: List[int] = []
 
         # Track agent IDs from the previous step to compute birth/death rates.
         prev_agent_ids: set = set()
@@ -418,7 +682,10 @@ class IntrinsicEvolutionExperiment:
             # At step 0 there is no previous step, so birth/death rates are 0.
             alive_agents = list(environment.alive_agent_objects)
             prev_agent_ids = {_agent_telemetry_key(a) for a in alive_agents}
-            gene_logger.snapshot(environment, step=0)
+            # Only record the initial snapshot when there is no warmup phase;
+            # warmup runs silence the logger until the population has stabilised.
+            if effective_warmup == 0:
+                gene_logger.snapshot(environment, step=0)
             _capture_current_state(environment, step=0)
 
         def _on_step_end(environment: Any, step: int) -> None:
@@ -427,12 +694,26 @@ class IntrinsicEvolutionExperiment:
             extra = _compute_step_telemetry(environment, prev_agent_ids)
             alive_agents = list(environment.alive_agent_objects)
             prev_agent_ids = {_agent_telemetry_key(a) for a in alive_agents}
-            gene_logger.snapshot(environment, step=logical_step, extra_fields=extra)
+
+            # Accumulate startup-transient metrics for the first
+            # transient_window post-environment-ready steps (regardless of
+            # whether those steps fall inside a warmup phase).
+            if logical_step <= transient_window:
+                _transient_birth_rates.append(extra["realized_birth_rate"])
+                _transient_death_rates.append(extra["realized_death_rate"])
+                _transient_populations.append(len(alive_agents))
+
+            # Suppress trajectory snapshots during the warmup phase so
+            # persisted artifacts only cover the stabilised population.
+            if logical_step > effective_warmup:
+                post_warmup_step = logical_step - effective_warmup
+                gene_logger.snapshot(environment, step=post_warmup_step, extra_fields=extra)
+
             _capture_current_state(environment, step=logical_step)
 
         try:
             run_simulation(
-                num_steps=self.config.num_steps,
+                num_steps=total_sim_steps,
                 config=run_config,
                 path=self.config.output_dir,
                 save_config=False,
@@ -450,15 +731,26 @@ class IntrinsicEvolutionExperiment:
             }
             gene_logger.close()
 
+        startup_transient_metrics = _compute_startup_transient_metrics(
+            _transient_birth_rates,
+            _transient_death_rates,
+            _transient_populations,
+            transient_window,
+        )
+
+        # num_steps_completed is relative to the post-warmup window.
+        post_warmup_latest = max(0, latest_step - effective_warmup)
         result = IntrinsicEvolutionResult(
-            num_steps_completed=min(self.config.num_steps, max(0, latest_step)),
+            num_steps_completed=min(self.config.num_steps, post_warmup_latest),
             final_population=latest_population,
             final_gene_statistics=latest_gene_statistics,
+            startup_transient_metrics=startup_transient_metrics,
         )
         self._persist(
             result,
             initial_diversity_config=run_config.initial_diversity,
             initial_diversity_metrics=latest_diversity_metrics,
+            resolved_initial_conditions=resolved_ic,
         )
         logger.info(
             "intrinsic_evolution_completed",
@@ -474,6 +766,7 @@ class IntrinsicEvolutionExperiment:
         *,
         initial_diversity_config: InitialDiversityConfig,
         initial_diversity_metrics: Optional[Any] = None,
+        resolved_initial_conditions: Optional[Dict[str, Any]] = None,
     ) -> None:
         if not self.config.output_dir:
             return
@@ -486,7 +779,10 @@ class IntrinsicEvolutionExperiment:
             "snapshot_interval": self.config.snapshot_interval,
             "final_population": result.final_population,
             "final_gene_statistics": result.final_gene_statistics,
+            "startup_transient_metrics": result.startup_transient_metrics,
             "policy": _serialize_policy(self.config.policy),
+            "initial_conditions": self.config.initial_conditions.to_dict(),
+            "resolved_initial_conditions": resolved_initial_conditions,
             "initial_diversity": initial_diversity_config.to_dict(),
             "initial_diversity_metrics": (
                 initial_diversity_metrics.to_dict()

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -262,6 +262,11 @@ class InitialConditionsConfig:
                 f"got {self.profile!r}."
             )
         if self.initial_agent_resource_level is not None:
+            if not isinstance(self.initial_agent_resource_level, int):
+                raise ValueError(
+                    "initial_agent_resource_level must be an integer when set; "
+                    f"got {type(self.initial_agent_resource_level).__name__}."
+                )
             if self.initial_agent_resource_level < 0:
                 raise ValueError(
                     "initial_agent_resource_level must be a non-negative integer when set."

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -140,7 +140,19 @@ class _InitialConditionsPreset:
 
 _INITIAL_CONDITIONS_PRESETS: Dict[str, _InitialConditionsPreset] = {
     # stable: higher agent and environment resources → agents survive early steps,
-    # reproduce sooner, and the population stabilises without a sharp spike/crash.
+    # reproduce sooner, and the population stabilizes without a sharp spike/crash.
+    #
+    # Rationale for specific values:
+    #   initial_agent_resource_level=20.0: agents start with ~2–4× the default
+    #     fallback level (5.0) so they can gather and meet the default
+    #     min_reproduction_resources threshold (8) within the first few steps
+    #     rather than starving before they find food.
+    #   initial_resource_count=30: 50% more resource nodes than the default (20)
+    #     ensures food density is high enough for the whole starting population.
+    #   resource_regen_rate=0.15: ~50% higher than the default (0.1) so that
+    #     the environment recovers quickly after the initial feeding burst.
+    #   resource_regen_amount=3: slightly above the default (2) to keep per-node
+    #     regeneration meaningful while not making resources unlimited.
     "stable": _InitialConditionsPreset(
         initial_agent_resource_level=20.0,
         initial_resource_count=30,
@@ -149,6 +161,15 @@ _INITIAL_CONDITIONS_PRESETS: Dict[str, _InitialConditionsPreset] = {
     ),
     # stress: scarce resources → intense early selection; use when studying
     # how quickly adaptive traits emerge under pressure.
+    #
+    # Rationale:
+    #   initial_agent_resource_level=3.0: well below the default, forcing
+    #     immediate resource-seeking and creating strong early mortality.
+    #   initial_resource_count=10: half the default node count; food scarcity
+    #     is the dominant selection pressure from step 1.
+    #   resource_regen_rate=0.05: slow recovery prevents any surplus from
+    #     building up; only the most efficient foragers survive.
+    #   resource_regen_amount=1: minimal per-node yield amplifies scarcity.
     "stress": _InitialConditionsPreset(
         initial_agent_resource_level=3.0,
         initial_resource_count=10,
@@ -157,6 +178,11 @@ _INITIAL_CONDITIONS_PRESETS: Dict[str, _InitialConditionsPreset] = {
     ),
     # exploratory: moderate resources similar to defaults; intended for runs
     # focused on genetic diversity rather than survival pressure.
+    #
+    # Rationale: values match the SimulationConfig defaults (resource_regen_rate=0.1,
+    # resource_regen_amount=2, initial_resources=20) with a modest agent resource
+    # bump (12.0 vs the fallback 5.0) so agents are not immediately at risk
+    # while still experiencing meaningful selection.
     "exploratory": _InitialConditionsPreset(
         initial_agent_resource_level=12.0,
         initial_resource_count=20,
@@ -207,7 +233,7 @@ class InitialConditionsConfig:
     ----------------
     When > 0 the simulation runs for ``warmup_steps`` extra steps *before* the
     main telemetry window.  Gene-trajectory snapshots are suppressed during the
-    warmup phase so the persistent artifacts reflect only the stabilised
+    warmup phase so the persistent artifacts reflect only the stabilized
     population.  The ``startup_transient_metrics`` in
     :class:`IntrinsicEvolutionResult` are still computed from the very first
     ``transient_window`` steps regardless of warmup.
@@ -683,7 +709,7 @@ class IntrinsicEvolutionExperiment:
             alive_agents = list(environment.alive_agent_objects)
             prev_agent_ids = {_agent_telemetry_key(a) for a in alive_agents}
             # Only record the initial snapshot when there is no warmup phase;
-            # warmup runs silence the logger until the population has stabilised.
+            # warmup runs silence the logger until the population has stabilized.
             if effective_warmup == 0:
                 gene_logger.snapshot(environment, step=0)
             _capture_current_state(environment, step=0)
@@ -704,7 +730,7 @@ class IntrinsicEvolutionExperiment:
                 _transient_populations.append(len(alive_agents))
 
             # Suppress trajectory snapshots during the warmup phase so
-            # persisted artifacts only cover the stabilised population.
+            # persisted artifacts only cover the stabilized population.
             if logical_step > effective_warmup:
                 post_warmup_step = logical_step - effective_warmup
                 gene_logger.snapshot(environment, step=post_warmup_step, extra_fields=extra)

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -13,6 +13,7 @@ GA *between* simulations.  Both runners are complementary, not substitutes.
 from __future__ import annotations
 
 import json
+import math
 import os
 import random
 from dataclasses import asdict, dataclass, field
@@ -245,7 +246,7 @@ class InitialConditionsConfig:
     to 50.  Does not affect the total number of steps run.
     """
 
-    profile: Optional[str] = "stable"
+    profile: Optional[InitialConditionsProfileName] = "stable"
     # Per-field manual overrides (win over preset when set)
     initial_agent_resource_level: Optional[float] = None
     initial_resource_count: Optional[int] = None
@@ -260,6 +261,27 @@ class InitialConditionsConfig:
                 f"profile must be one of {list(_INITIAL_CONDITIONS_PRESETS)} or None; "
                 f"got {self.profile!r}."
             )
+        if self.initial_agent_resource_level is not None:
+            if (
+                not math.isfinite(self.initial_agent_resource_level)
+                or self.initial_agent_resource_level < 0.0
+            ):
+                raise ValueError(
+                    "initial_agent_resource_level must be a finite, non-negative number when set."
+                )
+        if self.initial_resource_count is not None and self.initial_resource_count < 0:
+            raise ValueError("initial_resource_count must be non-negative when set.")
+        if self.resource_regen_rate is not None:
+            if (
+                not math.isfinite(self.resource_regen_rate)
+                or self.resource_regen_rate < 0.0
+                or self.resource_regen_rate > 1.0
+            ):
+                raise ValueError(
+                    "resource_regen_rate must be a finite value between 0.0 and 1.0 when set."
+                )
+        if self.resource_regen_amount is not None and self.resource_regen_amount < 0:
+            raise ValueError("resource_regen_amount must be non-negative when set.")
         if self.warmup_steps < 0:
             raise ValueError("warmup_steps must be non-negative.")
         if self.transient_window < 1:
@@ -546,6 +568,15 @@ class IntrinsicEvolutionExperiment:
         # ── Apply initial-conditions overrides ───────────────────────────────
         # Resolve the effective initial-condition settings by merging the
         # selected profile defaults with any explicit per-field overrides.
+        if self.config.initial_conditions.profile == "stable":
+            logger.info(
+                "intrinsic_evolution_initial_conditions_profile_applied",
+                profile="stable",
+                note=(
+                    "stable profile modifies startup resources; set profile='legacy' "
+                    "for parity with pre-profile behavior."
+                ),
+            )
         resolved_ic = self.config.initial_conditions.resolve()
         if resolved_ic.get("initial_agent_resource_level") is not None:
             run_config.agent_behavior.initial_resource_level = int(

--- a/scripts/run_intrinsic_evolution_experiment.py
+++ b/scripts/run_intrinsic_evolution_experiment.py
@@ -99,7 +99,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--initial-conditions-profile",
         type=str,
-        default="stable",
+        default=None,
         choices=["stable", "stress", "exploratory", "legacy"],
         help=(
             "Preset for initial simulation state. "
@@ -270,8 +270,9 @@ def _build_run(args: argparse.Namespace) -> IntrinsicEvolutionExperiment:
         seed=args.seed,
     )
 
+    initial_conditions_profile = args.initial_conditions_profile or "stable"
     initial_conditions = InitialConditionsConfig(
-        profile=args.initial_conditions_profile,
+        profile=initial_conditions_profile,
         initial_agent_resource_level=args.initial_agent_resource_level,
         initial_resource_count=args.initial_resource_count,
         resource_regen_rate=args.resource_regen_rate,
@@ -305,6 +306,15 @@ def main() -> int:
         disable_console=False,
     )
     logger = get_logger(__name__)
+    if args.initial_conditions_profile is None:
+        logger.warning(
+            "intrinsic_evolution_cli_default_initial_conditions_profile",
+            profile="stable",
+            note=(
+                "No --initial-conditions-profile provided; defaulting to 'stable'. "
+                "Pass --initial-conditions-profile legacy to match older runs."
+            ),
+        )
 
     manifest = {
         "script": "scripts/run_intrinsic_evolution_experiment.py",
@@ -362,6 +372,7 @@ def main() -> int:
         "num_steps_completed": result.num_steps_completed,
         "final_population": result.final_population,
         "final_gene_statistics": result.final_gene_statistics,
+        "startup_transient_metrics": result.startup_transient_metrics,
         "output_dir": args.output_dir,
     }
     print(json.dumps(summary, indent=2))

--- a/scripts/run_intrinsic_evolution_experiment.py
+++ b/scripts/run_intrinsic_evolution_experiment.py
@@ -47,6 +47,7 @@ from farm.core.initial_diversity import (  # noqa: E402
 )
 from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger  # noqa: E402
 from farm.runners.intrinsic_evolution_experiment import (  # noqa: E402
+    InitialConditionsConfig,
     IntrinsicEvolutionExperiment,
     IntrinsicEvolutionExperimentConfig,
     IntrinsicEvolutionPolicy,
@@ -93,6 +94,59 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=[m.value for m in BoundaryMode],
     )
     parser.add_argument("--interior-bias-fraction", type=float, default=1e-3)
+
+    # Initial conditions (startup state overrides; see InitialConditionsConfig).
+    parser.add_argument(
+        "--initial-conditions-profile",
+        type=str,
+        default="stable",
+        choices=["stable", "stress", "exploratory", "legacy"],
+        help=(
+            "Preset for initial simulation state. "
+            "'stable' (default) reduces early boom-bust by giving agents and the "
+            "environment more starting resources. 'legacy' reproduces pre-feature "
+            "behavior exactly."
+        ),
+    )
+    parser.add_argument(
+        "--initial-agent-resource-level",
+        type=float,
+        default=None,
+        help="Override: starting resource level for each agent (overrides profile).",
+    )
+    parser.add_argument(
+        "--initial-resource-count",
+        type=int,
+        default=None,
+        help="Override: number of resource nodes at simulation start (overrides profile).",
+    )
+    parser.add_argument(
+        "--resource-regen-rate",
+        type=float,
+        default=None,
+        help="Override: resource regeneration probability per step (overrides profile).",
+    )
+    parser.add_argument(
+        "--resource-regen-amount",
+        type=int,
+        default=None,
+        help="Override: resource amount regenerated per node per step (overrides profile).",
+    )
+    parser.add_argument(
+        "--warmup-steps",
+        type=int,
+        default=0,
+        help=(
+            "Extra steps run before telemetry collection begins. "
+            "Gene-trajectory snapshots are suppressed during the warmup phase."
+        ),
+    )
+    parser.add_argument(
+        "--transient-window",
+        type=int,
+        default=50,
+        help="Number of initial steps used to compute startup-transient metrics.",
+    )
 
     # Initial diversity seeding (platform-wide; see farm/core/initial_diversity.py).
     # The intrinsic-evolution runner installs INDEPENDENT_MUTATION as the default
@@ -216,12 +270,23 @@ def _build_run(args: argparse.Namespace) -> IntrinsicEvolutionExperiment:
         seed=args.seed,
     )
 
+    initial_conditions = InitialConditionsConfig(
+        profile=args.initial_conditions_profile,
+        initial_agent_resource_level=args.initial_agent_resource_level,
+        initial_resource_count=args.initial_resource_count,
+        resource_regen_rate=args.resource_regen_rate,
+        resource_regen_amount=args.resource_regen_amount,
+        warmup_steps=args.warmup_steps,
+        transient_window=args.transient_window,
+    )
+
     config = IntrinsicEvolutionExperimentConfig(
         num_steps=args.num_steps,
         snapshot_interval=args.snapshot_interval,
         install_default_initial_diversity=(
             SeedingMode(args.initial_diversity_mode) is not SeedingMode.NONE
         ),
+        initial_conditions=initial_conditions,
         policy=policy,
         output_dir=args.output_dir,
         seed=args.seed,

--- a/scripts/run_intrinsic_evolution_experiment.py
+++ b/scripts/run_intrinsic_evolution_experiment.py
@@ -110,7 +110,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--initial-agent-resource-level",
-        type=float,
+        type=int,
         default=None,
         help="Override: starting resource level for each agent (overrides profile).",
     )

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -704,6 +704,30 @@ class TestInitialConditionsConfig(unittest.TestCase):
         with self.assertRaises(ValueError):
             InitialConditionsConfig(transient_window=0)
 
+    def test_negative_initial_agent_resource_level_raises(self):
+        from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+        with self.assertRaises(ValueError):
+            InitialConditionsConfig(initial_agent_resource_level=-1.0)
+
+    def test_negative_initial_resource_count_raises(self):
+        from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+        with self.assertRaises(ValueError):
+            InitialConditionsConfig(initial_resource_count=-1)
+
+    def test_out_of_range_resource_regen_rate_raises(self):
+        from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+        with self.assertRaises(ValueError):
+            InitialConditionsConfig(resource_regen_rate=1.1)
+
+    def test_negative_resource_regen_amount_raises(self):
+        from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+        with self.assertRaises(ValueError):
+            InitialConditionsConfig(resource_regen_amount=-1)
+
     def test_stable_profile_resolve_returns_higher_resources(self):
         from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
 
@@ -993,6 +1017,113 @@ class TestStartupTransientMetrics(unittest.TestCase):
         self.assertEqual(metrics["oscillation_amplitude"], 0)
         self.assertEqual(metrics["n_steps_observed"], 0)
         self.assertEqual(metrics["transient_window"], 50)
+
+    def _make_seeded_benchmark_side_effect(self):
+        """Deterministic startup benchmark model keyed by seed + run config.
+
+        This is a lightweight stand-in for an early-steps ecology where higher
+        startup resources reduce initial mortality and therefore the boom-bust
+        wave amplitude.
+        """
+
+        def _side_effect(*args, **kwargs):
+            on_environment_ready = kwargs.get("on_environment_ready")
+            on_step_end = kwargs.get("on_step_end")
+            run_config = kwargs.get("config")
+            seed = int(kwargs.get("seed") or 0)
+            rng = random.Random(seed)
+
+            agents = [_make_fake_agent(0.01 + float(i) / 1000) for i in range(12)]
+            env = _FakeEnvironment(agents)
+            env.initial_diversity_metrics = None
+            if on_environment_ready is not None:
+                on_environment_ready(env)
+
+            # Resource-rich starts (stable profile) should produce lower early
+            # deaths than legacy-like starts under the same seed.
+            initial_level = float(getattr(run_config.agent_behavior, "initial_resource_level", 0))
+            initial_resources = int(getattr(run_config.resources, "initial_resources", 0))
+            scarcity = max(
+                0.0,
+                1.0
+                - min(initial_level / 20.0, 1.0) * 0.6
+                - min(initial_resources / 30.0, 1.0) * 0.4,
+            )
+
+            # Use only the first few steps as the startup-transient benchmark window.
+            for step in range(5):
+                alive = [a for a in env._agents if a.alive]
+                prev = len(alive)
+                if prev <= 1:
+                    env.time = step + 1
+                    if on_step_end is not None:
+                        on_step_end(env, step)
+                    continue
+
+                deaths = int(round(scarcity * 4))
+                if (step + rng.randint(0, 1)) % 3 == 0:
+                    deaths += int(round(scarcity))
+                deaths = min(prev - 1, max(0, deaths))
+                for victim in alive[:deaths]:
+                    victim.alive = False
+
+                env.time = step + 1
+                if on_step_end is not None:
+                    on_step_end(env, step)
+
+            env.time = 6
+            return env
+
+        return _side_effect
+
+    def test_stable_profile_reduces_startup_wave_vs_legacy_benchmark(self):
+        """Benchmark acceptance check: stable startup wave < legacy startup wave."""
+        from farm.runners.intrinsic_evolution_experiment import (
+            InitialConditionsConfig,
+            IntrinsicEvolutionExperiment,
+            IntrinsicEvolutionExperimentConfig,
+        )
+
+        side_effect = self._make_seeded_benchmark_side_effect()
+        representative_seeds = [7, 19, 41]
+        for seed in representative_seeds:
+            with self.subTest(seed=seed):
+                with patch(
+                    "farm.runners.intrinsic_evolution_experiment.run_simulation",
+                    side_effect=side_effect,
+                ):
+                    stable_cfg = IntrinsicEvolutionExperimentConfig(
+                        num_steps=5,
+                        snapshot_interval=1,
+                        seed=seed,
+                        initial_conditions=InitialConditionsConfig(profile="stable"),
+                    )
+                    stable_result = IntrinsicEvolutionExperiment(
+                        SimulationConfig(), stable_cfg
+                    ).run()
+
+                with patch(
+                    "farm.runners.intrinsic_evolution_experiment.run_simulation",
+                    side_effect=side_effect,
+                ):
+                    legacy_cfg = IntrinsicEvolutionExperimentConfig(
+                        num_steps=5,
+                        snapshot_interval=1,
+                        seed=seed,
+                        initial_conditions=InitialConditionsConfig(profile="legacy"),
+                    )
+                    legacy_result = IntrinsicEvolutionExperiment(
+                        SimulationConfig(), legacy_cfg
+                    ).run()
+
+                self.assertLess(
+                    stable_result.startup_transient_metrics["peak_death_rate"],
+                    legacy_result.startup_transient_metrics["peak_death_rate"],
+                )
+                self.assertLess(
+                    stable_result.startup_transient_metrics["oscillation_amplitude"],
+                    legacy_result.startup_transient_metrics["oscillation_amplitude"],
+                )
 
 
 class TestMetadataPersistsInitialConditions(unittest.TestCase):

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -1005,8 +1005,8 @@ class TestStartupTransientMetrics(unittest.TestCase):
         self.assertEqual(result.startup_transient_metrics["n_steps_observed"], 2)
         self.assertEqual(result.startup_transient_metrics["transient_window"], 2)
 
-    def test_empty_run_gives_zero_transient_metrics(self):
-        """A run with 0 steps still produces zeroed transient metrics."""
+    def test_empty_input_series_give_zero_transient_metrics(self):
+        """Empty inputs to _compute_startup_transient_metrics produce zeroed metrics."""
         from farm.runners.intrinsic_evolution_experiment import (
             _compute_startup_transient_metrics,
         )
@@ -1359,7 +1359,7 @@ class TestWarmupSteps(unittest.TestCase):
 
 
 class TestDeterministicReproducibility(unittest.TestCase):
-    """Fixed seeds must produce identical results regardless of initial-conditions profile."""
+    """Fixed seeds must reproduce identical results for repeated runs of the same initial-conditions profile."""
 
     def _collect_snapshots(self, profile: str, seed: int, num_steps: int = 4):
         """Run with a stub and return the list of trajectory records."""

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -658,5 +658,633 @@ class TestTrajectoryTelemetryFields(unittest.TestCase):
             self.assertAlmostEqual(record["realized_death_rate"], 0.0)
 
 
+# ──────────────────────────────────────────────────────────────────────────────
+# InitialConditionsConfig tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestInitialConditionsConfig(unittest.TestCase):
+    """Unit tests for InitialConditionsConfig validation and resolve()."""
+
+    def test_default_profile_is_stable(self):
+        from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+        cfg = InitialConditionsConfig()
+        self.assertEqual(cfg.profile, "stable")
+
+    def test_valid_profiles_accepted(self):
+        from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+        for profile in ("stable", "stress", "exploratory", "legacy"):
+            with self.subTest(profile=profile):
+                cfg = InitialConditionsConfig(profile=profile)
+                self.assertEqual(cfg.profile, profile)
+
+    def test_none_profile_accepted(self):
+        from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+        cfg = InitialConditionsConfig(profile=None)
+        self.assertIsNone(cfg.profile)
+
+    def test_unknown_profile_raises(self):
+        from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+        with self.assertRaises(ValueError):
+            InitialConditionsConfig(profile="nonexistent")
+
+    def test_negative_warmup_steps_raises(self):
+        from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+        with self.assertRaises(ValueError):
+            InitialConditionsConfig(warmup_steps=-1)
+
+    def test_zero_transient_window_raises(self):
+        from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+        with self.assertRaises(ValueError):
+            InitialConditionsConfig(transient_window=0)
+
+    def test_stable_profile_resolve_returns_higher_resources(self):
+        from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+        stable = InitialConditionsConfig(profile="stable").resolve()
+        legacy = InitialConditionsConfig(profile="legacy").resolve()
+
+        # stable must give agents more resources than legacy (which has None → no override)
+        self.assertIsNotNone(stable["initial_agent_resource_level"])
+        self.assertIsNone(legacy["initial_agent_resource_level"])
+
+    def test_stable_resource_level_greater_than_stress(self):
+        from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+        stable = InitialConditionsConfig(profile="stable").resolve()
+        stress = InitialConditionsConfig(profile="stress").resolve()
+        self.assertGreater(
+            stable["initial_agent_resource_level"],
+            stress["initial_agent_resource_level"],
+        )
+
+    def test_manual_override_wins_over_preset(self):
+        from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+        cfg = InitialConditionsConfig(
+            profile="stable",
+            initial_agent_resource_level=999.0,
+        )
+        resolved = cfg.resolve()
+        self.assertEqual(resolved["initial_agent_resource_level"], 999.0)
+
+    def test_none_profile_with_all_none_overrides_gives_all_none(self):
+        from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+        cfg = InitialConditionsConfig(profile=None)
+        resolved = cfg.resolve()
+        self.assertIsNone(resolved["initial_agent_resource_level"])
+        self.assertIsNone(resolved["initial_resource_count"])
+        self.assertIsNone(resolved["resource_regen_rate"])
+        self.assertIsNone(resolved["resource_regen_amount"])
+
+    def test_resolve_always_includes_warmup_and_window_keys(self):
+        from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+        cfg = InitialConditionsConfig(warmup_steps=5, transient_window=20)
+        resolved = cfg.resolve()
+        self.assertEqual(resolved["warmup_steps"], 5)
+        self.assertEqual(resolved["transient_window"], 20)
+
+    def test_to_dict_round_trips_profile(self):
+        from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
+
+        cfg = InitialConditionsConfig(profile="stress", warmup_steps=3)
+        d = cfg.to_dict()
+        self.assertEqual(d["profile"], "stress")
+        self.assertEqual(d["warmup_steps"], 3)
+        self.assertIn("resolved", d)
+
+
+class TestInitialConditionsAppliedToConfig(unittest.TestCase):
+    """The runner must apply resolved initial-condition overrides to run_config."""
+
+    def _run_with_profile(self, profile: str):
+        """Run with the given profile and return the config passed to run_simulation."""
+        with patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation"
+        ) as run_mock:
+            from farm.runners.intrinsic_evolution_experiment import (
+                InitialConditionsConfig,
+                IntrinsicEvolutionExperiment,
+                IntrinsicEvolutionExperimentConfig,
+            )
+
+            cfg = IntrinsicEvolutionExperimentConfig(
+                num_steps=1,
+                snapshot_interval=1,
+                seed=7,
+                initial_conditions=InitialConditionsConfig(profile=profile),
+            )
+            base_config = SimulationConfig()
+            IntrinsicEvolutionExperiment(base_config, cfg).run()
+
+        return run_mock.call_args.kwargs["config"]
+
+    def test_stable_profile_overrides_agent_resource_level(self):
+        """stable profile must set a non-zero initial_resource_level on run config."""
+        run_config = self._run_with_profile("stable")
+        # stable preset sets initial_agent_resource_level=20.0
+        self.assertEqual(run_config.agent_behavior.initial_resource_level, 20)
+
+    def test_stable_profile_overrides_resource_count(self):
+        run_config = self._run_with_profile("stable")
+        # stable preset sets initial_resource_count=30
+        self.assertEqual(run_config.resources.initial_resources, 30)
+
+    def test_stable_profile_overrides_regen_rate(self):
+        run_config = self._run_with_profile("stable")
+        self.assertAlmostEqual(run_config.resources.resource_regen_rate, 0.15)
+
+    def test_legacy_profile_does_not_modify_agent_resource_level(self):
+        """legacy profile has None overrides → base config values unchanged."""
+        base = SimulationConfig()
+        original_level = base.agent_behavior.initial_resource_level
+
+        with patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation"
+        ) as run_mock:
+            from farm.runners.intrinsic_evolution_experiment import (
+                InitialConditionsConfig,
+                IntrinsicEvolutionExperiment,
+                IntrinsicEvolutionExperimentConfig,
+            )
+
+            cfg = IntrinsicEvolutionExperimentConfig(
+                num_steps=1,
+                snapshot_interval=1,
+                seed=3,
+                initial_conditions=InitialConditionsConfig(profile="legacy"),
+            )
+            IntrinsicEvolutionExperiment(base, cfg).run()
+
+        passed_config = run_mock.call_args.kwargs["config"]
+        self.assertEqual(passed_config.agent_behavior.initial_resource_level, original_level)
+
+    def test_manual_override_applied_regardless_of_profile(self):
+        """An explicit override wins over any profile."""
+        with patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation"
+        ) as run_mock:
+            from farm.runners.intrinsic_evolution_experiment import (
+                InitialConditionsConfig,
+                IntrinsicEvolutionExperiment,
+                IntrinsicEvolutionExperimentConfig,
+            )
+
+            cfg = IntrinsicEvolutionExperimentConfig(
+                num_steps=1,
+                snapshot_interval=1,
+                seed=2,
+                initial_conditions=InitialConditionsConfig(
+                    profile="legacy",
+                    initial_agent_resource_level=42.0,
+                ),
+            )
+            IntrinsicEvolutionExperiment(SimulationConfig(), cfg).run()
+
+        passed_config = run_mock.call_args.kwargs["config"]
+        self.assertEqual(passed_config.agent_behavior.initial_resource_level, 42)
+
+    def test_caller_base_config_not_modified(self):
+        """The runner must operate on a copy; the caller's config must remain unchanged."""
+        from farm.runners.intrinsic_evolution_experiment import (
+            InitialConditionsConfig,
+            IntrinsicEvolutionExperiment,
+            IntrinsicEvolutionExperimentConfig,
+        )
+
+        base = SimulationConfig()
+        original_level = base.agent_behavior.initial_resource_level
+
+        with patch("farm.runners.intrinsic_evolution_experiment.run_simulation"):
+            cfg = IntrinsicEvolutionExperimentConfig(
+                num_steps=1,
+                snapshot_interval=1,
+                seed=5,
+                initial_conditions=InitialConditionsConfig(profile="stable"),
+            )
+            IntrinsicEvolutionExperiment(base, cfg).run()
+
+        self.assertEqual(base.agent_behavior.initial_resource_level, original_level)
+
+
+class TestStartupTransientMetrics(unittest.TestCase):
+    """Tests for the startup-transient metrics computation and result field."""
+
+    def _make_run_with_population_change(self, initial_agents: int, step_deaths: int):
+        """Simulate a run where `step_deaths` agents die on step 1."""
+        agents = [_make_fake_agent(0.01) for _ in range(initial_agents)]
+        env = _FakeEnvironment(agents)
+
+        def _side_effect(*args, **kwargs):
+            on_environment_ready = kwargs.get("on_environment_ready")
+            on_step_end = kwargs.get("on_step_end")
+            if on_environment_ready is not None:
+                on_environment_ready(env)
+            # Kill some agents on step 0 → appears as deaths on step 1
+            for i in range(step_deaths):
+                env._agents[i].alive = False
+            env.time = 1
+            if on_step_end is not None:
+                on_step_end(env, 0)
+            env.time = 2
+            return env
+
+        return _side_effect, env
+
+    def test_startup_transient_metrics_in_result(self):
+        from farm.runners.intrinsic_evolution_experiment import (
+            IntrinsicEvolutionExperiment,
+            IntrinsicEvolutionExperimentConfig,
+        )
+
+        side_effect, _ = self._make_run_with_population_change(
+            initial_agents=4, step_deaths=2
+        )
+        with patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation",
+            side_effect=side_effect,
+        ):
+            cfg = IntrinsicEvolutionExperimentConfig(num_steps=1, snapshot_interval=1, seed=1)
+            result = IntrinsicEvolutionExperiment(SimulationConfig(), cfg).run()
+
+        self.assertIn("peak_death_rate", result.startup_transient_metrics)
+        self.assertIn("peak_birth_rate", result.startup_transient_metrics)
+        self.assertIn("oscillation_amplitude", result.startup_transient_metrics)
+        self.assertIn("n_steps_observed", result.startup_transient_metrics)
+        self.assertIn("transient_window", result.startup_transient_metrics)
+
+    def test_nonzero_death_rate_recorded(self):
+        from farm.runners.intrinsic_evolution_experiment import (
+            IntrinsicEvolutionExperiment,
+            IntrinsicEvolutionExperimentConfig,
+        )
+
+        side_effect, _ = self._make_run_with_population_change(
+            initial_agents=4, step_deaths=2
+        )
+        with patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation",
+            side_effect=side_effect,
+        ):
+            cfg = IntrinsicEvolutionExperimentConfig(num_steps=1, snapshot_interval=1, seed=1)
+            result = IntrinsicEvolutionExperiment(SimulationConfig(), cfg).run()
+
+        # 2 deaths out of 4 initial agents → rate = 0.5
+        self.assertAlmostEqual(
+            result.startup_transient_metrics["peak_death_rate"], 0.5, places=6
+        )
+
+    def test_transient_window_respected(self):
+        """Steps beyond transient_window are not counted in the metric."""
+        from farm.runners.intrinsic_evolution_experiment import (
+            InitialConditionsConfig,
+            IntrinsicEvolutionExperiment,
+            IntrinsicEvolutionExperimentConfig,
+        )
+
+        agents = [_make_fake_agent(0.01) for _ in range(3)]
+        env = _FakeEnvironment(agents)
+
+        def _side_effect(*args, **kwargs):
+            on_environment_ready = kwargs.get("on_environment_ready")
+            on_step_end = kwargs.get("on_step_end")
+            if on_environment_ready is not None:
+                on_environment_ready(env)
+            for step in range(5):
+                env.time = step + 1
+                if on_step_end is not None:
+                    on_step_end(env, step)
+            env.time = 6
+            return env
+
+        with patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation",
+            side_effect=_side_effect,
+        ):
+            cfg = IntrinsicEvolutionExperimentConfig(
+                num_steps=5,
+                snapshot_interval=1,
+                seed=42,
+                initial_conditions=InitialConditionsConfig(transient_window=2),
+            )
+            result = IntrinsicEvolutionExperiment(SimulationConfig(), cfg).run()
+
+        # Only 2 steps recorded in transient window.
+        self.assertEqual(result.startup_transient_metrics["n_steps_observed"], 2)
+        self.assertEqual(result.startup_transient_metrics["transient_window"], 2)
+
+    def test_empty_run_gives_zero_transient_metrics(self):
+        """A run with 0 steps still produces zeroed transient metrics."""
+        from farm.runners.intrinsic_evolution_experiment import (
+            _compute_startup_transient_metrics,
+        )
+
+        metrics = _compute_startup_transient_metrics([], [], [], transient_window=50)
+        self.assertEqual(metrics["peak_birth_rate"], 0.0)
+        self.assertEqual(metrics["peak_death_rate"], 0.0)
+        self.assertEqual(metrics["oscillation_amplitude"], 0)
+        self.assertEqual(metrics["n_steps_observed"], 0)
+        self.assertEqual(metrics["transient_window"], 50)
+
+
+class TestMetadataPersistsInitialConditions(unittest.TestCase):
+    """Metadata JSON must include initial_conditions and startup_transient_metrics."""
+
+    def _stub_run_simulation(self, num_agents: int = 2, num_steps: int = 2):
+        agents = [_make_fake_agent(0.01) for _ in range(num_agents)]
+        env = _FakeEnvironment(agents)
+
+        def _side_effect(*args, **kwargs):
+            on_environment_ready = kwargs.get("on_environment_ready")
+            on_step_end = kwargs.get("on_step_end")
+            env.initial_diversity_metrics = None
+            if on_environment_ready is not None:
+                on_environment_ready(env)
+            for step in range(num_steps):
+                env.time = step + 1
+                if on_step_end is not None:
+                    on_step_end(env, step)
+            env.time += 1
+            return env
+
+        return _side_effect
+
+    def test_metadata_contains_initial_conditions_section(self):
+        from farm.runners.intrinsic_evolution_experiment import (
+            InitialConditionsConfig,
+            IntrinsicEvolutionExperiment,
+            IntrinsicEvolutionExperimentConfig,
+        )
+
+        side_effect = self._stub_run_simulation()
+        with tempfile.TemporaryDirectory() as output_dir, patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation",
+            side_effect=side_effect,
+        ):
+            cfg = IntrinsicEvolutionExperimentConfig(
+                num_steps=2,
+                snapshot_interval=1,
+                output_dir=output_dir,
+                seed=77,
+                initial_conditions=InitialConditionsConfig(profile="stable"),
+            )
+            IntrinsicEvolutionExperiment(SimulationConfig(), cfg).run()
+
+            with open(
+                os.path.join(output_dir, "intrinsic_evolution_metadata.json"),
+                encoding="utf-8",
+            ) as fh:
+                meta = json.load(fh)
+
+        self.assertIn("initial_conditions", meta)
+        self.assertEqual(meta["initial_conditions"]["profile"], "stable")
+        self.assertIn("resolved", meta["initial_conditions"])
+
+    def test_metadata_contains_resolved_initial_conditions(self):
+        from farm.runners.intrinsic_evolution_experiment import (
+            InitialConditionsConfig,
+            IntrinsicEvolutionExperiment,
+            IntrinsicEvolutionExperimentConfig,
+        )
+
+        side_effect = self._stub_run_simulation()
+        with tempfile.TemporaryDirectory() as output_dir, patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation",
+            side_effect=side_effect,
+        ):
+            cfg = IntrinsicEvolutionExperimentConfig(
+                num_steps=2,
+                snapshot_interval=1,
+                output_dir=output_dir,
+                seed=88,
+                initial_conditions=InitialConditionsConfig(profile="stable"),
+            )
+            IntrinsicEvolutionExperiment(SimulationConfig(), cfg).run()
+
+            with open(
+                os.path.join(output_dir, "intrinsic_evolution_metadata.json"),
+                encoding="utf-8",
+            ) as fh:
+                meta = json.load(fh)
+
+        self.assertIn("resolved_initial_conditions", meta)
+        # stable preset sets initial_agent_resource_level to a non-None value
+        self.assertIsNotNone(
+            meta["resolved_initial_conditions"]["initial_agent_resource_level"]
+        )
+
+    def test_metadata_contains_startup_transient_metrics(self):
+        from farm.runners.intrinsic_evolution_experiment import (
+            IntrinsicEvolutionExperiment,
+            IntrinsicEvolutionExperimentConfig,
+        )
+
+        side_effect = self._stub_run_simulation()
+        with tempfile.TemporaryDirectory() as output_dir, patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation",
+            side_effect=side_effect,
+        ):
+            cfg = IntrinsicEvolutionExperimentConfig(
+                num_steps=2,
+                snapshot_interval=1,
+                output_dir=output_dir,
+                seed=99,
+            )
+            IntrinsicEvolutionExperiment(SimulationConfig(), cfg).run()
+
+            with open(
+                os.path.join(output_dir, "intrinsic_evolution_metadata.json"),
+                encoding="utf-8",
+            ) as fh:
+                meta = json.load(fh)
+
+        self.assertIn("startup_transient_metrics", meta)
+        stm = meta["startup_transient_metrics"]
+        self.assertIn("peak_birth_rate", stm)
+        self.assertIn("peak_death_rate", stm)
+        self.assertIn("oscillation_amplitude", stm)
+
+
+class TestWarmupSteps(unittest.TestCase):
+    """Warmup steps suppress gene-logger snapshots for the first N steps."""
+
+    def _build_side_effect(self, num_agents: int, num_steps: int):
+        """Side-effect that honours total_sim_steps from the run_simulation call."""
+        agents = [_make_fake_agent(0.01) for _ in range(num_agents)]
+        env = _FakeEnvironment(agents)
+
+        def _side_effect(*args, **kwargs):
+            on_environment_ready = kwargs.get("on_environment_ready")
+            on_step_end = kwargs.get("on_step_end")
+            actual_steps = kwargs.get("num_steps", num_steps)
+            env.initial_diversity_metrics = None
+            if on_environment_ready is not None:
+                on_environment_ready(env)
+            for step in range(actual_steps):
+                env.time = step + 1
+                if on_step_end is not None:
+                    on_step_end(env, step)
+            env.time += 1
+            return env
+
+        return _side_effect, env
+
+    def test_warmup_suppresses_initial_snapshot(self):
+        """With warmup_steps=2 and num_steps=3, snapshot at step 0 must be absent."""
+        from farm.runners.intrinsic_evolution_experiment import (
+            InitialConditionsConfig,
+            IntrinsicEvolutionExperiment,
+            IntrinsicEvolutionExperimentConfig,
+        )
+
+        side_effect, _ = self._build_side_effect(num_agents=2, num_steps=5)
+        with tempfile.TemporaryDirectory() as output_dir, patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation",
+            side_effect=side_effect,
+        ):
+            cfg = IntrinsicEvolutionExperimentConfig(
+                num_steps=3,
+                snapshot_interval=1,
+                output_dir=output_dir,
+                seed=11,
+                initial_conditions=InitialConditionsConfig(
+                    profile="legacy", warmup_steps=2
+                ),
+            )
+            IntrinsicEvolutionExperiment(SimulationConfig(), cfg).run()
+
+            traj_path = os.path.join(output_dir, "intrinsic_gene_trajectory.jsonl")
+            with open(traj_path, encoding="utf-8") as fh:
+                lines = [json.loads(line) for line in fh if line.strip()]
+
+        # No step-0 record; post-warmup steps start at 1.
+        recorded_steps = [r["step"] for r in lines]
+        self.assertNotIn(0, recorded_steps)
+        # Post-warmup steps are numbered starting at 1.
+        self.assertIn(1, recorded_steps)
+
+    def test_warmup_zero_behaves_like_no_warmup(self):
+        """warmup_steps=0 must record step 0 as in the non-warmup path."""
+        from farm.runners.intrinsic_evolution_experiment import (
+            InitialConditionsConfig,
+            IntrinsicEvolutionExperiment,
+            IntrinsicEvolutionExperimentConfig,
+        )
+
+        side_effect, _ = self._build_side_effect(num_agents=2, num_steps=2)
+        with tempfile.TemporaryDirectory() as output_dir, patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation",
+            side_effect=side_effect,
+        ):
+            cfg = IntrinsicEvolutionExperimentConfig(
+                num_steps=2,
+                snapshot_interval=1,
+                output_dir=output_dir,
+                seed=13,
+                initial_conditions=InitialConditionsConfig(
+                    profile="legacy", warmup_steps=0
+                ),
+            )
+            IntrinsicEvolutionExperiment(SimulationConfig(), cfg).run()
+
+            traj_path = os.path.join(output_dir, "intrinsic_gene_trajectory.jsonl")
+            with open(traj_path, encoding="utf-8") as fh:
+                lines = [json.loads(line) for line in fh if line.strip()]
+
+        recorded_steps = [r["step"] for r in lines]
+        self.assertIn(0, recorded_steps)
+
+    def test_warmup_extends_total_sim_steps(self):
+        """run_simulation must be called with num_steps + warmup_steps."""
+        from farm.runners.intrinsic_evolution_experiment import (
+            InitialConditionsConfig,
+            IntrinsicEvolutionExperiment,
+            IntrinsicEvolutionExperimentConfig,
+        )
+
+        with patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation"
+        ) as run_mock:
+            cfg = IntrinsicEvolutionExperimentConfig(
+                num_steps=10,
+                snapshot_interval=1,
+                seed=5,
+                initial_conditions=InitialConditionsConfig(
+                    profile="legacy", warmup_steps=5
+                ),
+            )
+            IntrinsicEvolutionExperiment(SimulationConfig(), cfg).run()
+
+        called_num_steps = run_mock.call_args.kwargs["num_steps"]
+        self.assertEqual(called_num_steps, 15)  # 10 + 5
+
+
+class TestDeterministicReproducibility(unittest.TestCase):
+    """Fixed seeds must produce identical results regardless of initial-conditions profile."""
+
+    def _collect_snapshots(self, profile: str, seed: int, num_steps: int = 4):
+        """Run with a stub and return the list of trajectory records."""
+        from farm.runners.intrinsic_evolution_experiment import (
+            InitialConditionsConfig,
+            IntrinsicEvolutionExperiment,
+            IntrinsicEvolutionExperimentConfig,
+        )
+
+        agents = [_make_fake_agent(0.01 + float(i) / 100) for i in range(3)]
+        env = _FakeEnvironment(agents)
+
+        def _side_effect(*args, **kwargs):
+            on_environment_ready = kwargs.get("on_environment_ready")
+            on_step_end = kwargs.get("on_step_end")
+            actual_steps = kwargs.get("num_steps", num_steps)
+            env.initial_diversity_metrics = None
+            if on_environment_ready is not None:
+                on_environment_ready(env)
+            for step in range(actual_steps):
+                env.time = step + 1
+                if on_step_end is not None:
+                    on_step_end(env, step)
+            env.time += 1
+            return env
+
+        with tempfile.TemporaryDirectory() as output_dir, patch(
+            "farm.runners.intrinsic_evolution_experiment.run_simulation",
+            side_effect=_side_effect,
+        ):
+            cfg = IntrinsicEvolutionExperimentConfig(
+                num_steps=num_steps,
+                snapshot_interval=1,
+                output_dir=output_dir,
+                seed=seed,
+                initial_conditions=InitialConditionsConfig(profile=profile),
+            )
+            result = IntrinsicEvolutionExperiment(SimulationConfig(), cfg).run()
+        return result
+
+    def test_same_seed_same_profile_gives_same_result(self):
+        """Two runs with the same seed and profile must produce identical results."""
+        r1 = self._collect_snapshots("stable", seed=42)
+        r2 = self._collect_snapshots("stable", seed=42)
+        self.assertEqual(r1.final_population, r2.final_population)
+        self.assertEqual(r1.num_steps_completed, r2.num_steps_completed)
+        self.assertEqual(
+            r1.startup_transient_metrics, r2.startup_transient_metrics
+        )
+
+    def test_legacy_profile_same_seed_reproducible(self):
+        r1 = self._collect_snapshots("legacy", seed=77)
+        r2 = self._collect_snapshots("legacy", seed=77)
+        self.assertEqual(r1.final_population, r2.final_population)
+        self.assertEqual(r1.num_steps_completed, r2.num_steps_completed)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -753,10 +753,10 @@ class TestInitialConditionsConfig(unittest.TestCase):
 
         cfg = InitialConditionsConfig(
             profile="stable",
-            initial_agent_resource_level=999.0,
+            initial_agent_resource_level=999,
         )
         resolved = cfg.resolve()
-        self.assertEqual(resolved["initial_agent_resource_level"], 999.0)
+        self.assertEqual(resolved["initial_agent_resource_level"], 999)
 
     def test_none_profile_with_all_none_overrides_gives_all_none(self):
         from farm.runners.intrinsic_evolution_experiment import InitialConditionsConfig
@@ -868,7 +868,7 @@ class TestInitialConditionsAppliedToConfig(unittest.TestCase):
                 seed=2,
                 initial_conditions=InitialConditionsConfig(
                     profile="legacy",
-                    initial_agent_resource_level=42.0,
+                    initial_agent_resource_level=42,
                 ),
             )
             IntrinsicEvolutionExperiment(SimulationConfig(), cfg).run()

--- a/tests/spatial/test_gpu_spatial.py
+++ b/tests/spatial/test_gpu_spatial.py
@@ -1,0 +1,433 @@
+"""Tests for GPU-accelerated spatial kernels and SpatialIndex GPU integration.
+
+These tests cover:
+- SpatialGpuKernels accuracy (results match scipy reference)
+- CPU-fallback correctness (torch but no CUDA, or torch absent)
+- SpatialIndex.use_gpu flag and batch query methods
+- Edge cases: empty positions, single entity, large counts
+"""
+
+import os
+import sys
+import unittest
+
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from farm.core.spatial import SpatialIndex, SpatialGpuKernels, is_gpu_available
+from farm.core.spatial.gpu_kernels import (
+    _TORCH_AVAILABLE,
+    _np_pairwise_distances,
+    get_spatial_device,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_positions(n: int, seed: int = 42, width: float = 100.0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return rng.uniform(0, width, size=(n, 2))
+
+
+def _scipy_radius_query(positions, query_point, radius):
+    """Reference implementation using NumPy."""
+    diffs = positions - np.asarray(query_point)
+    dists = np.sqrt((diffs**2).sum(axis=1))
+    return sorted(np.where(dists <= radius)[0].tolist())
+
+
+def _scipy_nearest_query(positions, query_point):
+    """Reference implementation using NumPy."""
+    diffs = positions - np.asarray(query_point)
+    dists = (diffs**2).sum(axis=1)
+    return int(dists.argmin())
+
+
+# ---------------------------------------------------------------------------
+# SpatialGpuKernels unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSpatialGpuKernelsBasic(unittest.TestCase):
+    """Tests for SpatialGpuKernels correctness on CPU (no CUDA required)."""
+
+    def setUp(self):
+        # Always use CPU to keep tests deterministic on CI without a GPU
+        self.kernels = SpatialGpuKernels(use_gpu=False)
+        self.positions = _make_positions(50)
+        self.query = (30.0, 30.0)
+        self.radius = 25.0
+
+    # ------------------------------------------------------------------
+    # radius_query
+    # ------------------------------------------------------------------
+
+    def test_radius_query_matches_reference(self):
+        got = sorted(self.kernels.radius_query(self.positions, self.query, self.radius))
+        expected = _scipy_radius_query(self.positions, self.query, self.radius)
+        self.assertEqual(got, expected)
+
+    def test_radius_query_empty_positions(self):
+        result = self.kernels.radius_query(np.empty((0, 2)), self.query, self.radius)
+        self.assertEqual(result, [])
+
+    def test_radius_query_zero_radius_returns_empty(self):
+        result = self.kernels.radius_query(self.positions, (50.0, 50.0), radius=0.0)
+        # radius=0 should return at most the exact match; empty is acceptable too
+        self.assertIsInstance(result, list)
+
+    def test_radius_query_very_large_radius_returns_all(self):
+        result = self.kernels.radius_query(self.positions, (50.0, 50.0), radius=1e9)
+        self.assertEqual(len(result), len(self.positions))
+
+    # ------------------------------------------------------------------
+    # nearest_query
+    # ------------------------------------------------------------------
+
+    def test_nearest_query_matches_reference(self):
+        got = self.kernels.nearest_query(self.positions, self.query)
+        expected = _scipy_nearest_query(self.positions, self.query)
+        self.assertEqual(got, expected)
+
+    def test_nearest_query_empty_positions(self):
+        result = self.kernels.nearest_query(np.empty((0, 2)), (0.0, 0.0))
+        self.assertEqual(result, -1)
+
+    def test_nearest_query_single_entity(self):
+        pos = np.array([[10.0, 10.0]])
+        result = self.kernels.nearest_query(pos, (20.0, 20.0))
+        self.assertEqual(result, 0)
+
+    # ------------------------------------------------------------------
+    # batch_radius_query
+    # ------------------------------------------------------------------
+
+    def test_batch_radius_query_shape(self):
+        qp = _make_positions(8, seed=7)
+        results = self.kernels.batch_radius_query(self.positions, qp, self.radius)
+        self.assertEqual(len(results), 8)
+        for r in results:
+            self.assertIsInstance(r, list)
+
+    def test_batch_radius_query_matches_single(self):
+        qp = _make_positions(5, seed=99)
+        batch = self.kernels.batch_radius_query(self.positions, qp, self.radius)
+        for i, q in enumerate(qp):
+            expected = _scipy_radius_query(self.positions, q, self.radius)
+            self.assertEqual(sorted(batch[i]), expected)
+
+    def test_batch_radius_query_empty_positions(self):
+        qp = _make_positions(4)
+        results = self.kernels.batch_radius_query(np.empty((0, 2)), qp, self.radius)
+        self.assertEqual(results, [[], [], [], []])
+
+    def test_batch_radius_query_empty_queries(self):
+        results = self.kernels.batch_radius_query(
+            self.positions, np.empty((0, 2)), self.radius
+        )
+        self.assertEqual(results, [])
+
+    # ------------------------------------------------------------------
+    # batch_nearest_query
+    # ------------------------------------------------------------------
+
+    def test_batch_nearest_query_shape(self):
+        qp = _make_positions(10, seed=11)
+        result = self.kernels.batch_nearest_query(self.positions, qp)
+        self.assertEqual(result.shape, (10,))
+
+    def test_batch_nearest_query_matches_single(self):
+        qp = _make_positions(6, seed=55)
+        batch = self.kernels.batch_nearest_query(self.positions, qp)
+        for i, q in enumerate(qp):
+            expected = _scipy_nearest_query(self.positions, q)
+            self.assertEqual(int(batch[i]), expected)
+
+    def test_batch_nearest_query_empty_positions(self):
+        qp = _make_positions(3)
+        result = self.kernels.batch_nearest_query(np.empty((0, 2)), qp)
+        np.testing.assert_array_equal(result, [-1, -1, -1])
+
+    def test_batch_nearest_query_empty_queries(self):
+        result = self.kernels.batch_nearest_query(self.positions, np.empty((0, 2)))
+        self.assertEqual(len(result), 0)
+
+    # ------------------------------------------------------------------
+    # pairwise_distances
+    # ------------------------------------------------------------------
+
+    def test_pairwise_distances_shape(self):
+        qp = _make_positions(4)
+        dist = self.kernels.pairwise_distances(self.positions, qp)
+        self.assertEqual(dist.shape, (4, len(self.positions)))
+
+    def test_pairwise_distances_symmetry(self):
+        pos = _make_positions(5, seed=1)
+        qp = _make_positions(5, seed=2)
+        dist = self.kernels.pairwise_distances(pos, qp)
+        np_dist = _np_pairwise_distances(pos, qp)
+        np.testing.assert_allclose(dist, np_dist, rtol=1e-4)
+
+    def test_pairwise_distances_non_negative(self):
+        qp = _make_positions(5)
+        dist = self.kernels.pairwise_distances(self.positions, qp)
+        self.assertTrue((dist >= 0).all())
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    def test_on_gpu_is_false_for_cpu_kernels(self):
+        self.assertFalse(self.kernels.on_gpu)
+
+    def test_device_is_cpu(self):
+        if _TORCH_AVAILABLE:
+            self.assertEqual(str(self.kernels.device), "cpu")
+
+
+# ---------------------------------------------------------------------------
+# SpatialGpuKernels – GPU-only tests
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(is_gpu_available(), "CUDA not available")
+class TestSpatialGpuKernelsGpu(unittest.TestCase):
+    """Tests requiring an actual CUDA GPU."""
+
+    def setUp(self):
+        self.kernels = SpatialGpuKernels(use_gpu=True)
+        self.positions = _make_positions(500)
+        self.radius = 20.0
+
+    def test_on_gpu(self):
+        self.assertTrue(self.kernels.on_gpu)
+
+    def test_gpu_radius_query_matches_numpy(self):
+        qp = (50.0, 50.0)
+        got = sorted(self.kernels.radius_query(self.positions, qp, self.radius))
+        expected = _scipy_radius_query(self.positions, qp, self.radius)
+        self.assertEqual(got, expected)
+
+    def test_gpu_nearest_query_matches_numpy(self):
+        qp = (50.0, 50.0)
+        got = self.kernels.nearest_query(self.positions, qp)
+        expected = _scipy_nearest_query(self.positions, qp)
+        self.assertEqual(got, expected)
+
+    def test_gpu_batch_matches_cpu(self):
+        cpu_kernels = SpatialGpuKernels(use_gpu=False)
+        qp = _make_positions(20, seed=77)
+        cpu_result = cpu_kernels.batch_nearest_query(self.positions, qp)
+        gpu_result = self.kernels.batch_nearest_query(self.positions, qp)
+        np.testing.assert_array_equal(cpu_result, gpu_result)
+
+
+# ---------------------------------------------------------------------------
+# SpatialIndex GPU integration tests
+# ---------------------------------------------------------------------------
+
+
+class _MockAgent:
+    """Minimal mock agent for spatial index tests."""
+
+    def __init__(self, agent_id, x, y):
+        self.agent_id = agent_id
+        self.position = (x, y)
+        self.alive = True
+
+
+class TestSpatialIndexGpuIntegration(unittest.TestCase):
+    """Tests for SpatialIndex with use_gpu=True (uses CPU tensors when no CUDA)."""
+
+    def _build_index(self, n_agents=50, use_gpu=True, gpu_threshold=10):
+        index = SpatialIndex(
+            width=100,
+            height=100,
+            use_gpu=use_gpu,
+            gpu_threshold=gpu_threshold,
+        )
+        agents = [_MockAgent(i, float(i % 10) * 10, float(i // 10) * 10) for i in range(n_agents)]
+        index.set_references(agents, [])
+        index.update()
+        return index, agents
+
+    def test_gpu_enabled_property(self):
+        index, _ = self._build_index(use_gpu=True)
+        self.assertTrue(index.gpu_enabled)
+
+    def test_gpu_disabled_property(self):
+        index, _ = self._build_index(use_gpu=False)
+        self.assertFalse(index.gpu_enabled)
+
+    def test_get_nearby_gpu_matches_cpu(self):
+        cpu_idx, agents = self._build_index(use_gpu=False)
+        gpu_idx, _ = self._build_index(use_gpu=True, gpu_threshold=1)
+        # Re-attach same agents to both
+        cpu_idx.set_references(agents, [])
+        gpu_idx.set_references(agents, [])
+        cpu_idx.update()
+        gpu_idx.update()
+
+        pos = (25.0, 25.0)
+        radius = 20.0
+        cpu_result = cpu_idx.get_nearby(pos, radius, ["agents"])
+        gpu_result = gpu_idx.get_nearby(pos, radius, ["agents"])
+        # Compare by agent_id sets
+        cpu_ids = {a.agent_id for a in cpu_result.get("agents", [])}
+        gpu_ids = {a.agent_id for a in gpu_result.get("agents", [])}
+        self.assertEqual(cpu_ids, gpu_ids)
+
+    def test_get_nearest_gpu_matches_cpu(self):
+        agents = [_MockAgent(i, float(i) * 2.5, float(i) * 2.5) for i in range(20)]
+        cpu_idx = SpatialIndex(width=100, height=100, use_gpu=False)
+        gpu_idx = SpatialIndex(width=100, height=100, use_gpu=True, gpu_threshold=1)
+        for idx in (cpu_idx, gpu_idx):
+            idx.set_references(agents, [])
+            idx.update()
+
+        pos = (30.0, 30.0)
+        cpu_r = cpu_idx.get_nearest(pos, ["agents"])
+        gpu_r = gpu_idx.get_nearest(pos, ["agents"])
+        self.assertEqual(
+            cpu_r.get("agents").agent_id,  # type: ignore[union-attr]
+            gpu_r.get("agents").agent_id,  # type: ignore[union-attr]
+        )
+
+    # ------------------------------------------------------------------
+    # batch_radius_query
+    # ------------------------------------------------------------------
+
+    def test_batch_radius_query_returns_dict(self):
+        index, agents = self._build_index()
+        query_positions = [(10.0, 10.0), (50.0, 50.0), (90.0, 90.0)]
+        results = index.batch_radius_query(query_positions, radius=15.0)
+        self.assertIn("agents", results)
+        self.assertEqual(len(results["agents"]), 3)
+
+    def test_batch_radius_query_matches_individual_get_nearby(self):
+        index, agents = self._build_index(n_agents=30, use_gpu=True, gpu_threshold=1)
+        query_positions = [(float(x), float(y)) for x, y in [(0, 0), (50, 50), (99, 99)]]
+        radius = 20.0
+        batch = index.batch_radius_query(query_positions, radius=radius)
+        for i, qp in enumerate(query_positions):
+            single = index.get_nearby(qp, radius, ["agents"])
+            batch_ids = {a.agent_id for a in batch["agents"][i]}
+            single_ids = {a.agent_id for a in single.get("agents", [])}
+            self.assertEqual(batch_ids, single_ids, f"Mismatch at query {i}: {qp}")
+
+    def test_batch_radius_query_empty_positions(self):
+        index = SpatialIndex(width=100, height=100, use_gpu=True)
+        index.set_references([], [])
+        index.update()
+        results = index.batch_radius_query([(10.0, 10.0)], radius=5.0)
+        self.assertIn("agents", results)
+        self.assertEqual(results["agents"], [[]])
+
+    def test_batch_radius_query_empty_query_positions(self):
+        index, _ = self._build_index()
+        results = index.batch_radius_query([], radius=10.0)
+        self.assertEqual(results, {})
+
+    # ------------------------------------------------------------------
+    # batch_nearest_query
+    # ------------------------------------------------------------------
+
+    def test_batch_nearest_query_returns_dict(self):
+        index, _ = self._build_index()
+        query_positions = [(10.0, 10.0), (50.0, 50.0)]
+        results = index.batch_nearest_query(query_positions)
+        self.assertIn("agents", results)
+        self.assertEqual(len(results["agents"]), 2)
+
+    def test_batch_nearest_query_matches_individual_get_nearest(self):
+        index, agents = self._build_index(n_agents=25, use_gpu=True, gpu_threshold=1)
+        query_positions = [(float(x), float(y)) for x, y in [(5, 5), (45, 45), (85, 85)]]
+        batch = index.batch_nearest_query(query_positions)
+        for i, qp in enumerate(query_positions):
+            single = index.get_nearest(qp, ["agents"])
+            self.assertEqual(
+                batch["agents"][i].agent_id,  # type: ignore[union-attr]
+                single.get("agents").agent_id,  # type: ignore[union-attr]
+            )
+
+    def test_batch_nearest_query_empty_positions(self):
+        index = SpatialIndex(width=100, height=100, use_gpu=True)
+        index.set_references([], [])
+        index.update()
+        results = index.batch_nearest_query([(10.0, 10.0)])
+        self.assertIn("agents", results)
+        self.assertIsNone(results["agents"][0])
+
+    def test_batch_nearest_query_empty_queries(self):
+        index, _ = self._build_index()
+        results = index.batch_nearest_query([])
+        self.assertEqual(results, {})
+
+    # ------------------------------------------------------------------
+    # Accuracy: large population
+    # ------------------------------------------------------------------
+
+    def test_large_population_accuracy(self):
+        """Verify GPU path gives same results as scipy for N > gpu_threshold."""
+        rng = np.random.default_rng(0)
+        n = 400
+        agents = [
+            _MockAgent(i, float(rng.uniform(0, 100)), float(rng.uniform(0, 100)))
+            for i in range(n)
+        ]
+        cpu_idx = SpatialIndex(width=100, height=100, use_gpu=False)
+        gpu_idx = SpatialIndex(width=100, height=100, use_gpu=True, gpu_threshold=10)
+        for idx in (cpu_idx, gpu_idx):
+            idx.set_references(agents, [])
+            idx.update()
+
+        query_positions = [(rng.uniform(0, 100), rng.uniform(0, 100)) for _ in range(20)]
+        radius = 15.0
+        for qp in query_positions:
+            cpu_r = cpu_idx.get_nearby(qp, radius, ["agents"])
+            gpu_r = gpu_idx.get_nearby(qp, radius, ["agents"])
+            cpu_ids = {a.agent_id for a in cpu_r.get("agents", [])}
+            gpu_ids = {a.agent_id for a in gpu_r.get("agents", [])}
+            self.assertEqual(cpu_ids, gpu_ids)
+
+
+# ---------------------------------------------------------------------------
+# is_gpu_available / get_spatial_device helpers
+# ---------------------------------------------------------------------------
+
+
+class TestGpuHelpers(unittest.TestCase):
+    def test_is_gpu_available_returns_bool(self):
+        result = is_gpu_available()
+        self.assertIsInstance(result, bool)
+
+    def test_get_spatial_device_prefer_false_returns_cpu(self):
+        if not _TORCH_AVAILABLE:
+            self.skipTest("torch not installed")
+        import torch
+
+        device = get_spatial_device(prefer_gpu=False)
+        self.assertEqual(device.type, "cpu")
+
+    def test_get_spatial_device_prefer_true_returns_device(self):
+        if not _TORCH_AVAILABLE:
+            self.skipTest("torch not installed")
+        import torch
+
+        device = get_spatial_device(prefer_gpu=True)
+        self.assertIn(device.type, ("cpu", "cuda"))
+
+    def test_np_pairwise_distances(self):
+        pos = np.array([[0.0, 0.0], [3.0, 4.0]])
+        qp = np.array([[0.0, 0.0]])
+        dist = _np_pairwise_distances(pos, qp)
+        self.assertAlmostEqual(float(dist[0, 0]), 0.0)
+        self.assertAlmostEqual(float(dist[0, 1]), 5.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/spatial/test_gpu_spatial.py
+++ b/tests/spatial/test_gpu_spatial.py
@@ -33,14 +33,14 @@ def _make_positions(n: int, seed: int = 42, width: float = 100.0) -> np.ndarray:
     return rng.uniform(0, width, size=(n, 2))
 
 
-def _scipy_radius_query(positions, query_point, radius):
+def _numpy_radius_query(positions, query_point, radius):
     """Reference implementation using NumPy."""
     diffs = positions - np.asarray(query_point)
     dists = np.sqrt((diffs**2).sum(axis=1))
     return sorted(np.where(dists <= radius)[0].tolist())
 
 
-def _scipy_nearest_query(positions, query_point):
+def _numpy_nearest_query(positions, query_point):
     """Reference implementation using NumPy."""
     diffs = positions - np.asarray(query_point)
     dists = (diffs**2).sum(axis=1)
@@ -68,7 +68,7 @@ class TestSpatialGpuKernelsBasic(unittest.TestCase):
 
     def test_radius_query_matches_reference(self):
         got = sorted(self.kernels.radius_query(self.positions, self.query, self.radius))
-        expected = _scipy_radius_query(self.positions, self.query, self.radius)
+        expected = _numpy_radius_query(self.positions, self.query, self.radius)
         self.assertEqual(got, expected)
 
     def test_radius_query_empty_positions(self):
@@ -90,7 +90,7 @@ class TestSpatialGpuKernelsBasic(unittest.TestCase):
 
     def test_nearest_query_matches_reference(self):
         got = self.kernels.nearest_query(self.positions, self.query)
-        expected = _scipy_nearest_query(self.positions, self.query)
+        expected = _numpy_nearest_query(self.positions, self.query)
         self.assertEqual(got, expected)
 
     def test_nearest_query_empty_positions(self):
@@ -117,7 +117,7 @@ class TestSpatialGpuKernelsBasic(unittest.TestCase):
         qp = _make_positions(5, seed=99)
         batch = self.kernels.batch_radius_query(self.positions, qp, self.radius)
         for i, q in enumerate(qp):
-            expected = _scipy_radius_query(self.positions, q, self.radius)
+            expected = _numpy_radius_query(self.positions, q, self.radius)
             self.assertEqual(sorted(batch[i]), expected)
 
     def test_batch_radius_query_empty_positions(self):
@@ -144,7 +144,7 @@ class TestSpatialGpuKernelsBasic(unittest.TestCase):
         qp = _make_positions(6, seed=55)
         batch = self.kernels.batch_nearest_query(self.positions, qp)
         for i, q in enumerate(qp):
-            expected = _scipy_nearest_query(self.positions, q)
+            expected = _numpy_nearest_query(self.positions, q)
             self.assertEqual(int(batch[i]), expected)
 
     def test_batch_nearest_query_empty_positions(self):
@@ -209,13 +209,13 @@ class TestSpatialGpuKernelsGpu(unittest.TestCase):
     def test_gpu_radius_query_matches_numpy(self):
         qp = (50.0, 50.0)
         got = sorted(self.kernels.radius_query(self.positions, qp, self.radius))
-        expected = _scipy_radius_query(self.positions, qp, self.radius)
+        expected = _numpy_radius_query(self.positions, qp, self.radius)
         self.assertEqual(got, expected)
 
     def test_gpu_nearest_query_matches_numpy(self):
         qp = (50.0, 50.0)
         got = self.kernels.nearest_query(self.positions, qp)
-        expected = _scipy_nearest_query(self.positions, qp)
+        expected = _numpy_nearest_query(self.positions, qp)
         self.assertEqual(got, expected)
 
     def test_gpu_batch_matches_cpu(self):


### PR DESCRIPTION
This pull request introduces GPU-accelerated spatial query support to the core spatial indexing system, leveraging PyTorch when available. The main changes add a new `SpatialGpuKernels` module for fast radius and nearest-neighbor queries, integrate it into the `SpatialIndex` class with policy-driven selection, and update the documentation and tests to reflect new experiment configuration options and output fields.

**Spatial acceleration and API changes:**

* Added the `SpatialGpuKernels` class in `farm/core/spatial/gpu_kernels.py`, providing GPU-accelerated (or vectorized-CPU) radius and nearest-neighbor queries, with seamless fallback to NumPy and deferred import of PyTorch for environments without it. Also provides helpers for device selection and availability checks.
* Updated `farm/core/spatial/index.py` to support GPU acceleration via new `use_gpu` and `gpu_threshold` parameters. The `SpatialIndex` class now routes radius and nearest-neighbor queries to the GPU path when enabled and for large entity counts, falling back to `cKDTree` for smaller queries or when disabled. [[1]](diffhunk://#diff-a26d889bccc9d6eaee4fa3909fe3445e4d046ffcb8ad9054b0bf8ae67a584eedR39) [[2]](diffhunk://#diff-a26d889bccc9d6eaee4fa3909fe3445e4d046ffcb8ad9054b0bf8ae67a584eedR94-R95) [[3]](diffhunk://#diff-a26d889bccc9d6eaee4fa3909fe3445e4d046ffcb8ad9054b0bf8ae67a584eedR122-R162) [[4]](diffhunk://#diff-a26d889bccc9d6eaee4fa3909fe3445e4d046ffcb8ad9054b0bf8ae67a584eedL963-R1012) [[5]](diffhunk://#diff-a26d889bccc9d6eaee4fa3909fe3445e4d046ffcb8ad9054b0bf8ae67a584eedR1074-R1085)
* Updated `farm/core/spatial/__init__.py` to expose `SpatialGpuKernels`, `is_gpu_available`, and `get_spatial_device` in the package API. [[1]](diffhunk://#diff-d341c694d884fd09aec423b31d3df39fa63166fdb98f3aa4dab80570240c9d4dR9-R13) [[2]](diffhunk://#diff-d341c694d884fd09aec423b31d3df39fa63166fdb98f3aa4dab80570240c9d4dR35-R37)

**Documentation and experiment config updates:**

* Documented the new `InitialConditionsConfig` and startup profile system for intrinsic evolution experiments, including CLI and Python usage, and the rationale for the new default and legacy modes.
* Updated the experiment output schema to include `startup_transient_metrics`, `initial_conditions`, and `resolved_initial_conditions` blocks, reflecting the new configuration and metrics.
* Expanded test coverage documentation to include startup-transient metrics and stable-vs-legacy benchmark assertions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes intrinsic-evolution run semantics (new default `stable` startup overrides, warmup step handling, and new persisted metadata fields) and adds an alternate GPU/tensor execution path for spatial queries that could affect performance/behavior under load.
> 
> **Overview**
> **Adds optional GPU/vectorized acceleration for spatial queries.** Introduces `SpatialGpuKernels` (deferred PyTorch import with NumPy fallback) and wires it into `SpatialIndex` via new `use_gpu`/`gpu_threshold` options, plus new batch query APIs (`batch_radius_query`, `batch_nearest_query`) and exported helpers (`is_gpu_available`, `get_spatial_device`).
> 
> **Changes intrinsic evolution startup behavior and artifacts.** Adds `InitialConditionsConfig` with preset profiles (default `stable`, plus `stress`/`exploratory`/`legacy`) that override agent/environment starting resources and regeneration rates; supports `warmup_steps` that run extra steps while suppressing trajectory snapshots until post-warmup.
> 
> **Extends run outputs and CLI.** Computes and persists `startup_transient_metrics`, records both `initial_conditions` and `resolved_initial_conditions` in `intrinsic_evolution_metadata.json`, adds CLI flags for initial-conditions settings (with a warning when defaulting to `stable`), and expands tests/docs to cover these behaviors and GPU integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3403e36750db6d816bb048c8bf52a40951404e3f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->