### PR TITLE
Expand deterministic simulation workflow coverage

### DIFF
--- a/.github/workflows/deterministic-simulation.yml
+++ b/.github/workflows/deterministic-simulation.yml
@@ -2,9 +2,14 @@ name: Deterministic Simulation Check
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
+  workflow_dispatch:
+
+env:
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
 
 permissions:
   contents: read
@@ -12,37 +17,43 @@ permissions:
 jobs:
   deterministic-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-        
-    - name: Cache pip dependencies
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-          
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        
-    - name: Install package
-      run: |
-        pip install -e .
-        
-    - name: Run deterministic simulation test
-      run: |
-        python tests/test_deterministic.py --environment testing --steps 50 --seed 42
-        
-    - name: Run extended deterministic test
-      run: |
-        python tests/test_deterministic.py --environment testing --steps 100 --seed 123
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            pyproject.toml
+            setup.py
+
+      - name: Install package and dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+
+      - name: Run deterministic pytest suite
+        run: |
+          python -m pytest -q -o addopts='' -m "determinism or determinism_regression" \
+            tests/test_deterministic_pytest.py \
+            tests/test_component_determinism.py \
+            --tb=short
+
+      - name: Run deterministic CLI smoke test
+        run: |
+          python tests/test_deterministic.py --environment testing --steps 50 --seed 42
+
+      - name: Upload simulation artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: deterministic-simulation-output
+          path: simulations/
+          if-no-files-found: ignore

--- a/.github/workflows/deterministic-simulation.yml
+++ b/.github/workflows/deterministic-simulation.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Run critical deterministic simulation regression
         run: |
-          timeout 10m python -m pytest -vv -o addopts='' -m "determinism_regression and not slow and not integration" \
-            tests/test_deterministic_pytest.py \
+          timeout 10m python -m pytest -vv -o addopts='' \
+            tests/test_deterministic_pytest.py::test_determinism_regression_critical \
             --tb=short \
             --durations=10
 

--- a/.github/workflows/deterministic-simulation.yml
+++ b/.github/workflows/deterministic-simulation.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   deterministic-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     
     steps:
       - name: Checkout code
@@ -39,16 +39,27 @@ jobs:
           pip install -r requirements.txt
           pip install -e .
 
-      - name: Run deterministic pytest suite
+      - name: Run deterministic component pytest suite
         run: |
-          python -m pytest -q -o addopts='' -m "determinism or determinism_regression" \
-            tests/test_deterministic_pytest.py \
+          timeout 5m python -m pytest -vv -o addopts='' -m "determinism and not slow and not integration" \
             tests/test_component_determinism.py \
-            --tb=short
+            --tb=short \
+            --durations=10
+
+      - name: Run critical deterministic simulation regression
+        run: |
+          timeout 10m python -m pytest -vv -o addopts='' -m "determinism_regression and not slow and not integration" \
+            tests/test_deterministic_pytest.py \
+            --tb=short \
+            --durations=10
 
       - name: Run deterministic CLI smoke test
         run: |
-          python tests/test_deterministic.py --environment testing --steps 50 --seed 42
+          timeout 8m python tests/test_deterministic.py --environment testing --steps 50 --seed 42
+
+      - name: Run extended deterministic CLI smoke test
+        run: |
+          timeout 12m python tests/test_deterministic.py --environment testing --steps 100 --seed 123
 
       - name: Upload simulation artifacts on failure
         if: failure()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Run the deterministic workflow for both `main` and `dev`, plus manual dispatch.
- Align Python setup/caching with the current test workflow and install the package with the full requirements set.
- Cover the current determinism surface with separate, bounded layers: component determinism pytest, the explicit critical simulation regression pytest node, and the original 50/100-step CLI smoke checks.
- Add verbose pytest output, slowest-test durations, per-step shell timeouts, and failure artifact upload so future deterministic failures show where time is spent.

## Investigation
- The original cancelled PR run installed dependencies in about 2 minutes, then stayed in `Run deterministic pytest suite` until cancellation about 35 minutes later.
- The previous marker expression used `-o addopts='' -m "determinism or determinism_regression"`, which bypassed the repository's default `not slow and not integration` pytest filter and pulled in `test_determinism_long_simulation` (`@pytest.mark.slow`, 200 steps) along with many repeated full simulation runs.
- Local focused timings show component determinism is fast (~4s), but full simulation determinism is expensive: the critical 100-step pytest regression takes ~29-34s, and CLI smoke checks take ~60s for 50 steps and ~82s for 100 steps.
- A follow-up CI run showed that the marker selection for `determinism_regression` selected zero tests on the runner; the workflow now runs the critical regression by explicit pytest node id to avoid marker-selection drift.

## Testing
- `PYTHONHASHSEED=0 PYTHONUNBUFFERED=1 timeout 5m python -m pytest -vv -o addopts='' -m "determinism and not slow and not integration" tests/test_component_determinism.py --tb=short --durations=10`
- `PYTHONHASHSEED=0 PYTHONUNBUFFERED=1 timeout 10m python -m pytest -vv -o addopts='' tests/test_deterministic_pytest.py::test_determinism_regression_critical --tb=short --durations=10`
- `PYTHONHASHSEED=0 PYTHONUNBUFFERED=1 timeout 8m python tests/test_deterministic.py --environment testing --steps 50 --seed 42`
- `PYTHONHASHSEED=0 PYTHONUNBUFFERED=1 timeout 12m python tests/test_deterministic.py --environment testing --steps 100 --seed 123`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1701d053-e4cf-41c4-a812-3930840b0e87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1701d053-e4cf-41c4-a812-3930840b0e87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

