### PR TITLE
Add crossover rerun experiment and comparison scripts

### DIFF
--- a/docs/experiments/intrinsic_evolution/crossover_rerun.md
+++ b/docs/experiments/intrinsic_evolution/crossover_rerun.md
@@ -1,0 +1,129 @@
+# Crossover Rerun — Intrinsic Evolution
+
+This experiment re-runs the May-12 [stable-profile seed sweep](../../devlog/2026-05-12-seed-sweep-reality-check.md)
+with intrinsic-evolution **crossover enabled**, then compares the result
+against the no-crossover baseline paired by seed.
+
+Related issues / context:
+
+- Issue [#845](https://github.com/Dooders/AgentFarm/issues/845) — buffered + crossover follow-up
+- Issue [#867](https://github.com/Dooders/AgentFarm/issues/867) — long-horizon conservative follow-up (out of scope here)
+- Devlog: [When one seed disagrees with six](../../devlog/2026-05-12-seed-sweep-reality-check.md)
+- Devlog: [Does the resource buffer pick the genes?](../../devlog/2026-05-04-resource-buffer-shapes-intrinsic-evolution.md)
+
+## Hypothesis
+
+The 6-seed sweep established that all three stable profiles
+(`conservative`, `balanced`, `buffered`) show diverging speciation
+trajectories under the current setup, with mean final speciation index
+~0.59–0.75. That divergence was generated **without** gene flow: the
+intrinsic-evolution policy ran with `crossover_enabled=False`, so children
+inherited the parent chromosome modulo mutation.
+
+If gene flow is the missing homogenizing force, enabling crossover should
+**collapse** the rising speciation index. If the divergence is structural
+(carried by speciation/spatial selection rather than weak mixing), gene
+flow may shift gene-level magnitudes but should leave the speciation
+direction alone.
+
+## Design
+
+Two crossover arms × three profiles × six seeds = **36 runs**, paired
+by seed against the existing baseline at
+`experiments/stable_profile_sweep/stable_{profile}/seed_{seed}/`.
+
+### Arms
+
+| Arm | `crossover_mode` | `blend_alpha` | Notes |
+| --- | --- | --- | --- |
+| `uniform` | `uniform` | n/a | per-gene coin flip from either parent; standard "recombination" interpretation |
+| `blend`   | `blend`   | 0.5 | BLX-α continuous interpolation; strongest continuous-gene mixer |
+
+### Profiles
+
+`conservative` / `balanced` / `buffered` from
+[`STABLE_SUB_PROFILES`](../../../farm/runners/intrinsic_evolution_experiment.py).
+Resource-buffer settings are unchanged from the baseline sweep.
+
+### What was held fixed (matches baseline)
+
+| Setting | Value |
+| --- | --- |
+| Seeds | 42, 7, 19, 101, 137, 256 |
+| Steps logged | 1000 |
+| Warmup steps | 200 |
+| Snapshot interval | 50 |
+| Mutation | gaussian, rate 0.15, scale 0.10, reflect boundary |
+| Selection pressure | low |
+| Co-parent strategy | nearest_alive_same_type |
+| Co-parent max radius | unbounded |
+| Cross-type pollination | off |
+| Speciation tracking | GMM, max_k=4 |
+| Initial diversity | INDEPENDENT_MUTATION, rate 1.0, scale 0.25 |
+
+## Commands
+
+### 1. Run both arms across all profiles and seeds
+
+```bash
+python scripts/run_crossover_rerun.py \
+    --output-dir experiments/crossover_rerun
+```
+
+This invokes [`scripts/run_stable_profile_seed_sweep.py`](../../../scripts/run_stable_profile_seed_sweep.py)
+in-process for each arm. Each arm writes to
+`experiments/crossover_rerun/{arm}/stable_{profile}/seed_{seed}/` and a
+top-level `rerun_manifest.json`. By default, `analyze_stable_profile_seed_sweep.py`
+is then invoked on each arm directory to produce per-arm aggregates.
+
+For dry-run inspection only:
+
+```bash
+python scripts/run_crossover_rerun.py --output-dir experiments/crossover_rerun --dry-run
+```
+
+### 2. Paired-seed comparison vs baseline
+
+```bash
+python scripts/compare_crossover_arms.py \
+    --baseline-dir experiments/stable_profile_sweep \
+    --treatment-dir experiments/crossover_rerun/uniform \
+    --treatment-dir experiments/crossover_rerun/blend \
+    --arm-labels uniform blend \
+    --output-dir experiments/crossover_rerun/aggregate
+```
+
+## Outputs
+
+The comparison analyzer writes the following to `--output-dir`:
+
+- `crossover_rerun_summary.md` — verdict-per-profile narrative ("Does
+  gene flow collapse the rising speciation pattern?") plus paired-delta
+  and gene-shift tables. Verdict thresholds: paired-delta 95% CI excludes
+  zero **and** ≥75% within-profile sign agreement (matches
+  `SIGN_AGREEMENT_THRESHOLD` in
+  [`scripts/analyze_stable_profile_seed_sweep.py`](../../../scripts/analyze_stable_profile_seed_sweep.py)).
+- `crossover_rerun_summary.json` — machine-readable form of the above.
+- `speciation_trajectories_with_arms.png` — speciation traces per
+  profile, baseline + each arm (mean ribbon + per-seed lines).
+- `paired_delta_heatmap.png` — rows = (profile × arm), columns = key
+  metrics (`speciation_final`, `speciation_slope`, lineage cluster count
+  and churn, plus convergent and direction-flip genes). Asterisk
+  annotations mark cells where the paired delta is robust.
+- `lineage_cluster_count.png` — mean cluster count per step, one curve
+  per arm, per profile.
+
+## Out of scope
+
+- Long-horizon (3k / 5k step) runs — see Issue [#867](https://github.com/Dooders/AgentFarm/issues/867).
+- The `stress` / `legacy` initial-conditions profiles — see Issue [#846](https://github.com/Dooders/AgentFarm/issues/846).
+- Tuning `coparent_max_radius` and `allow_cross_type_pollination`. Both
+  stay at the policy defaults so the only varied axes are
+  `crossover_mode` and the existing `stable` sub-profile.
+
+## Results
+
+To be filled in once the sweep completes. Pointers to the generated
+artifacts will be added under
+`experiments/crossover_rerun/aggregate/` and a devlog follow-up will be
+linked here.

--- a/scripts/compare_crossover_arms.py
+++ b/scripts/compare_crossover_arms.py
@@ -560,8 +560,10 @@ def _build_markdown(
     lines += [
         "# Crossover rerun — paired-seed comparison",
         "",
-        "Compares crossover-enabled arms against the no-crossover baseline "
-        "across the three stable resource profiles, paired by seed.",
+        (
+            "Compares crossover-enabled arms against the no-crossover baseline "
+            + "across the three stable resource profiles, paired by seed."
+        ),
         "",
         "## Verdict: does gene flow collapse the rising speciation pattern?",
         "",

--- a/scripts/compare_crossover_arms.py
+++ b/scripts/compare_crossover_arms.py
@@ -1,0 +1,760 @@
+#!/usr/bin/env python3
+"""Compare crossover-rerun arms against the no-crossover baseline sweep.
+
+Reads per-seed run dirs from a baseline sweep and one or more crossover-arm
+sweeps (both produced by ``run_stable_profile_seed_sweep.py``) and emits a
+paired-seed comparison answering: "Does gene flow collapse the rising
+speciation pattern?"
+
+Outputs
+-------
+- ``crossover_rerun_summary.json`` — machine-readable aggregates and per-arm
+  paired-delta statistics
+- ``crossover_rerun_summary.md`` — verdict-per-profile markdown report
+- ``speciation_trajectories_with_arms.png`` — speciation traces per profile,
+  baseline + each arm
+- ``paired_delta_heatmap.png`` — mean paired delta for key metrics per
+  (profile, arm)
+- ``lineage_cluster_count.png`` — mean cluster-count trajectory per profile,
+  one curve per arm
+
+Usage
+-----
+::
+
+    python scripts/compare_crossover_arms.py \\
+        --baseline-dir experiments/stable_profile_sweep \\
+        --treatment-dir experiments/crossover_rerun/uniform \\
+        --treatment-dir experiments/crossover_rerun/blend \\
+        --arm-labels uniform blend \\
+        --output-dir experiments/crossover_rerun/aggregate
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+_repo_root = Path(__file__).resolve().parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from scripts.analyze_stable_profile_seed_sweep import (  # noqa: E402
+    CONVERGENT_GENES,
+    PROFILE_COLORS,
+    PROFILE_ORDER,
+    SIGN_AGREEMENT_THRESHOLD,
+    _classify_speciation_direction,
+    _discover_runs,
+    _extract_run_metrics,
+    _mean,
+    _mean_trajectory,
+    _sign_agreement,
+    _t_ci,
+    _variance,
+)
+
+# ── Lineage-file parsing ──────────────────────────────────────────────────────
+
+CLUSTER_LINEAGE_FILENAME = "cluster_lineage.jsonl"
+
+
+def _read_jsonl(path: Path) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    if not path.is_file():
+        return rows
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    return rows
+
+
+def _lineage_metrics(run_dir: Path) -> Dict[str, Any]:
+    """Per-run lineage summary from ``cluster_lineage.jsonl``.
+
+    Returns
+    -------
+    dict with keys:
+      - ``cluster_count_trace``: list of (step, k) tuples (k = #clusters at step)
+      - ``mean_k``: mean cluster count across clustering steps (NaN if absent)
+      - ``churn_rate``: mean per-step fraction of cluster IDs at step t that
+        do NOT survive to step t+1.  In [0, 1].  NaN if fewer than two
+        clustering steps were recorded.
+    """
+    rows = _read_jsonl(run_dir / CLUSTER_LINEAGE_FILENAME)
+    if not rows:
+        return {
+            "cluster_count_trace": [],
+            "mean_k": float("nan"),
+            "churn_rate": float("nan"),
+        }
+
+    steps_to_ids: Dict[int, set] = defaultdict(set)
+    for r in rows:
+        try:
+            step = int(r["step"])
+            cid = r["cluster_id"]
+        except (KeyError, TypeError, ValueError):
+            continue
+        steps_to_ids[step].add(cid)
+
+    sorted_steps = sorted(steps_to_ids.keys())
+    trace = [(s, len(steps_to_ids[s])) for s in sorted_steps]
+    mean_k = _mean([k for _, k in trace]) if trace else float("nan")
+
+    if len(sorted_steps) < 2:
+        churn = float("nan")
+    else:
+        churns: List[float] = []
+        for s_prev, s_next in zip(sorted_steps, sorted_steps[1:]):
+            prev = steps_to_ids[s_prev]
+            nxt = steps_to_ids[s_next]
+            if not prev:
+                continue
+            died = prev - nxt
+            churns.append(len(died) / len(prev))
+        churn = _mean(churns) if churns else float("nan")
+
+    return {
+        "cluster_count_trace": trace,
+        "mean_k": mean_k,
+        "churn_rate": churn,
+    }
+
+
+# ── Paired-delta stats ────────────────────────────────────────────────────────
+
+
+def _paired_delta_summary(deltas: Sequence[float]) -> Dict[str, Any]:
+    """Mean / variance / 95% CI / sign-agreement for paired deltas (NaNs filtered)."""
+    clean = [d for d in deltas if not (isinstance(d, float) and math.isnan(d))]
+    if not clean:
+        return {
+            "mean_delta": float("nan"),
+            "variance": float("nan"),
+            "ci95": [float("nan"), float("nan")],
+            "sign_agreement": float("nan"),
+            "n": 0,
+        }
+    lo, hi = _t_ci(clean)
+    return {
+        "mean_delta": _mean(clean),
+        "variance": _variance(clean),
+        "ci95": [lo, hi],
+        "sign_agreement": _sign_agreement(clean),
+        "n": len(clean),
+    }
+
+
+def _ci_excludes_zero(ci: Sequence[float]) -> bool:
+    """True iff a two-sided CI is finite and does not straddle zero."""
+    if len(ci) != 2:
+        return False
+    lo, hi = ci
+    if math.isnan(lo) or math.isnan(hi):
+        return False
+    return (lo > 0 and hi > 0) or (lo < 0 and hi < 0)
+
+
+def _classify_collapse_verdict(
+    spec_final_delta: Dict[str, Any],
+    spec_slope_delta: Dict[str, Any],
+) -> str:
+    """One-line verdict for "does gene flow collapse the rising speciation pattern?".
+
+    "Collapse" means the speciation trajectory under the treatment is
+    *lower* and/or *less rising* than the baseline (i.e. negative paired
+    deltas with both robustness criteria satisfied).
+    """
+    robust = (
+        spec_final_delta.get("sign_agreement", 0.0) >= SIGN_AGREEMENT_THRESHOLD
+        and _ci_excludes_zero(spec_final_delta.get("ci95", []))
+    ) or (
+        spec_slope_delta.get("sign_agreement", 0.0) >= SIGN_AGREEMENT_THRESHOLD
+        and _ci_excludes_zero(spec_slope_delta.get("ci95", []))
+    )
+    if not robust:
+        return "no robust effect"
+    sf_mean = spec_final_delta.get("mean_delta", 0.0)
+    sl_mean = spec_slope_delta.get("mean_delta", 0.0)
+    if sf_mean < 0 or sl_mean < 0:
+        return "robustly collapses"
+    return "robustly amplifies"
+
+
+# ── Per-run data extraction ───────────────────────────────────────────────────
+
+
+def _extract_full_run(run_dir: Path) -> Optional[Dict[str, Any]]:
+    """Combine baseline-style metrics with lineage metrics for one run."""
+    metrics = _extract_run_metrics(run_dir)
+    if metrics is None:
+        return None
+    metrics.update({"lineage": _lineage_metrics(run_dir)})
+    return metrics
+
+
+def _load_arm(sweep_dir: Path, profiles: Sequence[str]) -> Dict[str, Dict[int, Dict[str, Any]]]:
+    """Load per-(profile, seed) run metrics for one sweep directory.
+
+    Returns a nested dict ``{profile: {seed: metrics}}``.
+    """
+    out: Dict[str, Dict[int, Dict[str, Any]]] = {}
+    run_map = _discover_runs(sweep_dir, list(profiles))
+    for profile, seed_dirs in run_map.items():
+        out[profile] = {}
+        for seed, run_dir in seed_dirs:
+            metrics = _extract_full_run(run_dir)
+            if metrics is None:
+                continue
+            out[profile][seed] = metrics
+    return out
+
+
+# ── Paired aggregation ────────────────────────────────────────────────────────
+
+
+METRIC_KEYS: List[str] = [
+    "speciation_final",
+    "speciation_slope",
+    "speciation_mean",
+    "population_mean",
+]
+LINEAGE_KEYS: List[str] = ["mean_k", "churn_rate"]
+
+
+def _paired_metric_deltas(
+    baseline_runs: Dict[int, Dict[str, Any]],
+    treatment_runs: Dict[int, Dict[str, Any]],
+) -> Dict[str, Dict[str, Any]]:
+    """Compute paired-seed deltas for every metric key in ``METRIC_KEYS``,
+    plus every gene appearing in both baseline and treatment, plus lineage
+    metrics.  Each delta is ``treatment - baseline``.
+    """
+    paired_seeds = sorted(set(baseline_runs.keys()) & set(treatment_runs.keys()))
+    out: Dict[str, Dict[str, Any]] = {}
+
+    for key in METRIC_KEYS:
+        deltas = []
+        for seed in paired_seeds:
+            b = baseline_runs[seed].get(key)
+            t = treatment_runs[seed].get(key)
+            if b is None or t is None:
+                continue
+            if math.isnan(b) or math.isnan(t):
+                continue
+            deltas.append(t - b)
+        out[key] = _paired_delta_summary(deltas)
+
+    for lk in LINEAGE_KEYS:
+        deltas = []
+        for seed in paired_seeds:
+            b = baseline_runs[seed].get("lineage", {}).get(lk)
+            t = treatment_runs[seed].get("lineage", {}).get(lk)
+            if b is None or t is None:
+                continue
+            if math.isnan(b) or math.isnan(t):
+                continue
+            deltas.append(t - b)
+        out[f"lineage.{lk}"] = _paired_delta_summary(deltas)
+
+    gene_names: set[str] = set()
+    for seed in paired_seeds:
+        gene_names.update(baseline_runs[seed].get("gene_pct_shift", {}).keys())
+        gene_names.update(treatment_runs[seed].get("gene_pct_shift", {}).keys())
+    for gene in sorted(gene_names):
+        deltas = []
+        for seed in paired_seeds:
+            b = baseline_runs[seed].get("gene_pct_shift", {}).get(gene)
+            t = treatment_runs[seed].get("gene_pct_shift", {}).get(gene)
+            if b is None or t is None:
+                continue
+            if math.isnan(b) or math.isnan(t):
+                continue
+            deltas.append(t - b)
+        if deltas:
+            out[f"gene.{gene}"] = _paired_delta_summary(deltas)
+
+    out["_paired_seeds"] = paired_seeds  # type: ignore[assignment]
+    return out
+
+
+# ── Plotting ──────────────────────────────────────────────────────────────────
+
+
+def _arm_color(label: str, idx: int) -> str:
+    palette = ["#1f77b4", "#d62728", "#9467bd", "#8c564b", "#e377c2"]
+    return palette[idx % len(palette)]
+
+
+def _plot_speciation_with_arms(
+    baseline: Dict[str, Dict[int, Dict[str, Any]]],
+    arms: Dict[str, Dict[str, Dict[int, Dict[str, Any]]]],
+    output: Path,
+) -> Optional[Path]:
+    profiles = [p for p in PROFILE_ORDER if p in baseline and baseline[p]]
+    if not profiles:
+        return None
+
+    arm_labels = list(arms.keys())
+    fig, axes = plt.subplots(
+        1, len(profiles), figsize=(5.2 * len(profiles), 4.2), sharey=True
+    )
+    if len(profiles) == 1:
+        axes = [axes]
+
+    def _trace_pairs(runs: Dict[int, Dict[str, Any]]) -> List[Tuple[np.ndarray, np.ndarray]]:
+        traces: List[Tuple[np.ndarray, np.ndarray]] = []
+        for run in runs.values():
+            traj = run.get("trajectory", [])
+            spec = [
+                (float(r["step"]), float(r["speciation_index"]))
+                for r in traj
+                if r.get("speciation_index") is not None
+            ]
+            if not spec:
+                continue
+            traces.append(
+                (np.array([s[0] for s in spec]), np.array([s[1] for s in spec]))
+            )
+        return traces
+
+    for ax, profile in zip(axes, profiles):
+        # baseline
+        base_color = PROFILE_COLORS.get(profile, "#333333")
+        base_traces = _trace_pairs(baseline.get(profile, {}))
+        for s, v in base_traces:
+            ax.plot(s, v, color=base_color, alpha=0.18, lw=1.0)
+        if len(base_traces) > 1:
+            m = _mean_trajectory(base_traces)
+            if m is not None:
+                grid, vals = m
+                ax.plot(grid, vals, color=base_color, lw=2.4, label="baseline")
+
+        for idx, label in enumerate(arm_labels):
+            color = _arm_color(label, idx)
+            arm_traces = _trace_pairs(arms[label].get(profile, {}))
+            for s, v in arm_traces:
+                ax.plot(s, v, color=color, alpha=0.18, lw=1.0)
+            if len(arm_traces) > 1:
+                m = _mean_trajectory(arm_traces)
+                if m is not None:
+                    grid, vals = m
+                    ax.plot(grid, vals, color=color, lw=2.4, label=label)
+
+        ax.set_title(profile, fontsize=12, fontweight="bold", color=base_color)
+        ax.set_xlabel("step")
+        ax.set_ylim(-0.05, 1.05)
+        ax.grid(alpha=0.25)
+        ax.spines["top"].set_visible(False)
+        ax.spines["right"].set_visible(False)
+        ax.legend(fontsize=8, loc="lower right")
+
+    axes[0].set_ylabel("speciation index")
+    fig.suptitle(
+        "Speciation Index — baseline vs crossover arms (paired seeds)", fontsize=13
+    )
+    fig.tight_layout()
+    out = output / "speciation_trajectories_with_arms.png"
+    fig.savefig(out, dpi=140, bbox_inches="tight")
+    plt.close(fig)
+    return out
+
+
+def _plot_paired_delta_heatmap(
+    deltas: Dict[str, Dict[str, Dict[str, Dict[str, Any]]]],
+    output: Path,
+) -> Optional[Path]:
+    """Heatmap rows = (profile, arm), cols = metric → mean delta."""
+    # Build (profile, arm) row keys
+    rows: List[Tuple[str, str]] = []
+    for profile in PROFILE_ORDER:
+        if profile not in deltas:
+            continue
+        for arm in deltas[profile]:
+            rows.append((profile, arm))
+    if not rows:
+        return None
+
+    headline_keys = [
+        "speciation_final",
+        "speciation_slope",
+        "speciation_mean",
+        "population_mean",
+        "lineage.mean_k",
+        "lineage.churn_rate",
+    ]
+    gene_keys = [
+        f"gene.{g}" for g in CONVERGENT_GENES + ["learning_rate", "ensemble_size"]
+    ]
+    all_keys = headline_keys + gene_keys
+
+    # Restrict to keys present in at least one cell
+    present_keys: List[str] = []
+    for key in all_keys:
+        for profile, arm in rows:
+            d = deltas[profile][arm].get(key, {})
+            if not math.isnan(d.get("mean_delta", float("nan"))):
+                present_keys.append(key)
+                break
+
+    if not present_keys:
+        return None
+
+    matrix = np.full((len(rows), len(present_keys)), float("nan"))
+    robust_mask = np.zeros_like(matrix, dtype=bool)
+    for i, (profile, arm) in enumerate(rows):
+        for j, key in enumerate(present_keys):
+            d = deltas[profile][arm].get(key, {})
+            mean = d.get("mean_delta", float("nan"))
+            matrix[i, j] = mean
+            if (
+                d.get("sign_agreement", 0.0) >= SIGN_AGREEMENT_THRESHOLD
+                and _ci_excludes_zero(d.get("ci95", []))
+            ):
+                robust_mask[i, j] = True
+
+    vmax = float(np.nanmax(np.abs(matrix))) if not np.all(np.isnan(matrix)) else 1.0
+    fig, ax = plt.subplots(
+        figsize=(0.65 * len(present_keys) + 2.5, 0.55 * len(rows) + 1.5)
+    )
+    im = ax.imshow(
+        matrix, aspect="auto", cmap="RdBu_r", vmin=-vmax, vmax=vmax, interpolation="nearest"
+    )
+    row_labels = [f"{p} / {a}" for p, a in rows]
+    col_labels = [k.replace("gene.", "").replace("lineage.", "L:") for k in present_keys]
+    ax.set_xticks(range(len(present_keys)))
+    ax.set_xticklabels(col_labels, rotation=45, ha="right", fontsize=9)
+    ax.set_yticks(range(len(rows)))
+    ax.set_yticklabels(row_labels, fontsize=9)
+    ax.set_title("Paired-seed mean delta (treatment − baseline). * = robust", fontsize=12)
+
+    for i in range(len(rows)):
+        for j in range(len(present_keys)):
+            v = matrix[i, j]
+            if math.isnan(v):
+                continue
+            star = "*" if robust_mask[i, j] else ""
+            ax.text(
+                j, i, f"{v:+.2f}{star}",
+                ha="center", va="center", fontsize=7,
+                color="black" if abs(v) < 0.5 * vmax else "white",
+            )
+
+    plt.colorbar(im, ax=ax, label="mean delta", shrink=0.8)
+    fig.tight_layout()
+    out = output / "paired_delta_heatmap.png"
+    fig.savefig(out, dpi=140, bbox_inches="tight")
+    plt.close(fig)
+    return out
+
+
+def _plot_lineage_cluster_count(
+    baseline: Dict[str, Dict[int, Dict[str, Any]]],
+    arms: Dict[str, Dict[str, Dict[int, Dict[str, Any]]]],
+    output: Path,
+) -> Optional[Path]:
+    profiles = [p for p in PROFILE_ORDER if p in baseline]
+    if not profiles:
+        return None
+
+    arm_labels = list(arms.keys())
+    fig, axes = plt.subplots(
+        1, len(profiles), figsize=(5.0 * len(profiles), 3.8), sharey=True
+    )
+    if len(profiles) == 1:
+        axes = [axes]
+
+    def _traces(runs: Dict[int, Dict[str, Any]]) -> List[Tuple[np.ndarray, np.ndarray]]:
+        out: List[Tuple[np.ndarray, np.ndarray]] = []
+        for r in runs.values():
+            trace = r.get("lineage", {}).get("cluster_count_trace", [])
+            if not trace:
+                continue
+            steps = np.array([t[0] for t in trace], dtype=float)
+            ks = np.array([t[1] for t in trace], dtype=float)
+            out.append((steps, ks))
+        return out
+
+    rendered_any = False
+    for ax, profile in zip(axes, profiles):
+        base_color = PROFILE_COLORS.get(profile, "#333333")
+        bt = _traces(baseline.get(profile, {}))
+        if len(bt) > 1:
+            m = _mean_trajectory(bt)
+            if m is not None:
+                grid, vals = m
+                ax.plot(grid, vals, color=base_color, lw=2.2, label="baseline")
+                rendered_any = True
+
+        for idx, label in enumerate(arm_labels):
+            ts = _traces(arms[label].get(profile, {}))
+            if len(ts) > 1:
+                m = _mean_trajectory(ts)
+                if m is not None:
+                    grid, vals = m
+                    ax.plot(grid, vals, color=_arm_color(label, idx), lw=2.2, label=label)
+                    rendered_any = True
+
+        ax.set_title(profile, fontsize=12, color=base_color, fontweight="bold")
+        ax.set_xlabel("step")
+        ax.grid(alpha=0.25)
+        ax.spines["top"].set_visible(False)
+        ax.spines["right"].set_visible(False)
+        ax.legend(fontsize=8, loc="upper right")
+
+    if not rendered_any:
+        plt.close(fig)
+        return None
+
+    axes[0].set_ylabel("# clusters (mean across seeds)")
+    fig.suptitle("Cluster count per step — baseline vs crossover arms", fontsize=13)
+    fig.tight_layout()
+    out = output / "lineage_cluster_count.png"
+    fig.savefig(out, dpi=140, bbox_inches="tight")
+    plt.close(fig)
+    return out
+
+
+# ── Markdown ─────────────────────────────────────────────────────────────────
+
+
+def _fmt(v: Any, decimals: int = 3) -> str:
+    if v is None:
+        return "n/a"
+    if isinstance(v, float):
+        if math.isnan(v):
+            return "n/a"
+        return f"{v:.{decimals}f}"
+    if isinstance(v, (list, tuple)) and len(v) == 2:
+        return f"[{_fmt(v[0], decimals)}, {_fmt(v[1], decimals)}]"
+    return str(v)
+
+
+def _build_markdown(
+    deltas: Dict[str, Dict[str, Dict[str, Dict[str, Any]]]],
+    verdicts: Dict[str, Dict[str, str]],
+    arm_labels: Sequence[str],
+    artifacts: Dict[str, Optional[str]],
+) -> str:
+    """Build a verdict-headlined markdown report."""
+    lines: List[str] = []
+    profiles = [p for p in PROFILE_ORDER if p in deltas]
+
+    lines += [
+        "# Crossover rerun — paired-seed comparison",
+        "",
+        "Compares crossover-enabled arms against the no-crossover baseline "
+        "across the three stable resource profiles, paired by seed.",
+        "",
+        "## Verdict: does gene flow collapse the rising speciation pattern?",
+        "",
+    ]
+    lines += ["| Profile | " + " | ".join(arm_labels) + " |",
+              "| --- |" + " --- |" * len(arm_labels)]
+    for profile in profiles:
+        cells = [verdicts.get(profile, {}).get(arm, "n/a") for arm in arm_labels]
+        lines.append(f"| {profile} | " + " | ".join(cells) + " |")
+    lines.append("")
+    lines.append(
+        "*Verdict thresholds: paired-delta 95% CI excludes zero AND "
+        f"within-profile sign agreement ≥ {SIGN_AGREEMENT_THRESHOLD:.0%}.*"
+    )
+    lines.append("")
+
+    # Per-(profile, arm) headline-metric tables
+    headline_keys = [
+        ("speciation_final", "speciation final"),
+        ("speciation_slope", "speciation slope/100"),
+        ("speciation_mean", "speciation mean"),
+        ("population_mean", "population mean"),
+        ("lineage.mean_k", "cluster count (mean k)"),
+        ("lineage.churn_rate", "cluster churn rate"),
+    ]
+    lines += ["## Paired deltas (treatment − baseline)", ""]
+    for profile in profiles:
+        lines += [f"### {profile}", ""]
+        lines += [
+            "| Arm | Metric | Mean delta | 95% CI | Sign agreement | n |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+        for arm in arm_labels:
+            arm_d = deltas[profile].get(arm, {})
+            for key, label in headline_keys:
+                d = arm_d.get(key, {})
+                if not d or (
+                    isinstance(d.get("mean_delta"), float)
+                    and math.isnan(d["mean_delta"])
+                ):
+                    continue
+                lines.append(
+                    f"| {arm} | {label} "
+                    f"| {_fmt(d.get('mean_delta'), 4)} "
+                    f"| {_fmt(d.get('ci95'), 4)} "
+                    f"| {_fmt(d.get('sign_agreement'), 2)} "
+                    f"| {d.get('n', 0)} |"
+                )
+        lines.append("")
+
+    # Gene-shift deltas table
+    gene_list = CONVERGENT_GENES + ["learning_rate", "ensemble_size"]
+    lines += ["## Gene-shift deltas (treatment − baseline; mean % shift)", ""]
+    header = "| Profile | Arm | " + " | ".join(gene_list) + " |"
+    lines.append(header)
+    lines.append("| --- | --- |" + " --- |" * len(gene_list))
+    for profile in profiles:
+        for arm in arm_labels:
+            arm_d = deltas[profile].get(arm, {})
+            cells = []
+            for g in gene_list:
+                d = arm_d.get(f"gene.{g}", {})
+                mean = d.get("mean_delta", float("nan"))
+                cells.append(_fmt(mean, 1) if not math.isnan(mean) else "n/a")
+            lines.append(f"| {profile} | {arm} | " + " | ".join(cells) + " |")
+    lines.append("")
+
+    # Artifacts
+    lines += ["## Artifacts", ""]
+    for name, path in artifacts.items():
+        if path:
+            lines.append(f"- [{name}]({path})")
+        else:
+            lines.append(f"- {name}: not produced")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+# ── Driver ────────────────────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Paired-seed comparison of crossover arms vs no-crossover baseline.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--baseline-dir", type=str, required=True)
+    parser.add_argument(
+        "--treatment-dir",
+        type=str,
+        action="append",
+        required=True,
+        help="One per crossover arm; repeat for each arm.",
+    )
+    parser.add_argument(
+        "--arm-labels",
+        nargs="+",
+        required=True,
+        help="Human-readable label per --treatment-dir, in the same order.",
+    )
+    parser.add_argument("--output-dir", type=str, required=True)
+    parser.add_argument(
+        "--profiles",
+        nargs="+",
+        default=list(PROFILE_ORDER),
+        choices=list(PROFILE_ORDER),
+        metavar="PROFILE",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    if len(args.treatment_dir) != len(args.arm_labels):
+        print(
+            "Number of --treatment-dir entries must match --arm-labels.",
+            file=sys.stderr,
+        )
+        return 1
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    baseline_dir = Path(args.baseline_dir)
+    if not baseline_dir.is_dir():
+        print(f"Baseline directory not found: {baseline_dir}", file=sys.stderr)
+        return 1
+
+    print(f"Loading baseline from {baseline_dir} ...")
+    baseline = _load_arm(baseline_dir, args.profiles)
+
+    arms: Dict[str, Dict[str, Dict[int, Dict[str, Any]]]] = {}
+    for label, tdir in zip(args.arm_labels, args.treatment_dir):
+        tpath = Path(tdir)
+        if not tpath.is_dir():
+            print(f"Treatment dir not found, skipping: {tpath}", file=sys.stderr)
+            continue
+        print(f"Loading arm '{label}' from {tpath} ...")
+        arms[label] = _load_arm(tpath, args.profiles)
+
+    # deltas[profile][arm] → {metric_key: paired_delta_summary}
+    deltas: Dict[str, Dict[str, Dict[str, Dict[str, Any]]]] = {}
+    verdicts: Dict[str, Dict[str, str]] = {}
+    for profile in args.profiles:
+        if profile not in baseline or not baseline[profile]:
+            continue
+        deltas[profile] = {}
+        verdicts[profile] = {}
+        for arm_label, arm_runs in arms.items():
+            paired = _paired_metric_deltas(
+                baseline.get(profile, {}), arm_runs.get(profile, {})
+            )
+            deltas[profile][arm_label] = paired
+            verdicts[profile][arm_label] = _classify_collapse_verdict(
+                paired.get("speciation_final", {}),
+                paired.get("speciation_slope", {}),
+            )
+
+    artifacts: Dict[str, Optional[str]] = {}
+    p = _plot_speciation_with_arms(baseline, arms, output_dir)
+    artifacts["speciation_trajectories_with_arms"] = str(p) if p else None
+    p = _plot_paired_delta_heatmap(deltas, output_dir)
+    artifacts["paired_delta_heatmap"] = str(p) if p else None
+    p = _plot_lineage_cluster_count(baseline, arms, output_dir)
+    artifacts["lineage_cluster_count"] = str(p) if p else None
+
+    summary = {
+        "baseline_dir": str(baseline_dir),
+        "treatment_dirs": [str(Path(t)) for t in args.treatment_dir],
+        "arm_labels": list(args.arm_labels),
+        "profiles": list(args.profiles),
+        "deltas": deltas,
+        "verdicts": verdicts,
+        "artifacts": artifacts,
+    }
+    summary_path = output_dir / "crossover_rerun_summary.json"
+    with summary_path.open("w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=2, default=str)
+
+    md = _build_markdown(deltas, verdicts, list(args.arm_labels), artifacts)
+    md_path = output_dir / "crossover_rerun_summary.md"
+    md_path.write_text(md, encoding="utf-8")
+
+    print(f"\nComparison complete. Outputs in: {output_dir}")
+    print(f"  summary JSON : {summary_path}")
+    print(f"  summary MD   : {md_path}")
+    for name, path in artifacts.items():
+        if path:
+            print(f"  {name}: {path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/compare_crossover_arms.py
+++ b/scripts/compare_crossover_arms.py
@@ -55,7 +55,6 @@ from scripts.analyze_stable_profile_seed_sweep import (  # noqa: E402
     PROFILE_COLORS,
     PROFILE_ORDER,
     SIGN_AGREEMENT_THRESHOLD,
-    _classify_speciation_direction,
     _discover_runs,
     _extract_run_metrics,
     _mean,

--- a/scripts/compare_crossover_arms.py
+++ b/scripts/compare_crossover_arms.py
@@ -182,18 +182,19 @@ def _classify_collapse_verdict(
     *lower* and/or *less rising* than the baseline (i.e. negative paired
     deltas with both robustness criteria satisfied).
     """
-    robust = (
+    final_robust = (
         spec_final_delta.get("sign_agreement", 0.0) >= SIGN_AGREEMENT_THRESHOLD
         and _ci_excludes_zero(spec_final_delta.get("ci95", []))
-    ) or (
+    )
+    slope_robust = (
         spec_slope_delta.get("sign_agreement", 0.0) >= SIGN_AGREEMENT_THRESHOLD
         and _ci_excludes_zero(spec_slope_delta.get("ci95", []))
     )
-    if not robust:
+    if not final_robust and not slope_robust:
         return "no robust effect"
     sf_mean = spec_final_delta.get("mean_delta", 0.0)
     sl_mean = spec_slope_delta.get("mean_delta", 0.0)
-    if sf_mean < 0 or sl_mean < 0:
+    if (final_robust and sf_mean < 0) or (slope_robust and sl_mean < 0):
         return "robustly collapses"
     return "robustly amplifies"
 

--- a/scripts/run_crossover_rerun.py
+++ b/scripts/run_crossover_rerun.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Crossover rerun orchestrator for the stable resource profiles.
+
+Issue: https://github.com/Dooders/AgentFarm/issues/845
+Devlog: https://dooders.github.io/AgentFarm/devlog/2026-05-12-seed-sweep-reality-check/
+
+Re-runs the May-12 stable-profile seed sweep across two crossover arms:
+
+- ``uniform``: per-gene coin flip from either parent (standard recombination)
+- ``blend``:   BLX-alpha continuous interpolation (strongest mixing operator)
+
+Each arm sweeps all three stable sub-profiles (conservative, balanced,
+buffered) over the same six seeds as the baseline so the comparison against
+``experiments/stable_profile_sweep/`` is paired by seed.
+
+Outputs
+-------
+Per-arm artifacts use the same per-(profile, seed) layout as the baseline::
+
+    {output_dir}/{arm}/stable_{profile}/seed_{seed}/
+
+Plus a top-level orchestrator manifest::
+
+    {output_dir}/rerun_manifest.json
+
+After both arms complete, per-arm aggregates are produced by invoking
+``analyze_stable_profile_seed_sweep.py`` on each arm directory.
+
+Example
+-------
+::
+
+    # Default: 6 seeds, 3 profiles, 2 arms = 36 runs
+    python scripts/run_crossover_rerun.py \\
+        --output-dir experiments/crossover_rerun
+
+    # Just one arm, e.g. for an initial smoke check
+    python scripts/run_crossover_rerun.py --arms blend
+
+    # Print the planned matrix without running anything
+    python scripts/run_crossover_rerun.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+_repo_root = Path(__file__).resolve().parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from scripts import analyze_stable_profile_seed_sweep as analyzer_mod  # noqa: E402
+from scripts import run_stable_profile_seed_sweep as runner_mod  # noqa: E402
+from scripts.run_stable_profile_seed_sweep import (  # noqa: E402
+    DEFAULT_PROFILES,
+    DEFAULT_SEEDS,
+)
+
+ARM_PRESETS: Dict[str, Dict[str, Any]] = {
+    "uniform": {
+        "crossover_mode": "uniform",
+        "blend_alpha": 0.5,
+        "num_crossover_points": 2,
+    },
+    "blend": {
+        "crossover_mode": "blend",
+        "blend_alpha": 0.5,
+        "num_crossover_points": 2,
+    },
+}
+
+DEFAULT_ARMS: List[str] = ["uniform", "blend"]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Orchestrate a crossover rerun of the stable-profile seed sweep "
+            "across one or more crossover arms."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--arms",
+        nargs="+",
+        default=DEFAULT_ARMS,
+        choices=list(ARM_PRESETS),
+        metavar="ARM",
+        help="Crossover arms to run.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="experiments/crossover_rerun",
+        help="Base directory for all arm artifacts.",
+    )
+    parser.add_argument("--environment", type=str, default="development")
+    parser.add_argument(
+        "--profiles",
+        nargs="+",
+        default=DEFAULT_PROFILES,
+        metavar="PROFILE",
+        help="Stable sub-profiles to sweep (forwarded to the runner).",
+    )
+    parser.add_argument(
+        "--seeds",
+        nargs="+",
+        type=int,
+        default=DEFAULT_SEEDS,
+        metavar="SEED",
+        help="Seeds to sweep (must match the baseline sweep for paired comparison).",
+    )
+    parser.add_argument("--num-steps", type=int, default=1000)
+    parser.add_argument("--warmup-steps", type=int, default=200)
+    parser.add_argument("--snapshot-interval", type=int, default=50)
+    parser.add_argument("--mutation-rate", type=float, default=0.15)
+    parser.add_argument("--mutation-scale", type=float, default=0.10)
+    parser.add_argument("--selection-pressure", type=str, default="low")
+    parser.add_argument("--initial-diversity-mutation-rate", type=float, default=1.0)
+    parser.add_argument("--initial-diversity-mutation-scale", type=float, default=0.25)
+    parser.add_argument(
+        "--coparent-strategy",
+        type=str,
+        default="nearest_alive_same_type",
+        choices=runner_mod.COPARENT_STRATEGIES,
+    )
+    parser.add_argument(
+        "--coparent-max-radius",
+        type=float,
+        default=None,
+        help="Spatial cap on the co-parent search (None = unbounded).",
+    )
+    parser.add_argument(
+        "--allow-cross-type-pollination",
+        action="store_true",
+        help="Allow cross-type co-parents (default: same-type only).",
+    )
+    parser.add_argument(
+        "--disk-database",
+        action="store_true",
+        help="Use disk-backed SQLite for each run.",
+    )
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Abort the rerun on the first run failure.",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip per-run work that already has a completed metadata file.",
+    )
+    parser.add_argument(
+        "--skip-analyze",
+        action="store_true",
+        help="Skip the per-arm analyze_stable_profile_seed_sweep.py invocation.",
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="WARNING",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the planned arm × profile × seed matrix and exit.",
+    )
+    return parser
+
+
+def _build_runner_args(
+    args: argparse.Namespace, arm: str, arm_output_dir: Path
+) -> argparse.Namespace:
+    """Build the ``argparse.Namespace`` expected by ``run_stable_profile_seed_sweep``.
+
+    We avoid shelling out to a subprocess so the rerun stays in one Python
+    process with a shared config + logger.  The runner's ``_execute_sweep``
+    only reads attributes off the namespace, so an in-memory namespace built
+    with the right fields is equivalent to a parsed CLI invocation.
+    """
+    preset = ARM_PRESETS[arm]
+    return argparse.Namespace(
+        environment=args.environment,
+        profiles=list(args.profiles),
+        seeds=list(args.seeds),
+        output_dir=str(arm_output_dir),
+        num_steps=args.num_steps,
+        warmup_steps=args.warmup_steps,
+        snapshot_interval=args.snapshot_interval,
+        mutation_rate=args.mutation_rate,
+        mutation_scale=args.mutation_scale,
+        selection_pressure=args.selection_pressure,
+        initial_diversity_mutation_rate=args.initial_diversity_mutation_rate,
+        initial_diversity_mutation_scale=args.initial_diversity_mutation_scale,
+        log_level=args.log_level,
+        fail_fast=args.fail_fast,
+        disk_database=args.disk_database,
+        resume=args.resume,
+        dry_run=False,
+        crossover_enabled=True,
+        crossover_mode=preset["crossover_mode"],
+        blend_alpha=preset["blend_alpha"],
+        num_crossover_points=preset["num_crossover_points"],
+        coparent_strategy=args.coparent_strategy,
+        coparent_max_radius=args.coparent_max_radius,
+        allow_cross_type_pollination=args.allow_cross_type_pollination,
+    )
+
+
+def _run_arm(
+    args: argparse.Namespace,
+    arm: str,
+    output_dir: Path,
+    logger: Any,
+) -> Dict[str, Any]:
+    """Execute one crossover arm by invoking the existing sweep runner in-process."""
+    arm_output_dir = output_dir / arm
+    arm_output_dir.mkdir(parents=True, exist_ok=True)
+    runner_args = _build_runner_args(args, arm, arm_output_dir)
+
+    print(
+        f"\n=== Arm '{arm}' "
+        f"(crossover_mode={runner_args.crossover_mode}, "
+        f"blend_alpha={runner_args.blend_alpha}) ==="
+    )
+    print(f"  output : {arm_output_dir}")
+    print(f"  runs   : {len(runner_args.profiles) * len(runner_args.seeds)}")
+
+    t0 = time.time()
+    records, n_ok, n_fail = runner_mod._execute_sweep(
+        runner_args, arm_output_dir, logger
+    )
+    elapsed = time.time() - t0
+
+    arm_manifest = {
+        "arm": arm,
+        "output_dir": str(arm_output_dir),
+        "crossover": runner_mod._crossover_settings_dict(runner_args),
+        "profiles": runner_args.profiles,
+        "seeds": runner_args.seeds,
+        "num_steps": runner_args.num_steps,
+        "warmup_steps": runner_args.warmup_steps,
+        "snapshot_interval": runner_args.snapshot_interval,
+        "n_ok": n_ok,
+        "n_fail": n_fail,
+        "elapsed_seconds": round(elapsed, 3),
+        "runs": records,
+    }
+    arm_manifest_path = arm_output_dir / "sweep_manifest.json"
+    with arm_manifest_path.open("w", encoding="utf-8") as fh:
+        json.dump(arm_manifest, fh, indent=2, default=str)
+    print(
+        f"  done   : {n_ok}/{n_ok + n_fail} runs ok in {elapsed:.1f}s "
+        f"(manifest: {arm_manifest_path})"
+    )
+    return arm_manifest
+
+
+def _analyze_arm(arm_dir: Path) -> bool:
+    """Invoke the per-arm analyzer in-process; returns True on success."""
+    print(f"\n--- Aggregating arm at {arm_dir} ---")
+    argv = ["analyze_stable_profile_seed_sweep.py", "--sweep-dir", str(arm_dir)]
+    old_argv = sys.argv
+    sys.argv = argv
+    try:
+        rc = analyzer_mod.main()
+    finally:
+        sys.argv = old_argv
+    return rc == 0
+
+
+def _print_dry_run(args: argparse.Namespace, output_dir: Path) -> None:
+    total = len(args.arms) * len(args.profiles) * len(args.seeds)
+    print("Crossover rerun — DRY RUN")
+    print(f"  output_dir : {output_dir}")
+    print(f"  arms       : {args.arms}")
+    print(f"  profiles   : {args.profiles}")
+    print(f"  seeds      : {args.seeds}")
+    print(f"  total runs : {total}")
+    print()
+    for arm in args.arms:
+        preset = ARM_PRESETS[arm]
+        print(f"  {arm}: {preset}")
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    output_dir = Path(args.output_dir)
+
+    if args.dry_run:
+        _print_dry_run(args, output_dir)
+        return 0
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    runner_mod.configure_logging(
+        environment=args.environment,
+        log_dir="logs",
+        log_level=args.log_level,
+        disable_console=False,
+    )
+    logger = runner_mod.get_logger(__name__)
+
+    overall: Dict[str, Any] = {
+        "rerun_type": "crossover_rerun",
+        "output_dir": str(output_dir),
+        "arms": args.arms,
+        "profiles": args.profiles,
+        "seeds": args.seeds,
+        "num_steps": args.num_steps,
+        "arm_manifests": {},
+    }
+
+    total_ok = 0
+    total_fail = 0
+    for arm in args.arms:
+        arm_manifest = _run_arm(args, arm, output_dir, logger)
+        overall["arm_manifests"][arm] = {
+            "output_dir": arm_manifest["output_dir"],
+            "n_ok": arm_manifest["n_ok"],
+            "n_fail": arm_manifest["n_fail"],
+            "elapsed_seconds": arm_manifest["elapsed_seconds"],
+        }
+        total_ok += arm_manifest["n_ok"]
+        total_fail += arm_manifest["n_fail"]
+        if arm_manifest["n_fail"] and args.fail_fast:
+            print("Aborting rerun (--fail-fast).", file=sys.stderr)
+            break
+
+    manifest_path = output_dir / "rerun_manifest.json"
+    with manifest_path.open("w", encoding="utf-8") as fh:
+        json.dump(overall, fh, indent=2, default=str)
+
+    print(f"\nCrossover rerun complete: {total_ok} ok, {total_fail} failed.")
+    print(f"Manifest: {manifest_path}")
+
+    if not args.skip_analyze:
+        for arm in args.arms:
+            arm_dir = output_dir / arm
+            if arm_dir.is_dir():
+                ok = _analyze_arm(arm_dir)
+                if not ok:
+                    print(f"Per-arm aggregation failed for {arm_dir}", file=sys.stderr)
+
+    print(
+        "\nNext step: python scripts/compare_crossover_arms.py \\\n"
+        "    --baseline-dir experiments/stable_profile_sweep \\\n"
+        + " \\\n".join(
+            f"    --treatment-dir {output_dir / arm}" for arm in args.arms
+        )
+        + " \\\n    --arm-labels "
+        + " ".join(args.arms)
+        + f" \\\n    --output-dir {output_dir / 'aggregate'}"
+    )
+
+    return 0 if total_fail == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_stable_profile_seed_sweep.py
+++ b/scripts/run_stable_profile_seed_sweep.py
@@ -56,7 +56,11 @@ if str(_repo_root) not in sys.path:
     sys.path.insert(0, str(_repo_root))
 
 from farm.config import SimulationConfig  # noqa: E402
-from farm.core.hyperparameter_chromosome import BoundaryMode, MutationMode  # noqa: E402
+from farm.core.hyperparameter_chromosome import (  # noqa: E402
+    BoundaryMode,
+    CrossoverMode,
+    MutationMode,
+)
 from farm.core.initial_diversity import InitialDiversityConfig, SeedingMode  # noqa: E402
 from farm.runners.intrinsic_evolution_experiment import (  # noqa: E402
     STABLE_SUB_PROFILES,
@@ -70,6 +74,12 @@ from farm.utils.logging import configure_logging, get_logger  # noqa: E402
 
 DEFAULT_SEEDS: List[int] = [42, 7, 19, 101, 137, 256]
 DEFAULT_PROFILES: List[str] = ["conservative", "balanced", "buffered"]
+
+CROSSOVER_MODES: List[str] = [m.value for m in CrossoverMode]
+COPARENT_STRATEGIES: List[str] = [
+    "nearest_alive_same_type",
+    "random_alive_same_type",
+]
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -132,6 +142,67 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--crossover-enabled",
+        action="store_true",
+        help=(
+            "Enable in-situ chromosome crossover during reproduction. When set, each "
+            "reproduction picks a co-parent and runs the configured crossover operator "
+            "before mutation. When unset (default), reproduction inherits the parent's "
+            "chromosome unchanged (modulo mutation)."
+        ),
+    )
+    parser.add_argument(
+        "--crossover-mode",
+        type=str,
+        default="uniform",
+        choices=CROSSOVER_MODES,
+        help="Crossover operator (only used when --crossover-enabled is set).",
+    )
+    parser.add_argument(
+        "--blend-alpha",
+        type=float,
+        default=0.5,
+        help="BLX-alpha for blend crossover (only used when --crossover-mode=blend).",
+    )
+    parser.add_argument(
+        "--num-crossover-points",
+        type=int,
+        default=2,
+        help=(
+            "Number of pivots for multi-point crossover "
+            "(only used when --crossover-mode=multi_point)."
+        ),
+    )
+    parser.add_argument(
+        "--coparent-strategy",
+        type=str,
+        default="nearest_alive_same_type",
+        choices=COPARENT_STRATEGIES,
+        help="How to pick the co-parent when crossover is enabled.",
+    )
+    parser.add_argument(
+        "--coparent-max-radius",
+        type=float,
+        default=None,
+        help="Spatial cap on the co-parent search (None = unbounded).",
+    )
+    parser.add_argument(
+        "--allow-cross-type-pollination",
+        action="store_true",
+        help=(
+            "Allow co-parents of any agent_type. When unset (default), only "
+            "same-type agents are eligible."
+        ),
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help=(
+            "Skip per-(profile, seed) runs whose output directory already contains "
+            "a completed metadata file with num_steps_completed >= --num-steps."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print the planned (profile, seed) matrix and resolved overrides, then exit.",
@@ -163,7 +234,15 @@ def _build_run(profile: str, seed: int, args: argparse.Namespace, run_dir: Path)
         mutation_scale=args.mutation_scale,
         mutation_mode=MutationMode.GAUSSIAN,
         boundary_mode=BoundaryMode.REFLECT,
-        crossover_enabled=False,
+        crossover_enabled=bool(getattr(args, "crossover_enabled", False)),
+        crossover_mode=CrossoverMode(getattr(args, "crossover_mode", "uniform")),
+        blend_alpha=float(getattr(args, "blend_alpha", 0.5)),
+        num_crossover_points=int(getattr(args, "num_crossover_points", 2)),
+        coparent_strategy=getattr(args, "coparent_strategy", "nearest_alive_same_type"),
+        coparent_max_radius=getattr(args, "coparent_max_radius", None),
+        allow_cross_type_pollination=bool(
+            getattr(args, "allow_cross_type_pollination", False)
+        ),
         selection_pressure=args.selection_pressure,
         seed=seed,
     )
@@ -292,6 +371,23 @@ def _run_one(
         return False, record
 
 
+def _crossover_settings_dict(args: argparse.Namespace) -> Dict[str, Any]:
+    """Snapshot of the resolved crossover-related CLI args for the manifest."""
+    return {
+        "crossover_enabled": bool(getattr(args, "crossover_enabled", False)),
+        "crossover_mode": str(getattr(args, "crossover_mode", "uniform")),
+        "blend_alpha": float(getattr(args, "blend_alpha", 0.5)),
+        "num_crossover_points": int(getattr(args, "num_crossover_points", 2)),
+        "coparent_strategy": str(
+            getattr(args, "coparent_strategy", "nearest_alive_same_type")
+        ),
+        "coparent_max_radius": getattr(args, "coparent_max_radius", None),
+        "allow_cross_type_pollination": bool(
+            getattr(args, "allow_cross_type_pollination", False)
+        ),
+    }
+
+
 def _print_dry_run_plan(args: argparse.Namespace, output_dir: Path) -> None:
     print("Stable-profile seed sweep — DRY RUN")
     print(f"  output_dir : {output_dir}")
@@ -300,6 +396,7 @@ def _print_dry_run_plan(args: argparse.Namespace, output_dir: Path) -> None:
     print(f"  num_steps  : {args.num_steps} (warmup {args.warmup_steps}, "
           f"snapshot/{args.snapshot_interval})")
     print(f"  disk_db    : {getattr(args, 'disk_database', False)}")
+    print(f"  crossover  : {_crossover_settings_dict(args)}")
     print(f"  total runs : {len(args.profiles) * len(args.seeds)}")
     print()
     print("Resolved sub-profile overrides:")
@@ -372,6 +469,7 @@ def main() -> int:
         "mutation_rate": args.mutation_rate,
         "mutation_scale": args.mutation_scale,
         "selection_pressure": args.selection_pressure,
+        "crossover": _crossover_settings_dict(args),
         "sub_profile_overrides": {p: STABLE_SUB_PROFILES[p] for p in args.profiles},
         "runs": sweep_records,
         "n_ok": n_ok,

--- a/tests/runners/test_stable_profile_seed_sweep.py
+++ b/tests/runners/test_stable_profile_seed_sweep.py
@@ -850,5 +850,101 @@ class _NullLogger:
         pass
 
 
+# ── Tests: crossover CLI flag wiring ──────────────────────────────────────────
+
+
+class TestCrossoverCLI(unittest.TestCase):
+    """Verify that the new crossover CLI flags reach IntrinsicEvolutionPolicy."""
+
+    def test_default_args_disable_crossover(self):
+        args = runner_mod._build_parser().parse_args(
+            ["--profiles", "buffered", "--seeds", "42"]
+        )
+        self.assertFalse(args.crossover_enabled)
+        self.assertEqual(args.crossover_mode, "uniform")
+        self.assertEqual(args.coparent_strategy, "nearest_alive_same_type")
+        self.assertFalse(args.allow_cross_type_pollination)
+        self.assertIsNone(args.coparent_max_radius)
+
+    def test_crossover_flags_parse(self):
+        args = runner_mod._build_parser().parse_args([
+            "--profiles", "buffered",
+            "--seeds", "42",
+            "--crossover-enabled",
+            "--crossover-mode", "blend",
+            "--blend-alpha", "0.3",
+            "--num-crossover-points", "3",
+            "--coparent-strategy", "random_alive_same_type",
+            "--coparent-max-radius", "12.5",
+            "--allow-cross-type-pollination",
+        ])
+        self.assertTrue(args.crossover_enabled)
+        self.assertEqual(args.crossover_mode, "blend")
+        self.assertAlmostEqual(args.blend_alpha, 0.3)
+        self.assertEqual(args.num_crossover_points, 3)
+        self.assertEqual(args.coparent_strategy, "random_alive_same_type")
+        self.assertAlmostEqual(args.coparent_max_radius, 12.5)
+        self.assertTrue(args.allow_cross_type_pollination)
+
+    def test_crossover_settings_dict_snapshot(self):
+        args = runner_mod._build_parser().parse_args([
+            "--crossover-enabled",
+            "--crossover-mode", "single_point",
+            "--blend-alpha", "0.7",
+        ])
+        snapshot = runner_mod._crossover_settings_dict(args)
+        self.assertTrue(snapshot["crossover_enabled"])
+        self.assertEqual(snapshot["crossover_mode"], "single_point")
+        self.assertAlmostEqual(snapshot["blend_alpha"], 0.7)
+        self.assertEqual(snapshot["coparent_strategy"], "nearest_alive_same_type")
+
+    def test_build_run_wires_crossover_into_policy(self):
+        """End-to-end: parsed CLI flags should produce a policy with matching fields.
+
+        We exercise ``_build_run`` so the wiring (rather than just the CLI
+        surface) is exercised, but only inspect attributes on the constructed
+        experiment object — no simulation steps are executed.
+        """
+        from farm.core.hyperparameter_chromosome import CrossoverMode
+
+        with tempfile.TemporaryDirectory() as tmp:
+            args = runner_mod._build_parser().parse_args([
+                "--profiles", "buffered",
+                "--seeds", "42",
+                "--output-dir", tmp,
+                "--crossover-enabled",
+                "--crossover-mode", "blend",
+                "--blend-alpha", "0.4",
+                "--num-crossover-points", "3",
+                "--coparent-strategy", "random_alive_same_type",
+                "--coparent-max-radius", "8.0",
+                "--allow-cross-type-pollination",
+            ])
+            run_dir = Path(tmp) / "stable_buffered" / "seed_42"
+            run_dir.mkdir(parents=True)
+            experiment = runner_mod._build_run("buffered", 42, args, run_dir)
+            policy = experiment.config.policy
+            self.assertTrue(policy.crossover_enabled)
+            self.assertEqual(policy.crossover_mode, CrossoverMode.BLEND)
+            self.assertAlmostEqual(policy.blend_alpha, 0.4)
+            self.assertEqual(policy.num_crossover_points, 3)
+            self.assertEqual(policy.coparent_strategy, "random_alive_same_type")
+            self.assertAlmostEqual(policy.coparent_max_radius, 8.0)
+            self.assertTrue(policy.allow_cross_type_pollination)
+
+    def test_build_run_defaults_crossover_disabled(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            args = runner_mod._build_parser().parse_args([
+                "--profiles", "buffered",
+                "--seeds", "42",
+                "--output-dir", tmp,
+            ])
+            run_dir = Path(tmp) / "stable_buffered" / "seed_42"
+            run_dir.mkdir(parents=True)
+            experiment = runner_mod._build_run("buffered", 42, args, run_dir)
+            policy = experiment.config.policy
+            self.assertFalse(policy.crossover_enabled)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/scripts/test_compare_crossover_arms.py
+++ b/tests/scripts/test_compare_crossover_arms.py
@@ -136,6 +136,15 @@ class TestClassifyCollapseVerdict(unittest.TestCase):
             "robustly collapses",
         )
 
+    def test_robust_amplifies_when_only_slope_evidence_positive(self):
+        # Noisy spec_final must not flip the verdict away from robust slope evidence.
+        spec_final = self._summary(-0.05, [-0.20, 0.10], 0.5)
+        spec_slope = self._summary(0.008, [0.002, 0.014], 1.0)
+        self.assertEqual(
+            _classify_collapse_verdict(spec_final, spec_slope),
+            "robustly amplifies",
+        )
+
 
 # ── _lineage_metrics ──────────────────────────────────────────────────────────
 

--- a/tests/scripts/test_compare_crossover_arms.py
+++ b/tests/scripts/test_compare_crossover_arms.py
@@ -1,0 +1,323 @@
+"""Tests for scripts/compare_crossover_arms.py.
+
+Focuses on pure-logic helpers that don't require a full simulation:
+- _paired_delta_summary (mean / CI / sign-agreement under known inputs)
+- _ci_excludes_zero (boundary cases around zero)
+- _classify_collapse_verdict (verdict string given fixed paired-delta dicts)
+- _lineage_metrics (cluster-count trace and churn-rate from synthetic JSONL)
+- _build_markdown (renders without crashing, contains expected sections)
+- _paired_metric_deltas (paired computation when baseline/treatment partially
+  overlap by seed)
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+from scripts.compare_crossover_arms import (  # noqa: E402
+    _build_markdown,
+    _ci_excludes_zero,
+    _classify_collapse_verdict,
+    _lineage_metrics,
+    _paired_delta_summary,
+    _paired_metric_deltas,
+)
+
+
+# ── _paired_delta_summary ────────────────────────────────────────────────────
+
+
+class TestPairedDeltaSummary(unittest.TestCase):
+    def test_empty(self):
+        out = _paired_delta_summary([])
+        self.assertEqual(out["n"], 0)
+        self.assertTrue(math.isnan(out["mean_delta"]))
+
+    def test_all_negative_known(self):
+        out = _paired_delta_summary([-1.0, -2.0, -3.0, -4.0])
+        self.assertAlmostEqual(out["mean_delta"], -2.5)
+        self.assertAlmostEqual(out["sign_agreement"], 1.0)
+        self.assertEqual(out["n"], 4)
+        lo, hi = out["ci95"]
+        # 95% CI should bracket the mean
+        self.assertLess(lo, -2.5)
+        self.assertGreater(hi, -2.5)
+        # All-negative sample → CI should sit below zero
+        self.assertLess(hi, 0.0)
+
+    def test_mixed_signs_partial_agreement(self):
+        out = _paired_delta_summary([1.0, -1.0, 2.0, -3.0])
+        self.assertEqual(out["n"], 4)
+        self.assertAlmostEqual(out["sign_agreement"], 0.0)
+
+    def test_nan_filtered(self):
+        out = _paired_delta_summary([1.0, float("nan"), 2.0, float("nan"), 3.0])
+        self.assertEqual(out["n"], 3)
+        self.assertAlmostEqual(out["mean_delta"], 2.0)
+
+
+# ── _ci_excludes_zero ─────────────────────────────────────────────────────────
+
+
+class TestCiExcludesZero(unittest.TestCase):
+    def test_strictly_positive(self):
+        self.assertTrue(_ci_excludes_zero([0.1, 0.5]))
+
+    def test_strictly_negative(self):
+        self.assertTrue(_ci_excludes_zero([-0.5, -0.1]))
+
+    def test_straddles_zero(self):
+        self.assertFalse(_ci_excludes_zero([-0.1, 0.5]))
+
+    def test_touches_zero_lower(self):
+        # Touching zero counts as "not excluding zero" — strict inequality.
+        self.assertFalse(_ci_excludes_zero([0.0, 0.5]))
+
+    def test_nan_returns_false(self):
+        self.assertFalse(_ci_excludes_zero([float("nan"), 0.5]))
+
+    def test_wrong_length_returns_false(self):
+        self.assertFalse(_ci_excludes_zero([0.1]))
+
+
+# ── _classify_collapse_verdict ────────────────────────────────────────────────
+
+
+class TestClassifyCollapseVerdict(unittest.TestCase):
+    @staticmethod
+    def _summary(mean_delta, ci, sign_agreement):
+        return {
+            "mean_delta": mean_delta,
+            "ci95": ci,
+            "sign_agreement": sign_agreement,
+        }
+
+    def test_robust_collapse(self):
+        spec_final = self._summary(-0.15, [-0.20, -0.10], 1.0)
+        spec_slope = self._summary(-0.005, [-0.008, -0.002], 1.0)
+        self.assertEqual(
+            _classify_collapse_verdict(spec_final, spec_slope),
+            "robustly collapses",
+        )
+
+    def test_robust_amplifies(self):
+        spec_final = self._summary(0.15, [0.10, 0.20], 1.0)
+        spec_slope = self._summary(0.005, [0.002, 0.008], 1.0)
+        self.assertEqual(
+            _classify_collapse_verdict(spec_final, spec_slope),
+            "robustly amplifies",
+        )
+
+    def test_no_robust_effect_when_ci_straddles_zero(self):
+        spec_final = self._summary(-0.05, [-0.10, 0.05], 0.6)
+        spec_slope = self._summary(-0.001, [-0.005, 0.003], 0.5)
+        self.assertEqual(
+            _classify_collapse_verdict(spec_final, spec_slope),
+            "no robust effect",
+        )
+
+    def test_robust_when_only_slope_evidence(self):
+        # If speciation_final is noisy but slope is robust and negative,
+        # the verdict should still trigger as "robustly collapses".
+        spec_final = self._summary(-0.05, [-0.20, 0.10], 0.5)
+        spec_slope = self._summary(-0.008, [-0.012, -0.004], 1.0)
+        self.assertEqual(
+            _classify_collapse_verdict(spec_final, spec_slope),
+            "robustly collapses",
+        )
+
+
+# ── _lineage_metrics ──────────────────────────────────────────────────────────
+
+
+class TestLineageMetrics(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.run_dir = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _write_lineage(self, rows):
+        path = self.run_dir / "cluster_lineage.jsonl"
+        with path.open("w", encoding="utf-8") as fh:
+            for row in rows:
+                fh.write(json.dumps(row) + "\n")
+
+    def test_empty_returns_nans(self):
+        out = _lineage_metrics(self.run_dir)
+        self.assertEqual(out["cluster_count_trace"], [])
+        self.assertTrue(math.isnan(out["mean_k"]))
+        self.assertTrue(math.isnan(out["churn_rate"]))
+
+    def test_cluster_count_per_step(self):
+        rows = [
+            {"step": 50, "cluster_id": "c0"},
+            {"step": 50, "cluster_id": "c1"},
+            {"step": 100, "cluster_id": "c0"},
+            {"step": 100, "cluster_id": "c2"},
+            {"step": 100, "cluster_id": "c3"},
+        ]
+        self._write_lineage(rows)
+        out = _lineage_metrics(self.run_dir)
+        self.assertEqual(out["cluster_count_trace"], [(50, 2), (100, 3)])
+        # mean k = (2 + 3) / 2 = 2.5
+        self.assertAlmostEqual(out["mean_k"], 2.5)
+        # Step 50 had {c0, c1}; step 100 has {c0, c2, c3}.
+        # c1 died, c0 survived → churn at 50 = 1/2 = 0.5.
+        # Only one transition pair → mean churn = 0.5.
+        self.assertAlmostEqual(out["churn_rate"], 0.5)
+
+    def test_zero_churn_when_all_survive(self):
+        rows = [
+            {"step": 0, "cluster_id": "c0"},
+            {"step": 0, "cluster_id": "c1"},
+            {"step": 100, "cluster_id": "c0"},
+            {"step": 100, "cluster_id": "c1"},
+        ]
+        self._write_lineage(rows)
+        out = _lineage_metrics(self.run_dir)
+        self.assertAlmostEqual(out["churn_rate"], 0.0)
+
+    def test_full_churn_when_all_replaced(self):
+        rows = [
+            {"step": 0, "cluster_id": "c0"},
+            {"step": 0, "cluster_id": "c1"},
+            {"step": 100, "cluster_id": "c2"},
+            {"step": 100, "cluster_id": "c3"},
+        ]
+        self._write_lineage(rows)
+        out = _lineage_metrics(self.run_dir)
+        self.assertAlmostEqual(out["churn_rate"], 1.0)
+
+    def test_churn_nan_with_single_step(self):
+        rows = [
+            {"step": 0, "cluster_id": "c0"},
+            {"step": 0, "cluster_id": "c1"},
+        ]
+        self._write_lineage(rows)
+        out = _lineage_metrics(self.run_dir)
+        self.assertTrue(math.isnan(out["churn_rate"]))
+        self.assertAlmostEqual(out["mean_k"], 2.0)
+
+
+# ── _paired_metric_deltas ─────────────────────────────────────────────────────
+
+
+class TestPairedMetricDeltas(unittest.TestCase):
+    @staticmethod
+    def _run(spec_final, spec_slope, lr_shift, mean_k=2.0, churn=0.1):
+        return {
+            "speciation_final": spec_final,
+            "speciation_slope": spec_slope,
+            "speciation_mean": spec_final - 0.05,
+            "population_mean": 100.0,
+            "gene_pct_shift": {"learning_rate": lr_shift, "gamma": -1.0},
+            "lineage": {
+                "mean_k": mean_k,
+                "churn_rate": churn,
+                "cluster_count_trace": [],
+            },
+        }
+
+    def test_paired_deltas_by_seed(self):
+        baseline = {
+            42: self._run(0.7, 0.02, 5.0),
+            7: self._run(0.6, 0.01, 3.0),
+        }
+        treatment = {
+            42: self._run(0.5, 0.005, -2.0),
+            7: self._run(0.4, -0.005, -4.0),
+            # Seed 19 only in treatment → should be excluded from pairing.
+            19: self._run(0.9, 0.05, 10.0),
+        }
+        deltas = _paired_metric_deltas(baseline, treatment)
+        # Paired seeds = {42, 7}
+        self.assertEqual(sorted(deltas["_paired_seeds"]), [7, 42])
+
+        sf = deltas["speciation_final"]
+        self.assertEqual(sf["n"], 2)
+        # (0.5 - 0.7) + (0.4 - 0.6) = -0.4; mean = -0.2
+        self.assertAlmostEqual(sf["mean_delta"], -0.2)
+        self.assertAlmostEqual(sf["sign_agreement"], 1.0)
+
+        lr = deltas["gene.learning_rate"]
+        self.assertEqual(lr["n"], 2)
+        # (-2 - 5) + (-4 - 3) = -14; mean = -7
+        self.assertAlmostEqual(lr["mean_delta"], -7.0)
+
+    def test_excludes_runs_with_nan(self):
+        baseline = {
+            42: self._run(0.7, 0.02, 5.0),
+            7: self._run(float("nan"), 0.01, 3.0),
+        }
+        treatment = {
+            42: self._run(0.5, 0.005, -2.0),
+            7: self._run(0.6, -0.005, -4.0),
+        }
+        deltas = _paired_metric_deltas(baseline, treatment)
+        sf = deltas["speciation_final"]
+        # Seed 7 had NaN baseline → only seed 42 contributes
+        self.assertEqual(sf["n"], 1)
+        self.assertAlmostEqual(sf["mean_delta"], -0.2)
+
+
+# ── _build_markdown ───────────────────────────────────────────────────────────
+
+
+class TestBuildMarkdown(unittest.TestCase):
+    def _fake_summary(self, mean):
+        return {
+            "mean_delta": mean,
+            "variance": 0.001,
+            "ci95": [mean - 0.05, mean + 0.05],
+            "sign_agreement": 1.0,
+            "n": 6,
+        }
+
+    def test_markdown_contains_verdict_table(self):
+        deltas = {
+            "buffered": {
+                "uniform": {
+                    "speciation_final": self._fake_summary(-0.2),
+                    "speciation_slope": self._fake_summary(-0.005),
+                    "gene.learning_rate": self._fake_summary(-7.0),
+                },
+                "blend": {
+                    "speciation_final": self._fake_summary(0.1),
+                    "speciation_slope": self._fake_summary(0.003),
+                    "gene.learning_rate": self._fake_summary(2.0),
+                },
+            },
+        }
+        verdicts = {
+            "buffered": {
+                "uniform": "robustly collapses",
+                "blend": "robustly amplifies",
+            },
+        }
+        md = _build_markdown(deltas, verdicts, ["uniform", "blend"], {})
+        self.assertIn("Crossover rerun", md)
+        self.assertIn("buffered", md)
+        self.assertIn("robustly collapses", md)
+        self.assertIn("robustly amplifies", md)
+        self.assertIn("learning_rate", md)
+
+    def test_markdown_handles_empty_input(self):
+        md = _build_markdown({}, {}, ["uniform"], {})
+        self.assertIsInstance(md, str)
+        self.assertGreater(len(md), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Introduced `crossover_rerun.md` to document the crossover rerun experiment, detailing the hypothesis, design, and commands for execution.
- Added `compare_crossover_arms.py` to facilitate paired-seed comparisons between crossover arms and the no-crossover baseline, generating summary reports and visualizations.
- Implemented `run_crossover_rerun.py` to orchestrate the execution of crossover experiments across multiple profiles and seeds, integrating with existing seed sweep infrastructure.
- Updated `run_stable_profile_seed_sweep.py` to support crossover parameters and added relevant CLI flags for crossover configuration.
- Enhanced tests to validate the new crossover functionality and ensure proper integration with existing systems.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI surface and wiring that can materially change intrinsic-evolution reproduction behavior when enabled, plus new analysis/orchestration scripts; defaults preserve prior behavior but mistakes could alter experiment outputs or manifests.
> 
> **Overview**
> Adds a documented “crossover rerun” experiment with a new orchestrator (`run_crossover_rerun.py`) that re-runs the stable-profile seed sweep across multiple crossover arms and writes per-arm manifests/aggregates.
> 
> Introduces `compare_crossover_arms.py` to perform *paired-by-seed* baseline-vs-treatment comparisons, including lineage cluster-count/churn extraction from `cluster_lineage.jsonl`, robustness-style verdicting, and generation of summary reports + plots.
> 
> Extends `run_stable_profile_seed_sweep.py` with crossover/co-parent CLI flags (and manifest/dry-run reporting) and adds focused tests for the new flag parsing/wiring plus comparison-script helper logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82f8cd907a00297cd711e996f301fda1ebeaacf5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->