### PR TITLE
docs(readme): guide mature-framework seekers to Mesa and RL libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This repository is being developed to support research in the [Dooders](https://
 
 > **Note**: This project is currently in active development. APIs and features may change between releases. See the [Contributing Guidelines](CONTRIBUTING.md) for information on getting involved.
 
+**Choosing a framework:** AgentFarm targets research workflows and is still evolving. If you need a mature, battle-tested agent-based modeling stack, consider [Mesa](https://github.com/projectmesa/mesa) or other widely used ABM frameworks. For reinforcement learning, established ecosystems such as [Stable-Baselines3](https://github.com/DLR-RM/stable-baselines3), [RLlib](https://docs.ray.io/en/latest/rllib/index.html), and [CleanRL](https://github.com/vwxyzjn/cleanrl) are often better fits when reliability and community scale matter most.
+
 ## Key Features
 
 ### [Agent-Based Modeling & Analysis](docs/features/agent_based_modeling_analysis.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a short paragraph near the top of `README.md` (right after the active-development note) so readers who prioritize a mature, widely adopted ABM or RL stack are directed to Mesa and common reinforcement-learning ecosystems instead of expecting AgentFarm to fill that niche.

No code changes; documentation only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-681462b0-0908-4a79-88b0-f1bd291230a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-681462b0-0908-4a79-88b0-f1bd291230a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

