### PR TITLE
feat(evolution): Tier 1 evolvable genes (chromosomes A & B), fully wired

### DIFF
--- a/docs/evolution_surface_catalog.md
+++ b/docs/evolution_surface_catalog.md
@@ -29,12 +29,18 @@ These recommendations are anchored to what is currently wired up in the codebase
 
 ---
 
-## Tier 1 — drop-in additions (no framework changes)
+## Tier 1 — drop-in additions (no framework changes) — **IMPLEMENTED**
 
 These extend the existing **learning chromosome** by adding `HyperparameterGene`
 entries to `DEFAULT_HYPERPARAMETER_GENES`. Names already match `DecisionConfig`
 attributes, so `apply_chromosome_to_learning_config` will project them
 automatically.
+
+> **Status:** All Chromosome A and B genes below are now part of
+> `DEFAULT_HYPERPARAMETER_GENES` in `farm/core/hyperparameter_chromosome.py`
+> (31 evolvable loci total).  Encodings are registered in
+> `DEFAULT_GENE_ENCODINGS`; integer-typed `DecisionConfig` fields are
+> projected via the existing rounding-with-bounds-check path.
 
 ### Chromosome A — Learning / RL hyperparameters
 

--- a/docs/evolution_surface_catalog.md
+++ b/docs/evolution_surface_catalog.md
@@ -44,66 +44,60 @@ automatically.
 
 ### Runtime-effect audit
 
-Adding a gene to the chromosome does not, by itself, give it a runtime
-effect — the receiving config attribute also has to be **read** somewhere in
-the agent / decision pipeline.  The catalog below records which genes are
-already consumed by live code and which are only declared.
+All 31 default chromosome loci now have a runtime consumer.  Each gene
+flows into ``DecisionConfig`` via
+:func:`apply_chromosome_to_learning_config` and is read by exactly one
+identified pipeline path, summarized below.
 
-#### Active in the live simulation
+#### Chromosome A — learning / RL hyperparameters
 
-These genes flow into `DecisionConfig` via
-:func:`apply_chromosome_to_learning_config` and are read by
-`farm/core/decision/base_dqn.py` (`BaseDQNModule.__init__`) or by the
-Tianshou wrapper builders in `farm/core/decision/decision.py`, so mutating
-them changes the simulation when the agent's algorithm is rebuilt:
+| Gene | Consumer | Notes |
+|------|----------|-------|
+| `learning_rate` | `BaseDQNModule.__init__`, Tianshou builders | Adam optimizer LR |
+| `gamma` | `BaseDQNModule`, all Tianshou wrappers | discount factor |
+| `epsilon_start` | `BaseDQNModule`, Tianshou DQN (`eps_train`), fallback | exploration init |
+| `epsilon_min` | `BaseDQNModule`, Tianshou DQN (`eps_test`, `eps_train_final`) | exploration floor |
+| `epsilon_decay` | `BaseDQNModule` | decay multiplier |
+| `memory_size` | `BaseDQNModule.memory` | replay buffer size |
+| `tau` | `BaseDQNModule.tau` | soft target update |
+| `batch_size` | `BaseDQNModule.train` | gradient noise |
+| `target_update_freq` | Tianshou `DQNPolicy(target_update_freq=…)` (explicit kwarg) | hard target sync cadence |
+| `dqn_hidden_size` | `BaseDQNModule.q_network`, target net | network capacity |
+| `rl_train_freq` | All Tianshou wrappers (`train_freq=…`) | training cadence |
+| `per_alpha` | All Tianshou wrappers' replay buffer | PER prioritization |
+| `per_beta_start` | All Tianshou wrappers' replay buffer | IS-correction warmup |
+| `per_beta_end` | All Tianshou wrappers' replay buffer | IS-correction final |
+| `ensemble_size` | `RandomForestActionSelector.n_estimators` (auto-injected when `algorithm_type ∈ {"random_forest", "gradient_boost"}`) | tree-ensemble width |
 
-- `learning_rate`, `gamma`, `epsilon_start`, `epsilon_min`, `epsilon_decay`,
-  `memory_size`, `tau`, `batch_size`, `dqn_hidden_size`, `rl_train_freq`,
-  `per_alpha`, `per_beta_start`, `per_beta_end`.
+#### Chromosome B — action-policy priors
 
-#### Latent (declared but not yet consumed)
+Two-stage pipeline:
 
-These genes are part of the chromosome and project into `DecisionConfig`
-cleanly, but no current code path reads the projected attribute.  They
-need follow-up wiring before evolutionary pressure on them can produce
-phenotypic change:
+1. **Base weights** — `move_weight`, `gather_weight`, `share_weight`,
+   `attack_weight`, `reproduce_weight` are bridged into
+   ``core.actions[i].weight`` by
+   ``AgentCore._customize_action_weights`` (at construction) and
+   ``AgentCore.refresh_action_weights_from_decision_config`` (after
+   chromosome re-application).  Per-agent gene values win over the
+   environment-level ``agent_parameters`` block; default-valued genes
+   fall through unchanged.
+2. **State-aware re-weighting** — ``LearningAgentBehavior.decide_action``
+   calls ``compute_action_weights`` from
+   ``farm/core/decision/action_weight_policy.py`` to scale the base
+   weights by the eight multipliers gated by the three thresholds:
+   - `move_mult_no_resources` (no resources nearby)
+   - `gather_mult_low_resources` (resource ratio < 0.5)
+   - `share_mult_wealthy` (resource ratio ≥ 0.7)
+   - `share_mult_poor` (resource ratio < 0.3)
+   - `attack_mult_desperate` (starvation risk ≥ `attack_starvation_threshold`)
+   - `attack_mult_stable` (health ratio ≥ 1 − `attack_defense_threshold`)
+   - `reproduce_mult_wealthy` (resource ratio ≥ `reproduce_resource_threshold`)
+   - `reproduce_mult_poor` (resource ratio < `reproduce_resource_threshold`)
 
-- **Chromosome A:**
-  - `target_update_freq` — `farm/core/decision/decision.py` and
-    `farm/core/decision/algorithms/tianshou.py` hard-code `500` instead
-    of forwarding `self.config.target_update_freq`.
-  - `ensemble_size` — no algorithm constructor reads it.
-- **Chromosome B (all 16):** `move_weight`, `gather_weight`, `share_weight`,
-  `attack_weight`, `reproduce_weight`, `move_mult_no_resources`,
-  `gather_mult_low_resources`, `share_mult_wealthy`, `share_mult_poor`,
-  `attack_mult_desperate`, `attack_mult_stable`, `reproduce_mult_wealthy`,
-  `reproduce_mult_poor`, `attack_starvation_threshold`,
-  `attack_defense_threshold`, `reproduce_resource_threshold`.
-  - Action weights actually consumed by the policy come from
-    `core.actions[i].weight`, which is populated in
-    `AgentCore._customize_action_weights` from the environment-level
-    `agent_parameters` block (`farm/core/agent/core.py` ≈ L245–L304).
-    `LearningAgentBehavior.decide_action` then reads `action.weight`,
-    not `DecisionConfig.move_weight` etc.
-  - The state-based multipliers and thresholds have no consumer at all.
-
-#### Suggested wiring follow-ups
-
-1. **Bridge `DecisionConfig.{move,gather,share,attack,reproduce}_weight`
-   into `AgentCore.actions`** at agent construction (and on chromosome
-   re-application after mutation), so the per-agent gene values override
-   the global `agent_parameters` weights.  This single change activates
-   the five highest-impact Chromosome B loci.
-2. **Replace the hard-coded `target_update_freq=500`** in
-   `farm/core/decision/decision.py` and the Tianshou wrappers with
-   `self.config.target_update_freq`.
-3. **Decide on `ensemble_size` semantics** — either delete the gene/field
-   pair, or thread it through to ensemble-capable algorithm wrappers.
-4. **Consume the multiplier / threshold genes** in a state-aware action
-   re-weighter (a small helper invoked just before
-   `decision_module.decide_action`).  This is the cleanest path because
-   it keeps RL-only code untouched and gives the multipliers a single,
-   explicit application point.
+The scaled vector is then passed as `action_weights` to
+``DecisionModule.decide_action``, which already supports per-action
+biasing of both Q-value-based exploitation and weighted random
+exploration.
 
 ### Chromosome A — Learning / RL hyperparameters
 

--- a/docs/evolution_surface_catalog.md
+++ b/docs/evolution_surface_catalog.md
@@ -42,6 +42,69 @@ automatically.
 > `DEFAULT_GENE_ENCODINGS`; integer-typed `DecisionConfig` fields are
 > projected via the existing rounding-with-bounds-check path.
 
+### Runtime-effect audit
+
+Adding a gene to the chromosome does not, by itself, give it a runtime
+effect — the receiving config attribute also has to be **read** somewhere in
+the agent / decision pipeline.  The catalog below records which genes are
+already consumed by live code and which are only declared.
+
+#### Active in the live simulation
+
+These genes flow into `DecisionConfig` via
+:func:`apply_chromosome_to_learning_config` and are read by
+`farm/core/decision/base_dqn.py` (`BaseDQNModule.__init__`) or by the
+Tianshou wrapper builders in `farm/core/decision/decision.py`, so mutating
+them changes the simulation when the agent's algorithm is rebuilt:
+
+- `learning_rate`, `gamma`, `epsilon_start`, `epsilon_min`, `epsilon_decay`,
+  `memory_size`, `tau`, `batch_size`, `dqn_hidden_size`, `rl_train_freq`,
+  `per_alpha`, `per_beta_start`, `per_beta_end`.
+
+#### Latent (declared but not yet consumed)
+
+These genes are part of the chromosome and project into `DecisionConfig`
+cleanly, but no current code path reads the projected attribute.  They
+need follow-up wiring before evolutionary pressure on them can produce
+phenotypic change:
+
+- **Chromosome A:**
+  - `target_update_freq` — `farm/core/decision/decision.py` and
+    `farm/core/decision/algorithms/tianshou.py` hard-code `500` instead
+    of forwarding `self.config.target_update_freq`.
+  - `ensemble_size` — no algorithm constructor reads it.
+- **Chromosome B (all 16):** `move_weight`, `gather_weight`, `share_weight`,
+  `attack_weight`, `reproduce_weight`, `move_mult_no_resources`,
+  `gather_mult_low_resources`, `share_mult_wealthy`, `share_mult_poor`,
+  `attack_mult_desperate`, `attack_mult_stable`, `reproduce_mult_wealthy`,
+  `reproduce_mult_poor`, `attack_starvation_threshold`,
+  `attack_defense_threshold`, `reproduce_resource_threshold`.
+  - Action weights actually consumed by the policy come from
+    `core.actions[i].weight`, which is populated in
+    `AgentCore._customize_action_weights` from the environment-level
+    `agent_parameters` block (`farm/core/agent/core.py` ≈ L245–L304).
+    `LearningAgentBehavior.decide_action` then reads `action.weight`,
+    not `DecisionConfig.move_weight` etc.
+  - The state-based multipliers and thresholds have no consumer at all.
+
+#### Suggested wiring follow-ups
+
+1. **Bridge `DecisionConfig.{move,gather,share,attack,reproduce}_weight`
+   into `AgentCore.actions`** at agent construction (and on chromosome
+   re-application after mutation), so the per-agent gene values override
+   the global `agent_parameters` weights.  This single change activates
+   the five highest-impact Chromosome B loci.
+2. **Replace the hard-coded `target_update_freq=500`** in
+   `farm/core/decision/decision.py` and the Tianshou wrappers with
+   `self.config.target_update_freq`.
+3. **Decide on `ensemble_size` semantics** — either delete the gene/field
+   pair, or thread it through to ensemble-capable algorithm wrappers.
+4. **Consume the multiplier / threshold genes** in a state-aware action
+   re-weighter (a small helper invoked just before
+   `decision_module.decide_action`).  This is the cleanest path because
+   it keeps RL-only code untouched and gives the multipliers a single,
+   explicit application point.
+
 ### Chromosome A — Learning / RL hyperparameters
 
 Extends `DEFAULT_HYPERPARAMETER_GENES`.

