### PR TITLE
Add site notice for project status in default layout

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -27,6 +27,13 @@
 </head>
 <body class="page page--{{ page.layout | default: 'default' }}">
   {% include header.html %}
+  <aside class="site-notice" role="note" aria-label="Project status">
+    <div class="container">
+      <p class="site-notice__text">
+        AgentFarm is in active development and still incomplete.
+      </p>
+    </div>
+  </aside>
 
   <main id="content" class="site-main">
     {% unless page.layout == "home" %}

--- a/docs/assets/css/agentfarm.css
+++ b/docs/assets/css/agentfarm.css
@@ -253,6 +253,19 @@ samp {
   display: none;
 }
 
+.site-notice {
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-muted);
+}
+
+.site-notice__text {
+  margin: 0;
+  padding: 8px 0;
+  font-size: 0.88rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
 @media (max-width: 720px) {
   .site-nav__button {
     display: inline-flex;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: docs-only HTML/CSS change that adds a static banner and styling, with no behavioral or data-handling logic affected.
> 
> **Overview**
> Adds a global project-status notice banner to the docs `default` layout, displayed directly under the header.
> 
> Introduces new `.site-notice` / `.site-notice__text` styles in `agentfarm.css` to render the banner with muted background, border, and centered text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4e492753ec29810bce00f0aca98001e38b0c09e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->