### PR TITLE
Add long-horizon balanced-profile experiment scripts and documentation

### DIFF
--- a/docs/devlog/2026-05-12-seed-sweep-reality-check.md
+++ b/docs/devlog/2026-05-12-seed-sweep-reality-check.md
@@ -208,6 +208,12 @@ In short: publish fewer flip claims, publish more replicated patterns.
 Revising the four follow-ups at the end of the 05-04 post in light of
 the sweep:
 
+> **Update (2026-05-14):** Added execution-ready conservative long-horizon
+> command blocks (3k and 5k, multi-seed, on-disk DB) to
+> [Issue #867](https://github.com/Dooders/AgentFarm/issues/867), along with
+> a short runbook for aggregation. A completed balanced 5k long-horizon run
+> is also documented in the same issue as a reference analysis pattern.
+
 - The "small seed sweep per profile" item is now done.
 - Longer conservative runs are still worth doing, but the motivation
   changes. It's no longer "does the conservative cluster merge?" —

--- a/scripts/analyze_balanced_long_horizon.py
+++ b/scripts/analyze_balanced_long_horizon.py
@@ -51,7 +51,6 @@ if str(_repo_root) not in sys.path:
 
 from scripts.analyze_stable_profile_seed_sweep import (  # noqa: E402
     PROFILE_COLORS,
-    SLOPE_EPSILON,
     _classify_speciation_direction,
     _discover_runs,
     _extract_run_metrics,

--- a/scripts/analyze_balanced_long_horizon.py
+++ b/scripts/analyze_balanced_long_horizon.py
@@ -1,0 +1,569 @@
+#!/usr/bin/env python3
+"""Aggregate long-horizon balanced-profile runs.
+
+Reads ``stable_balanced/seed_*`` directories produced by
+``scripts/run_balanced_long_horizon_experiment.py`` (same layout as the general
+stable-profile sweep). Emphasises:
+
+- Speciation slope over the **full** logged horizon vs a **late window**
+  (default: last 1000 steps, matching the original short-run length).
+- **Final GMM cluster count** (``n_clusters`` from the last snapshot row).
+
+Outputs (under ``<sweep-dir>/aggregate`` by default)::
+
+    long_horizon_summary.json
+    long_horizon_summary.md
+    speciation_trajectories.png
+    final_n_clusters_bar.png
+
+Usage
+-----
+::
+
+    python scripts/analyze_balanced_long_horizon.py \\
+        --sweep-dir experiments/balanced_long_horizon
+
+    # Compare CI widths to the short balanced cohort in another directory
+    python scripts/analyze_balanced_long_horizon.py \\
+        --sweep-dir experiments/balanced_long_horizon \\
+        --compare-sweep-dir experiments/stable_profile_sweep
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+_repo_root = Path(__file__).resolve().parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from scripts.analyze_stable_profile_seed_sweep import (  # noqa: E402
+    PROFILE_COLORS,
+    SLOPE_EPSILON,
+    _classify_speciation_direction,
+    _discover_runs,
+    _extract_run_metrics,
+    _mean_trajectory,
+    _read_jsonl,
+    _speciation_slope,
+    _summarise,
+)
+
+PROFILE = "balanced"
+
+
+def _late_window_bounds(max_step: float, window_steps: int) -> Tuple[float, float]:
+    """Inclusive step range for the late window (length ``window_steps``)."""
+    if math.isnan(max_step) or window_steps < 1:
+        return float("nan"), float("nan")
+    hi = float(max_step)
+    lo = hi - float(window_steps) + 1.0
+    return lo, hi
+
+
+def _speciation_slope_window(
+    trajectory: List[Dict[str, Any]],
+    step_low: float,
+    step_high: float,
+) -> float:
+    """Slope of linear fit on speciation_index vs step (per 100 steps), windowed."""
+    if math.isnan(step_low) or math.isnan(step_high) or step_high < step_low:
+        return float("nan")
+    pairs = [
+        (float(row["step"]), float(row["speciation_index"]))
+        for row in trajectory
+        if "speciation_index" in row
+        and row.get("speciation_index") is not None
+        and step_low <= float(row["step"]) <= step_high
+    ]
+    if len(pairs) < 2:
+        return float("nan")
+    steps = np.array([p[0] for p in pairs])
+    vals = np.array([p[1] for p in pairs])
+    try:
+        slope = float(np.polyfit(steps, vals, 1)[0]) * 100.0
+    except (np.linalg.LinAlgError, ValueError):
+        slope = float("nan")
+    return slope
+
+
+def _final_n_clusters_from_trajectory(trajectory: List[Dict[str, Any]]) -> Optional[int]:
+    for row in reversed(trajectory):
+        sq = row.get("speciation_quality")
+        if isinstance(sq, dict) and sq.get("n_clusters") is not None:
+            try:
+                return int(sq["n_clusters"])
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def _final_n_clusters_from_lineage(run_dir: Path) -> Optional[int]:
+    path = run_dir / "cluster_lineage.jsonl"
+    if not path.is_file():
+        return None
+    rows = _read_jsonl(path)
+    if not rows:
+        return None
+    max_step = None
+    for row in rows:
+        if "step" not in row:
+            continue
+        try:
+            s = int(row["step"])
+        except (TypeError, ValueError):
+            continue
+        max_step = s if max_step is None else max(max_step, s)
+    if max_step is None:
+        return None
+    return sum(1 for row in rows if row.get("step") == max_step)
+
+
+def _final_n_clusters(run_dir: Path, trajectory: List[Dict[str, Any]]) -> float:
+    nc = _final_n_clusters_from_trajectory(trajectory)
+    if nc is not None:
+        return float(nc)
+    nc2 = _final_n_clusters_from_lineage(run_dir)
+    if nc2 is not None:
+        return float(nc2)
+    return float("nan")
+
+
+def _max_logged_step(trajectory: List[Dict[str, Any]]) -> float:
+    steps = [float(r["step"]) for r in trajectory if "step" in r and r["step"] is not None]
+    return max(steps) if steps else float("nan")
+
+
+def _extract_long_horizon_metrics(
+    run_dir: Path,
+    *,
+    window_steps: int,
+) -> Optional[Dict[str, Any]]:
+    """Per-run metrics including late-window slope and final cluster count."""
+    trajectory = _read_jsonl(run_dir / "intrinsic_gene_trajectory.jsonl")
+    if not trajectory:
+        return None
+
+    base = _extract_run_metrics(run_dir)
+    if base is None:
+        return None
+
+    max_step = _max_logged_step(trajectory)
+    lo, hi = _late_window_bounds(max_step, window_steps)
+    slope_full = _speciation_slope(trajectory)
+    slope_late = _speciation_slope_window(trajectory, lo, hi)
+
+    n_clusters_final = _final_n_clusters(run_dir, trajectory)
+
+    return {
+        **base,
+        "max_logged_step": max_step,
+        "late_window_step_low": lo,
+        "late_window_step_high": hi,
+        "late_window_steps_configured": window_steps,
+        "speciation_slope_full": slope_full,
+        "speciation_slope_late": slope_late,
+        "speciation_direction_full": _classify_speciation_direction(slope_full),
+        "speciation_direction_late": _classify_speciation_direction(slope_late),
+        "n_clusters_final": n_clusters_final,
+        "trajectory": trajectory,
+    }
+
+
+def _scalar_values(runs: Sequence[Dict[str, Any]], key: str) -> List[float]:
+    return [float(r[key]) for r in runs if key in r and not math.isnan(float(r[key]))]
+
+
+def _cluster_frequency_table(values: Sequence[float]) -> Dict[str, Any]:
+    ints = [int(v) for v in values if not math.isnan(v)]
+    if not ints:
+        return {"counts": {}, "mode": None, "n": 0}
+    ctr = Counter(ints)
+    mode_val, mode_count = ctr.most_common(1)[0]
+    return {
+        "counts": {str(k): v for k, v in sorted(ctr.items())},
+        "mode": mode_val,
+        "mode_count": mode_count,
+        "n": len(ints),
+    }
+
+
+def _plot_speciation_trajectories(runs: List[Dict[str, Any]], output: Path) -> Optional[Path]:
+    if not runs:
+        return None
+    color = PROFILE_COLORS.get(PROFILE, "#333333")
+    fig, ax = plt.subplots(figsize=(6.0, 4.0))
+    traces: List[Tuple[np.ndarray, np.ndarray]] = []
+
+    for run in runs:
+        traj = run.get("trajectory", [])
+        spec = [
+            (float(r["step"]), float(r["speciation_index"]))
+            for r in traj
+            if "speciation_index" in r and r["speciation_index"] is not None
+        ]
+        if not spec:
+            continue
+        steps = np.array([s[0] for s in spec])
+        vals = np.array([s[1] for s in spec])
+        ax.plot(steps, vals, color=color, alpha=0.4, lw=1.2)
+        traces.append((steps, vals))
+
+    if len(traces) > 1:
+        mean = _mean_trajectory(traces)
+        if mean is not None:
+            grid, mean_trace = mean
+            ax.plot(grid, mean_trace, color=color, lw=2.5, label="mean")
+
+    ax.set_title(f"{PROFILE} — speciation index (long horizon)", fontsize=12, color=color, fontweight="bold")
+    ax.set_xlabel("step")
+    ax.set_ylabel("speciation index")
+    ax.set_ylim(-0.05, 1.05)
+    ax.grid(alpha=0.25)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    fig.tight_layout()
+    out = output / "speciation_trajectories.png"
+    fig.savefig(out, dpi=140, bbox_inches="tight")
+    plt.close(fig)
+    return out
+
+
+def _plot_n_clusters_bar(runs: List[Dict[str, Any]], output: Path) -> Optional[Path]:
+    if not runs:
+        return None
+    seeds = [int(r["seed"]) for r in runs]
+    ks = [float(r["n_clusters_final"]) for r in runs]
+    if all(math.isnan(k) for k in ks):
+        return None
+
+    fig, ax = plt.subplots(figsize=(7.0, 3.5))
+    x = np.arange(len(seeds))
+    bars = ax.bar(x, [k if not math.isnan(k) else 0.0 for k in ks], color=PROFILE_COLORS.get(PROFILE, "#666"))
+    patch_list = list(bars.patches) if hasattr(bars, "patches") else list(bars)
+    ax.set_xticks(x)
+    ax.set_xticklabels([str(s) for s in seeds])
+    ax.set_xlabel("seed")
+    ax.set_ylabel("final n_clusters (GMM k)")
+    ax.set_title("Final cluster count by seed", fontsize=12)
+    for rect, k in zip(patch_list, ks):
+        if not math.isnan(k):
+            ax.text(
+                rect.get_x() + rect.get_width() / 2,
+                rect.get_height(),
+                str(int(k)),
+                ha="center",
+                va="bottom",
+                fontsize=9,
+            )
+    ax.grid(alpha=0.25, axis="y")
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    fig.tight_layout()
+    out = output / "final_n_clusters_bar.png"
+    fig.savefig(out, dpi=140, bbox_inches="tight")
+    plt.close(fig)
+    return out
+
+
+def _ci_width(agg: Dict[str, Any]) -> float:
+    lo, hi = agg["ci95"]
+    if any(math.isnan(float(x)) for x in (lo, hi)):
+        return float("nan")
+    return float(hi) - float(lo)
+
+
+def _fmt(v: Any, decimals: int = 3) -> str:
+    if v is None:
+        return "n/a"
+    if isinstance(v, float):
+        if math.isnan(v):
+            return "n/a"
+        return f"{v:.{decimals}f}"
+    if isinstance(v, (list, tuple)):
+        return f"[{_fmt(v[0], decimals)}, {_fmt(v[1], decimals)}]"
+    return str(v)
+
+
+def _build_markdown(
+    *,
+    window_steps: int,
+    primary_label: str,
+    compare_label: Optional[str],
+    per_seed: List[Dict[str, Any]],
+    summaries: Dict[str, Dict[str, Any]],
+    cluster_info: Dict[str, Any],
+    compare_summaries: Optional[Dict[str, Dict[str, Any]]],
+    artifacts: Dict[str, Optional[str]],
+) -> str:
+    lines: List[str] = [
+        "# Balanced long-horizon — aggregated results",
+        "",
+        f"**Primary sweep:** `{primary_label}`",
+        "",
+        f"- Late window: **last {window_steps} logged steps** (inclusive end step).",
+        "  If ``num_steps`` ≤ window length, late-window slope equals the full-run slope.",
+        "",
+    ]
+    if compare_label:
+        lines.append(f"- **Comparison sweep:** `{compare_label}` (balanced seeds only).")
+        lines.append("")
+
+    lines += ["## Per-seed metrics", "", "| seed | spec_final | slope_full | slope_late | dir_full | dir_late | n_clusters | pop_final |", "| --- | --- | --- | --- | --- | --- | --- | --- |"]
+    for row in sorted(per_seed, key=lambda r: r["seed"]):
+        lines.append(
+            f"| {row['seed']} "
+            f"| {_fmt(row['speciation_final'])} "
+            f"| {_fmt(row['speciation_slope_full'], 4)} "
+            f"| {_fmt(row['speciation_slope_late'], 4)} "
+            f"| {row['speciation_direction_full']} "
+            f"| {row['speciation_direction_late']} "
+            f"| {_fmt(row['n_clusters_final'], 0)} "
+            f"| {_fmt(row['population_final'], 1)} |"
+        )
+    lines.append("")
+
+    lines += ["## Summaries (primary)", ""]
+    sf = summaries["speciation_final"]
+    slf = summaries["speciation_slope_full"]
+    sll = summaries["speciation_slope_late"]
+    lines += [
+        "| Metric | mean | 95% CI | CI width |",
+        "| --- | --- | --- | --- |",
+        (
+            f"| Final speciation index | {_fmt(sf['mean'])} "
+            f"| {_fmt(sf['ci95'])} | {_fmt(_ci_width(sf), 4)} |"
+        ),
+        (
+            f"| Slope full (/100 steps) | {_fmt(slf['mean'], 4)} "
+            f"| {_fmt(slf['ci95'], 4)} | {_fmt(_ci_width(slf), 4)} |"
+        ),
+        (
+            f"| Slope late (/100 steps) | {_fmt(sll['mean'], 4)} "
+            f"| {_fmt(sll['ci95'], 4)} | {_fmt(_ci_width(sll), 4)} |"
+        ),
+        "",
+    ]
+
+    lines.append("### Final cluster counts (discrete)")
+    lines.append("")
+    lines.append(f"- Frequencies: `{cluster_info.get('counts', {})}`")
+    lines.append(f"- Mode: **{cluster_info.get('mode')}** ({cluster_info.get('mode_count')} / {cluster_info.get('n')} seeds)")
+    lines.append("")
+
+    lines.append("## Interpretation hints (wiki falsifiable targets)")
+    lines.append("")
+    lines.append(
+        "- **Narrowing dispersion:** late-window and full-run CIs on final speciation tighten vs a "
+        "1000-step balanced cohort → consistent with one attractor and slow convergence."
+    )
+    lines.append(
+        "- **Persistent / widening dispersion:** CIs stay wide or grow → consistent with a "
+        "multi-modal regime or unresolved mode-switching at the longer horizon."
+    )
+    lines.append(
+        "- **Cluster counts:** a single dominant ``n_clusters`` across seeds vs a spread indicates "
+        "whether runs agree on structural clustering at the final snapshot."
+    )
+    lines.append("")
+
+    if compare_summaries:
+        lines.append("## Comparison — CI widths (balanced)")
+        lines.append("")
+        psf = summaries["speciation_final"]
+        csf = compare_summaries["speciation_final"]
+        plf = summaries["speciation_slope_late"]
+        clf = compare_summaries["speciation_slope_late"]
+        lines += [
+            "| Metric | primary CI width | compare CI width |",
+            "| --- | --- | --- |",
+            (
+                f"| Final speciation | {_fmt(_ci_width(psf), 4)} "
+                f"| {_fmt(_ci_width(csf), 4)} |"
+            ),
+            (
+                f"| Late-window slope | {_fmt(_ci_width(plf), 4)} "
+                f"| {_fmt(_ci_width(clf), 4)} |"
+            ),
+            "",
+            "*Compare sweep uses the same late-window definition; if its horizon is shorter than "
+            "the window, late slope equals the full-run slope for that directory.*",
+            "",
+        ]
+
+    lines.append("## Artifacts")
+    lines.append("")
+    for name, path in artifacts.items():
+        lines.append(f"- **{name}:** {path or 'not produced'}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _load_balanced_runs(sweep_dir: Path, window_steps: int) -> List[Dict[str, Any]]:
+    run_map = _discover_runs(sweep_dir, [PROFILE])
+    if PROFILE not in run_map:
+        return []
+    runs: List[Dict[str, Any]] = []
+    for seed, run_dir in sorted(run_map[PROFILE], key=lambda t: t[0]):
+        metrics = _extract_long_horizon_metrics(run_dir, window_steps=window_steps)
+        if metrics is None:
+            print(f"  Skipping {run_dir} — trajectory missing or empty.")
+            continue
+        metrics["seed"] = seed
+        runs.append(metrics)
+        print(
+            f"  [balanced] seed={seed}: spec_final={_fmt(metrics['speciation_final'])}, "
+            f"slope_late={_fmt(metrics['speciation_slope_late'], 4)}, "
+            f"n_k={_fmt(metrics['n_clusters_final'], 0)}"
+        )
+    return runs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Aggregate balanced long-horizon intrinsic-evolution runs.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--sweep-dir",
+        type=str,
+        required=True,
+        help="Directory produced by run_balanced_long_horizon_experiment.py.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="Where to write aggregates (default: <sweep-dir>/aggregate).",
+    )
+    parser.add_argument(
+        "--late-window-steps",
+        type=int,
+        default=1000,
+        help="Number of logged steps in the late window (inclusive of final step).",
+    )
+    parser.add_argument(
+        "--compare-sweep-dir",
+        type=str,
+        default=None,
+        help=(
+            "Optional second sweep directory; only ``stable_balanced`` seeds are loaded "
+            "for CI-width comparison (e.g. short 1000-step cohort)."
+        ),
+    )
+    args = parser.parse_args()
+
+    sweep_dir = Path(args.sweep_dir)
+    if not sweep_dir.is_dir():
+        print(f"Sweep directory not found: {sweep_dir}", file=sys.stderr)
+        return 1
+
+    output_dir = Path(args.output_dir) if args.output_dir else sweep_dir / "aggregate"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Loading runs from {sweep_dir} …")
+    runs = _load_balanced_runs(sweep_dir, window_steps=args.late_window_steps)
+    if not runs:
+        print("No balanced runs found.", file=sys.stderr)
+        return 1
+    print(f"Loaded {len(runs)} run(s).")
+
+    summaries = {
+        "speciation_final": _summarise(_scalar_values(runs, "speciation_final")),
+        "speciation_slope_full": _summarise(_scalar_values(runs, "speciation_slope_full")),
+        "speciation_slope_late": _summarise(_scalar_values(runs, "speciation_slope_late")),
+        "population_final": _summarise(_scalar_values(runs, "population_final")),
+    }
+    cluster_info = _cluster_frequency_table([r["n_clusters_final"] for r in runs])
+
+    compare_summaries: Optional[Dict[str, Dict[str, Any]]] = None
+    compare_runs: Optional[List[Dict[str, Any]]] = None
+    if args.compare_sweep_dir:
+        cmp_dir = Path(args.compare_sweep_dir)
+        if cmp_dir.is_dir():
+            print(f"Loading comparison runs from {cmp_dir} …")
+            compare_runs = _load_balanced_runs(cmp_dir, window_steps=args.late_window_steps)
+            if compare_runs:
+                compare_summaries = {
+                    "speciation_final": _summarise(_scalar_values(compare_runs, "speciation_final")),
+                    "speciation_slope_late": _summarise(_scalar_values(compare_runs, "speciation_slope_late")),
+                }
+        else:
+            print(f"Warning: compare sweep dir not found: {cmp_dir}", file=sys.stderr)
+
+    artifacts: Dict[str, Optional[str]] = {}
+    p = _plot_speciation_trajectories(runs, output_dir)
+    artifacts["speciation_trajectories"] = str(p) if p else None
+    p = _plot_n_clusters_bar(runs, output_dir)
+    artifacts["final_n_clusters_bar"] = str(p) if p else None
+
+    per_seed_public = [
+        {
+            "seed": r["seed"],
+            "speciation_final": r["speciation_final"],
+            "speciation_slope_full": r["speciation_slope_full"],
+            "speciation_slope_late": r["speciation_slope_late"],
+            "speciation_direction_full": r["speciation_direction_full"],
+            "speciation_direction_late": r["speciation_direction_late"],
+            "n_clusters_final": r["n_clusters_final"],
+            "population_final": r["population_final"],
+            "max_logged_step": r["max_logged_step"],
+            "late_window_step_low": r["late_window_step_low"],
+            "late_window_step_high": r["late_window_step_high"],
+        }
+        for r in runs
+    ]
+
+    summary_payload: Dict[str, Any] = {
+        "profile": PROFILE,
+        "late_window_steps": args.late_window_steps,
+        "per_seed": per_seed_public,
+        "summaries": summaries,
+        "n_clusters_distribution": cluster_info,
+        "artifacts": artifacts,
+    }
+    if compare_summaries:
+        summary_payload["compare_sweep_dir"] = str(Path(args.compare_sweep_dir).resolve())
+        summary_payload["compare_summaries"] = compare_summaries
+
+    summary_path = output_dir / "long_horizon_summary.json"
+    with summary_path.open("w", encoding="utf-8") as fh:
+        json.dump(summary_payload, fh, indent=2, default=str)
+
+    md = _build_markdown(
+        window_steps=args.late_window_steps,
+        primary_label=str(sweep_dir.resolve()),
+        compare_label=str(Path(args.compare_sweep_dir).resolve()) if args.compare_sweep_dir else None,
+        per_seed=runs,
+        summaries=summaries,
+        cluster_info=cluster_info,
+        compare_summaries=compare_summaries,
+        artifacts=artifacts,
+    )
+    md_path = output_dir / "long_horizon_summary.md"
+    md_path.write_text(md, encoding="utf-8")
+
+    print(f"\nAggregation complete. Outputs in: {output_dir}")
+    print(f"  JSON: {summary_path}")
+    print(f"  MD:   {md_path}")
+    for name, path in artifacts.items():
+        if path:
+            print(f"  {name}: {path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analyze_balanced_long_horizon.py
+++ b/scripts/analyze_balanced_long_horizon.py
@@ -55,6 +55,7 @@ from scripts.analyze_stable_profile_seed_sweep import (  # noqa: E402
     _classify_speciation_direction,
     _discover_runs,
     _extract_run_metrics,
+    _fmt,
     _mean_trajectory,
     _read_jsonl,
     _speciation_slope,
@@ -283,18 +284,6 @@ def _ci_width(agg: Dict[str, Any]) -> float:
     if any(math.isnan(float(x)) for x in (lo, hi)):
         return float("nan")
     return float(hi) - float(lo)
-
-
-def _fmt(v: Any, decimals: int = 3) -> str:
-    if v is None:
-        return "n/a"
-    if isinstance(v, float):
-        if math.isnan(v):
-            return "n/a"
-        return f"{v:.{decimals}f}"
-    if isinstance(v, (list, tuple)):
-        return f"[{_fmt(v[0], decimals)}, {_fmt(v[1], decimals)}]"
-    return str(v)
 
 
 def _build_markdown(

--- a/scripts/analyze_balanced_long_horizon.py
+++ b/scripts/analyze_balanced_long_horizon.py
@@ -386,8 +386,10 @@ def _build_markdown(
                 f"| {_fmt(_ci_width(clf), 4)} |"
             ),
             "",
-            "*Compare sweep uses the same late-window definition; if its horizon is shorter than "
-            "the window, late slope equals the full-run slope for that directory.*",
+            (
+                "*Compare sweep uses the same late-window definition; if its horizon is shorter than "
+                + "the window, late slope equals the full-run slope for that directory.*"
+            ),
             "",
         ]
 

--- a/scripts/run_balanced_long_horizon_experiment.py
+++ b/scripts/run_balanced_long_horizon_experiment.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Long-horizon intrinsic-evolution runs for the balanced stable resource profile.
+
+Implements experiment #1 from the transition-regime wiki: same six seeds as the
+published stable-profile sweep, but many more logged steps after warmup, to see
+whether balanced-profile outcome dispersion narrows (slow convergence) or
+persists (bimodal regime).
+
+Wiki: https://github.com/Dooders/AgentFarm/wiki/Balanced-Profile-as-a-Transition-Regime
+
+Outputs mirror ``run_stable_profile_seed_sweep.py``::
+
+    {output_dir}/stable_balanced/seed_{seed}/
+    {output_dir}/sweep_manifest.json
+
+Analyze with::
+
+    python scripts/analyze_balanced_long_horizon.py --sweep-dir {output_dir}
+
+Example
+-------
+::
+
+    python scripts/run_balanced_long_horizon_experiment.py \\
+        --output-dir experiments/balanced_long_horizon
+
+    python scripts/run_balanced_long_horizon_experiment.py \\
+        --num-steps 3000 --resume \\
+        --output-dir experiments/balanced_long_horizon_3k
+
+    # Opt into :memory: DB (development default); long horizon uses disk DB by default.
+    python scripts/run_balanced_long_horizon_experiment.py --memory-db ...
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_repo_root = Path(__file__).resolve().parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from farm.runners.intrinsic_evolution_experiment import STABLE_SUB_PROFILES  # noqa: E402
+from farm.utils.logging import configure_logging, get_logger  # noqa: E402
+
+from scripts.run_stable_profile_seed_sweep import (  # noqa: E402
+    DEFAULT_SEEDS,
+    _execute_sweep,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Long-horizon seed sweep for the balanced stable profile only "
+            "(IntrinsicEvolutionExperiment). Writes stable_balanced/seed_*/ "
+            "under the output directory."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--environment", type=str, default="development")
+    parser.add_argument(
+        "--seeds",
+        nargs="+",
+        type=int,
+        default=list(DEFAULT_SEEDS),
+        metavar="SEED",
+        help="Seeds to sweep (same list as the published 6-seed sweep).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="experiments/balanced_long_horizon",
+        help="Base directory for all run artifacts.",
+    )
+    parser.add_argument("--num-steps", type=int, default=5000)
+    parser.add_argument("--warmup-steps", type=int, default=200)
+    parser.add_argument("--snapshot-interval", type=int, default=50)
+    parser.add_argument("--mutation-rate", type=float, default=0.15)
+    parser.add_argument("--mutation-scale", type=float, default=0.10)
+    parser.add_argument("--selection-pressure", type=str, default="low")
+    parser.add_argument("--initial-diversity-mutation-rate", type=float, default=1.0)
+    parser.add_argument("--initial-diversity-mutation-scale", type=float, default=0.25)
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="WARNING",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+    )
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Abort the entire sweep on the first run failure.",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help=(
+            "Skip a seed when intrinsic_evolution_metadata.json exists and "
+            "num_steps_completed >= configured num_steps."
+        ),
+    )
+    parser.add_argument(
+        "--memory-db",
+        action="store_true",
+        help=(
+            "Use the environment's default DB mode (:memory: under development). "
+            "Default for this script is disk-backed SQLite to reduce RAM pressure."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the planned seed matrix and resolved overrides, then exit.",
+    )
+    return parser
+
+
+def _print_dry_run_plan(args: argparse.Namespace, output_dir: Path) -> None:
+    profile = "balanced"
+    print("Balanced long-horizon experiment — DRY RUN")
+    print(f"  output_dir : {output_dir}")
+    print(f"  profile    : {profile} (fixed)")
+    print(f"  seeds      : {args.seeds}")
+    print(
+        f"  num_steps  : {args.num_steps} (warmup {args.warmup_steps}, "
+        f"snapshot every {args.snapshot_interval})"
+    )
+    print(f"  resume     : {args.resume}")
+    print(f"  disk_db    : {not args.memory_db}")
+    print(f"  total runs : {len(args.seeds)}")
+    print()
+    print("Resolved sub-profile overrides:")
+    print(f"  stable_{profile}: {STABLE_SUB_PROFILES[profile]}")
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    output_dir = Path(args.output_dir)
+
+    args.profiles = ["balanced"]
+    args.disk_database = not args.memory_db
+
+    if args.dry_run:
+        _print_dry_run_plan(args, output_dir)
+        return 0
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    configure_logging(
+        environment=args.environment,
+        log_dir="logs",
+        log_level=args.log_level,
+        disable_console=False,
+    )
+    logger = get_logger(__name__)
+
+    total = len(args.seeds)
+    print(
+        f"Balanced long-horizon: profile=balanced × {len(args.seeds)} seed(s) = {total} run(s)"
+    )
+    print(f"  seeds       : {args.seeds}")
+    print(f"  num_steps   : {args.num_steps}")
+    print(f"  resume      : {args.resume}")
+    print(f"  disk_db     : {args.disk_database}")
+    print(f"  output      : {output_dir}")
+
+    sweep_records, n_ok, n_fail = _execute_sweep(args, output_dir, logger)
+
+    manifest = {
+        "sweep_type": "balanced_long_horizon",
+        "profiles": args.profiles,
+        "seeds": args.seeds,
+        "num_steps": args.num_steps,
+        "warmup_steps": args.warmup_steps,
+        "snapshot_interval": args.snapshot_interval,
+        "mutation_rate": args.mutation_rate,
+        "mutation_scale": args.mutation_scale,
+        "selection_pressure": args.selection_pressure,
+        "resume": args.resume,
+        "disk_database": args.disk_database,
+        "sub_profile_overrides": {p: STABLE_SUB_PROFILES[p] for p in args.profiles},
+        "runs": sweep_records,
+        "n_ok": n_ok,
+        "n_fail": n_fail,
+    }
+    manifest_path = output_dir / "sweep_manifest.json"
+    with manifest_path.open("w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2, default=str)
+
+    print(f"\nSweep complete: {n_ok}/{total} runs succeeded (ok or skipped).")
+    print(f"Manifest: {manifest_path}")
+    if n_fail:
+        print(f"  {n_fail} run(s) failed — see manifest for details.")
+    print(
+        f"\nNext step: python scripts/analyze_balanced_long_horizon.py "
+        f"--sweep-dir {output_dir}"
+    )
+    return 0 if n_fail == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_stable_profile_seed_sweep.py
+++ b/scripts/run_stable_profile_seed_sweep.py
@@ -49,7 +49,7 @@ import sys
 import time
 import traceback
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 _repo_root = Path(__file__).resolve().parent.parent
 if str(_repo_root) not in sys.path:
@@ -124,6 +124,14 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Abort the entire sweep on the first run failure.",
     )
     parser.add_argument(
+        "--disk-database",
+        action="store_true",
+        help=(
+            "Use disk-backed SQLite instead of :memory: for each run (recommended for long "
+            "horizons). Writes simulation_<id>.db under each seed output directory."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print the planned (profile, seed) matrix and resolved overrides, then exit.",
@@ -136,6 +144,10 @@ def _build_run(profile: str, seed: int, args: argparse.Namespace, run_dir: Path)
     overrides = STABLE_SUB_PROFILES[profile]
 
     base_config = SimulationConfig.from_centralized_config(environment=args.environment)
+    if getattr(args, "disk_database", False):
+        base_config.database.use_in_memory_db = False
+        base_config.database.persist_db_on_completion = True
+
     base_config.initial_diversity = InitialDiversityConfig(
         mode=SeedingMode.INDEPENDENT_MUTATION,
         mutation_rate=args.initial_diversity_mutation_rate,
@@ -183,6 +195,40 @@ def _build_run(profile: str, seed: int, args: argparse.Namespace, run_dir: Path)
     return IntrinsicEvolutionExperiment(base_config, exp_config)
 
 
+def _maybe_resume_skip(
+    run_dir: Path,
+    args: argparse.Namespace,
+    record: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """If ``args.resume`` and prior metadata shows a full run, return a completed record.
+
+    Otherwise return ``None`` so the caller should execute the simulation.
+    """
+    if not getattr(args, "resume", False):
+        return None
+    meta_path = run_dir / "intrinsic_evolution_metadata.json"
+    if not meta_path.is_file():
+        return None
+    try:
+        with meta_path.open(encoding="utf-8") as fh:
+            meta = json.load(fh)
+        completed = meta.get("num_steps_completed")
+        if completed is None:
+            return None
+        if int(completed) < int(args.num_steps):
+            return None
+        record.update(
+            status="skipped_done",
+            elapsed_seconds=0.0,
+            num_steps_completed=int(completed),
+            final_population=meta.get("final_population"),
+            error=None,
+        )
+        return record
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        return None
+
+
 def _run_one(
     profile: str,
     seed: int,
@@ -192,9 +238,6 @@ def _run_one(
 ) -> Tuple[bool, Dict[str, Any]]:
     """Execute a single (profile, seed) experiment and return its manifest record."""
     run_dir = output_dir / f"stable_{profile}" / f"seed_{seed}"
-    run_dir.mkdir(parents=True, exist_ok=True)
-
-    logger.info("seed_sweep_run_start", profile=profile, seed=seed, run_dir=str(run_dir))
 
     record: Dict[str, Any] = {
         "profile": profile,
@@ -206,6 +249,21 @@ def _run_one(
         "final_population": None,
         "error": None,
     }
+
+    skipped = _maybe_resume_skip(run_dir, args, record)
+    if skipped is not None:
+        logger.info(
+            "seed_sweep_run_skipped_resume",
+            profile=profile,
+            seed=seed,
+            run_dir=str(run_dir),
+            num_steps_completed=record.get("num_steps_completed"),
+        )
+        return True, record
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    logger.info("seed_sweep_run_start", profile=profile, seed=seed, run_dir=str(run_dir))
 
     try:
         experiment = _build_run(profile, seed, args, run_dir)
@@ -241,6 +299,7 @@ def _print_dry_run_plan(args: argparse.Namespace, output_dir: Path) -> None:
     print(f"  seeds      : {args.seeds}")
     print(f"  num_steps  : {args.num_steps} (warmup {args.warmup_steps}, "
           f"snapshot/{args.snapshot_interval})")
+    print(f"  disk_db    : {getattr(args, 'disk_database', False)}")
     print(f"  total runs : {len(args.profiles) * len(args.seeds)}")
     print()
     print("Resolved sub-profile overrides:")
@@ -306,6 +365,7 @@ def main() -> int:
         "sweep_type": "stable_profile_seed_sweep",
         "profiles": args.profiles,
         "seeds": args.seeds,
+        "disk_database": getattr(args, "disk_database", False),
         "num_steps": args.num_steps,
         "warmup_steps": args.warmup_steps,
         "snapshot_interval": args.snapshot_interval,

--- a/tests/runners/test_balanced_long_horizon.py
+++ b/tests/runners/test_balanced_long_horizon.py
@@ -1,0 +1,178 @@
+"""Tests for balanced long-horizon experiment scripts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import patch
+
+_repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+from scripts import analyze_balanced_long_horizon as lh_analyze  # noqa: E402
+from scripts import run_balanced_long_horizon_experiment as lh_runner  # noqa: E402
+from scripts import run_stable_profile_seed_sweep as sweep_mod  # noqa: E402
+
+
+def _make_traj_step_spec(step: int, spec: float, n_alive: int = 50) -> Dict[str, Any]:
+    return {"step": step, "speciation_index": spec, "n_alive": n_alive}
+
+
+def _make_snap(step: int, lr: float = 0.01) -> Dict[str, Any]:
+    return {
+        "step": step,
+        "agents": [{"agent_id": "a1", "chromosome": {"learning_rate": lr, "gamma": 0.99}}],
+    }
+
+
+class _NullLogger:
+    def info(self, *_a, **_k):
+        pass
+
+    def error(self, *_a, **_k):
+        pass
+
+
+class TestLateWindowHelpers(unittest.TestCase):
+    def test_late_window_bounds(self):
+        lo, hi = lh_analyze._late_window_bounds(5000.0, 1000)
+        self.assertAlmostEqual(hi, 5000.0)
+        self.assertAlmostEqual(lo, 4001.0)
+
+    def test_slope_full_vs_late_differ(self):
+        # Early decline then rise in late window — full slope differs from late-only.
+        traj = []
+        for s in range(1, 501):
+            traj.append(_make_traj_step_spec(s, 0.8 - 0.0006 * s))
+        for s in range(501, 1001):
+            traj.append(_make_traj_step_spec(s, 0.5 + 0.0005 * (s - 500)))
+        full = lh_analyze._speciation_slope(traj)
+        lo, hi = lh_analyze._late_window_bounds(1000.0, 200)
+        late = lh_analyze._speciation_slope_window(traj, lo, hi)
+        self.assertFalse(math.isnan(full))
+        self.assertFalse(math.isnan(late))
+        self.assertGreater(late, full)
+
+    def test_empty_window_returns_nan_slope(self):
+        traj = [_make_traj_step_spec(1, 0.5), _make_traj_step_spec(2, 0.55)]
+        slope = lh_analyze._speciation_slope_window(traj, 100.0, 200.0)
+        self.assertTrue(math.isnan(slope))
+
+
+class TestFinalNClusters(unittest.TestCase):
+    def test_from_trajectory_last_quality_row(self):
+        traj = [
+            _make_traj_step_spec(0, 0.5),
+            {"step": 50, "speciation_index": 0.6, "speciation_quality": {"n_clusters": 2}},
+            {"step": 100, "speciation_index": 0.7, "speciation_quality": {"n_clusters": 4}},
+            {"step": 150, "speciation_index": 0.71},
+        ]
+        self.assertEqual(lh_analyze._final_n_clusters_from_trajectory(traj), 4)
+
+    def test_lineage_fallback_counts_last_step_rows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp)
+            lineage = run_dir / "cluster_lineage.jsonl"
+            rows = [
+                {"step": 100, "cluster_id": 1},
+                {"step": 100, "cluster_id": 2},
+                {"step": 50, "cluster_id": 0},
+            ]
+            with lineage.open("w", encoding="utf-8") as fh:
+                for r in rows:
+                    fh.write(json.dumps(r) + "\n")
+            self.assertEqual(lh_analyze._final_n_clusters_from_lineage(run_dir), 2)
+
+
+class TestLongHorizonDryRun(unittest.TestCase):
+    def test_dry_run_exits_zero(self):
+        argv = [
+            "run_balanced_long_horizon_experiment.py",
+            "--dry-run",
+            "--output-dir",
+            "/tmp/should_not_create_long_horizon_test",
+        ]
+        with patch.object(sys, "argv", argv):
+            rc = lh_runner.main()
+        self.assertEqual(rc, 0)
+
+
+class TestResumeIntegration(unittest.TestCase):
+    def test_resume_skips_when_metadata_complete(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            run_dir = out / "stable_balanced" / "seed_42"
+            run_dir.mkdir(parents=True)
+            meta = {
+                "num_steps_completed": 5000,
+                "num_steps_configured": 5000,
+                "final_population": 99,
+            }
+            with (run_dir / "intrinsic_evolution_metadata.json").open("w", encoding="utf-8") as fh:
+                json.dump(meta, fh)
+
+            args = argparse.Namespace(
+                resume=True,
+                num_steps=5000,
+                profiles=["balanced"],
+                seeds=[42],
+                fail_fast=False,
+                environment="development",
+                warmup_steps=200,
+                snapshot_interval=50,
+                mutation_rate=0.15,
+                mutation_scale=0.10,
+                selection_pressure="low",
+                initial_diversity_mutation_rate=1.0,
+                initial_diversity_mutation_scale=0.25,
+            )
+
+            ok, record = sweep_mod._run_one("balanced", 42, args, out, _NullLogger())
+            self.assertTrue(ok)
+            self.assertEqual(record["status"], "skipped_done")
+            self.assertEqual(record["num_steps_completed"], 5000)
+
+
+class TestExtractLongHorizonMetrics(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_extract_combines_slope_and_clusters(self):
+        run_dir = self.base / "stable_balanced" / "seed_7"
+        run_dir.mkdir(parents=True)
+        traj = []
+        for i in range(21):
+            step = i * 50
+            row = _make_traj_step_spec(step, 0.5 + 0.001 * i)
+            if step % 100 == 0:
+                row = dict(row)
+                row["speciation_quality"] = {"n_clusters": 3}
+            traj.append(row)
+        snaps = [_make_snap(0), _make_snap(1000)]
+        with (run_dir / "intrinsic_gene_trajectory.jsonl").open("w", encoding="utf-8") as fh:
+            for r in traj:
+                fh.write(json.dumps(r) + "\n")
+        with (run_dir / "intrinsic_gene_snapshots.jsonl").open("w", encoding="utf-8") as fh:
+            for r in snaps:
+                fh.write(json.dumps(r) + "\n")
+
+        m = lh_analyze._extract_long_horizon_metrics(run_dir, window_steps=500)
+        self.assertIsNotNone(m)
+        self.assertFalse(math.isnan(m["speciation_slope_late"]))
+        self.assertEqual(m["n_clusters_final"], 3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces a new script for running long-horizon experiments on the balanced stable resource profile and enhances the experiment management system with improved resume and database options. It also adds comprehensive tests for the new long-horizon workflow. The main themes are new experiment capabilities, improved experiment management, and expanded test coverage.

**New experiment script and workflow:**

* Added `scripts/run_balanced_long_horizon_experiment.py`, a script to run long-horizon intrinsic-evolution experiments for the balanced profile, supporting disk-backed databases, resume, and dry-run modes. This script mirrors the interface and output structure of the stable profile sweep, enabling consistent analysis workflows.

**Experiment management improvements:**

* Added a `--disk-database` option to `scripts/run_stable_profile_seed_sweep.py` to allow using disk-backed SQLite databases instead of in-memory databases, which is recommended for long-horizon runs. The configuration is respected throughout the run setup and dry-run output. [[1]](diffhunk://#diff-0c1a489d433979494f32421f58b59f1ea8b7da23264a71a83cebf915b9c95187R126-R133) [[2]](diffhunk://#diff-0c1a489d433979494f32421f58b59f1ea8b7da23264a71a83cebf915b9c95187R147-R150) [[3]](diffhunk://#diff-0c1a489d433979494f32421f58b59f1ea8b7da23264a71a83cebf915b9c95187R302) [[4]](diffhunk://#diff-0c1a489d433979494f32421f58b59f1ea8b7da23264a71a83cebf915b9c95187R368)
* Implemented a `_maybe_resume_skip` helper in `scripts/run_stable_profile_seed_sweep.py` to skip completed runs when the `--resume` flag is set and metadata indicates the run is already finished. This avoids redundant computation and supports robust experiment resumption. [[1]](diffhunk://#diff-0c1a489d433979494f32421f58b59f1ea8b7da23264a71a83cebf915b9c95187R198-R231) [[2]](diffhunk://#diff-0c1a489d433979494f32421f58b59f1ea8b7da23264a71a83cebf915b9c95187L195-L197) [[3]](diffhunk://#diff-0c1a489d433979494f32421f58b59f1ea8b7da23264a71a83cebf915b9c95187R253-R267)

**Documentation updates:**

* Updated the developer log (`docs/devlog/2026-05-12-seed-sweep-reality-check.md`) to reference the new long-horizon experiment script, runbook, and analysis pattern, providing context and usage guidance.

**Test coverage:**

* Added `tests/runners/test_balanced_long_horizon.py` with unit and integration tests for the new long-horizon script, resume logic, and analysis helpers. This ensures correctness of experiment execution and result extraction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new long-horizon runner/analyzer scripts and changes sweep execution behavior via `--resume` and `--disk-database`, which could affect experiment reproducibility and resource usage if misconfigured.
> 
> **Overview**
> Adds a new **balanced-only long-horizon experiment workflow**: `run_balanced_long_horizon_experiment.py` runs the standard six-seed sweep out to longer horizons (default 5k) with resume/dry-run support and disk-backed DB by default, and `analyze_balanced_long_horizon.py` aggregates these runs with *full vs late-window* speciation slopes plus final `n_clusters`, emitting JSON/Markdown summaries and plots (with optional CI-width comparison to another sweep).
> 
> Enhances `run_stable_profile_seed_sweep.py` with `--disk-database` to persist per-seed SQLite DBs and a resume mechanism that skips seeds already complete based on `intrinsic_evolution_metadata.json`, and records the disk-DB setting in the sweep manifest.
> 
> Updates the devlog to reference the new long-horizon runbook, and adds `tests/runners/test_balanced_long_horizon.py` covering late-window math, cluster-count extraction, dry-run exit behavior, and resume-skipping integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c0a3423aebc08d200676ec1688997fdd109c4ad. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->