--- a/docs/evolution_surface_catalog.md
+++ b/docs/evolution_surface_catalog.md
@@ -1,0 +1,270 @@
+# Evolution Surface Catalog: Candidate Genes & Chromosomes
+
+A proposal-style catalog of new genes and chromosome groupings that can be added
+to AgentFarm's existing evolutionary framework to grow the evolution surface.
+Each tier below is independent and can be adopted in isolation.
+
+## Framework grounding
+
+These recommendations are anchored to what is currently wired up in the codebase:
+
+- `farm/core/hyperparameter_chromosome.py` — `HyperparameterGene` +
+  `HyperparameterChromosome`. Currently 4 default genes:
+  `learning_rate`, `gamma`, `epsilon_decay`, `memory_size`.
+  Only `GeneValueType.REAL` is implemented; supports linear/log scale and
+  optional bit-width quantization. Mutation supports gaussian / multiplicative,
+  with `clamp` / `reflect` / `interior_biased` boundary modes. Crossover
+  supports single-point, uniform, BLEND (BLX-α), and multi-point.
+- `farm/core/genome.py` — `Genome` carries `action_set` (action weights) and
+  `module_states` (state dicts). Selection (tournament / roulette) lives here.
+- `farm/core/initial_diversity.py` — seeding modes `none` /
+  `independent_mutation` / `unique` / `min_distance`.
+- `farm/runners/intrinsic_evolution_experiment.py` — in-situ evolution:
+  chromosome inheritance + crossover + density-dependent reproduction cost.
+- `farm/core/agent/config/component_configs.py` + `farm/core/decision/config.py`
+  — the master `AgentComponentConfig` and `DecisionConfig` exposing every knob
+  that *could* become a locus.
+- `apply_chromosome_to_learning_config` currently writes back into
+  `agent.config.decision` only, by attribute-name match.
+
+---
+
+## Tier 1 — drop-in additions (no framework changes)
+
+These extend the existing **learning chromosome** by adding `HyperparameterGene`
+entries to `DEFAULT_HYPERPARAMETER_GENES`. Names already match `DecisionConfig`
+attributes, so `apply_chromosome_to_learning_config` will project them
+automatically.
+
+### Chromosome A — Learning / RL hyperparameters
+
+Extends `DEFAULT_HYPERPARAMETER_GENES`.
+
+| Gene | Range | Default | Scale | Notes |
+|---|---|---|---|---|
+| `learning_rate` *(existing)* | 1e-6 – 1.0 | 0.001 | log | already there |
+| `gamma` *(existing)* | 0.0 – 1.0 | 0.99 | linear | already there |
+| `epsilon_decay` *(existing)* | ~0 – 1.0 | 0.995 | linear | already there |
+| `memory_size` *(existing)* | 1 – 1e6 | 10000 | linear | already projected to int |
+| `epsilon_start` | 0.0 – 1.0 | 1.0 | linear | exploration aggressiveness |
+| `epsilon_min` | 0.0 – 0.5 | 0.01 | log | floor for exploration |
+| `tau` | 1e-4 – 0.5 | 0.005 | log | soft-update speed; major behaviour driver |
+| `batch_size` | 8 – 1024 | 32 | log | int-projected; affects gradient noise |
+| `target_update_freq` | 1 – 5000 | 100 | log | int-projected; complementary to `tau` |
+| `dqn_hidden_size` | 8 – 512 | 64 | log | int-projected; capacity vs. overfit |
+| `rl_train_freq` | 1 – 64 | 4 | log | how often to update |
+| `per_alpha` | 0.0 – 1.0 | 0.6 | linear | only meaningful when `replay_strategy="prioritized"` |
+| `per_beta_start` | 0.0 – 1.0 | 0.4 | linear | IS-correction warmup |
+| `per_beta_end` | 0.0 – 1.0 | 1.0 | linear | IS-correction final |
+| `ensemble_size` | 1 – 16 | 1 | linear | int-projected |
+
+### Chromosome B — Action-policy priors
+
+Live on `DecisionConfig`. These are *behavioural priors* that bias the policy
+before learning kicks in — they are extremely high-leverage selection targets.
+
+| Gene | Range | Default |
+|---|---|---|
+| `move_weight` | 0.0 – 2.0 | 0.30 |
+| `gather_weight` | 0.0 – 2.0 | 0.30 |
+| `share_weight` | 0.0 – 2.0 | 0.15 |
+| `attack_weight` | 0.0 – 2.0 | 0.10 |
+| `reproduce_weight` | 0.0 – 2.0 | 0.15 |
+| `move_mult_no_resources` | 0.5 – 3.0 | 1.5 |
+| `gather_mult_low_resources` | 0.5 – 3.0 | 1.5 |
+| `share_mult_wealthy` | 0.5 – 3.0 | 1.3 |
+| `share_mult_poor` | 0.0 – 1.5 | 0.5 |
+| `attack_mult_desperate` | 0.5 – 3.0 | 1.4 |
+| `attack_mult_stable` | 0.0 – 1.5 | 0.6 |
+| `reproduce_mult_wealthy` | 0.5 – 3.0 | 1.4 |
+| `reproduce_mult_poor` | 0.0 – 1.5 | 0.3 |
+| `attack_starvation_threshold` | 0.0 – 1.0 | 0.5 |
+| `attack_defense_threshold` | 0.0 – 1.0 | 0.3 |
+| `reproduce_resource_threshold` | 0.0 – 1.0 | 0.7 |
+
+The action-prior genes are the single largest evolution-surface win available
+without touching the framework. They are the dial between "aggressor",
+"cooperator", "hoarder", and "explorer" niches.
+
+---
+
+## Tier 2 — needs a small extension to `apply_chromosome_*`
+
+To evolve traits living on the *other* component configs (`combat`, `resource`,
+`movement`, `perception`, `reproduction`, `reward`, `communication`),
+generalize the projection step to walk `AgentComponentConfig` by namespaced
+gene names like `combat.starting_health`.
+
+Concretely: in `apply_chromosome_to_learning_config` (rename to
+`apply_chromosome_to_agent_config`), if a gene name contains `.`, split into
+`(component, attr)` and update `getattr(agent_config, component)` instead of
+`agent_config.decision`. The frozen component dataclasses already work with
+`dataclasses.replace`, so the SRP/OCP split is clean.
+
+### Chromosome C — Combat / physiology (`combat.*`)
+
+| Gene | Range | Default | Scale |
+|---|---|---|---|
+| `combat.starting_health` | 20 – 400 | 100 | log |
+| `combat.base_attack_strength` | 0 – 50 | 10 | linear |
+| `combat.base_defense_strength` | 0 – 30 | 5 | linear |
+| `combat.defense_damage_reduction` | 0.0 – 0.95 | 0.5 | linear |
+| `combat.defense_timer_duration` | 1 – 20 | 3 | linear (int) |
+
+### Chromosome D — Metabolism (`resource.*`)
+
+| Gene | Range | Default | Scale |
+|---|---|---|---|
+| `resource.base_consumption_rate` | 0.1 – 5.0 | 1.0 | log |
+| `resource.starvation_threshold` | 1 – 1000 | 100 | log (int) |
+
+### Chromosome E — Reproduction (`reproduction.*`)
+
+| Gene | Range | Default | Scale |
+|---|---|---|---|
+| `reproduction.offspring_cost` | 1.0 – 100.0 | 5.0 | log |
+| `reproduction.offspring_initial_resources` | 0.0 – 100.0 | 10.0 | log |
+
+These pair well with the runner's existing `ReproductionPressureConfig`: agents
+that lower their own cost too far will be punished by density terms, producing
+real selection.
+
+### Chromosome F — Movement & perception
+
+| Gene | Range | Default | Scale |
+|---|---|---|---|
+| `movement.max_movement` | 0.5 – 32.0 | 8.0 | log |
+| `movement.perception_radius` | 1 – 20 | 5 | linear (int) |
+| `perception.perception_radius` | 1 – 20 | 5 | linear (int) |
+
+Wider perception is "metabolically" costly only if you couple it to
+`resource.base_consumption_rate` in a custom reward-shaping rule.
+
+### Chromosome G — Communication
+
+| Gene | Range | Default | Scale |
+|---|---|---|---|
+| `communication.communication_range` | 0.0 – 200.0 | 50.0 | linear |
+| `communication.broadcast_cost` | 0.0 – 5.0 | 0.0 | linear |
+| `communication.reward_per_message` | -0.1 – 0.1 | 0.01 | linear |
+| `communication.inbox_capacity` | 1 – 200 | 20 | log (int) |
+
+This is one of the more interesting evolution surfaces — lets "talkative" vs.
+"silent" lineages emerge.
+
+### Chromosome H — Reward shaping (meta-evolution)
+
+Risky but powerful: evolvable reward weights produce drift away from the
+designer's reward signal, which is exactly what you want if you're studying
+intrinsic motivation.
+
+| Gene | Range | Default |
+|---|---|---|
+| `reward.resource_reward_scale` | 0.0 – 5.0 | 1.0 |
+| `reward.health_reward_scale` | 0.0 – 5.0 | 0.5 |
+| `reward.survival_bonus` | 0.0 – 1.0 | 0.1 |
+| `reward.death_penalty` | -50.0 – 0.0 | -10.0 |
+| `reward.age_bonus` | 0.0 – 0.1 | 0.01 |
+| `reward.combat_success_bonus` | 0.0 – 10.0 | 2.0 |
+| `reward.reproduction_bonus` | 0.0 – 20.0 | 5.0 |
+| `reward.cooperation_bonus` | 0.0 – 10.0 | 1.0 |
+
+> If you do this, freeze the *evaluation* fitness used by
+> `evolution_experiment.py` to a fixed external metric (population persistence,
+> diversity, etc.) so you don't reward Goodharting. Keep these genes off by
+> default and behind an explicit opt-in flag.
+
+---
+
+## Tier 3 — needs new gene **value types**
+
+Today only `GeneValueType.REAL` is implemented. The doc string explicitly says
+discrete/binary are reserved. Adding them unlocks a class of architectural /
+topological genes.
+
+### Suggested new value types
+
+- `INTEGER` — bounded int with native rounding (today you fake it via REAL +
+  projection in `apply_chromosome_to_learning_config`; a real type lets you
+  express the contract on the gene itself and validate).
+- `BINARY` — 0/1; trivial as a single quantization-1 REAL but cleaner to read.
+- `CATEGORICAL` — fixed list of choice strings/ints, with a Hamming-style
+  mutation operator and per-allele mutation probability.
+
+Crossover already works for these (single-point / uniform / multi-point); only
+BLEND would need a guard to no-op for non-real types.
+
+### Chromosome I — Architecture (categorical/integer)
+
+| Gene | Type | Domain |
+|---|---|---|
+| `decision.algorithm_type` | CATEGORICAL | `dqn`, `ddqn`, `ppo`, `sac`, `a2c`, `mlp`, `random_forest`, `gradient_boost`, `knn` |
+| `decision.replay_strategy` | CATEGORICAL | `uniform`, `prioritized` |
+| `decision.use_exploration_bonus` | BINARY | 0 / 1 |
+| `decision.dqn_hidden_size` | INTEGER | 8 – 512 |
+| `decision.ensemble_size` | INTEGER | 1 – 16 |
+| `decision.feature_engineering[*]` | BINARY × N | one bit per available flag |
+
+### Chromosome J — Action repertoire (binary mask)
+
+The current `Genome.action_set` evolves *weights*; turning **presence** into
+binary genes lets agents lose actions entirely.
+
+| Gene | Type | Notes |
+|---|---|---|
+| `action.attack_enabled` | BINARY | gates whether `attack` is in the action list |
+| `action.share_enabled` | BINARY | gates `share` |
+| `action.reproduce_enabled` | BINARY | gates `reproduce` |
+| `action.defend_enabled` | BINARY | gates `defend` |
+| `action.communicate_enabled` | BINARY | gates communicate, when communication is on |
+
+Pair with weight genes for full topology + magnitude evolution.
+
+---
+
+## Tier 4 — multi-chromosome organism (small structural change)
+
+`HyperparameterChromosome` is currently a flat tuple. To express *karyotype*
+(multiple chromosomes that recombine independently), introduce a
+`ChromosomeBundle` dataclass:
+
+```
+ChromosomeBundle
+├── learning:        HyperparameterChromosome  # Chromosomes A + B
+├── physiology:      HyperparameterChromosome  # C + D + E
+├── sensorimotor:    HyperparameterChromosome  # F + G
+├── reward_shaping:  HyperparameterChromosome  # H (optional)
+├── architecture:    HyperparameterChromosome  # I (needs Tier 3)
+└── repertoire:      HyperparameterChromosome  # J (needs Tier 3)
+```
+
+Benefits this gives you for free:
+
+- Per-chromosome mutation rate / scale (the genes you really want to drift fast
+  vs. slow live in different chromosomes).
+- Linkage groups: all combat genes recombine together via single-point
+  crossover but not with learning genes.
+- Independent assortment: the existing `crossover_chromosomes` runs once per
+  chromosome.
+- Cleaner `apply_*`: each chromosome's genes target one component config;
+  namespace prefixes become unnecessary.
+
+---
+
+## Recommended rollout order
+
+Go in this order; each step is independent and testable:
+
+1. **Tier 1 / Chromosome A + B** — pure additions to
+   `DEFAULT_HYPERPARAMETER_GENES`. Highest impact / lowest risk. Action-prior
+   genes (B) are likely the single biggest qualitative win.
+2. **Generalize `apply_chromosome_to_learning_config`** to
+   `apply_chromosome_to_agent_config` with namespaced gene names. Add
+   Chromosomes C–G.
+3. **Add `GeneValueType.INTEGER` and `BINARY` (then `CATEGORICAL`)** plus
+   matching mutation operators (uniform-int, bit-flip, allele-swap). Unlocks
+   Chromosomes I and J.
+4. **Introduce `ChromosomeBundle`** so chromosomes mutate / cross independently
+   and `IntrinsicEvolutionPolicy` can take per-chromosome rates.
+5. **Reward-shaping chromosome (H)** last, behind an opt-in flag, with an
+   external fitness metric to prevent Goodharting.

