### PR TITLE
Redesign GitHub Pages with minimalist, content-first layout

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -4,17 +4,17 @@ title: Page not found
 permalink: /404.html
 ---
 
-<div class="container" style="text-align:center; padding: 80px 20px;">
-  <p style="font-family: var(--font-mono); color: var(--text-soft); letter-spacing: 0.2em;">ERROR 404</p>
-  <h1 style="font-size: clamp(2rem, 1.4rem + 2vw, 3rem); margin: 8px 0 12px; letter-spacing: -0.02em;">
-    This page wandered off the simulation grid.
+<div class="container" style="text-align:center; padding: 96px 20px 80px;">
+  <p style="font-family: var(--font-mono); color: var(--text-soft); letter-spacing: 0.18em; margin: 0 0 8px;">404</p>
+  <h1 style="font-size: clamp(1.6rem, 1.2rem + 1.4vw, 2rem); margin: 0 0 12px; letter-spacing: -0.02em; font-weight: 600;">
+    Page not found
   </h1>
-  <p class="muted" style="max-width: 50ch; margin: 0 auto 24px;">
-    The page you're looking for doesn't exist or has been moved. Try the docs index, the devlog, or jump
-    back to the AgentFarm homepage.
+  <p class="muted" style="max-width: 52ch; margin: 0 auto 24px;">
+    The page you're looking for doesn't exist or has been moved. Try the docs index, the devlog, or
+    return to the homepage.
   </p>
   <p>
-    <a class="btn btn--primary" href="{{ '/' | relative_url }}">Back to home</a>
-    <a class="btn btn--ghost" style="background: var(--surface-muted); color: var(--text); border-color: var(--border);" href="{{ '/README/' | relative_url }}">Documentation index</a>
+    <a class="btn btn--primary" href="{{ '/' | relative_url }}">Home</a>
+    <a class="btn" href="{{ '/README/' | relative_url }}">Documentation</a>
   </p>
 </div>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{% if page.title and page.title != site.title %}{{ page.title | xml_escape }} · {{ site.title | xml_escape }}{% else %}{{ site.title | xml_escape }} · {{ site.tagline | xml_escape }}{% endif %}</title>
   <meta name="description" content="{{ page.description | default: site.description | strip_newlines | xml_escape }}" />
-  <meta name="theme-color" content="#0b1020" />
+  <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+  <meta name="theme-color" content="#0e0e10" media="(prefers-color-scheme: dark)" />
 
   <!-- Open Graph / social -->
   <meta property="og:type" content="website" />