--- a/farm/core/agent/behaviors/learning.py
+++ b/farm/core/agent/behaviors/learning.py
@@ -10,6 +10,10 @@ import numpy as np
 import torch
 
 from farm.core.action import Action, action_registry, action_name_to_index
+from farm.core.decision.action_weight_policy import (
+    compute_action_weights,
+    extract_signals,
+)
 from farm.core.decision.decision import DecisionModule
 from farm.utils.logging import get_logger
 
@@ -66,22 +70,48 @@ class LearningAgentBehavior(IAgentBehavior):
             enabled_action_indices = [core.actions.index(action) for action in enabled_actions]
         else:
             enabled_action_indices = None
-        
-        # Extract action weights for all actions in core.actions
-        # Map to indices matching DecisionModule's action space (0 to num_actions-1)
-        action_weights = np.zeros(self.decision_module.num_actions, dtype=np.float64)
+
+        # Build the per-action weight vector, then scale by state-aware
+        # multiplier / threshold genes (Chromosome B).  ``core.actions[i].weight``
+        # already reflects evolved base-weight genes via
+        # ``AgentCore.refresh_action_weights_from_decision_config``; this layer
+        # adds the situation-dependent biasing on top.
+        num_actions = self.decision_module.num_actions
+        base_weights = np.zeros(num_actions, dtype=np.float64)
+        action_names = ["" for _ in range(num_actions)]
         for i, action in enumerate(core.actions):
-            if i < len(action_weights):
-                action_weights[i] = action.weight
-        
-        # Normalize weights
+            if i < num_actions:
+                base_weights[i] = action.weight
+                action_names[i] = action.name
+
+        decision_config = getattr(getattr(core, "config", None), "decision", None)
+        if decision_config is not None:
+            try:
+                signals = extract_signals(core)
+                action_weights = compute_action_weights(
+                    base_weights=base_weights,
+                    action_names=action_names,
+                    decision_config=decision_config,
+                    signals=signals,
+                    enabled_actions=enabled_action_indices,
+                )
+            except Exception as exc:
+                logger.debug(
+                    "action_weight_policy_fallback",
+                    agent_id=getattr(core, "agent_id", "unknown"),
+                    error_type=type(exc).__name__,
+                    error_message=str(exc),
+                )
+                action_weights = base_weights
+        else:
+            action_weights = base_weights
+
         total_weight = np.sum(action_weights)
         if total_weight > 0:
             action_weights = action_weights / total_weight
         else:
-            # Fallback to uniform if all weights are zero
-            action_weights = np.ones(self.decision_module.num_actions) / self.decision_module.num_actions
-        
+            action_weights = np.ones(num_actions) / num_actions
+
         # Use DecisionModule to select action with weights
         action_index = self.decision_module.decide_action(
             state, enabled_action_indices, action_weights=action_weights

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -18,6 +18,7 @@ from farm.core.agent.behaviors.base import IAgentBehavior
 from farm.core.agent.components.base import AgentComponent
 from farm.core.agent.config.component_configs import AgentComponentConfig
 from farm.core.agent.services import AgentServices
+from farm.core.decision.config import DecisionConfig
 from farm.core.device_utils import create_device_from_config
 from farm.core.hyperparameter_chromosome import (
     HyperparameterChromosome,
@@ -242,21 +243,43 @@ class AgentCore:
                         f"config.decision.{field_name}={value!r} is invalid; {requirement}."
                     )
 
+    # Map of action names whose base weights are evolvable via Chromosome B
+    # (genes living on :class:`farm.core.decision.config.DecisionConfig`).
+    # When the named ``DecisionConfig`` attribute is present **and** its current
+    # value differs from the Pydantic default, the chromosome value wins over
+    # the global ``agent_parameters`` override.
+    _DECISION_ACTION_WEIGHT_FIELDS = {
+        "move": "move_weight",
+        "gather": "gather_weight",
+        "share": "share_weight",
+        "attack": "attack_weight",
+        "reproduce": "reproduce_weight",
+    }
+
     def _customize_action_weights(
         self, base_actions: list[Action], agent_type: str, environment: Optional["Environment"]
     ) -> list[Action]:
         """
         Customize action weights based on agent type from configuration.
-        
+
+        Precedence (highest wins):
+
+        1. Per-agent ``DecisionConfig.{move,gather,share,attack,reproduce}_weight``
+           — sourced from the agent's hyperparameter chromosome via
+           :func:`apply_chromosome_to_learning_config`.  This is the path that
+           lets evolutionary pressure on Chromosome B reshape the policy.
+        2. Environment-level ``agent_parameters[<AgentType>]`` ``share_weight``
+           / ``attack_weight`` overrides (legacy global biasing).
+        3. Action registry defaults.
+
         Args:
             base_actions: List of base actions from registry
             agent_type: Agent type (e.g., 'system', 'independent', 'control')
             environment: Environment instance that may contain config
-            
+
         Returns:
-            List of Action objects with customized weights
+            List of Action objects with normalized customized weights
         """
-        # Map agent_type to config key
         agent_type_map = {
             "system": "SystemAgent",
             "independent": "IndependentAgent",
@@ -265,45 +288,120 @@ class AgentCore:
             "chaos": "ChaosAgent",
         }
         config_key = agent_type_map.get(agent_type.lower())
-        
-        # Default weights (from global registry)
-        custom_actions = []
+
         share_weight = None
         attack_weight = None
-        
-        # Try to get agent-specific weights from config
         if environment and hasattr(environment, "config") and environment.config:
             agent_params = getattr(environment.config, "agent_parameters", None)
             if agent_params and config_key and config_key in agent_params:
                 params = agent_params[config_key]
                 share_weight = params.get("share_weight")
                 attack_weight = params.get("attack_weight")
-        
-        # Create new Action objects with customized weights
+
+        decision_overrides = self._action_weight_overrides_from_decision_config()
+
+        custom_actions: list[Action] = []
         for action in base_actions:
-            new_weight = action.weight  # Keep default weight
-            
-            # Override share and attack weights if specified in config
+            new_weight = action.weight
+
+            # Legacy environment-level overrides for share / attack.
             if action.name == "share" and share_weight is not None:
                 new_weight = share_weight
             elif action.name == "attack" and attack_weight is not None:
                 new_weight = attack_weight
-            
-            # Create new Action with same name and function but updated weight
+
+            # Per-agent chromosome value wins when explicitly set.
+            if action.name in decision_overrides:
+                new_weight = decision_overrides[action.name]
+
             custom_actions.append(Action(action.name, new_weight, action.function))
-        
-        # Normalize weights
-        total_weight = sum(action.weight for action in custom_actions)
-        if total_weight > 0:
-            for action in custom_actions:
-                action.weight /= total_weight
-        else:
-            # Fallback to uniform if all weights are zero
-            uniform_weight = 1.0 / len(custom_actions)
-            for action in custom_actions:
-                action.weight = uniform_weight
-        
+
+        self._normalize_action_weights(custom_actions)
         return custom_actions
+
+    def _action_weight_overrides_from_decision_config(self) -> Dict[str, float]:
+        """Resolve per-action weight overrides from ``self.config.decision``.
+
+        Only fields whose current value differs from the Pydantic default are
+        treated as overrides, so plain ``DecisionConfig()`` instances with
+        unmodified action weights fall through to the legacy precedence chain
+        and existing scenarios are preserved.
+        """
+        overrides: Dict[str, float] = {}
+        decision_config = getattr(self.config, "decision", None)
+        if decision_config is None:
+            return overrides
+        defaults = self._decision_action_weight_defaults()
+        for action_name, field_name in self._DECISION_ACTION_WEIGHT_FIELDS.items():
+            if not hasattr(decision_config, field_name):
+                continue
+            value = getattr(decision_config, field_name)
+            if value is None or not isinstance(value, (int, float)):
+                continue
+            default_value = defaults.get(field_name)
+            if default_value is not None and float(value) == float(default_value):
+                continue
+            overrides[action_name] = float(value)
+        return overrides
+
+    @staticmethod
+    def _decision_action_weight_defaults() -> Dict[str, float]:
+        """Return the Pydantic-default values of the action-weight fields.
+
+        Cached on the class so :func:`getattr` for each agent does not
+        instantiate :class:`DecisionConfig` repeatedly.
+        """
+        cached = getattr(AgentCore, "_DECISION_ACTION_WEIGHT_DEFAULTS_CACHE", None)
+        if cached is not None:
+            return cached
+        try:
+            defaults_obj = DecisionConfig()
+        except Exception:
+            cached = {}
+        else:
+            cached = {
+                field_name: float(getattr(defaults_obj, field_name))
+                for field_name in AgentCore._DECISION_ACTION_WEIGHT_FIELDS.values()
+                if hasattr(defaults_obj, field_name)
+            }
+        AgentCore._DECISION_ACTION_WEIGHT_DEFAULTS_CACHE = cached
+        return cached
+
+    @staticmethod
+    def _normalize_action_weights(actions: list[Action]) -> None:
+        """Normalize a list of :class:`Action` weights in place to sum to 1.0.
+
+        Falls back to a uniform distribution when every weight is zero (or
+        negative) so the policy never receives a degenerate ``[0, 0, …]``
+        weight vector.
+        """
+        if not actions:
+            return
+        total_weight = sum(max(0.0, action.weight) for action in actions)
+        if total_weight > 0:
+            for action in actions:
+                action.weight = max(0.0, action.weight) / total_weight
+            return
+        uniform_weight = 1.0 / len(actions)
+        for action in actions:
+            action.weight = uniform_weight
+
+    def refresh_action_weights_from_decision_config(self) -> None:
+        """Re-derive ``self.actions[*].weight`` from the current ``DecisionConfig``.
+
+        Called after the agent's hyperparameter chromosome is re-applied
+        (e.g. by ``ChromosomeDiversitySource``) so any mutated Chromosome B
+        action-weight gene takes effect on the very next decision step.
+        """
+        if not getattr(self, "actions", None):
+            return
+        overrides = self._action_weight_overrides_from_decision_config()
+        if not overrides:
+            return
+        for action in self.actions:
+            if action.name in overrides:
+                action.weight = overrides[action.name]
+        self._normalize_action_weights(self.actions)
 
     def attach_component(self, component: AgentComponent) -> None:
         """

--- a/farm/core/decision/action_weight_policy.py
+++ b/farm/core/decision/action_weight_policy.py
@@ -1,0 +1,306 @@
+"""State-aware action re-weighter consuming Chromosome B multiplier/threshold genes.
+
+The decision module already knows how to bias action probabilities by an
+optional ``action_weights`` vector (see
+:meth:`farm.core.decision.decision.DecisionModule._apply_action_weights_to_probs`).
+Until now, the only signal it received was the static
+``core.actions[i].weight`` — meaning the multiplier and threshold genes that
+live on :class:`farm.core.decision.config.DecisionConfig` had no consumer.
+
+This module bridges that gap: given the current agent state, it scales the
+base per-action weights using the eight state-aware multiplier genes plus
+their three companion threshold genes:
+
+- ``move_mult_no_resources``       (active when no resources are nearby)
+- ``gather_mult_low_resources``    (active when the agent is below half resources)
+- ``share_mult_wealthy``           (active when the agent has plenty of resources)
+- ``share_mult_poor``              (active when the agent is below the wealth threshold)
+- ``attack_mult_desperate``        (active when starvation risk exceeds
+  ``attack_starvation_threshold``)
+- ``attack_mult_stable``           (active when combat health is above
+  ``attack_defense_threshold``)
+- ``reproduce_mult_wealthy``       (active when resources are above
+  ``reproduce_resource_threshold``)
+- ``reproduce_mult_poor``          (active when below that same threshold)
+
+The function is intentionally a pure helper so it can be unit-tested without
+constructing a full agent / decision pipeline.  Heuristics are best-effort:
+when an attribute is missing the corresponding multiplier is skipped so the
+helper degrades gracefully on unusual agent shapes.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, List, Optional, Sequence
+
+import numpy as np
+
+__all__ = [
+    "ActionStateSignals",
+    "compute_action_weights",
+    "extract_signals",
+]
+
+
+class ActionStateSignals:
+    """Plain-data container for the state signals consumed by the re-weighter.
+
+    Values are normalized to the unit interval where applicable so the
+    multiplier-gating thresholds (which all live in ``[0, 1]``) can be
+    interpreted consistently.
+
+    Attributes:
+        resource_ratio: ``resource_level / max_resource_level`` clipped to
+            ``[0, 1]``.  ``None`` when the max is unknown.
+        health_ratio: ``current_health / starting_health`` clipped to
+            ``[0, 1]``.  ``None`` when the agent has no combat component.
+        starvation_risk: ``starvation_counter / starvation_threshold`` clipped
+            to ``[0, 1]``.  Equals ``0.0`` for agents without a resource
+            component.
+        nearby_resources: ``True`` when the agent perceives at least one
+            resource within its perception radius.  ``None`` when the
+            component is unavailable.
+    """
+
+    __slots__ = (
+        "resource_ratio",
+        "health_ratio",
+        "starvation_risk",
+        "nearby_resources",
+    )
+
+    def __init__(
+        self,
+        *,
+        resource_ratio: Optional[float] = None,
+        health_ratio: Optional[float] = None,
+        starvation_risk: float = 0.0,
+        nearby_resources: Optional[bool] = None,
+    ) -> None:
+        self.resource_ratio = resource_ratio
+        self.health_ratio = health_ratio
+        self.starvation_risk = float(np.clip(starvation_risk, 0.0, 1.0))
+        self.nearby_resources = nearby_resources
+
+
+def _clip_ratio(numerator: float, denominator: float) -> Optional[float]:
+    """Return ``numerator / denominator`` clipped to ``[0, 1]`` (``None`` on bad input)."""
+    if denominator is None or denominator <= 0.0:
+        return None
+    try:
+        return float(np.clip(float(numerator) / float(denominator), 0.0, 1.0))
+    except (TypeError, ValueError):
+        return None
+
+
+def extract_signals(agent: Any) -> ActionStateSignals:
+    """Best-effort extraction of state signals from an :class:`AgentCore`-shaped object.
+
+    Designed to be tolerant of partial agents in tests.  Missing attributes
+    map to ``None`` (or, for ``starvation_risk``, ``0.0``).
+    """
+    resource_level = getattr(agent, "resource_level", None)
+    max_resource_level = None
+
+    config = getattr(agent, "config", None)
+    if config is not None:
+        reward_cfg = getattr(config, "reward", None)
+        if reward_cfg is not None:
+            max_resource_level = getattr(reward_cfg, "max_resource_level", None)
+    if max_resource_level is None:
+        # Fall back to environment-level config when reward config is absent.
+        env = getattr(agent, "environment", None)
+        env_config = getattr(env, "config", None) if env is not None else None
+        max_resource_level = getattr(env_config, "max_resource_amount", None) if env_config else None
+
+    resource_ratio = (
+        _clip_ratio(float(resource_level), float(max_resource_level))
+        if resource_level is not None and max_resource_level is not None
+        else None
+    )
+
+    starting_health = getattr(agent, "starting_health", None)
+    current_health = getattr(agent, "current_health", None)
+    health_ratio = (
+        _clip_ratio(float(current_health), float(starting_health))
+        if current_health is not None and starting_health is not None
+        else None
+    )
+
+    starvation_risk = 0.0
+    get_component = getattr(agent, "get_component", None)
+    resource_comp = get_component("resource") if callable(get_component) else None
+    if resource_comp is not None:
+        threshold = getattr(getattr(resource_comp, "config", None), "starvation_threshold", None)
+        counter = getattr(resource_comp, "starvation_counter", 0)
+        if threshold is not None and threshold > 0:
+            starvation_risk = float(np.clip(float(counter) / float(threshold), 0.0, 1.0))
+
+    nearby_resources: Optional[bool] = None
+    perception_comp = get_component("perception") if callable(get_component) else None
+    if perception_comp is not None and hasattr(perception_comp, "_get_cached_spatial_query"):
+        try:
+            radius = getattr(getattr(perception_comp, "config", None), "perception_radius", None)
+            if radius is not None:
+                nearby = perception_comp._get_cached_spatial_query(int(radius), ["resources"])
+                nearby_resources = bool(nearby.get("resources") if isinstance(nearby, dict) else nearby)
+        except Exception:
+            nearby_resources = None
+
+    return ActionStateSignals(
+        resource_ratio=resource_ratio,
+        health_ratio=health_ratio,
+        starvation_risk=starvation_risk,
+        nearby_resources=nearby_resources,
+    )
+
+
+def _multiplier(value: Optional[float], default: float = 1.0) -> float:
+    """Coerce a config value into a non-negative multiplier (``default`` on bad input)."""
+    if value is None:
+        return default
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not np.isfinite(f) or f < 0.0:
+        return default
+    return f
+
+
+def compute_action_weights(
+    base_weights: Sequence[float],
+    action_names: Sequence[str],
+    decision_config: Any,
+    signals: ActionStateSignals,
+    enabled_actions: Optional[Iterable[int]] = None,
+) -> np.ndarray:
+    """Return a per-action weight vector with state-aware multipliers applied.
+
+    Args:
+        base_weights: Per-action base weights (already populated from
+            :class:`farm.core.action.Action` ``weight`` fields, which
+            themselves derive from Chromosome B action-weight genes via
+            :meth:`AgentCore.refresh_action_weights_from_decision_config`).
+        action_names: ``len(base_weights)``-aligned names (lowercase action
+            identifiers).
+        decision_config: The agent's :class:`DecisionConfig` (carries the
+            multiplier and threshold genes).
+        signals: Pre-computed :class:`ActionStateSignals`.
+        enabled_actions: Optional iterable of indices that are currently
+            allowed.  Disabled actions get a weight of ``0.0``.
+
+    Returns:
+        Float-64 numpy array of length ``len(base_weights)`` with normalized
+        weights summing to ``1.0`` (or uniform across enabled actions when the
+        scaled weights collapse to zero).
+    """
+    if len(base_weights) != len(action_names):
+        raise ValueError(
+            "base_weights and action_names must be the same length; "
+            f"got {len(base_weights)} vs {len(action_names)}."
+        )
+
+    weights = np.asarray(base_weights, dtype=np.float64).copy()
+    if weights.size == 0:
+        return weights
+
+    name_to_idx = {name: idx for idx, name in enumerate(action_names)}
+
+    def _scale(action_name: str, factor: float) -> None:
+        idx = name_to_idx.get(action_name)
+        if idx is None:
+            return
+        weights[idx] = weights[idx] * factor
+
+    # ── move ────────────────────────────────────────────────────────────────
+    if signals.nearby_resources is False:
+        _scale(
+            "move",
+            _multiplier(getattr(decision_config, "move_mult_no_resources", None)),
+        )
+
+    # ── gather ──────────────────────────────────────────────────────────────
+    if signals.resource_ratio is not None and signals.resource_ratio < 0.5:
+        _scale(
+            "gather",
+            _multiplier(getattr(decision_config, "gather_mult_low_resources", None)),
+        )
+
+    # ── share ───────────────────────────────────────────────────────────────
+    if signals.resource_ratio is not None:
+        if signals.resource_ratio >= 0.7:
+            _scale("share", _multiplier(getattr(decision_config, "share_mult_wealthy", None)))
+        elif signals.resource_ratio < 0.3:
+            _scale("share", _multiplier(getattr(decision_config, "share_mult_poor", None)))
+
+    # ── attack ──────────────────────────────────────────────────────────────
+    starv_threshold = float(
+        np.clip(
+            float(getattr(decision_config, "attack_starvation_threshold", 0.5)),
+            0.0,
+            1.0,
+        )
+    )
+    defense_threshold = float(
+        np.clip(
+            float(getattr(decision_config, "attack_defense_threshold", 0.3)),
+            0.0,
+            1.0,
+        )
+    )
+    if signals.starvation_risk >= starv_threshold:
+        _scale(
+            "attack",
+            _multiplier(getattr(decision_config, "attack_mult_desperate", None)),
+        )
+    if signals.health_ratio is not None and signals.health_ratio >= (1.0 - defense_threshold):
+        _scale(
+            "attack",
+            _multiplier(getattr(decision_config, "attack_mult_stable", None)),
+        )
+
+    # ── reproduce ───────────────────────────────────────────────────────────
+    repro_threshold = float(
+        np.clip(
+            float(getattr(decision_config, "reproduce_resource_threshold", 0.7)),
+            0.0,
+            1.0,
+        )
+    )
+    if signals.resource_ratio is not None:
+        if signals.resource_ratio >= repro_threshold:
+            _scale(
+                "reproduce",
+                _multiplier(getattr(decision_config, "reproduce_mult_wealthy", None)),
+            )
+        else:
+            _scale(
+                "reproduce",
+                _multiplier(getattr(decision_config, "reproduce_mult_poor", None)),
+            )
+
+    # ── enabled mask ────────────────────────────────────────────────────────
+    if enabled_actions is not None:
+        enabled_set = {int(i) for i in enabled_actions}
+        for idx in range(weights.size):
+            if idx not in enabled_set:
+                weights[idx] = 0.0
+
+    # Guard against negative or non-finite values that may sneak in via
+    # malformed configs; mutate_chromosome already keeps genes in range,
+    # but defensive normalization keeps the helper robust to future edits.
+    weights = np.where(np.isfinite(weights) & (weights >= 0.0), weights, 0.0)
+
+    total = weights.sum()
+    if total > 0.0:
+        return weights / total
+
+    # All-zero fallback: uniform across enabled (or all) actions.
+    if enabled_actions is not None:
+        enabled_list: List[int] = [int(i) for i in enabled_actions]
+        if enabled_list:
+            uniform = np.zeros_like(weights)
+            uniform[enabled_list] = 1.0 / len(enabled_list)
+            return uniform
+    return np.full_like(weights, 1.0 / weights.size)

--- a/farm/core/decision/algorithms/tianshou.py
+++ b/farm/core/decision/algorithms/tianshou.py
@@ -27,7 +27,12 @@ class TianshouWrapper(RLAlgorithm):
     """
 
     # Parameters that are handled separately and should be filtered out
-    # when passing config to Tianshou policy constructors
+    # when passing config to Tianshou policy constructors.
+    #
+    # ``target_update_freq`` stays in this set because most Tianshou policies
+    # (PPO / SAC / A2C / DDPG) do not accept it.  The DQN branch forwards the
+    # value via an explicit kwarg below so the Chromosome A
+    # ``target_update_freq`` gene actually controls the hard target sync.
     _EXCLUDED_PARAMS = frozenset([
         "lr", "device", "gamma", "tau", "alpha", "auto_alpha", "target_entropy",
         "n_step", "target_update_freq", "eps_test", "eps_train", "eps_train_final",
@@ -545,12 +550,28 @@ class TianshouWrapper(RLAlgorithm):
                     q_net.parameters(), lr=self.algorithm_config["lr"]
                 )
 
-                # Create policy
+                # Create policy.  ``target_update_freq`` and ``estimation_step``
+                # are first-class DQNPolicy constructor args, so we pass them
+                # explicitly rather than letting the EXCLUDED_PARAMS filter
+                # drop them.  This makes the Chromosome A
+                # ``target_update_freq`` gene control the hard target sync
+                # cadence end-to-end.
+                target_update_freq = int(
+                    self.algorithm_config.get("target_update_freq", 500)
+                )
+                if target_update_freq <= 0:
+                    raise ValueError(
+                        "target_update_freq must be a positive integer; got "
+                        f"{target_update_freq}."
+                    )
+                estimation_step = int(self.algorithm_config.get("n_step", 1))
 
                 self.policy = DQNPolicy(
                     model=q_net,
                     optim=optim,
                     action_space=gymnasium.spaces.Discrete(self.num_actions),
+                    target_update_freq=target_update_freq,
+                    estimation_step=estimation_step,
                     **{
                         k: v
                         for k, v in self.algorithm_config.items()

--- a/farm/core/decision/decision.py
+++ b/farm/core/decision/decision.py
@@ -142,6 +142,13 @@ class DecisionModule:
 
         logger.info(f"Initialized DecisionModule for agent {self.agent_id} with {config.algorithm_type}")
 
+    # Algorithm types whose constructors accept an ``n_estimators`` kwarg.
+    # When the active algorithm is one of these, ``DecisionConfig.ensemble_size``
+    # is auto-injected as ``n_estimators`` if the caller hasn't already
+    # supplied it via ``algorithm_params``.  This activates the
+    # Chromosome A ``ensemble_size`` gene end-to-end.
+    _ENSEMBLE_ALGORITHM_TYPES = frozenset({"random_forest", "gradient_boost"})
+
     def _initialize_algorithm(self):
         """Initialize the decision algorithm based on configuration."""
         algorithm_type = self.config.algorithm_type
@@ -156,6 +163,15 @@ class DecisionModule:
             self._initialize_tianshou_a2c()
         elif algorithm_type == "ddpg" and TIANSHOU_AVAILABLE:
             self._initialize_tianshou_ddpg()
+        elif algorithm_type in {
+            "mlp",
+            "svm",
+            "random_forest",
+            "gradient_boost",
+            "naive_bayes",
+            "knn",
+        }:
+            self._initialize_traditional_ml(algorithm_type)
         elif algorithm_type == "fallback":
             # Explicit fallback algorithm
             self._initialize_fallback()
@@ -165,6 +181,52 @@ class DecisionModule:
                 algorithm_type=algorithm_type,
                 agent_id=self.agent_id,
                 message="Using fallback",
+            )
+            self._initialize_fallback()
+
+    def _initialize_traditional_ml(self, algorithm_type: str) -> None:
+        """Instantiate a traditional-ML action selector via the registry.
+
+        Threads ``DecisionConfig.ensemble_size`` into ``n_estimators`` for
+        ensemble-class algorithms when the caller hasn't already provided one
+        through ``algorithm_params``.  Falls back to the random-fallback
+        algorithm if construction fails so the simulation can still proceed.
+        """
+        try:
+            from farm.core.decision.algorithms.base import AlgorithmRegistry
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                "traditional_ml_registry_unavailable",
+                algorithm_type=algorithm_type,
+                agent_id=self.agent_id,
+                error_type=type(exc).__name__,
+                error_message=str(exc),
+            )
+            self._initialize_fallback()
+            return
+
+        params: Dict[str, Any] = dict(self.config.algorithm_params or {})
+        if algorithm_type in self._ENSEMBLE_ALGORITHM_TYPES:
+            params.setdefault("n_estimators", int(self.config.ensemble_size))
+        if self.config.seed is not None:
+            params.setdefault("random_state", int(self.config.seed))
+
+        try:
+            self.algorithm = AlgorithmRegistry.create(
+                algorithm_type, num_actions=self.num_actions, **params
+            )
+            logger.info(
+                "algorithm_initialized",
+                algorithm=algorithm_type,
+                agent_id=self.agent_id,
+            )
+        except Exception as exc:
+            logger.error(
+                "algorithm_initialization_failed",
+                algorithm=algorithm_type,
+                agent_id=self.agent_id,
+                error_type=type(exc).__name__,
+                error_message=str(exc),
             )
             self._initialize_fallback()
 
@@ -296,7 +358,7 @@ class DecisionModule:
                 "lr": self.config.learning_rate,
                 "gamma": self.config.gamma,
                 "n_step": 3,
-                "target_update_freq": 500,
+                "target_update_freq": int(self.config.target_update_freq),
                 "eps_test": self.config.epsilon_min,
                 "eps_train": self.config.epsilon_start,
                 "eps_train_final": self.config.epsilon_min,

--- a/farm/core/hyperparameter_chromosome.py
+++ b/farm/core/hyperparameter_chromosome.py
@@ -364,25 +364,75 @@ class HyperparameterChromosome:
 
 
 # Default encoding policy by gene name.
-# learning_rate uses log-space 8-bit quantization so equal bucket changes map to
-# multiplicative LR changes, which is typically more meaningful than linear shifts.
-# epsilon_decay and gamma use linear 8-bit quantization; their ranges are bounded
-# and do not span multiple orders of magnitude in a way that requires log space.
+#
+# Log-space quantization is used for genes whose useful range spans multiple
+# orders of magnitude, so equal bucket changes map to multiplicative shifts in
+# the underlying value (typically more meaningful than linear shifts).  Linear
+# 8-bit quantization is used for bounded ratios and probabilities whose ranges
+# do not span multiple decades.
 DEFAULT_GENE_ENCODINGS: Dict[str, GeneEncodingSpec] = {
+    # ── Chromosome A: learning / RL hyperparameters ──────────────────────────
     "learning_rate": GeneEncodingSpec(scale=GeneEncodingScale.LOG, bit_width=8),
     "epsilon_decay": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
     "gamma": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "epsilon_start": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    # epsilon_min uses linear encoding (not log) so the gene can accept the
+    # legal DecisionConfig boundary value of 0.0; log-scale would require a
+    # strictly positive lower bound and reject configs that disable exploration.
+    "epsilon_min": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    # tau, batch_size, target_update_freq, dqn_hidden_size, and rl_train_freq
+    # all span multiple orders of magnitude where multiplicative steps are
+    # more meaningful than absolute ones, so they use log-scale encoding.
+    "tau": GeneEncodingSpec(scale=GeneEncodingScale.LOG, bit_width=8),
+    "batch_size": GeneEncodingSpec(scale=GeneEncodingScale.LOG, bit_width=8),
+    "target_update_freq": GeneEncodingSpec(scale=GeneEncodingScale.LOG, bit_width=8),
+    "dqn_hidden_size": GeneEncodingSpec(scale=GeneEncodingScale.LOG, bit_width=8),
+    "rl_train_freq": GeneEncodingSpec(scale=GeneEncodingScale.LOG, bit_width=8),
+    "per_alpha": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "per_beta_start": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "per_beta_end": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "ensemble_size": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    # ── Chromosome B: action-policy priors ───────────────────────────────────
+    "move_weight": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "gather_weight": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "share_weight": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "attack_weight": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "reproduce_weight": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "move_mult_no_resources": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "gather_mult_low_resources": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "share_mult_wealthy": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "share_mult_poor": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "attack_mult_desperate": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "attack_mult_stable": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "reproduce_mult_wealthy": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "reproduce_mult_poor": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "attack_starvation_threshold": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "attack_defense_threshold": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
+    "reproduce_resource_threshold": GeneEncodingSpec(scale=GeneEncodingScale.LINEAR, bit_width=8),
 }
 
 # Smallest positive IEEE-754 binary64; mirrors DecisionConfig allowing any (0, 1].
 _EPSILON_DECAY_GENE_MIN = math.ldexp(1.0, -1074)
 
 
+
 # Default hyperparameter loci.
-# learning_rate, gamma, epsilon_decay, and memory_size are all evolvable.
-# memory_size is projected to integer config fields via rounding with a bounds
-# safety check in ``apply_chromosome_to_learning_config``.
+#
+# These cover two logical chromosomes (kept in a single tuple so the existing
+# crossover/mutation pipeline operates over all of them):
+#
+# - **Chromosome A — learning / RL hyperparameters** (DQN/PER knobs).
+# - **Chromosome B — action-policy priors** (base action weights, state-based
+#   multipliers, and policy thresholds on ``DecisionConfig``).
+#
+# All names match attributes on :class:`farm.core.decision.config.DecisionConfig`,
+# so :func:`apply_chromosome_to_learning_config` projects gene values back into
+# the live config automatically.  Genes whose target attribute is an ``int``
+# (``memory_size``, ``batch_size``, ``target_update_freq``, ``dqn_hidden_size``,
+# ``rl_train_freq``, ``ensemble_size``) are projected via rounding with a bounds
+# safety check in :func:`apply_chromosome_to_learning_config`.
 DEFAULT_HYPERPARAMETER_GENES: Tuple[HyperparameterGene, ...] = (
+    # ── Chromosome A: learning / RL hyperparameters ──────────────────────────
     HyperparameterGene(
         name="learning_rate",
         value_type=GeneValueType.REAL,
@@ -417,6 +467,250 @@ DEFAULT_HYPERPARAMETER_GENES: Tuple[HyperparameterGene, ...] = (
         min_value=1.0,
         max_value=1_000_000.0,
         default=10000.0,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="epsilon_start",
+        value_type=GeneValueType.REAL,
+        value=1.0,
+        min_value=0.0,
+        max_value=1.0,
+        default=1.0,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="epsilon_min",
+        value_type=GeneValueType.REAL,
+        value=0.01,
+        min_value=0.0,
+        max_value=0.5,
+        default=0.01,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="tau",
+        value_type=GeneValueType.REAL,
+        value=0.005,
+        min_value=1e-4,
+        max_value=0.5,
+        default=0.005,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="batch_size",
+        value_type=GeneValueType.REAL,
+        value=32.0,
+        min_value=8.0,
+        max_value=1024.0,
+        default=32.0,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="target_update_freq",
+        value_type=GeneValueType.REAL,
+        value=100.0,
+        min_value=1.0,
+        max_value=5000.0,
+        default=100.0,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="dqn_hidden_size",
+        value_type=GeneValueType.REAL,
+        value=64.0,
+        min_value=8.0,
+        max_value=512.0,
+        default=64.0,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="rl_train_freq",
+        value_type=GeneValueType.REAL,
+        value=4.0,
+        min_value=1.0,
+        max_value=64.0,
+        default=4.0,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="per_alpha",
+        value_type=GeneValueType.REAL,
+        value=0.6,
+        min_value=0.0,
+        max_value=1.0,
+        default=0.6,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="per_beta_start",
+        value_type=GeneValueType.REAL,
+        value=0.4,
+        min_value=0.0,
+        max_value=1.0,
+        default=0.4,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="per_beta_end",
+        value_type=GeneValueType.REAL,
+        value=1.0,
+        min_value=0.0,
+        max_value=1.0,
+        default=1.0,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="ensemble_size",
+        value_type=GeneValueType.REAL,
+        value=1.0,
+        min_value=1.0,
+        max_value=16.0,
+        default=1.0,
+        evolvable=True,
+    ),
+    # ── Chromosome B: action-policy priors ───────────────────────────────────
+    HyperparameterGene(
+        name="move_weight",
+        value_type=GeneValueType.REAL,
+        value=0.30,
+        min_value=0.0,
+        max_value=2.0,
+        default=0.30,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="gather_weight",
+        value_type=GeneValueType.REAL,
+        value=0.30,
+        min_value=0.0,
+        max_value=2.0,
+        default=0.30,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="share_weight",
+        value_type=GeneValueType.REAL,
+        value=0.15,
+        min_value=0.0,
+        max_value=2.0,
+        default=0.15,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="attack_weight",
+        value_type=GeneValueType.REAL,
+        value=0.10,
+        min_value=0.0,
+        max_value=2.0,
+        default=0.10,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="reproduce_weight",
+        value_type=GeneValueType.REAL,
+        value=0.15,
+        min_value=0.0,
+        max_value=2.0,
+        default=0.15,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="move_mult_no_resources",
+        value_type=GeneValueType.REAL,
+        value=1.5,
+        min_value=0.5,
+        max_value=3.0,
+        default=1.5,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="gather_mult_low_resources",
+        value_type=GeneValueType.REAL,
+        value=1.5,
+        min_value=0.5,
+        max_value=3.0,
+        default=1.5,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="share_mult_wealthy",
+        value_type=GeneValueType.REAL,
+        value=1.3,
+        min_value=0.5,
+        max_value=3.0,
+        default=1.3,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="share_mult_poor",
+        value_type=GeneValueType.REAL,
+        value=0.5,
+        min_value=0.0,
+        max_value=1.5,
+        default=0.5,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="attack_mult_desperate",
+        value_type=GeneValueType.REAL,
+        value=1.4,
+        min_value=0.5,
+        max_value=3.0,
+        default=1.4,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="attack_mult_stable",
+        value_type=GeneValueType.REAL,
+        value=0.6,
+        min_value=0.0,
+        max_value=1.5,
+        default=0.6,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="reproduce_mult_wealthy",
+        value_type=GeneValueType.REAL,
+        value=1.4,
+        min_value=0.5,
+        max_value=3.0,
+        default=1.4,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="reproduce_mult_poor",
+        value_type=GeneValueType.REAL,
+        value=0.3,
+        min_value=0.0,
+        max_value=1.5,
+        default=0.3,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="attack_starvation_threshold",
+        value_type=GeneValueType.REAL,
+        value=0.5,
+        min_value=0.0,
+        max_value=1.0,
+        default=0.5,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="attack_defense_threshold",
+        value_type=GeneValueType.REAL,
+        value=0.3,
+        min_value=0.0,
+        max_value=1.0,
+        default=0.3,
+        evolvable=True,
+    ),
+    HyperparameterGene(
+        name="reproduce_resource_threshold",
+        value_type=GeneValueType.REAL,
+        value=0.7,
+        min_value=0.0,
+        max_value=1.0,
+        default=0.7,
         evolvable=True,
     ),
 )

--- a/farm/core/initial_diversity.py
+++ b/farm/core/initial_diversity.py
@@ -274,6 +274,11 @@ def _apply_chromosome_to_agent(agent: Any, chromosome: HyperparameterChromosome)
     seeding: rewrite ``hyperparameter_chromosome``, recompute the learning
     config, and reinitialize the decision module's algorithm when one already
     exists so optimizer hyperparameters track the seeded values.
+
+    In addition, the agent's per-action ``Action.weight`` values are refreshed
+    from the new ``DecisionConfig`` so any mutated Chromosome B action-weight
+    gene (``move_weight``, ``gather_weight``, ``share_weight``,
+    ``attack_weight``, ``reproduce_weight``) takes effect on the next decision.
     """
     agent.hyperparameter_chromosome = chromosome
     new_decision_config = apply_chromosome_to_learning_config(
@@ -286,6 +291,12 @@ def _apply_chromosome_to_agent(agent: Any, chromosome: HyperparameterChromosome)
     reinitialize = getattr(decision_module, "reinitialize_algorithm", None)
     if callable(reinitialize):
         reinitialize(new_decision_config)
+
+    refresh_action_weights = getattr(
+        agent, "refresh_action_weights_from_decision_config", None
+    )
+    if callable(refresh_action_weights):
+        refresh_action_weights()
 
 
 class ChromosomeDiversitySource:

--- a/tests/analysis/test_speciation.py
+++ b/tests/analysis/test_speciation.py
@@ -899,9 +899,41 @@ class TestComputeNicheCorrelation:
 
 
 def _make_fake_chromosome(lr: float = 0.01, gamma: float = 0.99):
-    """Build a minimal HyperparameterChromosome-like object."""
-    from farm.core.hyperparameter_chromosome import chromosome_from_values
-    return chromosome_from_values({"learning_rate": lr, "gamma": gamma})
+    """Build a minimal HyperparameterChromosome-like object.
+
+    Constructs a 2-gene chromosome directly so the speciation tests operate on
+    a low-dimensional feature matrix.  Using the platform-wide default
+    chromosome would pad the vector with many constant loci, which makes GMM's
+    BIC criterion prefer k=1 even when the population is clearly bimodal in
+    one dimension.
+    """
+    from farm.core.hyperparameter_chromosome import (
+        GeneValueType,
+        HyperparameterChromosome,
+        HyperparameterGene,
+    )
+    return HyperparameterChromosome(
+        genes=(
+            HyperparameterGene(
+                name="learning_rate",
+                value_type=GeneValueType.REAL,
+                value=lr,
+                min_value=1e-6,
+                max_value=1.0,
+                default=0.001,
+                evolvable=True,
+            ),
+            HyperparameterGene(
+                name="gamma",
+                value_type=GeneValueType.REAL,
+                value=gamma,
+                min_value=0.0,
+                max_value=1.0,
+                default=0.99,
+                evolvable=True,
+            ),
+        )
+    )
 
 
 def _make_fake_agent(lr: float = 0.01, gamma: float = 0.99):

--- a/tests/runners/test_evolution_experiment.py
+++ b/tests/runners/test_evolution_experiment.py
@@ -225,12 +225,17 @@ class TestEvolutionExperiment(unittest.TestCase):
 
     def test_boundary_penalty_adjusts_candidate_fitness(self):
         base_config = SimulationConfig()
+        # Place learning_rate at its min boundary so it incurs the full
+        # per-gene penalty.  Other evolvable genes inherit their defaults from
+        # ``DEFAULT_HYPERPARAMETER_GENES``; whichever of those happen to sit on
+        # a boundary contribute additional penalty, so the expected value is
+        # computed from the same source of truth rather than hard-coded.
         base_config.learning.learning_rate = 1e-6
-        # Move all other evolvable genes well inside bounds so only learning_rate
-        # (at its min boundary) incurs a penalty, keeping the expected values simple.
         base_config.learning.gamma = 0.5
         base_config.learning.epsilon_decay = 0.5
         base_config.learning.memory_size = 500_000
+        penalty_strength = 0.2
+        near_boundary_threshold = 0.05
         config = EvolutionExperimentConfig(
             num_generations=1,
             population_size=3,
@@ -238,12 +243,27 @@ class TestEvolutionExperiment(unittest.TestCase):
             mutation_scale=0.0,
             boundary_penalty=BoundaryPenaltyConfig(
                 enabled=True,
-                penalty_strength=0.2,
-                near_boundary_threshold=0.05,
+                penalty_strength=penalty_strength,
+                near_boundary_threshold=near_boundary_threshold,
             ),
             seed=23,
         )
         experiment = EvolutionExperiment(base_config, config)
+
+        from farm.core.hyperparameter_chromosome import (
+            BoundaryPenaltyConfig as _BPC,
+            chromosome_from_learning_config,
+            compute_boundary_penalty,
+        )
+
+        expected_penalty = compute_boundary_penalty(
+            chromosome_from_learning_config(base_config.learning),
+            _BPC(
+                enabled=True,
+                penalty_strength=penalty_strength,
+                near_boundary_threshold=near_boundary_threshold,
+            ),
+        )
 
         def evaluator(candidate, candidate_config, generation, member_index):
             return 1.0, {"member": member_index}
@@ -252,8 +272,8 @@ class TestEvolutionExperiment(unittest.TestCase):
         self.assertEqual(len(result.evaluations), 3)
         for evaluation in result.evaluations:
             self.assertAlmostEqual(evaluation.metadata["raw_fitness"], 1.0)
-            self.assertAlmostEqual(evaluation.metadata["boundary_penalty"], 0.2)
-            self.assertAlmostEqual(evaluation.fitness, 0.8)
+            self.assertAlmostEqual(evaluation.metadata["boundary_penalty"], expected_penalty)
+            self.assertAlmostEqual(evaluation.fitness, 1.0 - expected_penalty)
 
     @patch("farm.runners.evolution_experiment.mutate_chromosome")
     def test_boundary_mode_is_forwarded_to_mutation_calls(self, mutate_mock):

--- a/tests/test_action_weight_bridging.py
+++ b/tests/test_action_weight_bridging.py
@@ -1,0 +1,199 @@
+"""Tests for the Chromosome B action-weight gene bridging.
+
+These tests exercise the path that lets evolved
+``DecisionConfig.{move,gather,share,attack,reproduce}_weight`` values flow
+into ``core.actions[i].weight`` so they actually shape the policy.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import Mock
+
+from farm.core.action import (
+    Action,
+    attack_action,
+    defend_action,
+    gather_action,
+    move_action,
+    pass_action,
+    reproduce_action,
+    share_action,
+)
+from farm.core.agent.config.component_configs import AgentComponentConfig
+from farm.core.agent.core import AgentCore
+from farm.core.decision.config import DecisionConfig
+
+
+def _build_default_actions() -> list[Action]:
+    """Reproduce the platform's default action set with neutral starting weights."""
+    return [
+        Action("attack", 0.10, attack_action),
+        Action("move", 0.40, move_action),
+        Action("gather", 0.30, gather_action),
+        Action("reproduce", 0.15, reproduce_action),
+        Action("share", 0.20, share_action),
+        Action("defend", 0.25, defend_action),
+        Action("pass", 0.05, pass_action),
+    ]
+
+
+def _make_agent_with_decision_config(decision_config: DecisionConfig) -> AgentCore:
+    """Build a partial :class:`AgentCore` exposing only the surface used here."""
+    agent = object.__new__(AgentCore)
+    agent.agent_id = "test"
+    agent.agent_type = "system"
+    config = AgentComponentConfig.default()
+    config.decision = decision_config
+    agent.config = config
+    return agent
+
+
+def _weight_for(actions, name: str) -> float:
+    for action in actions:
+        if action.name == name:
+            return action.weight
+    raise KeyError(name)
+
+
+class TestCustomizeActionWeightsFromDecisionConfig(unittest.TestCase):
+    """``_customize_action_weights`` should pick up evolved DecisionConfig weights."""
+
+    def test_default_decision_config_does_not_change_legacy_behaviour(self):
+        """A pristine DecisionConfig() must leave registry weights normalized only."""
+        agent = _make_agent_with_decision_config(DecisionConfig())
+        base = _build_default_actions()
+        customized = AgentCore._customize_action_weights(agent, base, "system", environment=None)
+        # Customized weights are normalized relative to one another.
+        total = sum(a.weight for a in customized)
+        self.assertAlmostEqual(total, 1.0, places=12)
+        # Order matches input order.
+        self.assertEqual([a.name for a in customized], [a.name for a in base])
+        # Each action's relative ranking should mirror the registry defaults
+        # since none of the genes diverge from the Pydantic defaults.
+        baseline_total = sum(a.weight for a in base)
+        for original, custom in zip(base, customized):
+            expected = original.weight / baseline_total
+            self.assertAlmostEqual(custom.weight, expected, places=12)
+
+    def test_attack_weight_gene_overrides_registry_default(self):
+        cfg = DecisionConfig(attack_weight=1.5)
+        agent = _make_agent_with_decision_config(cfg)
+        customized = AgentCore._customize_action_weights(
+            agent, _build_default_actions(), "system", environment=None
+        )
+        attack_share = _weight_for(customized, "attack")
+        # With attack_weight elevated to 1.5, attack should dominate the
+        # normalized vector relative to the other actions.
+        for name in ("move", "gather", "share", "reproduce", "defend", "pass"):
+            self.assertGreater(attack_share, _weight_for(customized, name))
+
+    def test_chromosome_value_wins_over_environment_agent_parameters(self):
+        cfg = DecisionConfig(share_weight=0.95)  # near max
+        agent = _make_agent_with_decision_config(cfg)
+        env = Mock()
+        env.config = Mock()
+        env.config.agent_parameters = {"SystemAgent": {"share_weight": 0.01}}
+        customized = AgentCore._customize_action_weights(
+            agent, _build_default_actions(), "system", environment=env
+        )
+        # Compute what the gene-driven share would normalize to.
+        # base after override = registry weights with share=0.95 instead of 0.20
+        base_after_override = [
+            ("attack", 0.10),
+            ("move", 0.40),
+            ("gather", 0.30),
+            ("reproduce", 0.15),
+            ("share", 0.95),  # gene wins
+            ("defend", 0.25),
+            ("pass", 0.05),
+        ]
+        total = sum(w for _, w in base_after_override)
+        expected_share = 0.95 / total
+        self.assertAlmostEqual(_weight_for(customized, "share"), expected_share, places=12)
+
+    def test_unmodified_gene_falls_through_to_agent_parameters(self):
+        # share_weight is left at its Pydantic default → DecisionConfig has no
+        # effective opinion on it, so the legacy environment override wins.
+        cfg = DecisionConfig()
+        agent = _make_agent_with_decision_config(cfg)
+        env = Mock()
+        env.config = Mock()
+        env.config.agent_parameters = {"SystemAgent": {"share_weight": 0.95}}
+        customized = AgentCore._customize_action_weights(
+            agent, _build_default_actions(), "system", environment=env
+        )
+        # The gene didn't override, so share weight = 0.95 from agent_parameters.
+        base_after_override = [
+            ("attack", 0.10),
+            ("move", 0.40),
+            ("gather", 0.30),
+            ("reproduce", 0.15),
+            ("share", 0.95),
+            ("defend", 0.25),
+            ("pass", 0.05),
+        ]
+        total = sum(w for _, w in base_after_override)
+        expected_share = 0.95 / total
+        self.assertAlmostEqual(_weight_for(customized, "share"), expected_share, places=12)
+
+    def test_normalization_falls_back_to_uniform_when_all_zero(self):
+        """If every gene zeroes out a weight, the helper falls back to uniform."""
+        cfg = DecisionConfig(
+            move_weight=0.0,
+            gather_weight=0.0,
+            share_weight=0.0,
+            attack_weight=0.0,
+            reproduce_weight=0.0,
+        )
+        agent = _make_agent_with_decision_config(cfg)
+        # Build actions list with everything zero so legacy registry doesn't add weight.
+        base = [
+            Action(name, 0.0, func)
+            for name, func in (
+                ("attack", attack_action),
+                ("move", move_action),
+                ("gather", gather_action),
+                ("reproduce", reproduce_action),
+                ("share", share_action),
+            )
+        ]
+        customized = AgentCore._customize_action_weights(agent, base, "system", environment=None)
+        # All five get equal share.
+        for action in customized:
+            self.assertAlmostEqual(action.weight, 1.0 / len(customized), places=12)
+
+
+class TestRefreshActionWeights(unittest.TestCase):
+    """`refresh_action_weights_from_decision_config` updates live actions."""
+
+    def test_refresh_picks_up_new_decision_config_values(self):
+        agent = _make_agent_with_decision_config(DecisionConfig())
+        agent.actions = _build_default_actions()
+        # Initial vector reflects registry defaults only -- attack weight is small.
+        initial_attack = _weight_for(agent.actions, "attack")
+
+        # Mutate the DecisionConfig to push attack_weight near the max bound.
+        agent.config.decision = DecisionConfig(attack_weight=1.9)
+        AgentCore.refresh_action_weights_from_decision_config(agent)
+
+        new_attack = _weight_for(agent.actions, "attack")
+        self.assertGreater(new_attack, initial_attack)
+        # Weights remain normalized after refresh.
+        self.assertAlmostEqual(sum(a.weight for a in agent.actions), 1.0, places=12)
+
+    def test_refresh_is_a_noop_when_no_genes_diverge_from_defaults(self):
+        agent = _make_agent_with_decision_config(DecisionConfig())
+        # Pre-existing custom action weights must not be wiped by a refresh
+        # whose source decision config is unchanged.
+        agent.actions = [
+            Action("attack", 0.5, attack_action),
+            Action("move", 0.5, move_action),
+        ]
+        AgentCore.refresh_action_weights_from_decision_config(agent)
+        self.assertEqual(_weight_for(agent.actions, "attack"), 0.5)
+        self.assertEqual(_weight_for(agent.actions, "move"), 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_action_weight_policy.py
+++ b/tests/test_action_weight_policy.py
@@ -1,0 +1,274 @@
+"""Unit tests for the state-aware action re-weighter.
+
+Verifies that each Chromosome B multiplier / threshold gene actually changes
+the per-action weight vector under the appropriate state conditions.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from farm.core.decision.action_weight_policy import (
+    ActionStateSignals,
+    compute_action_weights,
+    extract_signals,
+)
+from farm.core.decision.config import DecisionConfig
+
+ACTION_NAMES = (
+    "move",
+    "gather",
+    "share",
+    "attack",
+    "reproduce",
+    "defend",
+    "pass",
+    "communicate",
+)
+BASE_WEIGHTS = (0.30, 0.30, 0.15, 0.10, 0.15, 0.0, 0.0, 0.0)
+
+
+def _weight(weights: np.ndarray, name: str) -> float:
+    return float(weights[ACTION_NAMES.index(name)])
+
+
+_NEUTRAL_KWARGS = dict(
+    move_mult_no_resources=1.0,
+    gather_mult_low_resources=1.0,
+    share_mult_wealthy=1.0,
+    share_mult_poor=1.0,
+    attack_mult_desperate=1.0,
+    attack_mult_stable=1.0,
+    reproduce_mult_wealthy=1.0,
+    reproduce_mult_poor=1.0,
+)
+
+
+def _neutral_cfg(**overrides) -> DecisionConfig:
+    """Build a DecisionConfig where every multiplier is the identity (1.0).
+
+    Multiplier overrides supplied by individual tests still win, so they can
+    isolate the effect of a single gene under arbitrary state signals.
+    """
+    kwargs = dict(_NEUTRAL_KWARGS)
+    kwargs.update(overrides)
+    return DecisionConfig(**kwargs)
+
+
+def _baseline(cfg: DecisionConfig) -> np.ndarray:
+    """Reference scaled vector for *cfg* under fully-neutral state signals."""
+    sig = ActionStateSignals(
+        resource_ratio=0.5,
+        health_ratio=0.5,
+        starvation_risk=0.0,
+        nearby_resources=True,
+    )
+    return compute_action_weights(BASE_WEIGHTS, ACTION_NAMES, cfg, sig)
+
+
+class TestComputeActionWeights(unittest.TestCase):
+    def test_normalizes_to_unit_sum(self):
+        cfg = DecisionConfig()
+        sig = ActionStateSignals()
+        weights = compute_action_weights(BASE_WEIGHTS, ACTION_NAMES, cfg, sig)
+        self.assertAlmostEqual(weights.sum(), 1.0, places=12)
+        self.assertEqual(weights.shape, (len(ACTION_NAMES),))
+
+    def test_baseline_with_identity_multipliers_matches_normalized_base(self):
+        # When every multiplier is the identity (1.0), the vector is just the
+        # base weights renormalized -- regardless of state signals.
+        cfg = _neutral_cfg()
+        weights = _baseline(cfg)
+        expected = np.asarray(BASE_WEIGHTS) / sum(BASE_WEIGHTS)
+        np.testing.assert_allclose(weights, expected, atol=1e-12)
+
+    def test_default_decision_config_applies_reproduce_poor_at_mid_resource(self):
+        # With the platform default (reproduce_mult_poor=0.3,
+        # reproduce_resource_threshold=0.7), a half-resource agent has
+        # reproduce dampened relative to the identity-multiplier baseline.
+        # Note: ``share_mult_poor`` only fires below ratio 0.3, so it is
+        # untouched at ratio=0.5 -- intentional.
+        cfg_default = DecisionConfig()
+        cfg_neutral = _neutral_cfg()
+        sig = ActionStateSignals(
+            resource_ratio=0.5,
+            health_ratio=0.5,
+            starvation_risk=0.0,
+            nearby_resources=True,
+        )
+        weights_default = compute_action_weights(BASE_WEIGHTS, ACTION_NAMES, cfg_default, sig)
+        weights_neutral = compute_action_weights(BASE_WEIGHTS, ACTION_NAMES, cfg_neutral, sig)
+        self.assertLess(_weight(weights_default, "reproduce"), _weight(weights_neutral, "reproduce"))
+
+    def test_no_nearby_resources_boosts_move(self):
+        cfg = _neutral_cfg(move_mult_no_resources=3.0)
+        baseline = _baseline(cfg)
+        sig = ActionStateSignals(
+            resource_ratio=0.5,
+            health_ratio=0.5,
+            starvation_risk=0.0,
+            nearby_resources=False,
+        )
+        scaled = compute_action_weights(BASE_WEIGHTS, ACTION_NAMES, cfg, sig)
+        self.assertGreater(_weight(scaled, "move"), _weight(baseline, "move"))
+        # Other actions should shrink (mass conservation under normalization)
+        self.assertLess(_weight(scaled, "gather"), _weight(baseline, "gather"))
+
+    def test_low_resources_boosts_gather(self):
+        cfg = _neutral_cfg(gather_mult_low_resources=2.5)
+        sig = ActionStateSignals(
+            resource_ratio=0.2,
+            health_ratio=0.5,
+            starvation_risk=0.0,
+            nearby_resources=True,
+        )
+        scaled = compute_action_weights(BASE_WEIGHTS, ACTION_NAMES, cfg, sig)
+        self.assertGreater(_weight(scaled, "gather"), _weight(_baseline(cfg), "gather"))
+
+    def test_wealthy_boosts_share_and_reproduce(self):
+        cfg = _neutral_cfg(
+            share_mult_wealthy=2.0,
+            reproduce_mult_wealthy=2.0,
+            reproduce_resource_threshold=0.7,
+        )
+        sig = ActionStateSignals(
+            resource_ratio=0.9,
+            health_ratio=0.5,
+            starvation_risk=0.0,
+            nearby_resources=True,
+        )
+        scaled = compute_action_weights(BASE_WEIGHTS, ACTION_NAMES, cfg, sig)
+        baseline = _baseline(cfg)
+        self.assertGreater(_weight(scaled, "share"), _weight(baseline, "share"))
+        self.assertGreater(_weight(scaled, "reproduce"), _weight(baseline, "reproduce"))
+
+    def test_poor_throttles_share_and_reproduce(self):
+        # Compare two configs that differ only in share/reproduce poor
+        # multipliers, under identical poor-state signals.  The throttled
+        # config must redistribute mass away from share+reproduce.
+        sig = ActionStateSignals(
+            resource_ratio=0.1,  # below 0.3 (share-poor) and below 0.7 (reproduce-poor)
+            health_ratio=0.5,
+            starvation_risk=0.0,
+            nearby_resources=True,
+        )
+        cfg_neutral = _neutral_cfg(reproduce_resource_threshold=0.7)
+        cfg_throttled = _neutral_cfg(
+            share_mult_poor=0.1,
+            reproduce_mult_poor=0.1,
+            reproduce_resource_threshold=0.7,
+        )
+        weights_neutral = compute_action_weights(BASE_WEIGHTS, ACTION_NAMES, cfg_neutral, sig)
+        weights_throttled = compute_action_weights(BASE_WEIGHTS, ACTION_NAMES, cfg_throttled, sig)
+        self.assertLess(_weight(weights_throttled, "share"), _weight(weights_neutral, "share"))
+        self.assertLess(_weight(weights_throttled, "reproduce"), _weight(weights_neutral, "reproduce"))
+
+    def test_starvation_threshold_gates_attack_desperate(self):
+        cfg_off = _neutral_cfg(
+            attack_mult_desperate=3.0,
+            attack_starvation_threshold=0.9,
+        )
+        cfg_on = _neutral_cfg(
+            attack_mult_desperate=3.0,
+            attack_starvation_threshold=0.1,
+        )
+        sig = ActionStateSignals(
+            resource_ratio=0.5,
+            health_ratio=0.5,
+            starvation_risk=0.5,
+            nearby_resources=True,
+        )
+        weights_off = compute_action_weights(BASE_WEIGHTS, ACTION_NAMES, cfg_off, sig)
+        weights_on = compute_action_weights(BASE_WEIGHTS, ACTION_NAMES, cfg_on, sig)
+        # threshold above starvation_risk -> multiplier does NOT fire
+        # threshold below starvation_risk -> multiplier fires
+        self.assertGreater(_weight(weights_on, "attack"), _weight(weights_off, "attack"))
+
+    def test_defense_threshold_gates_attack_stable(self):
+        cfg_low = _neutral_cfg(
+            attack_mult_stable=0.1,
+            attack_defense_threshold=0.9,  # health_ratio>=1-0.9=0.1 -> fires almost always
+        )
+        cfg_high = _neutral_cfg(
+            attack_mult_stable=0.1,
+            attack_defense_threshold=0.05,  # health_ratio>=0.95 -> fires only when very healthy
+        )
+        sig = ActionStateSignals(
+            resource_ratio=0.5,
+            health_ratio=0.5,
+            starvation_risk=0.0,
+            nearby_resources=True,
+        )
+        weights_low = compute_action_weights(BASE_WEIGHTS, ACTION_NAMES, cfg_low, sig)
+        weights_high = compute_action_weights(BASE_WEIGHTS, ACTION_NAMES, cfg_high, sig)
+        # cfg_low fires the down-scaling multiplier; cfg_high does not.
+        self.assertLess(_weight(weights_low, "attack"), _weight(weights_high, "attack"))
+
+    def test_enabled_actions_zero_out_disabled(self):
+        cfg = _neutral_cfg()
+        sig = ActionStateSignals(resource_ratio=0.5, health_ratio=0.5)
+        # Only enable move (idx 0) and gather (idx 1).
+        weights = compute_action_weights(
+            BASE_WEIGHTS, ACTION_NAMES, cfg, sig, enabled_actions=[0, 1]
+        )
+        self.assertGreater(weights[0], 0.0)
+        self.assertGreater(weights[1], 0.0)
+        for idx in range(2, len(weights)):
+            self.assertEqual(weights[idx], 0.0)
+        self.assertAlmostEqual(weights.sum(), 1.0, places=12)
+
+    def test_zero_base_weights_falls_back_to_uniform(self):
+        cfg = _neutral_cfg()
+        sig = ActionStateSignals(resource_ratio=0.5)
+        weights = compute_action_weights(
+            tuple(0.0 for _ in BASE_WEIGHTS), ACTION_NAMES, cfg, sig
+        )
+        self.assertAlmostEqual(weights.sum(), 1.0, places=12)
+        np.testing.assert_allclose(weights, np.full(len(weights), 1.0 / len(weights)))
+
+    def test_zero_base_with_enabled_uniform_over_enabled(self):
+        cfg = _neutral_cfg()
+        sig = ActionStateSignals()
+        weights = compute_action_weights(
+            tuple(0.0 for _ in BASE_WEIGHTS),
+            ACTION_NAMES,
+            cfg,
+            sig,
+            enabled_actions=[2, 5],
+        )
+        self.assertAlmostEqual(weights.sum(), 1.0, places=12)
+        self.assertAlmostEqual(weights[2], 0.5)
+        self.assertAlmostEqual(weights[5], 0.5)
+
+    def test_length_mismatch_raises(self):
+        cfg = _neutral_cfg()
+        sig = ActionStateSignals(resource_ratio=0.5, nearby_resources=False)
+        with self.assertRaises(ValueError):
+            compute_action_weights(
+                BASE_WEIGHTS, ACTION_NAMES[:-1], cfg, sig
+            )
+
+
+class TestExtractSignals(unittest.TestCase):
+    def test_extracts_from_minimal_object(self):
+        class _Stub:
+            agent_id = "x"
+            resource_level = 25.0
+            current_health = 50.0
+            starting_health = 100.0
+            config = type("C", (), {"reward": type("R", (), {"max_resource_level": 100.0})()})()
+
+            def get_component(self, _name):
+                return None
+
+        sig = extract_signals(_Stub())
+        self.assertAlmostEqual(sig.resource_ratio, 0.25)
+        self.assertAlmostEqual(sig.health_ratio, 0.5)
+        self.assertEqual(sig.starvation_risk, 0.0)
+        self.assertIsNone(sig.nearby_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_decision_config_wiring.py
+++ b/tests/test_decision_config_wiring.py
@@ -1,0 +1,98 @@
+"""Wiring tests for the previously-latent Tier 1 chromosome genes.
+
+Each test exercises one of the four follow-up wiring changes and asserts the
+gene actually controls a runtime artifact rather than just being declared on
+``DecisionConfig``.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import gymnasium
+
+from farm.core.decision.config import DecisionConfig
+from farm.core.decision.decision import DecisionModule, TIANSHOU_AVAILABLE
+
+
+class _FakeAgent:
+    """Minimal stand-in accepted by :class:`DecisionModule`."""
+
+    def __init__(self, agent_id: str = "test_agent") -> None:
+        self.agent_id = agent_id
+
+
+def _make_module(config: DecisionConfig) -> DecisionModule:
+    return DecisionModule(
+        agent=_FakeAgent(),
+        action_space=gymnasium.spaces.Discrete(4),
+        observation_space=gymnasium.spaces.Box(low=-1, high=1, shape=(8,)),
+        config=config,
+    )
+
+
+@unittest.skipUnless(TIANSHOU_AVAILABLE, "Tianshou required for DQN target-update wiring tests")
+class TestTargetUpdateFreqWiring(unittest.TestCase):
+    """`DecisionConfig.target_update_freq` must reach the live DQN policy."""
+
+    def _read_freq(self, module: DecisionModule) -> int:
+        # Tianshou stores target_update_freq on _freq (versioned attr name).
+        policy = module.algorithm.policy
+        for attr in ("_freq", "target_update_freq"):
+            if hasattr(policy, attr):
+                return int(getattr(policy, attr))
+        self.fail(f"Could not locate target_update_freq on {type(policy).__name__}")
+
+    def test_default_target_update_freq_propagates(self):
+        cfg = DecisionConfig(algorithm_type="dqn")
+        module = _make_module(cfg)
+        self.assertEqual(self._read_freq(module), int(cfg.target_update_freq))
+
+    def test_overridden_target_update_freq_propagates(self):
+        cfg = DecisionConfig(algorithm_type="dqn", target_update_freq=250)
+        module = _make_module(cfg)
+        self.assertEqual(self._read_freq(module), 250)
+
+    def test_distinct_values_yield_distinct_policies(self):
+        m1 = _make_module(DecisionConfig(algorithm_type="dqn", target_update_freq=50))
+        m2 = _make_module(DecisionConfig(algorithm_type="dqn", target_update_freq=750))
+        self.assertNotEqual(self._read_freq(m1), self._read_freq(m2))
+
+
+class TestEnsembleSizeWiring(unittest.TestCase):
+    """`DecisionConfig.ensemble_size` must control RandomForest n_estimators."""
+
+    def test_random_forest_uses_ensemble_size(self):
+        cfg = DecisionConfig(algorithm_type="random_forest", ensemble_size=7, seed=0)
+        module = _make_module(cfg)
+        self.assertEqual(type(module.algorithm).__name__, "RandomForestActionSelector")
+        self.assertEqual(module.algorithm.model.n_estimators, 7)
+
+    def test_random_forest_ensemble_size_is_evolvable(self):
+        m1 = _make_module(DecisionConfig(algorithm_type="random_forest", ensemble_size=5, seed=0))
+        m2 = _make_module(DecisionConfig(algorithm_type="random_forest", ensemble_size=12, seed=0))
+        self.assertEqual(m1.algorithm.model.n_estimators, 5)
+        self.assertEqual(m2.algorithm.model.n_estimators, 12)
+
+    def test_explicit_algorithm_params_n_estimators_wins_over_ensemble_size(self):
+        cfg = DecisionConfig(
+            algorithm_type="random_forest",
+            ensemble_size=10,
+            algorithm_params={"n_estimators": 3},
+            seed=0,
+        )
+        module = _make_module(cfg)
+        self.assertEqual(module.algorithm.model.n_estimators, 3)
+
+    def test_naive_bayes_does_not_get_n_estimators(self):
+        # naive_bayes is reachable through the new traditional-ML route but
+        # is not in the ensemble whitelist, so n_estimators must NOT be
+        # injected into its constructor.
+        cfg = DecisionConfig(algorithm_type="naive_bayes", ensemble_size=99)
+        module = _make_module(cfg)
+        self.assertEqual(type(module.algorithm).__name__, "NaiveBayesActionSelector")
+        self.assertFalse(hasattr(module.algorithm.model, "n_estimators"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hyperparameter_chromosome.py
+++ b/tests/test_hyperparameter_chromosome.py
@@ -446,8 +446,9 @@ class TestAdditionalContinuousGenes(unittest.TestCase):
     def test_multi_gene_chromosome_vector_encode_decode_round_trip(self):
         chromosome = chromosome_from_values({"learning_rate": 0.005, "gamma": 0.95, "epsilon_decay": 0.99})
         vec = encode_chromosome_vector(chromosome)
-        # 4 evolvable genes → 4-element vector
-        self.assertEqual(len(vec), 4)
+        # Vector length follows the count of evolvable genes in the default
+        # chromosome, so it adapts as new loci are added.
+        self.assertEqual(len(vec), len(chromosome.evolvable_gene_names()))
         decoded = decode_chromosome_vector(vec, template=chromosome)
         self.assertAlmostEqual(decoded.get_value("learning_rate"), 0.005, delta=0.005 * 0.06)
         self.assertAlmostEqual(decoded.get_value("gamma"), 0.95, delta=0.01)
@@ -1009,26 +1010,57 @@ class TestComputeBoundaryPenalty(unittest.TestCase):
         self.assertEqual(compute_boundary_penalty(chromosome, cfg), 0.0)
 
     def test_full_penalty_at_max_boundary(self):
-        # Set all other evolvable genes to midpoints so only learning_rate (at max) incurs a penalty.
-        chromosome = chromosome_from_values(
-            {"learning_rate": 1.0, "gamma": 0.5, "epsilon_decay": 0.5, "memory_size": 500_000.0}
+        # Use a single-gene chromosome so only the boundary-positioned gene
+        # contributes to the penalty, decoupled from the (growing) default
+        # gene set.
+        chromosome = HyperparameterChromosome(
+            genes=(
+                HyperparameterGene(
+                    name="locus",
+                    value_type=GeneValueType.REAL,
+                    value=1.0,
+                    min_value=0.0,
+                    max_value=1.0,
+                    default=0.5,
+                    evolvable=True,
+                ),
+            )
         )
         cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.05, near_boundary_threshold=0.1)
         penalty = compute_boundary_penalty(chromosome, cfg)
         self.assertAlmostEqual(penalty, 0.05)
 
     def test_full_penalty_at_min_boundary(self):
-        # Set all other evolvable genes to midpoints so only learning_rate (at min) incurs a penalty.
-        chromosome = chromosome_from_values(
-            {"learning_rate": 1e-6, "gamma": 0.5, "epsilon_decay": 0.5, "memory_size": 500_000.0}
+        chromosome = HyperparameterChromosome(
+            genes=(
+                HyperparameterGene(
+                    name="locus",
+                    value_type=GeneValueType.REAL,
+                    value=0.0,
+                    min_value=0.0,
+                    max_value=1.0,
+                    default=0.5,
+                    evolvable=True,
+                ),
+            )
         )
         cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.05, near_boundary_threshold=0.1)
         penalty = compute_boundary_penalty(chromosome, cfg)
         self.assertAlmostEqual(penalty, 0.05)
 
     def test_zero_penalty_well_inside_bounds(self):
-        chromosome = chromosome_from_values(
-            {"learning_rate": 0.5, "gamma": 0.5, "epsilon_decay": 0.5, "memory_size": 500_000.0}
+        chromosome = HyperparameterChromosome(
+            genes=(
+                HyperparameterGene(
+                    name="locus",
+                    value_type=GeneValueType.REAL,
+                    value=0.5,
+                    min_value=0.0,
+                    max_value=1.0,
+                    default=0.5,
+                    evolvable=True,
+                ),
+            )
         )
         cfg = BoundaryPenaltyConfig(enabled=True, penalty_strength=0.1, near_boundary_threshold=0.05)
         penalty = compute_boundary_penalty(chromosome, cfg)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Tier 1 of the evolution-surface catalog **and** activates every locus end-to-end:

- 27 new real-valued loci added to `DEFAULT_HYPERPARAMETER_GENES` (default chromosome grows from 4 to 31 evolvable genes).
- All 31 loci are now consumed by live runtime code; nothing is declared-but-unread anymore.

## Runtime-effect audit (post-wiring)

Every gene now has a confirmed consumer pipeline.

### Chromosome A — learning / RL hyperparameters

| Gene | Consumer |
|------|----------|
| `learning_rate`, `gamma`, `epsilon_start`, `epsilon_min`, `epsilon_decay`, `memory_size`, `tau`, `batch_size`, `dqn_hidden_size` | `BaseDQNModule.__init__` and Tianshou builders |
| `rl_train_freq`, `per_alpha`, `per_beta_start`, `per_beta_end` | All Tianshou wrappers' replay buffer |
| `target_update_freq` | Tianshou `DQNPolicy(target_update_freq=…)` (explicit kwarg, not filtered) |
| `ensemble_size` | `RandomForestActionSelector.n_estimators` (auto-injected for `random_forest` / `gradient_boost`) |

### Chromosome B — action-policy priors

Two-stage pipeline:

1. **Base weights** — `move/gather/share/attack/reproduce_weight` are bridged into `core.actions[i].weight` by `AgentCore._customize_action_weights` (at construction) and `AgentCore.refresh_action_weights_from_decision_config` (after chromosome re-application). Per-agent gene values win over environment-level `agent_parameters`; default-valued genes fall through unchanged.
2. **State-aware re-weighting** — `LearningAgentBehavior.decide_action` now calls `compute_action_weights` from the new `farm/core/decision/action_weight_policy.py` module, which scales the base vector by the eight multipliers gated by the three thresholds (`move_mult_no_resources`, `gather_mult_low_resources`, `share_mult_{wealthy,poor}`, `attack_mult_{desperate,stable}`, `reproduce_mult_{wealthy,poor}` gated by `attack_starvation_threshold`, `attack_defense_threshold`, `reproduce_resource_threshold`).

The scaled vector is passed to `DecisionModule.decide_action(... action_weights=...)`, which already biases both Q-value exploitation and weighted-random exploration.

## Code changes

- `farm/core/hyperparameter_chromosome.py` — 27 new gene specs in `DEFAULT_HYPERPARAMETER_GENES` plus matching `DEFAULT_GENE_ENCODINGS` (log/linear 8-bit choices).
- `farm/core/agent/core.py`
  - `_customize_action_weights` resolves overrides from `self.config.decision`; default-aware so unaltered configs preserve legacy behaviour.
  - new `refresh_action_weights_from_decision_config()` for live re-application.
  - `_DECISION_ACTION_WEIGHT_FIELDS` map + cached Pydantic-default lookup.
- `farm/core/initial_diversity.py::_apply_chromosome_to_agent` calls the new refresh helper after applying a fresh chromosome.
- `farm/core/decision/decision.py`
  - `_initialize_tianshou_dqn` forwards `int(self.config.target_update_freq)` instead of the hard-coded `500`.
  - new `_initialize_traditional_ml(algorithm_type)` routes `mlp`/`svm`/`random_forest`/`gradient_boost`/`naive_bayes`/`knn` through `AlgorithmRegistry`, with `ensemble_size` auto-injected as `n_estimators` for ensemble-class algorithms.
- `farm/core/decision/algorithms/tianshou.py::DQNWrapper` passes `target_update_freq` and `estimation_step` as explicit `DQNPolicy` constructor kwargs (with a positive-int guard) instead of relying on the `_EXCLUDED_PARAMS` filter.
- `farm/core/decision/action_weight_policy.py` (new) — `ActionStateSignals`, `extract_signals`, `compute_action_weights`. Pure helpers, fully unit-testable without a full agent stack.
- `farm/core/agent/behaviors/learning.py::LearningAgentBehavior.decide_action` builds the weight vector via `compute_action_weights` (state-aware) instead of feeding raw `action.weight` values; falls back gracefully on signal-extraction failure.

## Tests

Added (28 new tests across 3 files; all passing):

- `tests/test_action_weight_policy.py` — 14 cases for the state-aware re-weighter (each multiplier/threshold gate, enabled-mask, all-zero fallback, length-mismatch input validation).
- `tests/test_decision_config_wiring.py` — 7 cases for `target_update_freq` reaching `DQNPolicy._freq` and `ensemble_size` reaching `RandomForestActionSelector.n_estimators` (with `algorithm_params` precedence and non-ensemble-algorithm isolation).
- `tests/test_action_weight_bridging.py` — 7 cases for per-agent gene → `core.actions[i].weight` flow, the legacy `agent_parameters` precedence rule, and the live `refresh_action_weights_from_decision_config()` path.

Updated (preserving existing semantics under the larger default chromosome):

- `tests/test_hyperparameter_chromosome.py` — derive vector length from `chromosome.evolvable_gene_names()`; rewrite `TestComputeBoundaryPenalty` cases as single-gene chromosomes.
- `tests/runners/test_evolution_experiment.py::test_boundary_penalty_adjusts_candidate_fitness` — compute expected penalty programmatically.
- `tests/analysis/test_speciation.py::_make_fake_chromosome` — explicit 2-gene chromosome so GMM clustering isn't dominated by 30 constant loci.

## Testing

See the final summary in the PR thread for the full pytest run.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d889282a-c84e-4aa6-a1d6-308a8643c8d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d889282a-c84e-4aa6-a1d6-308a8643c8d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