--- a/docs/assets/css/agentfarm.css
+++ b/docs/assets/css/agentfarm.css
@@ -5,7 +5,6 @@
 :root {
   --surface: #ffffff;
   --surface-muted: #f7f7f8;
-  --surface-sunken: #f2f2f4;
   --border: #e5e7eb;
   --border-strong: #d4d4d8;
 
@@ -39,7 +38,6 @@
   :root {
     --surface: #0e0e10;
     --surface-muted: #161618;
-    --surface-sunken: #1c1c1f;
     --border: #2a2a2e;
     --border-strong: #3a3a3f;
 

--- a/docs/assets/css/agentfarm.css
+++ b/docs/assets/css/agentfarm.css
@@ -1,39 +1,33 @@
 /* ==========================================================================
    AgentFarm docs — design tokens
+   Clean, minimalist, content-first. No gradients, single restrained accent.
    ========================================================================== */
 :root {
-  --bg: #0b1020;
-  --bg-elev: #111733;
-  --bg-soft: #0f1530;
   --surface: #ffffff;
-  --surface-muted: #f5f7fb;
-  --surface-card: #ffffff;
-  --border: #e3e7f0;
-  --border-strong: #cdd4e3;
+  --surface-muted: #f7f7f8;
+  --surface-sunken: #f2f2f4;
+  --border: #e5e7eb;
+  --border-strong: #d4d4d8;
 
-  --text: #0f172a;
-  --text-muted: #475569;
-  --text-soft: #64748b;
-  --text-inverse: #f8fafc;
-  --text-inverse-muted: #b7c0d6;
+  --text: #111827;
+  --text-muted: #4b5563;
+  --text-soft: #6b7280;
 
-  --brand: #6366f1;
-  --brand-strong: #4f46e5;
-  --brand-soft: #eef2ff;
-  --accent: #22d3ee;
-  --accent-strong: #0891b2;
-  --success: #10b981;
-  --warning: #f59e0b;
+  --accent: #111827;
+  --accent-muted: #374151;
+  --link: #1f2937;
+  --link-hover: #000000;
 
-  --radius-sm: 6px;
-  --radius: 12px;
-  --radius-lg: 18px;
-  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
-  --shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
-  --shadow-lg: 0 20px 48px rgba(15, 23, 42, 0.16);
+  --code-bg: #f7f7f8;
+  --code-border: #e5e7eb;
+  --code-text: #111827;
 
-  --maxw: 1140px;
-  --maxw-prose: 760px;
+  --radius-sm: 4px;
+  --radius: 6px;
+  --radius-lg: 8px;
+
+  --maxw: 1040px;
+  --maxw-prose: 720px;
 
   --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif;
@@ -43,15 +37,24 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --surface: #0f1530;
-    --surface-muted: #131a3a;
-    --surface-card: #131a3a;
-    --border: #25305a;
-    --border-strong: #344075;
-    --text: #e6e9f5;
-    --text-muted: #b7c0d6;
-    --text-soft: #8d97b8;
-    --brand-soft: #1c2256;
+    --surface: #0e0e10;
+    --surface-muted: #161618;
+    --surface-sunken: #1c1c1f;
+    --border: #2a2a2e;
+    --border-strong: #3a3a3f;
+
+    --text: #ececef;
+    --text-muted: #b3b3b8;
+    --text-soft: #8a8a92;
+
+    --accent: #ececef;
+    --accent-muted: #d1d1d6;
+    --link: #ececef;
+    --link-hover: #ffffff;
+
+    --code-bg: #161618;
+    --code-border: #2a2a2e;
+    --code-text: #ececef;
   }
 }
 
@@ -70,13 +73,8 @@ html {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  html {
-    scroll-behavior: auto;
-  }
-
-  *,
-  *::before,
-  *::after {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
@@ -103,15 +101,16 @@ video {
 }
 
 a {
-  color: var(--brand-strong);
-  text-decoration: none;
-  transition: color 0.15s ease;
-}
-a:hover {
-  color: var(--brand);
+  color: var(--link);
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 3px;
+  text-decoration-color: var(--border-strong);
+  transition: color 0.12s ease, text-decoration-color 0.12s ease;
+}
+a:hover {
+  color: var(--link-hover);
+  text-decoration-color: currentColor;
 }
 
 code,
@@ -132,14 +131,21 @@ samp {
   position: absolute;
   left: -9999px;
   top: 0;
-  background: var(--brand-strong);
-  color: #fff;
+  background: var(--accent);
+  color: var(--surface);
   padding: 8px 12px;
   z-index: 100;
+  text-decoration: none;
 }
 .skip-link:focus {
   left: 12px;
   top: 12px;
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 /* ==========================================================================
@@ -149,15 +155,8 @@ samp {
   position: sticky;
   top: 0;
   z-index: 50;
-  background: rgba(255, 255, 255, 0.85);
-  backdrop-filter: saturate(140%) blur(10px);
-  -webkit-backdrop-filter: saturate(140%) blur(10px);
+  background: var(--surface);
   border-bottom: 1px solid var(--border);
-}
-@media (prefers-color-scheme: dark) {
-  .site-header {
-    background: rgba(15, 21, 48, 0.82);
-  }
 }
 
 .site-header__inner {
@@ -165,29 +164,40 @@ samp {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  height: 64px;
+  height: 60px;
 }
 
 .site-header__brand {
   display: inline-flex;
   align-items: center;
   gap: 10px;
-  font-weight: 700;
+  font-weight: 600;
   color: var(--text);
-  letter-spacing: -0.01em;
+  letter-spacing: -0.005em;
+  text-decoration: none;
 }
 .site-header__brand:hover {
+  color: var(--text);
   text-decoration: none;
-  color: var(--brand-strong);
 }
 .site-header__title {
-  font-size: 1.05rem;
+  font-size: 1rem;
+}
+.site-header__logo,
+.site-footer__brand img {
+  display: block;
+}
+@media (prefers-color-scheme: dark) {
+  .site-header__logo,
+  .site-footer__brand img {
+    filter: invert(1);
+  }
 }
 
 .site-nav__list {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -196,11 +206,12 @@ samp {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 8px 12px;
+  padding: 6px 10px;
   border-radius: var(--radius-sm);
   color: var(--text-muted);
   font-weight: 500;
-  font-size: 0.95rem;
+  font-size: 0.92rem;
+  text-decoration: none;
 }
 .site-nav__link:hover,
 .site-nav__link:focus-visible {
@@ -209,12 +220,11 @@ samp {
   text-decoration: none;
 }
 .site-nav__link.is-active {
-  color: var(--brand-strong);
-  background: var(--brand-soft);
+  color: var(--text);
 }
 .site-nav__ext {
   font-size: 0.8em;
-  opacity: 0.7;
+  color: var(--text-soft);
 }
 
 .site-nav__toggle,
@@ -227,34 +237,34 @@ samp {
     display: inline-flex;
     flex-direction: column;
     justify-content: space-between;
-    width: 28px;
-    height: 22px;
+    width: 26px;
+    height: 20px;
     cursor: pointer;
   }
   .site-nav__button span {
     display: block;
-    height: 2px;
+    height: 1.5px;
     background: var(--text);
     border-radius: 2px;
   }
   .site-nav__list {
     display: none;
     position: absolute;
-    top: 64px;
+    top: 60px;
     left: 0;
     right: 0;
     flex-direction: column;
     align-items: stretch;
     background: var(--surface);
     border-bottom: 1px solid var(--border);
-    padding: 12px 24px 16px;
-    gap: 4px;
+    padding: 8px 24px 14px;
+    gap: 2px;
   }
   .site-nav__toggle:checked ~ .site-nav__list {
     display: flex;
   }
   .site-nav__link {
-    padding: 10px 12px;
+    padding: 10px 8px;
   }
 }
 
@@ -266,25 +276,27 @@ samp {
 }
 
 .page-header {
-  margin: 56px 0 24px;
+  margin: 48px 0 24px;
   padding-bottom: 16px;
   border-bottom: 1px solid var(--border);
 }
 .page-header__title {
-  font-size: clamp(1.8rem, 1.4rem + 1.4vw, 2.6rem);
-  line-height: 1.15;
+  font-size: clamp(1.75rem, 1.4rem + 1.2vw, 2.25rem);
+  line-height: 1.2;
   letter-spacing: -0.02em;
-  margin: 0 0 8px;
+  margin: 0 0 6px;
+  font-weight: 600;
 }
 .page-header__subtitle {
   margin: 0;
   color: var(--text-muted);
-  font-size: 1.05rem;
+  font-size: 1.02rem;
 }
 .page-header__meta {
   margin: 8px 0 0;
   color: var(--text-soft);
-  font-size: 0.9rem;
+  font-size: 0.88rem;
+  font-family: var(--font-mono);
 }
 
 .prose {
@@ -296,53 +308,51 @@ samp {
 .prose h2,
 .prose h3,
 .prose h4 {
-  line-height: 1.25;
+  line-height: 1.3;
   letter-spacing: -0.01em;
-  margin-top: 2em;
-  margin-bottom: 0.6em;
+  margin-top: 1.8em;
+  margin-bottom: 0.5em;
+  font-weight: 600;
 }
 .prose h2 {
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   padding-bottom: 0.3em;
   border-bottom: 1px solid var(--border);
 }
 .prose h3 {
-  font-size: 1.25rem;
+  font-size: 1.15rem;
 }
 .prose p,
 .prose ul,
 .prose ol {
-  margin: 0 0 1.1em;
+  margin: 0 0 1em;
 }
 .prose ul,
 .prose ol {
   padding-left: 1.4em;
 }
 .prose li + li {
-  margin-top: 0.25em;
+  margin-top: 0.2em;
 }
 .prose blockquote {
-  margin: 1.4em 0;
-  padding: 12px 18px;
-  border-left: 3px solid var(--brand);
-  background: var(--surface-muted);
+  margin: 1.2em 0;
+  padding: 4px 16px;
+  border-left: 2px solid var(--border-strong);
   color: var(--text-muted);
-  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 }
 .prose code {
-  background: var(--surface-muted);
-  padding: 0.15em 0.4em;
-  border-radius: 4px;
-  border: 1px solid var(--border);
+  background: var(--code-bg);
+  padding: 0.12em 0.35em;
+  border-radius: 3px;
+  border: 1px solid var(--code-border);
 }
 .prose pre {
-  background: #0b1020;
-  color: #e6e9f5;
-  padding: 16px 18px;
+  background: var(--code-bg);
+  color: var(--code-text);
+  padding: 14px 16px;
   border-radius: var(--radius);
   overflow-x: auto;
-  border: 1px solid #1f2a55;
-  box-shadow: var(--shadow-sm);
+  border: 1px solid var(--code-border);
 }
 .prose pre code {
   background: transparent;
@@ -354,7 +364,7 @@ samp {
   width: 100%;
   border-collapse: collapse;
   margin: 1.2em 0;
-  font-size: 0.95em;
+  font-size: 0.94em;
 }
 .prose th,
 .prose td {
@@ -363,8 +373,8 @@ samp {
   border-bottom: 1px solid var(--border);
 }
 .prose th {
-  background: var(--surface-muted);
   font-weight: 600;
+  color: var(--text);
 }
 .prose hr {
   border: 0;
@@ -377,288 +387,229 @@ samp {
 }
 
 /* ==========================================================================
-   Home page
+   Home page — minimalist sections
    ========================================================================== */
 .hero {
-  position: relative;
-  overflow: hidden;
-  background:
-    radial-gradient(1100px 500px at 80% -10%, rgba(99, 102, 241, 0.35), transparent 60%),
-    radial-gradient(900px 500px at 0% 0%, rgba(34, 211, 238, 0.2), transparent 60%),
-    linear-gradient(180deg, #0b1020 0%, #0d1330 100%);
-  color: var(--text-inverse);
-  padding: 88px 0 96px;
-  border-bottom: 1px solid #1a2350;
-}
-.hero::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background-image:
-    linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
-  background-size: 44px 44px;
-  mask-image: radial-gradient(ellipse at 50% 30%, #000 30%, transparent 75%);
-  -webkit-mask-image: radial-gradient(ellipse at 50% 30%, #000 30%, transparent 75%);
-  pointer-events: none;
+  padding: 72px 0 48px;
+  border-bottom: 1px solid var(--border);
 }
 .hero__inner {
-  position: relative;
-  z-index: 1;
   display: grid;
-  grid-template-columns: 1.2fr 0.8fr;
+  grid-template-columns: 1.1fr 0.9fr;
   gap: 48px;
-  align-items: center;
+  align-items: start;
 }
 @media (max-width: 880px) {
   .hero__inner {
     grid-template-columns: 1fr;
-    gap: 24px;
+    gap: 32px;
   }
 }
-.hero__eyebrow {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  background: rgba(99, 102, 241, 0.15);
-  border: 1px solid rgba(99, 102, 241, 0.4);
-  color: #c7d2fe;
-  font-size: 0.82rem;
-  font-weight: 500;
-  padding: 6px 12px;
-  border-radius: 999px;
-  margin-bottom: 18px;
-}
-.hero__eyebrow .dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent);
-  box-shadow: 0 0 12px var(--accent);
-}
 .hero__title {
-  font-size: clamp(2.2rem, 1.6rem + 2.4vw, 3.6rem);
-  line-height: 1.05;
-  letter-spacing: -0.03em;
-  margin: 0 0 16px;
-  font-weight: 700;
-}
-.hero__title .gradient {
-  background: linear-gradient(90deg, #818cf8 0%, #22d3ee 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
+  font-size: clamp(2rem, 1.6rem + 1.6vw, 2.75rem);
+  line-height: 1.15;
+  letter-spacing: -0.025em;
+  margin: 0 0 18px;
+  font-weight: 600;
+  color: var(--text);
 }
 .hero__lede {
-  color: var(--text-inverse-muted);
-  font-size: 1.15rem;
-  max-width: 56ch;
-  margin: 0 0 28px;
+  color: var(--text-muted);
+  font-size: 1.08rem;
+  line-height: 1.6;
+  max-width: 60ch;
+  margin: 0 0 24px;
 }
 .hero__cta {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 10px;
+  margin-bottom: 28px;
 }
 .hero__meta {
-  margin-top: 28px;
   display: flex;
   flex-wrap: wrap;
-  gap: 18px;
-  color: var(--text-inverse-muted);
-  font-size: 0.92rem;
+  gap: 18px 28px;
+  color: var(--text-soft);
+  font-size: 0.88rem;
 }
 .hero__meta strong {
-  color: var(--text-inverse);
+  color: var(--text);
+  font-weight: 600;
 }
 
 .btn {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 11px 18px;
+  gap: 6px;
+  padding: 8px 14px;
   border-radius: var(--radius);
-  font-weight: 600;
-  font-size: 0.95rem;
-  border: 1px solid transparent;
-  transition: transform 0.1s ease, background 0.15s ease, border-color 0.15s ease;
+  font-weight: 500;
+  font-size: 0.92rem;
+  border: 1px solid var(--border-strong);
+  background: var(--surface);
+  color: var(--text);
   cursor: pointer;
   text-decoration: none;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
 }
-.btn:active {
-  transform: translateY(1px);
+.btn:hover {
+  background: var(--surface-muted);
+  border-color: var(--text-soft);
+  color: var(--text);
+  text-decoration: none;
 }
 .btn--primary {
-  background: linear-gradient(135deg, var(--brand) 0%, var(--brand-strong) 100%);
-  color: #fff;
-  box-shadow: 0 6px 20px rgba(79, 70, 229, 0.35);
+  background: var(--accent);
+  color: var(--surface);
+  border-color: var(--accent);
 }
 .btn--primary:hover {
-  text-decoration: none;
-  filter: brightness(1.07);
-  color: #fff;
+  background: var(--accent-muted);
+  border-color: var(--accent-muted);
+  color: var(--surface);
 }
 .btn--ghost {
-  background: rgba(255, 255, 255, 0.06);
-  color: #fff;
-  border-color: rgba(255, 255, 255, 0.18);
-}
-.btn--ghost:hover {
-  text-decoration: none;
-  background: rgba(255, 255, 255, 0.12);
-  color: #fff;
+  background: transparent;
 }
 
-/* Hero side card with code preview */
-.hero__card {
-  background: rgba(15, 21, 48, 0.6);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: var(--radius-lg);
-  padding: 0;
-  box-shadow: var(--shadow-lg);
+/* Code preview block (hero, quickstart, etc.) — flat, no chrome bar. */
+.codeblock {
+  background: var(--code-bg);
+  border: 1px solid var(--code-border);
+  border-radius: var(--radius);
   overflow: hidden;
-  backdrop-filter: blur(6px);
 }
-.hero__card-bar {
+.codeblock__head {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 10px 14px;
-  background: rgba(255, 255, 255, 0.04);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-}
-.hero__card-bar .dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.18);
-}
-.hero__card-bar .dot:nth-child(1) { background: #ff5f57; }
-.hero__card-bar .dot:nth-child(2) { background: #febc2e; }
-.hero__card-bar .dot:nth-child(3) { background: #28c840; }
-.hero__card-bar span.label {
-  margin-left: 8px;
-  font-size: 0.78rem;
-  color: var(--text-inverse-muted);
+  justify-content: space-between;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--code-border);
   font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-soft);
+  background: var(--surface-muted);
 }
-.hero__code {
-  padding: 18px;
+.codeblock__body {
+  padding: 14px 16px;
   margin: 0;
   background: transparent;
-  color: #e6e9f5;
+  color: var(--code-text);
   font-family: var(--font-mono);
-  font-size: 0.86rem;
-  line-height: 1.6;
+  font-size: 0.84rem;
+  line-height: 1.65;
   overflow-x: auto;
 }
-.hero__code .tk-kw { color: #c4b5fd; }
-.hero__code .tk-fn { color: #7dd3fc; }
-.hero__code .tk-str { color: #86efac; }
-.hero__code .tk-num { color: #fcd34d; }
-.hero__code .tk-cm { color: #94a3b8; font-style: italic; }
+.codeblock__body .tk-kw  { color: var(--text); font-weight: 600; }
+.codeblock__body .tk-fn  { color: var(--text); }
+.codeblock__body .tk-str { color: var(--text-muted); }
+.codeblock__body .tk-num { color: var(--text-muted); }
+.codeblock__body .tk-cm  { color: var(--text-soft); font-style: italic; }
 
 /* Section structure */
 .section {
-  padding: 72px 0;
-}
-.section--muted {
-  background: var(--surface-muted);
-  border-top: 1px solid var(--border);
+  padding: 56px 0;
   border-bottom: 1px solid var(--border);
 }
-.section__head {
-  text-align: center;
-  max-width: 720px;
-  margin: 0 auto 40px;
+.section--last {
+  border-bottom: 0;
 }
-.section__eyebrow {
-  display: inline-block;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: var(--brand-strong);
-  margin-bottom: 8px;
+.section__head {
+  max-width: 720px;
+  margin: 0 0 28px;
 }
 .section__title {
-  font-size: clamp(1.6rem, 1.2rem + 1.2vw, 2.2rem);
-  line-height: 1.2;
-  letter-spacing: -0.02em;
-  margin: 0 0 10px;
+  font-size: 1.4rem;
+  line-height: 1.25;
+  letter-spacing: -0.015em;
+  margin: 0 0 6px;
+  font-weight: 600;
 }
 .section__lede {
   color: var(--text-muted);
-  font-size: 1.05rem;
+  font-size: 1rem;
   margin: 0;
+  max-width: 64ch;
 }
 
-/* Feature grid */
+/* Feature list — restrained, no icon tiles. */
 .feature-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 20px;
+  gap: 0;
+  border-top: 1px solid var(--border);
 }
-@media (max-width: 900px) {
+.feature-grid > .feature {
+  border-bottom: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+}
+.feature-grid > .feature:nth-child(3n) {
+  border-right: 0;
+}
+@media (max-width: 880px) {
   .feature-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+  .feature-grid > .feature {
+    border-right: 1px solid var(--border);
+  }
+  .feature-grid > .feature:nth-child(3n) {
+    border-right: 1px solid var(--border);
+  }
+  .feature-grid > .feature:nth-child(2n) {
+    border-right: 0;
+  }
 }
-@media (max-width: 600px) {
+@media (max-width: 560px) {
   .feature-grid {
     grid-template-columns: 1fr;
   }
+  .feature-grid > .feature,
+  .feature-grid > .feature:nth-child(3n),
+  .feature-grid > .feature:nth-child(2n) {
+    border-right: 0;
+  }
 }
 .feature {
-  background: var(--surface-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 22px;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
-}
-.feature:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow);
-  border-color: var(--border-strong);
-}
-.feature__icon {
-  width: 40px;
-  height: 40px;
-  border-radius: 10px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--brand-soft);
-  color: var(--brand-strong);
-  margin-bottom: 14px;
-  font-size: 1.2rem;
-  font-weight: 700;
+  padding: 22px 22px 24px;
+  background: var(--surface);
 }
 .feature__title {
   margin: 0 0 6px;
-  font-size: 1.05rem;
+  font-size: 1rem;
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.005em;
+  color: var(--text);
 }
 .feature__desc {
   margin: 0 0 12px;
   color: var(--text-muted);
-  font-size: 0.95rem;
+  font-size: 0.94rem;
+  line-height: 1.55;
 }
 .feature__link {
-  font-size: 0.9rem;
-  font-weight: 600;
+  display: inline-block;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--text);
+  text-decoration: none;
+  border-bottom: 1px solid var(--border-strong);
+  padding-bottom: 1px;
+  margin-right: 14px;
 }
-.feature__link::after {
-  content: " →";
+.feature__link:hover {
+  color: var(--text);
+  border-bottom-color: var(--text);
+  text-decoration: none;
 }
 
-/* Quick start strip */
+/* Quickstart — two-column, plain. */
 .quickstart {
   display: grid;
   grid-template-columns: 1fr 1.1fr;
-  gap: 36px;
-  align-items: center;
+  gap: 32px;
+  align-items: start;
 }
 @media (max-width: 880px) {
   .quickstart {
@@ -668,48 +619,42 @@ samp {
 .quickstart__steps {
   display: grid;
   gap: 18px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  counter-reset: qs;
 }
 .quickstart__step {
   display: grid;
-  grid-template-columns: 36px 1fr;
-  gap: 14px;
+  grid-template-columns: 28px 1fr;
+  gap: 12px;
   align-items: start;
+  counter-increment: qs;
 }
-.quickstart__step-num {
-  width: 32px;
-  height: 32px;
-  border-radius: 999px;
+.quickstart__step::before {
+  content: counter(qs);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: var(--brand-soft);
-  color: var(--brand-strong);
-  font-weight: 700;
-  font-size: 0.9rem;
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  border: 1px solid var(--border-strong);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  margin-top: 2px;
 }
 .quickstart__step h4 {
-  margin: 4px 0 4px;
-  font-size: 1rem;
+  margin: 0 0 2px;
+  font-size: 0.98rem;
+  font-weight: 600;
 }
 .quickstart__step p {
   margin: 0;
   color: var(--text-muted);
-  font-size: 0.95rem;
+  font-size: 0.94rem;
 }
-.quickstart__code {
-  background: #0b1020;
-  color: #e6e9f5;
-  border-radius: var(--radius);
-  padding: 20px;
-  font-family: var(--font-mono);
-  font-size: 0.88rem;
-  line-height: 1.7;
-  overflow-x: auto;
-  border: 1px solid #1f2a55;
-  box-shadow: var(--shadow);
-}
-.quickstart__code .c { color: #94a3b8; }
-.quickstart__code .p { color: #f472b6; }
 
 /* Devlog list */
 .posts {
@@ -717,53 +662,51 @@ samp {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 16px;
+  gap: 0;
+  border-top: 1px solid var(--border);
+}
+.posts > li {
+  border-bottom: 1px solid var(--border);
 }
 .post-card {
   display: block;
-  background: var(--surface-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 20px 22px;
+  padding: 18px 0;
   color: inherit;
-  transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+  text-decoration: none;
 }
 .post-card:hover {
   text-decoration: none;
-  border-color: var(--border-strong);
-  transform: translateY(-1px);
-  box-shadow: var(--shadow);
   color: inherit;
 }
+.post-card:hover .post-card__title {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
 .post-card__date {
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   color: var(--text-soft);
   font-family: var(--font-mono);
   letter-spacing: 0.02em;
 }
 .post-card__title {
-  margin: 4px 0 6px;
-  font-size: 1.15rem;
+  margin: 4px 0 4px;
+  font-size: 1.05rem;
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.005em;
   color: var(--text);
 }
 .post-card__excerpt {
   margin: 0;
   color: var(--text-muted);
   font-size: 0.95rem;
+  line-height: 1.55;
 }
 .post-card__more {
-  margin-top: 10px;
-  font-size: 0.88rem;
-  font-weight: 600;
-  color: var(--brand-strong);
-}
-.post-card__more::after {
-  content: " →";
+  display: none;
 }
 
-/* Devlog index (and similar) lives inside `.prose`; beat `.prose ul` / `.prose h3` / `.prose p`. */
+/* Devlog index inside `.prose` overrides. */
 .prose .posts {
   margin: 0;
   padding: 0;
@@ -772,118 +715,96 @@ samp {
   margin: 0;
 }
 .prose .post-card__title {
-  margin: 4px 0 6px;
-  font-size: 1.15rem;
+  margin: 4px 0 4px;
+  font-size: 1.05rem;
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.005em;
   color: var(--text);
 }
 .prose .post-card__excerpt {
   margin: 0;
 }
 
-/* CTA banner */
-.cta {
-  text-align: center;
-  padding: 72px 24px;
-  background: linear-gradient(135deg, #4f46e5 0%, #0891b2 100%);
-  color: #fff;
-  border-radius: var(--radius-lg);
-  margin: 24px auto 64px;
-  max-width: var(--maxw);
-  box-shadow: var(--shadow-lg);
-}
-.cta h2 {
-  margin: 0 0 10px;
-  font-size: clamp(1.6rem, 1.2rem + 1vw, 2rem);
-  letter-spacing: -0.02em;
-}
-.cta p {
-  margin: 0 auto 22px;
-  max-width: 60ch;
-  color: rgba(255, 255, 255, 0.9);
-}
-.cta .btn--primary {
-  background: #fff;
-  color: var(--brand-strong);
-  box-shadow: none;
-}
-.cta .btn--primary:hover {
-  background: #f1f5f9;
-}
-.cta .btn--ghost {
-  border-color: rgba(255, 255, 255, 0.5);
+.section__more {
+  margin-top: 24px;
 }
 
 /* ==========================================================================
    Footer
    ========================================================================== */
 .site-footer {
-  background: var(--bg);
-  color: var(--text-inverse);
-  padding: 56px 0 24px;
-  margin-top: 40px;
+  background: var(--surface);
+  color: var(--text-muted);
+  padding: 40px 0 28px;
+  margin-top: 0;
+  border-top: 1px solid var(--border);
 }
 .site-footer__inner {
   display: grid;
   grid-template-columns: 1.4fr 1fr 1fr;
-  gap: 36px;
+  gap: 32px;
 }
 @media (max-width: 720px) {
   .site-footer__inner {
     grid-template-columns: 1fr;
+    gap: 24px;
   }
 }
 .site-footer__brand {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  color: #fff;
-  font-size: 1.05rem;
+  color: var(--text);
+  font-size: 0.98rem;
+  text-decoration: none;
 }
 .site-footer__brand:hover {
   text-decoration: none;
-  color: #fff;
+  color: var(--text);
 }
 .site-footer__tagline {
-  color: var(--text-inverse-muted);
+  color: var(--text-soft);
   margin-top: 8px;
-  font-size: 0.95rem;
-  max-width: 40ch;
+  font-size: 0.92rem;
+  max-width: 44ch;
 }
 .site-footer h4 {
-  font-size: 0.85rem;
+  font-size: 0.78rem;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--text-inverse-muted);
-  margin: 0 0 12px;
+  letter-spacing: 0.08em;
+  color: var(--text-soft);
+  margin: 0 0 10px;
+  font-weight: 600;
 }
 .site-footer ul {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 8px;
+  gap: 6px;
 }
 .site-footer a {
-  color: var(--text-inverse);
-  font-size: 0.95rem;
-}
-.site-footer a:hover {
-  color: var(--accent);
+  color: var(--text-muted);
+  font-size: 0.93rem;
   text-decoration: none;
 }
+.site-footer a:hover {
+  color: var(--text);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
 .site-footer__bottom {
-  margin-top: 36px;
-  padding-top: 18px;
-  border-top: 1px solid #1f2a55;
+  margin-top: 28px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
   display: flex;
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 12px;
-  color: var(--text-inverse-muted);
-  font-size: 0.88rem;
+  color: var(--text-soft);
+  font-size: 0.85rem;
 }
 
 /* ==========================================================================

--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <defs>
-    <linearGradient id="g" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#818cf8"/>
-      <stop offset="1" stop-color="#22d3ee"/>
-    </linearGradient>
-  </defs>
-  <rect width="64" height="64" rx="14" fill="url(#g)"/>
-  <g fill="#0b1020">
+  <rect width="64" height="64" rx="10" fill="#111827"/>
+  <g stroke="#ffffff" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <line x1="32" y1="32" x2="16" y2="20"/>
+    <line x1="32" y1="32" x2="48" y2="20"/>
+    <line x1="32" y1="32" x2="16" y2="44"/>
+    <line x1="32" y1="32" x2="48" y2="44"/>
+  </g>
+  <g fill="#ffffff">
     <circle cx="32" cy="32" r="5"/>
     <circle cx="16" cy="20" r="3"/>
     <circle cx="48" cy="20" r="3"/>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,20 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" aria-hidden="true">
-  <defs>
-    <linearGradient id="af-g" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#818cf8"/>
-      <stop offset="1" stop-color="#22d3ee"/>
-    </linearGradient>
-  </defs>
-  <rect x="2" y="2" width="60" height="60" rx="14" fill="url(#af-g)"/>
-  <g stroke="#0b1020" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" fill="none">
-    <circle cx="32" cy="32" r="4" fill="#0b1020"/>
-    <circle cx="16" cy="20" r="2.6" fill="#0b1020"/>
-    <circle cx="48" cy="20" r="2.6" fill="#0b1020"/>
-    <circle cx="16" cy="44" r="2.6" fill="#0b1020"/>
-    <circle cx="48" cy="44" r="2.6" fill="#0b1020"/>
+  <g stroke="#111827" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" fill="none">
     <line x1="32" y1="32" x2="16" y2="20"/>
     <line x1="32" y1="32" x2="48" y2="20"/>
     <line x1="32" y1="32" x2="16" y2="44"/>
     <line x1="32" y1="32" x2="48" y2="44"/>
+  </g>
+  <g fill="#111827">
+    <circle cx="32" cy="32" r="4.5"/>
+    <circle cx="16" cy="20" r="3"/>
+    <circle cx="48" cy="20" r="3"/>
+    <circle cx="16" cy="44" r="3"/>
+    <circle cx="48" cy="44" r="3"/>
   </g>
 </svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,36 +7,33 @@ description: A Python-first platform for agent-based simulation, reinforcement l
 <section class="hero">
   <div class="container hero__inner">
     <div class="hero__copy">
-      <span class="hero__eyebrow"><span class="dot"></span> In active development · MIT-style research code</span>
       <h1 class="hero__title">
-        Simulate agents.<br />
-        <span class="gradient">Study what emerges.</span>
+        AgentFarm — a research workbench for agent-based simulation.
       </h1>
       <p class="hero__lede">
-        AgentFarm is an open-source workbench for agent-based modeling, reinforcement learning experiments,
-        and complex adaptive systems research. Build environments, evolve hyperparameters, and analyze
-        emergent behavior at scale.
+        Python-first tools for agent-based modeling, reinforcement learning,
+        and emergent-behavior research. Build environments, run experiments,
+        and persist structured data for reproducible analysis.
       </p>
       <div class="hero__cta">
-        <a class="btn btn--primary" href="{{ '/README/' | relative_url }}">Read the docs</a>
-        <a class="btn btn--ghost" href="https://github.com/Dooders/AgentFarm" target="_blank" rel="noopener">
-          GitHub
-          <span aria-hidden="true">↗</span>
-        </a>
+        <a class="btn btn--primary" href="{{ '/README/' | relative_url }}">Documentation</a>
+        <a class="btn" href="https://github.com/Dooders/AgentFarm" target="_blank" rel="noopener">GitHub</a>
+        <a class="btn btn--ghost" href="#quickstart">Quick start</a>
       </div>
       <div class="hero__meta">
-        <span><strong>Python 3.10+</strong> · simulation core</span>
-        <span><strong>structlog</strong> · observability</span>
-        <span><strong>Tianshou + PyTorch</strong> · learning</span>
+        <span><strong>Python 3.10+</strong></span>
+        <span><strong>PyTorch + Tianshou</strong></span>
+        <span><strong>SQLite-backed runs</strong></span>
+        <span><strong>structlog</strong></span>
       </div>
     </div>
 
-    <aside class="hero__card" aria-hidden="true">
-      <div class="hero__card-bar">
-        <span class="dot"></span><span class="dot"></span><span class="dot"></span>
-        <span class="label">run_simulation.py</span>
+    <aside class="codeblock" aria-hidden="true">
+      <div class="codeblock__head">
+        <span>run_simulation.py</span>
+        <span>python</span>
       </div>
-<pre class="hero__code"><span class="tk-kw">from</span> farm.config <span class="tk-kw">import</span> SimulationConfig
+<pre class="codeblock__body"><span class="tk-kw">from</span> farm.config <span class="tk-kw">import</span> SimulationConfig
 <span class="tk-kw">from</span> farm.core.simulation <span class="tk-kw">import</span> run_simulation
 
 config = SimulationConfig.from_centralized_config(
@@ -57,142 +54,142 @@ env = run_simulation(
 <section class="section" id="features">
   <div class="container">
     <header class="section__head">
-      <span class="section__eyebrow">What it does</span>
-      <h2 class="section__title">A platform built for emergent-behavior research</h2>
+      <h2 class="section__title">What's in the box</h2>
       <p class="section__lede">
-        Compose simulations, run reinforcement-learning experiments, and analyze what comes out — with
-        structured data, reproducible runs, and a clean Python API.
+        Composable primitives for simulation, learning, and analysis — wired together
+        with structured logging and reproducible run artifacts.
       </p>
     </header>
 
     <div class="feature-grid">
       <div class="feature">
-        <div class="feature__icon">AB</div>
         <h3 class="feature__title">Agent-based modeling</h3>
         <p class="feature__desc">
-          Compose adaptive agents, environments, and rules. Track interactions, resources, and emergent dynamics over time.
+          Compose adaptive agents, environments, and rules. Track interactions,
+          resources, and emergent dynamics over time.
         </p>
-        <a class="feature__link" href="{{ '/features/agent_based_modeling_analysis/' | relative_url }}">Explore modeling</a>
+        <a class="feature__link" href="{{ '/features/agent_based_modeling_analysis/' | relative_url }}">Modeling</a>
       </div>
 
       <div class="feature">
-        <div class="feature__icon">RL</div>
         <h3 class="feature__title">Reinforcement learning</h3>
         <p class="feature__desc">
-          PyTorch + Tianshou-backed decision modules with prioritized experience replay and evolvable hyperparameters.
+          PyTorch + Tianshou-backed decision modules with prioritized experience
+          replay and evolvable hyperparameters.
         </p>
-        <a class="feature__link" href="{{ '/deep_q_learning/' | relative_url }}">Deep Q-learning guide</a>
+        <a class="feature__link" href="{{ '/deep_q_learning/' | relative_url }}">Deep Q-learning</a>
       </div>
 
       <div class="feature">
-        <div class="feature__icon">EV</div>
         <h3 class="feature__title">Hyperparameter evolution</h3>
         <p class="feature__desc">
-          Genetics-inspired chromosomes for learning hyperparameters with mutation, crossover, and adaptive rates.
+          Genetics-inspired chromosomes for learning hyperparameters with mutation,
+          crossover, and adaptive rates.
         </p>
-        <a class="feature__link" href="{{ '/design/hyperparameter_chromosome/' | relative_url }}">Chromosome design</a>
+        <a class="feature__link" href="{{ '/design/hyperparameter_chromosome/' | relative_url }}">Chromosomes</a>
       </div>
 
       <div class="feature">
-        <div class="feature__icon">SP</div>
-        <h3 class="feature__title">Spatial indexing at scale</h3>
+        <h3 class="feature__title">Spatial indexing</h3>
         <p class="feature__desc">
-          KD-tree, Quadtree, and Spatial Hash Grid backends with dirty-region tracking — thousands of agents, fast.
+          KD-tree, Quadtree, and Spatial Hash Grid backends with dirty-region
+          tracking — thousands of agents, fast.
         </p>
-        <a class="feature__link" href="{{ '/features/spatial_indexing_performance/' | relative_url }}">Performance details</a>
+        <a class="feature__link" href="{{ '/features/spatial_indexing_performance/' | relative_url }}">Performance</a>
       </div>
 
       <div class="feature">
-        <div class="feature__icon">DB</div>
         <h3 class="feature__title">Data &amp; analysis</h3>
         <p class="feature__desc">
-          Repository-backed databases, behavioral clustering, causal analysis, and experiment-level comparisons.
+          Repository-backed databases, behavioral clustering, causal analysis,
+          and experiment-level comparisons.
         </p>
         <a class="feature__link" href="{{ '/features/data_system/' | relative_url }}">Data system</a>
-        <a class="feature__link" href="{{ '/genetics_analysis/' | relative_url }}">Genetics analysis module</a>
+        <a class="feature__link" href="{{ '/genetics_analysis/' | relative_url }}">Genetics</a>
       </div>
 
       <div class="feature">
-        <div class="feature__icon">LO</div>
         <h3 class="feature__title">Structured logging</h3>
         <p class="feature__desc">
-          <code>structlog</code>-powered context-rich, machine-readable logs with sampling and sensitive-data censoring.
+          <code>structlog</code>-powered, context-rich, machine-readable logs
+          with sampling and sensitive-data censoring.
         </p>
-        <a class="feature__link" href="{{ '/LOGGING_QUICK_REFERENCE/' | relative_url }}">Logging quick reference</a>
+        <a class="feature__link" href="{{ '/LOGGING_QUICK_REFERENCE/' | relative_url }}">Logging</a>
       </div>
     </div>
   </div>
 </section>
 
-<section class="section section--muted" id="quickstart">
+<section class="section" id="quickstart">
   <div class="container">
     <header class="section__head">
-      <span class="section__eyebrow">Quick start</span>
-      <h2 class="section__title">Up and running in a few commands</h2>
+      <h2 class="section__title">Quick start</h2>
       <p class="section__lede">
-        Clone the repository, create a virtualenv, install AgentFarm, and run your first simulation.
+        Clone the repository, create a virtualenv, install AgentFarm, and run
+        your first simulation.
       </p>
     </header>
 
     <div class="quickstart">
-      <div class="quickstart__steps">
-        <div class="quickstart__step">
-          <span class="quickstart__step-num">1</span>
+      <ol class="quickstart__steps">
+        <li class="quickstart__step">
           <div>
             <h4>Clone &amp; create a virtualenv</h4>
             <p>AgentFarm targets Python 3.10+. A virtualenv keeps experiment dependencies isolated.</p>
           </div>
-        </div>
-        <div class="quickstart__step">
-          <span class="quickstart__step-num">2</span>
+        </li>
+        <li class="quickstart__step">
           <div>
             <h4>Install in editable mode</h4>
             <p>Editable installs make it easy to extend agents, environments, or analysis pipelines.</p>
           </div>
-        </div>
-        <div class="quickstart__step">
-          <span class="quickstart__step-num">3</span>
+        </li>
+        <li class="quickstart__step">
           <div>
             <h4>Run a simulation</h4>
             <p>The CLI emits a SQLite <code>.db</code> under <code>simulations/</code> for downstream analysis.</p>
           </div>
-        </div>
-        <div class="quickstart__step">
-          <span class="quickstart__step-num">4</span>
+        </li>
+        <li class="quickstart__step">
           <div>
             <h4>Open the docs</h4>
             <p>Browse the <a href="{{ '/README/' | relative_url }}">documentation index</a> for guides, API, and case studies.</p>
           </div>
+        </li>
+      </ol>
+
+      <div class="codeblock">
+        <div class="codeblock__head">
+          <span>shell</span>
+          <span>bash</span>
         </div>
-      </div>
-
-<pre class="quickstart__code"><span class="c"># 1. Clone</span>
+<pre class="codeblock__body"><span class="tk-cm"># 1. Clone</span>
 git clone https://github.com/Dooders/AgentFarm.git
-<span class="p">cd</span> AgentFarm
+cd AgentFarm
 
-<span class="c"># 2. Virtualenv + install</span>
+<span class="tk-cm"># 2. Virtualenv + install</span>
 python -m venv venv
-<span class="p">source</span> venv/bin/activate
+source venv/bin/activate
 pip install -r requirements.txt
 pip install -e .
 
-<span class="c"># 3. Run a small simulation</span>
+<span class="tk-cm"># 3. Run a small simulation</span>
 python run_simulation.py \
   --environment development \
   --steps 500
 
-<span class="c"># 4. Run the test suite</span>
+<span class="tk-cm"># 4. Run the test suite</span>
 pytest -q
 </pre>
+      </div>
     </div>
   </div>
 </section>
 
-<section class="section">
+<section class="section section--last">
   <div class="container">
     <header class="section__head">
-      <span class="section__eyebrow">Latest from the devlog</span>
-      <h2 class="section__title">What we've been building</h2>
+      <h2 class="section__title">From the devlog</h2>
       <p class="section__lede">
         Build notes, design decisions, and experiment outcomes from the AgentFarm team.
       </p>
@@ -201,41 +198,27 @@ pytest -q
     <ul class="posts">
       <li>
         <a class="post-card" href="{{ '/devlog/2026-04-23-evolving-hyperparameter-genomes-foraging-learning-agents/' | relative_url }}">
-          <span class="post-card__date">April 23, 2026</span>
+          <span class="post-card__date">2026-04-23</span>
           <h3 class="post-card__title">Evolving hyperparameter genomes in foraging and learning agents</h3>
           <p class="post-card__excerpt">
             Each agent carries its own hyperparameter chromosome, offspring inherit it (with mutation and
             crossover), and selection is whatever the resource environment happens to apply.
           </p>
-          <span class="post-card__more">Read the post</span>
         </a>
       </li>
       <li>
         <a class="post-card" href="{{ '/devlog/2026-04-17-dna-hyperparameter-evolution/' | relative_url }}">
-          <span class="post-card__date">April 17, 2026</span>
+          <span class="post-card__date">2026-04-17</span>
           <h3 class="post-card__title">DNA-style hyperparameter evolution results</h3>
           <p class="post-card__excerpt">
             Design and initial outcomes of the genetics-inspired hyperparameter evolution work in AgentFarm.
           </p>
-          <span class="post-card__more">Read the post</span>
         </a>
       </li>
     </ul>
 
-    <p class="text-center" style="margin-top: 28px;">
-      <a class="btn btn--primary" href="{{ '/devlog/' | relative_url }}">Browse the full devlog</a>
+    <p class="section__more">
+      <a class="btn" href="{{ '/devlog/' | relative_url }}">All devlog posts</a>
     </p>
-  </div>
-</section>
-
-<section class="cta">
-  <h2>Build, evolve, and study agent populations</h2>
-  <p>
-    Whether you're researching emergent behavior, comparing learning algorithms, or running parameter
-    sweeps, AgentFarm gives you the primitives and the data to do it reproducibly.
-  </p>
-  <div class="hero__cta" style="justify-content: center;">
-    <a class="btn btn--primary" href="{{ '/README/' | relative_url }}">Get started</a>
-    <a class="btn btn--ghost" href="https://github.com/Dooders/AgentFarm" target="_blank" rel="noopener">Star on GitHub ↗</a>
   </div>
 </section>


### PR DESCRIPTION
This pull request updates the AgentFarm documentation site to improve clarity, accessibility, and consistency, especially on the landing page and error page. The main changes include a rewrite and redesign of the homepage (`index.md`) for clearer messaging and improved feature presentation, as well as visual and accessibility improvements to the 404 error page and default layout.

**Homepage and Feature Presentation Updates:**

- Rewrote and simplified the homepage hero section in `index.md` for clearer messaging, highlighting AgentFarm as a research workbench for agent-based simulation, and restructured the feature grid for brevity and clarity. Feature titles, descriptions, and links were made more concise and consistent. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L10-R36) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L60-R192)
- Updated the quickstart section to use an ordered list and improved code block formatting for better readability and accessibility.
- Refreshed the devlog section to use ISO-style dates, simplified post cards, and updated the call-to-action for devlog browsing.

**Visual and Accessibility Improvements:**

- Redesigned the 404 error page in `404.html` with improved layout, clearer language, and more accessible button styles.
- Improved theme color handling in `default.html` to support both light and dark modes using the `prefers-color-scheme` media query.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to docs-site HTML/CSS and SVG assets, with no runtime/application logic impact; main risk is unintended visual/layout regressions across breakpoints and dark mode.
> 
> **Overview**
> Refreshes the GitHub Pages docs UI to a **minimalist, content-first** design: replaces the previous gradient/brand-heavy styling with new CSS tokens, link/button styles, flatter sections, and updated typography/layout for header, hero, feature grid, quickstart, devlog list, and footer.
> 
> Updates `index.md` copy and structure (new CTAs, simplified feature links, ordered quickstart steps, new `codeblock` component, and ISO-style devlog dates), revamps `404.html` messaging/CTAs, adds light/dark `theme-color` meta tags in `default.html`, and replaces `favicon.svg`/`logo.svg` with new monochrome icons plus dark-mode inversion handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e15899151487daceddfd1505fd6f90f97c829a1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->