### PR TITLE
fix(dqn): wire epsilon schedule, hidden size, replay knobs, and auto-scale training throttle

### DIFF
--- a/docs/devlog/2026-05-16-is-the-dqn-actually-learning.md
+++ b/docs/devlog/2026-05-16-is-the-dqn-actually-learning.md
@@ -1,0 +1,360 @@
+---
+layout: page
+title: "Is the DQN actually learning? A diagnostic, four bugs, and a sobering answer"
+---
+
+A simulation user reported a suspicion that their DQN decision module wasn't
+actually learning — agents weren't getting better at making decisions, and
+they wondered whether agents were just dying before their internal model
+had a chance to adapt. That hypothesis is partly right, but the more
+interesting story turned out to be that the DQN was being quietly
+half-broken in four places at once: a global training throttle, a never-
+applied epsilon schedule, a YAML-to-config mapping that dropped knobs on
+the floor, and a hidden-size field that did nothing. The diagnostic also
+ended with an honest finding: even after fixing all four, agents only
+*barely* start making better decisions in late life vs early life at the
+default simulation horizon. The cause is no longer the code — it is the
+environment's signal-to-noise ratio.
+
+This is the walkthrough.
+
+## Setup
+
+The active decision stack is:
+
+| Piece | File |
+|---|---|
+| Agent-facing API | `farm/core/decision/decision.py` |
+| Tianshou integration | `farm/core/decision/algorithms/tianshou.py` |
+| Replay buffer (PER) | `farm/core/decision/algorithms/rl_base.py` |
+| Per-agent wiring | `farm/core/agent/behaviors/learning.py` |
+| Per-step agent loop | `farm/core/agent/core.py` |
+| Deferred-training scheduler | `farm/core/simulation.py` |
+
+I wrote a diagnostic harness, `scripts/diagnose_dqn_learning.py`, that
+wraps `DecisionModule` and `TianshouWrapper` and records per agent:
+replay-buffer stores, `should_train()` outcomes, real `policy.learn()`
+calls, the L2 movement of the Q-network's first parameter tensor (so we
+can prove weights actually moved, not just that `learn` returned), buffer
+size and `policy.eps` at end of run, and lifespan. Later in the session I
+extended it to record `(env_time, action, reward)` per store so I could
+do a proper residualised late-vs-early reward analysis. Everything ran
+with `PYTHONHASHSEED=0` for determinism on the default config (30
+starting learning agents, 100–500 steps).
+
+The point throughout was the same one I keep making to myself: do not
+guess at RL bugs from the code; instrument, run, look at numbers.
+
+## What the first run found
+
+Default config, 100 steps:
+
+| Per-agent metric | Median | p75 | Notes |
+|---|---:|---:|---|
+| Stores per agent | 93 | 100 | replay fills fine |
+| `policy.learn()` calls | **2** | 4.5 | barely any training |
+| `train-ready=False` | **61** | 69 | almost every chance, skipped |
+| `\|Δw\|₂` of first Q-param | ~0 | 0.1 | weights barely move |
+| Final `policy.eps` | **0.000** | 0.000 | exploration broken |
+| Lifespan | 95 | 101 | mean **81 steps** |
+
+That is enough to falsify the user's hypothesis right away. Mean
+lifespan is 81 steps, the batch threshold is 32, and 58/63 agents
+filled their buffer past it. Lifespan is *not* the bottleneck. The
+bottleneck is somewhere between the buffer being ready and `policy.learn()`
+actually getting called. And the `policy.eps = 0.000` for *every*
+trained agent at end of run is suspicious — none of them are exploring.
+
+So I went looking. Four real bugs surfaced.
+
+### Bug 1: the global training throttle
+
+`farm/core/simulation.py` runs deferred RL updates via
+`_run_deferred_learning_updates(env, max_updates, rr_cursor)`, with
+`max_updates = performance.max_learning_updates_per_step` and a default
+of `4`. With ~30 alive agents and the round-robin scheduler, that caps
+total gradient updates per env step at 4, no matter how many agents are
+ready. Over 100 steps that's at most 400 updates spread across 30+
+agents — median 2 per agent. When I disabled deferred training entirely
+(`--no-defer`, training happens inline on every store) the same agents
+ran median **18** gradient steps. So the throttle was costing ~9× the
+training volume.
+
+### Bug 2: epsilon-greedy was always off
+
+Tianshou's `DQNPolicy.__init__` sets `self.eps = 0.0` and only changes
+it when someone calls `policy.set_eps(...)`. The wrapper was passing
+`eps_train`, `eps_test`, `eps_train_final` into the policy's
+`algorithm_config`, but `set_eps()` was never called anywhere in the
+codebase. Direct repro:
+
+```python
+DQNWrapper(..., algorithm_config={"eps_train": 0.5, ...}).policy.eps
+# -> 0.0
+```
+
+So the configured `epsilon_start: 1.0`, `epsilon_min: 0.01`,
+`epsilon_decay: 0.995` in `default.yaml` were all dead. The agent's
+"epsilon-greedy" was pure greedy on a near-random Q-network. There was
+still some exploration in the system, but it came from a hard-coded
+`predict_proba` heuristic (0.8 mass on the policy's argmax + 0.2
+uniform) multiplied by per-action priors from `action_weights`, *not*
+from the configured schedule. The DQN policy never got a "test/greedy"
+mode and never had its exploration anneal over time.
+
+### Bug 3: YAML-to-DecisionConfig wiring silently dropped knobs
+
+`AgentComponentConfig.from_simulation_config` mapped:
+
+```
+learning.memory_size  -> decision.memory_size
+learning.batch_size   -> decision.batch_size
+learning.dqn_hidden_size -> decision.dqn_hidden_size
+```
+
+But the Tianshou wrapper reads `decision.rl_buffer_size` and
+`decision.rl_batch_size`, *not* `memory_size` / `batch_size` (those are
+consumed by the legacy `BaseDQNModule`, which the production stack
+doesn't use). So `learning.memory_size: 2000` in YAML actually produced
+a 10000-entry replay buffer (the `rl_buffer_size` default). The
+`dqn_hidden_size: 24` knob did nothing for the same reason (see Bug 4).
+Anyone tuning these from YAML was tuning ghosts.
+
+### Bug 4: dqn_hidden_size was decorative
+
+`AdaptiveQNet` in `tianshou.py` had hard-coded FC widths of 512 / 256 /
+128 in the constructor. `DecisionConfig.dqn_hidden_size` was declared
+as a real Pydantic field but never plumbed through. Width was *always*
+512/256/128 regardless of the config.
+
+### Bug 5 (cleanup): swallowed exceptions in the agent step loop
+
+`AgentCore.step` had:
+
+```python
+try:
+    action = self.behavior.decide_action(self, state_tensor, enabled_actions)
+    self._execute_action(action, state_tensor)
+except Exception:
+    pass
+```
+
+So any exception during decision or execution looked exactly like "the
+agent simply isn't learning", with no log entry to distinguish a quiet
+step from a crashing one. This wasn't the cause of the user's symptom,
+but it would absolutely *hide* future versions of it.
+
+## The fixes
+
+Six commits on `cursor/diagnose-dqn-learning-a451`, PR
+[#878](https://github.com/Dooders/AgentFarm/pull/878):
+
+1. **Throttle auto-scale.** Change `max_learning_updates_per_step` to
+   default to `0`, and re-interpret `0` as the auto-scale sentinel —
+   every alive agent gets one gradient step per env step. Positive ints
+   remain a hard cap; negatives short-circuit to no training.
+
+2. **Epsilon-greedy actually wired.** `TianshouWrapper` snapshots
+   `eps_train` / `eps_train_final` / `eps_test` / `eps_decay` at init,
+   calls `policy.set_eps(epsilon_start)` immediately, decays
+   multiplicatively on every `select_action_with_mask` call (training
+   mode), floors at `epsilon_min`, and exposes `set_train_mode(False)`
+   to switch the policy to `eps_test` for evaluation.
+
+3. **YAML wiring.** `from_simulation_config` now maps
+   `learning.memory_size` and `learning.batch_size` to *both* the legacy
+   fields (so the deprecated DQN module still works) *and* the
+   `rl_buffer_size` / `rl_batch_size` fields that the Tianshou wrapper
+   actually reads.
+
+4. **`dqn_hidden_size` plumbed.** `AdaptiveQNet` takes a `hidden_size`
+   parameter and uses `h*4 / h*2 / h` widths, with a floor of 8.
+   `dqn_hidden_size` is added to `_EXCLUDED_PARAMS` so it doesn't leak
+   into `DQNPolicy`'s constructor.
+
+5. **Exceptions logged, not swallowed.** `AgentCore.step` failures
+   from `decide_action` / `_execute_action` now log at warning with the
+   agent id, exception type, message, and traceback (structlog
+   `exc_info=True`).
+
+6. **Tests.** New unit tests in
+   `tests/test_decision_config_wiring.py` and
+   `tests/test_rl_training_batching.py` lock down: initial `policy.eps
+   == epsilon_start`, the multiplicative decay, the
+   `epsilon_min` floor, `set_train_mode(False)` switching to
+   `eps_test`, `dqn_hidden_size` actually changing the network width,
+   the YAML-to-`rl_buffer_size` mapping, and the auto-scale sentinel.
+
+Full pytest run: **6492 passed, 0 failed**, 18 skipped (pre-existing
+CUDA / openpyxl skips).
+
+## Did "is the DQN learning?" change after the fixes?
+
+Yes. Same simulation, same seed, before-and-after at 100 steps:
+
+| Per-agent metric | Before | After | Δ |
+|---|---:|---:|---:|
+| Median `policy.learn()` calls | 2 | 18 | **9×** |
+| Median `\|Δw\|₂` of first Q-param | ~0 | 0.1 | weights actually move |
+| Final `policy.eps` | 0.000 | 0.606 | schedule alive (`1.0 × 0.995^100`) |
+
+And at 300 steps, simulating the legacy throttle + broken eps on the
+current code (`--legacy`) vs the post-fix defaults:
+
+| Per-agent metric | Legacy | Current | Δ |
+|---|---:|---:|---:|
+| Median `policy.learn()` calls | 5 | **34** | 6.8× |
+| `\|Δw\|₂` p75 | 0.1 | 0.2 | 2× |
+| Mean lifespan (steps) | 213 | **262** | +23% |
+| Final `policy.eps` | 0.000 | 0.222 | decayed correctly |
+
+That lifespan delta is the cleanest *behavioral* signal. Same seed,
+same population, same world — agents under the fixed system survive
+~23% longer.
+
+## But are agents actually making better decisions?
+
+Higher training volume, larger weight movement, longer survival. Those
+are inputs and outcomes. What I really wanted to see — and what the
+user actually asked — was *policy quality* over the lifetime of one
+agent. Is a 300-step-old agent picking better actions than a 50-step-old
+agent?
+
+To answer that I extended the diagnostic with:
+
+- `(env_time, action, reward)` per stored experience.
+- A cohort baseline: for each env time, the mean reward across all
+  alive agents at that moment. An agent's *residualised reward* is its
+  own reward minus that cohort mean, so anything common to the cohort
+  (food depleting, density, weather) cancels out.
+- Per-agent late-vs-early residualised reward, restricted to long-lived
+  agents (lifespan ≥ 100), with a one-sample t-stat on the per-agent
+  delta.
+- Action-distribution entropy and top-action share in the first vs the
+  last quartile of each agent's experience. A policy that is actually
+  *learning to commit* should show lower entropy / higher top-action
+  share in late life.
+
+Three configurations at 500 steps:
+
+| Long-lived agents (lifespan ≥ 100) | Legacy | Current | `--train-freq 1` |
+|---|---:|---:|---:|
+| Long-lived agents evaluated | 67 | 61 | 63 |
+| Median `policy.learn()` calls | 7 | 33 | **117** |
+| Max `policy.learn()` calls | 110 | 118 | **469** |
+| Mean Δ residualised reward (late − early) | +0.0082 | −0.0055 | **+0.0069** |
+| t-stat for Δ > 0 | +1.15 | −0.79 | **+0.97** |
+| Agents with Δ > 0 | 35/67 (52%) | 28/61 (46%) | 32/63 (51%) |
+| Δ action entropy (nats, late − early) | +0.013 | +0.002 | **−0.024** |
+| Δ top-action share | −0.014 | +0.002 | **+0.003** |
+| Mean lifespan (steps) | 306 | 355 | **391** |
+| `\|Δw\|₂` p75 | 0.1 | 0.2 | **0.3** |
+
+The numbers do not let me claim "agents make demonstrably better
+per-action decisions late in life." The largest t-stat is +1.15, well
+short of the t ≈ 2 threshold for p < 0.05. Even at the most aggressive
+training setting (`rl_train_freq=1`, 12× more gradient steps), the
+residualised-reward t-stat is only +0.97.
+
+What I *can* claim:
+
+- **The action distribution starts to commit when training is
+  aggressive enough.** At `rl_train_freq=1`, late-life action entropy
+  drops by `−0.024` nats (1.659 → 1.635). With only 5 actions the
+  entropy ceiling is `log(5) = 1.609`, so the policy is moving
+  meaningfully toward a non-uniform distribution. Under the default
+  `rl_train_freq=4`, entropy barely changes (`+0.002`). More gradient
+  steps → policy actually committing. That is exactly the
+  qualitative signature of learning, just at small amplitude.
+
+- **Lifespan keeps improving with training budget**: 306 → 355 → 391
+  steps across legacy → current → max-training. Better policies survive
+  longer, even when the per-action reward signal is noisy.
+
+- **Weight movement scales with gradient steps**: p75 `|Δw|₂` grows 0.1
+  → 0.2 → 0.3.
+
+## Why per-action reward is so noisy
+
+The dominant variance in per-store reward isn't the agent's choice —
+it's environment-level shocks (a nearby resource patch depleting, a
+neighbor moving in, a gather race) that every co-located agent
+experiences. Residualising against the cohort mean removes a *lot* of
+that but not all of it. The per-agent residual standard deviation is
+~0.06 across agents, while the policy-driven signal (the mean of the
+late-minus-early deltas) is ~0.007 — an SNR of roughly 0.1.
+
+The structural reason in the code is that `LearningAgentBehavior` never
+calls the policy in pure-greedy mode. The active path is
+`predict_proba(state) × action_weights → np.random.choice`, where
+`predict_proba` is a 0.8/0.2 heuristic around the policy's argmax.
+So even a perfectly trained Q-network's choice goes through one round
+of weighted sampling against per-action config priors before being
+executed. That dilutes whatever the policy has actually learned. It is
+not a bug — `action_weights` is the chromosome-A
+`move_weight / gather_weight / ...` prior — but it does make the
+signal harder to read on per-action reward.
+
+## What survived
+
+- The diagnostic harness, with the late-life-vs-early-life analysis
+  baked in. `scripts/diagnose_dqn_learning.py`. `--legacy` reproduces
+  the pre-fix behavior on current code; `--train-freq N` overrides the
+  gradient-step cadence; `--no-defer` runs inline training.
+- The four bug fixes plus the exception-logging cleanup, behind one PR
+  and one extended test file (`tests/test_decision_config_wiring.py`).
+- The auto-scale default for `max_learning_updates_per_step`. The
+  previous default cost ~9× the training volume and was not the kind
+  of thing that should ship as the recommended setting.
+- A clearer mental model of where in the stack the signal-to-noise
+  problem lives: not in the optimizer, not in the buffer, but in the
+  `predict_proba × action_weights` action-selection path that sits
+  between the Q-network and the executed action.
+
+## What didn't survive
+
+The hypothesis I started with: "if I unblock training, late-life
+decisions will measurably improve at the default horizon." They don't,
+not in a statistically defensible way. The improvement is directional
+across multiple proxies (entropy down a hair, lifespan up, residualised
+reward up by a fraction of a standard error) but not big enough to put
+a confidence interval around.
+
+The user's hypothesis: "maybe agents aren't living long enough."
+Falsified. Mean lifespan was already 81 steps with batch threshold 32.
+The bottleneck was global throttling, not individual lifespans.
+
+## What's next
+
+- **Longer simulations.** 500 steps is enough to see training happen
+  and enough to see lifespan respond; it is not enough to see per-
+  action reward signal beat per-step environment noise. Multi-thousand-
+  step runs are the obvious next experiment, on a smaller population so
+  per-agent gradient budgets stay high.
+- **Greedy-evaluation probe states.** Cache a fixed set of observation
+  tensors early in the run; at intervals, freeze each agent's Q-net
+  and report argmax + max-Q on the probe set. That gives a deterministic
+  per-policy quality metric independent of stochastic sampling and
+  environment dynamics.
+- **Audit the `predict_proba × action_weights` dilution.** If we want
+  the trained policy to actually drive behavior, the 0.8/0.2 heuristic
+  in `TianshouWrapper.predict_proba` probably needs to be replaced with
+  a real softmax over Q-values, and the multiplication by
+  `action_weights` should probably go through a log-additive bias on
+  the logits rather than a multiplicative reweighting in probability
+  space. This is a design call, not a clear bug.
+- **Smaller-population runs as a learning sanity check.** With 1–3
+  agents and a fixed resource layout, the cohort baseline goes away
+  and the per-action reward signal should be clean enough to show a
+  classic learning curve.
+
+In short: the DQN is now actually training, but the easiest way to
+*see* it learning is no longer to fix code — it's to design a
+simulation where the policy has enough room to matter.
+
+## Related docs
+
+- [Deep Q-learning module reference](../deep_q_learning.md)
+- [Hyperparameter chromosome design](../design/hyperparameter_chromosome.md)
+- [PR #878](https://github.com/Dooders/AgentFarm/pull/878)
+- Diagnostic script: `scripts/diagnose_dqn_learning.py`

--- a/docs/devlog/index.md
+++ b/docs/devlog/index.md
@@ -6,6 +6,29 @@ subtitle: Build notes, design decisions, and experiment outcomes from AgentFarm 
 
 <ul class="posts">
   <li>
+    <a class="post-card" href="{{ '/devlog/2026-05-16-is-the-dqn-actually-learning/' | relative_url }}">
+      <span class="post-card__date">2026-05-16</span>
+      <h3 class="post-card__title">Is the DQN actually learning?</h3>
+      <p class="post-card__excerpt">
+        A user suspected agents weren't learning. Instrumenting the
+        decision module surfaced four real bugs in one stack — a global
+        training throttle, a never-applied epsilon schedule, a
+        YAML-to-config mapping that dropped knobs on the floor, and a
+        hidden-size field that did nothing. After fixing all four,
+        training volume jumps ~9× and lifespan +23%, but the late-vs-
+        early decision-quality signal is still small. The remaining
+        bottleneck is the simulation's signal-to-noise ratio, not the
+        code.
+      </p>
+      <span class="post-card__more">Read the post</span>
+    </a>
+    <p class="post-card__excerpt">
+      Related docs:
+      <a href="{{ '/deep_q_learning/' | relative_url }}">Deep Q-learning module reference</a>,
+      <a href="{{ '/design/hyperparameter_chromosome/' | relative_url }}">Hyperparameter chromosome design</a>.
+    </p>
+  </li>
+  <li>
     <a class="post-card" href="{{ '/devlog/2026-05-12-seed-sweep-reality-check/' | relative_url }}">
       <span class="post-card__date">2026-05-12</span>
       <h3 class="post-card__title">When one seed disagrees with six</h3>

--- a/farm/config/config.py
+++ b/farm/config/config.py
@@ -509,14 +509,18 @@ class PerformanceConfig:
 
     # RL training orchestration
     defer_learning_training: bool = True  # Collect experience during agent steps and train in a step-level pass
-    max_learning_updates_per_step: int = 4  # Cap deferred RL updates executed after each global simulation step
+    # Cap on deferred RL updates executed after each global simulation step.
+    # Special value ``0`` means "auto-scale to the current alive-agent count" so
+    # every agent that is ready to train gets one gradient step per env step.
+    # A positive integer is a hard cap. Negative values are rejected.
+    max_learning_updates_per_step: int = 0
 
     def __post_init__(self) -> None:
         """Validate performance config values that affect RL training orchestration."""
         if self.max_learning_updates_per_step < 0:
             raise ValueError(
                 "performance.max_learning_updates_per_step must be >= 0 "
-                f"(got {self.max_learning_updates_per_step!r})"
+                f"(0 == auto-scale to alive agent count; got {self.max_learning_updates_per_step!r})"
             )
 
 

--- a/farm/config/default.yaml
+++ b/farm/config/default.yaml
@@ -251,7 +251,9 @@ memory_pool_size_mb: 100
 enable_state_caching: true
 cache_ttl_seconds: 60
 defer_learning_training: true
-max_learning_updates_per_step: 4
+# 0 = auto-scale: every ready agent gets one gradient step per env step.
+# Use a positive integer to cap the number of updates per env step.
+max_learning_updates_per_step: 0
 
 # Action reward configuration
 defend_success_reward: 0.02

--- a/farm/core/agent/config/component_configs.py
+++ b/farm/core/agent/config/component_configs.py
@@ -313,6 +313,13 @@ class AgentComponentConfig:
         
         decision_kwargs = {}
         if learning:
+            # Each YAML ``learning.*`` knob can flow into one or more
+            # ``DecisionConfig`` fields. Memory/batch size are duplicated so
+            # both the legacy ``BaseDQNModule`` (``memory_size``/``batch_size``)
+            # and the active Tianshou DQN wrapper
+            # (``rl_buffer_size``/``rl_batch_size``) honor the same YAML value.
+            # Without this, knobs like ``learning.memory_size`` were silently
+            # ignored on the Tianshou code path.
             learning_to_decision_fields = (
                 ("learning_rate", "learning_rate"),
                 ("gamma", "gamma"),
@@ -320,7 +327,9 @@ class AgentComponentConfig:
                 ("epsilon_min", "epsilon_min"),
                 ("epsilon_decay", "epsilon_decay"),
                 ("memory_size", "memory_size"),
+                ("memory_size", "rl_buffer_size"),
                 ("batch_size", "batch_size"),
+                ("batch_size", "rl_batch_size"),
                 ("training_frequency", "rl_train_freq"),
                 ("dqn_hidden_size", "dqn_hidden_size"),
                 ("tau", "tau"),

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -461,12 +461,23 @@ class AgentCore:
         # Get enabled actions (for curriculum learning)
         enabled_actions = self._get_enabled_actions()
 
-        # Decide and execute action
+        # Decide and execute action.
+        #
+        # Failures here used to be silently swallowed, which masked real
+        # decision/execution bugs as "the agent simply isn't learning". Log
+        # them at warning level (with the agent id and exception type) so they
+        # are visible without crashing the whole simulation.
         try:
             action = self.behavior.decide_action(self, state_tensor, enabled_actions)
             self._execute_action(action, state_tensor)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning(
+                "agent_step_failed",
+                agent_id=self.agent_id,
+                error_type=type(exc).__name__,
+                error_message=str(exc),
+                exc_info=True,
+            )
 
         # Call on_step_end on all components
         for component in self._components.values():

--- a/farm/core/decision/algorithms/tianshou.py
+++ b/farm/core/decision/algorithms/tianshou.py
@@ -916,12 +916,21 @@ class TianshouWrapper(RLAlgorithm):
         """
         return self.select_action_with_mask(state, action_mask=None)
 
-    def select_action_with_mask(self, state: np.ndarray, action_mask: Optional[np.ndarray] = None) -> int:
+    def select_action_with_mask(
+        self,
+        state: np.ndarray,
+        action_mask: Optional[np.ndarray] = None,
+        *,
+        apply_epsilon_decay: bool = True,
+    ) -> int:
         """Select an action using the Tianshou policy with action masking support.
 
         Args:
             state: Current state observation
             action_mask: Boolean mask where True indicates valid actions. If None, all actions are valid.
+            apply_epsilon_decay: If True (default), advance the epsilon schedule once for this call.
+                Set False for internal reads (e.g. :meth:`predict_proba`) so callers that also
+                invoke this method to commit an action do not double-decay in one decision.
 
         Returns:
             Selected action index
@@ -933,7 +942,8 @@ class TianshouWrapper(RLAlgorithm):
         # action. Without this, ``policy.eps`` would remain at its
         # ``DQNPolicy.__init__`` default of 0.0 and the policy would always be
         # purely greedy with respect to a near-random Q-network.
-        self._decay_eps()
+        if apply_epsilon_decay:
+            self._decay_eps()
 
         # Convert state to the expected format
         if isinstance(state, np.ndarray):
@@ -1077,7 +1087,7 @@ class TianshouWrapper(RLAlgorithm):
             return np.full(self.num_actions, 1.0 / self.num_actions, dtype=float)
 
         # For Tianshou, we can get action probabilities from the policy
-        action = self.select_action(state)
+        action = self.select_action_with_mask(state, action_mask=None, apply_epsilon_decay=False)
 
         # Create a probability distribution concentrated on the selected action
         probs = np.zeros(self.num_actions)

--- a/farm/core/decision/algorithms/tianshou.py
+++ b/farm/core/decision/algorithms/tianshou.py
@@ -36,7 +36,8 @@ class TianshouWrapper(RLAlgorithm):
     _EXCLUDED_PARAMS = frozenset([
         "lr", "device", "gamma", "tau", "alpha", "auto_alpha", "target_entropy",
         "n_step", "estimation_step", "target_update_freq", "eps_test", "eps_train", "eps_train_final",
-        "repeat_per_collect", "max_batchsize"
+        "eps_decay", "dqn_hidden_size",
+        "repeat_per_collect", "max_batchsize",
     ])
 
     def __init__(
@@ -108,6 +109,18 @@ class TianshouWrapper(RLAlgorithm):
                 )
                 self.algorithm_config["n_step"] = 1
 
+        # Snapshot the epsilon-greedy schedule so :meth:`select_action_with_mask`
+        # can drive ``policy.eps`` directly. Tianshou's ``DQNPolicy.__init__``
+        # initialises ``policy.eps = 0.0`` and there is no built-in schedule on
+        # the custom-replay code path; we therefore apply the configured
+        # multiplicative decay each time we ask the policy for an action.
+        self._eps_train = float(self.algorithm_config.get("eps_train", 1.0))
+        self._eps_train_final = float(self.algorithm_config.get("eps_train_final", 0.05))
+        self._eps_test = float(self.algorithm_config.get("eps_test", 0.05))
+        self._eps_decay = float(self.algorithm_config.get("eps_decay", 0.995))
+        self._eps_current = self._eps_train
+        self._train_mode = True
+
         # Initialize replay buffer (PER implementation supports uniform fallback).
         self.replay_buffer = PrioritizedReplayBuffer(
             max_size=buffer_size,
@@ -122,6 +135,52 @@ class TianshouWrapper(RLAlgorithm):
         # Initialize algorithm
         self.policy = None
         self._initialize_policy()
+        self._apply_eps_to_policy(initial=True)
+
+    def _apply_eps_to_policy(self, initial: bool = False) -> None:
+        """Push the wrapper-tracked epsilon onto the underlying Tianshou policy.
+
+        Tianshou's ``DQNPolicy`` exposes a ``set_eps()`` method but does not
+        otherwise drive an exploration schedule on this wrapper's custom replay
+        path. We mirror :attr:`_eps_current` (or :attr:`_eps_test` when not in
+        training mode) onto ``policy.eps`` so epsilon-greedy actually happens.
+        """
+        if self.policy is None:
+            return
+        if self._train_mode:
+            target = self._eps_current
+        else:
+            target = self._eps_test
+        setter = getattr(self.policy, "set_eps", None)
+        try:
+            if callable(setter):
+                setter(float(target))
+            else:
+                self.policy.eps = float(target)
+        except Exception as exc:
+            if initial:
+                logger.debug("could_not_set_initial_eps", error=str(exc))
+
+    def _decay_eps(self) -> None:
+        """Apply one tick of multiplicative epsilon decay (training mode only)."""
+        if not self._train_mode:
+            return
+        if self._eps_decay >= 1.0:
+            return
+        self._eps_current = max(
+            self._eps_train_final, self._eps_current * self._eps_decay
+        )
+        self._apply_eps_to_policy()
+
+    def set_train_mode(self, training: bool) -> None:
+        """Toggle between training and evaluation epsilon."""
+        self._train_mode = bool(training)
+        self._apply_eps_to_policy()
+
+    @property
+    def epsilon(self) -> float:
+        """Current epsilon-greedy exploration rate (mirrors ``policy.eps``)."""
+        return self._eps_current if self._train_mode else self._eps_test
 
     def _get_default_config(self, user_config: Dict[str, Any]) -> Dict[str, Any]:
         """Get default configuration for the algorithm."""
@@ -165,9 +224,12 @@ class TianshouWrapper(RLAlgorithm):
                 # The custom replay integration in this wrapper trains on one-step transitions.
                 "n_step": 1,
                 "target_update_freq": 500,
+                # Default exploration schedule: anneal multiplicatively from
+                # eps_train -> eps_train_final each select_action_with_mask call.
                 "eps_test": 0.05,
-                "eps_train": 0.1,
+                "eps_train": 1.0,
                 "eps_train_final": 0.05,
+                "eps_decay": 0.995,
             }
             base_config.update(dqn_defaults)
         elif self.algorithm_name == "A2C":
@@ -469,14 +531,22 @@ class TianshouWrapper(RLAlgorithm):
                 from tianshou.policy import DQNPolicy
                 import torch.nn as nn
 
+                # Pull the configured hidden width (the legacy hard-coded
+                # 512/256/128 stack is now derived from this base width so the
+                # ``dqn_hidden_size`` knob is honored end-to-end).
+                base_hidden = max(8, int(self.algorithm_config.get("dqn_hidden_size", 64)))
+
                 # Create Q-network that handles 1D, 2D, and 3D observations
                 class AdaptiveQNet(nn.Module):
-                    def __init__(self, observation_shape, num_actions, device):
+                    def __init__(self, observation_shape, num_actions, device, hidden_size: int):
                         super().__init__()
                         self.observation_shape = observation_shape
                         # Only treat as spatial if we have 3D observations (C, H, W)
                         # 2D observations are flattened feature vectors, not spatial
                         self.is_spatial = len(observation_shape) == 3
+                        h1 = max(8, hidden_size * 4)
+                        h2 = max(8, hidden_size * 2)
+                        h3 = max(8, hidden_size)
 
                         if self.is_spatial:
                             # CNN layers for spatial processing (3D observations: C, H, W)
@@ -498,24 +568,24 @@ class TianshouWrapper(RLAlgorithm):
                             # Q-value output layers for spatial observations
                             self.q_layers = nn.Sequential(
                                 nn.Flatten(),
-                                nn.Linear(self.flattened_size, 512),
+                                nn.Linear(self.flattened_size, h1),
                                 nn.ReLU(),
-                                nn.Linear(512, 256),
+                                nn.Linear(h1, h2),
                                 nn.ReLU(),
-                                nn.Linear(256, num_actions),  # Q-values for each action
+                                nn.Linear(h2, num_actions),
                             )
                         else:
                             # Fully connected layers for 1D and 2D observations
                             # 2D observations are flattened feature vectors
                             input_size = observation_shape[0]
                             self.q_layers = nn.Sequential(
-                                nn.Linear(input_size, 512),
+                                nn.Linear(input_size, h1),
                                 nn.ReLU(),
-                                nn.Linear(512, 256),
+                                nn.Linear(h1, h2),
                                 nn.ReLU(),
-                                nn.Linear(256, 128),
+                                nn.Linear(h2, h3),
                                 nn.ReLU(),
-                                nn.Linear(128, num_actions),  # Q-values for each action
+                                nn.Linear(h3, num_actions),
                             )
 
                     def forward(self, obs, state=None, info=None):
@@ -540,7 +610,12 @@ class TianshouWrapper(RLAlgorithm):
                         return q_values, state
 
                 # Create adaptive Q-network
-                q_net = AdaptiveQNet(self.observation_shape, self.num_actions, self.algorithm_config["device"])
+                q_net = AdaptiveQNet(
+                    self.observation_shape,
+                    self.num_actions,
+                    self.algorithm_config["device"],
+                    hidden_size=base_hidden,
+                )
 
                 # Move to device
                 q_net.to(self.algorithm_config["device"])
@@ -853,6 +928,12 @@ class TianshouWrapper(RLAlgorithm):
         """
         if self.policy is None:
             raise RuntimeError("Policy not initialized")
+
+        # Drive the epsilon-greedy schedule each time we ask the policy for an
+        # action. Without this, ``policy.eps`` would remain at its
+        # ``DQNPolicy.__init__`` default of 0.0 and the policy would always be
+        # purely greedy with respect to a near-random Q-network.
+        self._decay_eps()
 
         # Convert state to the expected format
         if isinstance(state, np.ndarray):

--- a/farm/core/decision/decision.py
+++ b/farm/core/decision/decision.py
@@ -366,6 +366,8 @@ class DecisionModule:
                 "eps_test": self.config.epsilon_min,
                 "eps_train": self.config.epsilon_start,
                 "eps_train_final": self.config.epsilon_min,
+                "eps_decay": self.config.epsilon_decay,
+                "dqn_hidden_size": int(self.config.dqn_hidden_size),
             }
 
             # Add any additional parameters from config

--- a/farm/core/simulation.py
+++ b/farm/core/simulation.py
@@ -68,12 +68,15 @@ def _run_deferred_learning_updates(environment: Environment, max_updates: int, r
     Args:
         environment: Active simulation environment.
         max_updates: Maximum number of training calls to execute this step.
+            ``0`` is the auto-scale sentinel — interpreted as
+            ``len(alive_agents)`` so every ready agent gets one gradient step
+            per env step.
         rr_cursor: Round-robin start index into alive agents.
 
     Returns:
         int: Number of training updates executed.
     """
-    if max_updates <= 0:
+    if max_updates < 0:
         return 0
 
     alive_agents = environment.alive_agent_objects
@@ -81,6 +84,8 @@ def _run_deferred_learning_updates(environment: Environment, max_updates: int, r
         return 0
 
     n_agents = len(alive_agents)
+    if max_updates == 0:
+        max_updates = n_agents
     start = rr_cursor % n_agents
     agent_queue = deque(alive_agents[start:] + alive_agents[:start])
     updates_run = 0
@@ -559,17 +564,19 @@ def run_simulation(
 
         perf_cfg = getattr(config, "performance", None)
         defer_learning_training = bool(getattr(perf_cfg, "defer_learning_training", True))
-        raw_max_learning_updates = getattr(perf_cfg, "max_learning_updates_per_step", 4)
+        raw_max_learning_updates = getattr(perf_cfg, "max_learning_updates_per_step", 0)
         try:
             parsed_max_learning_updates = int(raw_max_learning_updates)
         except (TypeError, ValueError):
             logger.warning(
                 "invalid_max_learning_updates_per_step_defaulted",
                 configured_value=raw_max_learning_updates,
-                default_value=4,
+                default_value=0,
             )
-            parsed_max_learning_updates = 4
+            parsed_max_learning_updates = 0
 
+        # 0 is the auto-scale sentinel (one update per ready agent each env
+        # step). Negative values are coerced to 0 with a warning.
         max_learning_updates_per_step = max(0, parsed_max_learning_updates)
         if max_learning_updates_per_step != parsed_max_learning_updates:
             logger.warning(

--- a/scripts/diagnose_dqn_learning.py
+++ b/scripts/diagnose_dqn_learning.py
@@ -196,6 +196,13 @@ def collect_final_state(env) -> None:
             stats.epsilon_at_end = float(getattr(policy, "eps", float("nan")))
         except Exception:
             stats.epsilon_at_end = None
+        # Wrapper-tracked schedule (preferred when present)
+        wrapper_eps = getattr(algorithm, "_eps_current", None)
+        if wrapper_eps is not None:
+            try:
+                stats.epsilon_at_end = float(wrapper_eps)
+            except Exception:
+                pass
         # Parameter snapshot for L2 movement
         sample = _sample_policy_params(getattr(algorithm, "policy", None))
         if sample is not None:

--- a/scripts/diagnose_dqn_learning.py
+++ b/scripts/diagnose_dqn_learning.py
@@ -1,0 +1,396 @@
+"""DQN learning diagnostic.
+
+Runs a real AgentFarm simulation with the default configuration, instruments
+every learning agent's ``DecisionModule`` (and the underlying Tianshou DQN
+policy) to record:
+
+* every ``store_experience`` call (replay-buffer fill rate per agent)
+* every ``train_if_ready`` outcome (whether a gradient step was taken)
+* every ``policy.learn`` call (independent confirmation that gradient
+  steps actually run end-to-end)
+* a tracked Q-network parameter snapshot so we can verify that weights
+  *actually move* across training (not just that ``learn`` returned)
+* per-agent lifespan in steps
+
+Then prints a per-agent table plus aggregate diagnostics so a human can see
+whether agents are learning at all and, if not, why.
+
+Run with ``PYTHONHASHSEED=0 python scripts/diagnose_dqn_learning.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections import defaultdict
+from typing import Any, Dict, Optional
+
+import numpy as np
+import torch
+
+from farm.config import SimulationConfig
+from farm.core.decision.algorithms.tianshou import TianshouWrapper
+from farm.core.decision.decision import DecisionModule
+from farm.core.simulation import run_simulation
+
+
+# ---------------------------------------------------------------------------
+# Stats container
+# ---------------------------------------------------------------------------
+
+
+class AgentStats:
+    """Per-agent learning instrumentation counters."""
+
+    __slots__ = (
+        "agent_id",
+        "store_calls",
+        "train_ready_true",
+        "train_ready_false",
+        "policy_learn_calls",
+        "policy_learn_succeeded",
+        "first_seen_step",
+        "last_seen_step",
+        "initial_param_sample",
+        "final_param_sample",
+        "param_change_l2",
+        "buffer_size_at_end",
+        "epsilon_at_end",
+    )
+
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.store_calls = 0
+        self.train_ready_true = 0
+        self.train_ready_false = 0
+        self.policy_learn_calls = 0
+        self.policy_learn_succeeded = 0
+        self.first_seen_step: Optional[int] = None
+        self.last_seen_step: Optional[int] = None
+        self.initial_param_sample: Optional[np.ndarray] = None
+        self.final_param_sample: Optional[np.ndarray] = None
+        self.param_change_l2: float = 0.0
+        self.buffer_size_at_end: int = 0
+        self.epsilon_at_end: Optional[float] = None
+
+
+_STATS: Dict[str, AgentStats] = defaultdict(lambda: AgentStats("?"))
+
+
+def _stats_for(agent_id: str) -> AgentStats:
+    s = _STATS.get(agent_id)
+    if s is None:
+        s = AgentStats(agent_id)
+        _STATS[agent_id] = s
+    return s
+
+
+def _sample_policy_params(policy: Any) -> Optional[np.ndarray]:
+    """Return a flat numpy snapshot of the first parameter tensor we find."""
+    model = getattr(policy, "model", None)
+    if model is None:
+        return None
+    for p in model.parameters():
+        return p.detach().flatten().cpu().numpy().copy()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Monkey-patches that instrument the DecisionModule + TianshouWrapper
+# ---------------------------------------------------------------------------
+
+
+def install_instrumentation() -> None:
+    """Wrap key methods to count calls without changing behavior."""
+
+    orig_store = TianshouWrapper.store_experience
+    orig_should_train = TianshouWrapper.should_train
+    orig_train_on_batch = TianshouWrapper.train_on_batch
+    orig_decision_train_if_ready = DecisionModule.train_if_ready
+
+    def patched_store(self, state, action, reward, next_state, done, **kwargs):
+        agent_id = getattr(self, "_diag_agent_id", "?")
+        stats = _stats_for(agent_id)
+        stats.store_calls += 1
+        # Take an initial parameter sample on the very first store so that
+        # comparisons later show real movement (or the absence of it).
+        if stats.initial_param_sample is None and self.policy is not None:
+            sample = _sample_policy_params(self.policy)
+            if sample is not None:
+                stats.initial_param_sample = sample
+        return orig_store(self, state, action, reward, next_state, done, **kwargs)
+
+    def patched_should_train(self) -> bool:
+        return orig_should_train(self)
+
+    def patched_train_on_batch(self, batch, **kwargs):
+        agent_id = getattr(self, "_diag_agent_id", "?")
+        stats = _stats_for(agent_id)
+        stats.policy_learn_calls += 1
+        result = orig_train_on_batch(self, batch, **kwargs)
+        # Treat any non-None metrics dict that has a finite loss as a success.
+        if isinstance(result, dict):
+            stats.policy_learn_succeeded += 1
+        return result
+
+    def patched_decision_train_if_ready(self) -> bool:
+        agent_id = getattr(self, "agent_id", "?")
+        stats = _stats_for(agent_id)
+        ready = self._should_train_algorithm() if self.algorithm is not None else False
+        if not ready:
+            stats.train_ready_false += 1
+            return False
+        stats.train_ready_true += 1
+        return orig_decision_train_if_ready(self)
+
+    TianshouWrapper.store_experience = patched_store  # type: ignore[assignment]
+    TianshouWrapper.should_train = patched_should_train  # type: ignore[assignment]
+    TianshouWrapper.train_on_batch = patched_train_on_batch  # type: ignore[assignment]
+    DecisionModule.train_if_ready = patched_decision_train_if_ready  # type: ignore[assignment]
+
+    # Tag the wrapper with the agent id so the patched methods can attribute
+    # their counts. We do this by patching DecisionModule.__init__ so that
+    # right after the algorithm is constructed we stash ``_diag_agent_id``
+    # on it.
+    orig_dm_init = DecisionModule.__init__
+
+    def patched_dm_init(self, agent, action_space, observation_space, *args, **kwargs):
+        orig_dm_init(self, agent, action_space, observation_space, *args, **kwargs)
+        if self.algorithm is not None:
+            self.algorithm._diag_agent_id = self.agent_id  # type: ignore[attr-defined]
+        # Track the agent so we can sample parameters at the end too.
+        _stats_for(self.agent_id).first_seen_step = 0
+
+    DecisionModule.__init__ = patched_dm_init  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# End-of-run snapshotting
+# ---------------------------------------------------------------------------
+
+
+def collect_final_state(env) -> None:
+    """Sample final parameters/buffer size/epsilon for every learning agent."""
+    agent_objs = list(getattr(env, "agent_objects", []) or [])
+    # Some agents may already be dead; pull from the agent registry too if present
+    for agent in agent_objs:
+        agent_id = getattr(agent, "agent_id", None)
+        if not agent_id:
+            continue
+        behavior = getattr(agent, "behavior", None)
+        decision_module = getattr(behavior, "decision_module", None)
+        if decision_module is None:
+            continue
+        algorithm = getattr(decision_module, "algorithm", None)
+        if algorithm is None:
+            continue
+        stats = _stats_for(agent_id)
+        # Buffer size / epsilon snapshot
+        try:
+            stats.buffer_size_at_end = len(algorithm.replay_buffer)
+        except Exception:
+            stats.buffer_size_at_end = -1
+        try:
+            policy = algorithm.policy
+            stats.epsilon_at_end = float(getattr(policy, "eps", float("nan")))
+        except Exception:
+            stats.epsilon_at_end = None
+        # Parameter snapshot for L2 movement
+        sample = _sample_policy_params(getattr(algorithm, "policy", None))
+        if sample is not None:
+            stats.final_param_sample = sample
+            if stats.initial_param_sample is not None and stats.initial_param_sample.shape == sample.shape:
+                stats.param_change_l2 = float(
+                    np.linalg.norm(sample - stats.initial_param_sample)
+                )
+
+
+# ---------------------------------------------------------------------------
+# Lifespan harvesting from the simulation database
+# ---------------------------------------------------------------------------
+
+
+def harvest_lifespans(env) -> Dict[str, int]:
+    """Return ``agent_id -> lifespan_in_steps`` from the in-memory env."""
+    out: Dict[str, int] = {}
+    final_time = int(getattr(env, "time", 0))
+    for agent in getattr(env, "agent_objects", []) or []:
+        agent_id = getattr(agent, "agent_id", None)
+        if not agent_id:
+            continue
+        birth = int(getattr(agent, "birth_time", 0))
+        # Use death_time if present, else current time (still alive at end of run).
+        death = getattr(agent, "death_time", None)
+        if death is None:
+            # Some implementations don't set death_time on alive agents
+            death = final_time
+        out[str(agent_id)] = max(0, int(death) - birth)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def _percentiles(values, qs=(0, 25, 50, 75, 100)) -> str:
+    if not values:
+        return "n/a"
+    arr = np.asarray(values, dtype=float)
+    return ", ".join(f"p{q}={np.percentile(arr, q):.1f}" for q in qs)
+
+
+def report(num_steps: int, lifespans: Dict[str, int]) -> None:
+    print("\n" + "=" * 78)
+    print("DQN learning diagnostic")
+    print("=" * 78)
+    if not _STATS:
+        print("No DecisionModule instances were instrumented. Did the simulation start?")
+        return
+
+    rows = []
+    for agent_id, s in _STATS.items():
+        rows.append(
+            {
+                "agent": agent_id,
+                "lifespan": lifespans.get(agent_id, -1),
+                "stores": s.store_calls,
+                "train_ready_T": s.train_ready_true,
+                "train_ready_F": s.train_ready_false,
+                "policy_learn_calls": s.policy_learn_calls,
+                "buf_end": s.buffer_size_at_end,
+                "param_l2": s.param_change_l2,
+                "eps_end": s.epsilon_at_end,
+            }
+        )
+
+    rows.sort(key=lambda r: r["agent"])
+
+    print(f"\nSimulation steps requested: {num_steps}")
+    print(f"Total agents instrumented:  {len(rows)}\n")
+
+    header = (
+        f"{'agent_id':<14} {'life':>5} {'stores':>7} {'train_ok':>9} "
+        f"{'train_skip':>11} {'learn_called':>13} {'buf_end':>8} "
+        f"{'|Δw|_2':>9} {'eps_end':>9}"
+    )
+    print(header)
+    print("-" * len(header))
+    for r in rows[:50]:  # cap the printout
+        eps = "n/a" if r["eps_end"] is None else f"{r['eps_end']:.3f}"
+        life = "?" if r["lifespan"] < 0 else str(r["lifespan"])
+        print(
+            f"{r['agent'][:14]:<14} {life:>5} {r['stores']:>7} "
+            f"{r['train_ready_T']:>9} {r['train_ready_F']:>11} "
+            f"{r['policy_learn_calls']:>13} {r['buf_end']:>8} "
+            f"{r['param_l2']:>9.4f} {eps:>9}"
+        )
+    if len(rows) > 50:
+        print(f"... ({len(rows) - 50} additional agents truncated)")
+
+    # Aggregates
+    stores = [r["stores"] for r in rows]
+    learns = [r["policy_learn_calls"] for r in rows]
+    skipped = [r["train_ready_F"] for r in rows]
+    successful_train_calls = [r["train_ready_T"] for r in rows]
+    param_moves = [r["param_l2"] for r in rows]
+    lifespan_vals = [r["lifespan"] for r in rows if r["lifespan"] >= 0]
+
+    print("\n--- Aggregates ---")
+    print(f"Stores per agent:                  {_percentiles(stores)}")
+    print(f"Train-ready=True calls per agent:  {_percentiles(successful_train_calls)}")
+    print(f"Train-ready=False calls per agent: {_percentiles(skipped)}")
+    print(f"policy.learn() calls per agent:    {_percentiles(learns)}")
+    print(f"|Δw|_2 of first param per agent:   {_percentiles(param_moves)}")
+    if lifespan_vals:
+        print(f"Lifespan in steps per agent:       {_percentiles(lifespan_vals)}")
+        print(f"  -> mean lifespan: {np.mean(lifespan_vals):.1f} steps")
+    else:
+        print("Lifespan in steps per agent:       n/a (no DB rows)")
+
+    n_agents = len(rows)
+    n_stored_anything = sum(1 for s in stores if s > 0)
+    n_ever_trained = sum(1 for L in learns if L > 0)
+    n_weights_moved = sum(1 for v in param_moves if v > 1e-8)
+    n_filled_batch = sum(
+        1 for r in rows if r["buf_end"] >= 32  # default rl_batch_size
+    )
+
+    print("\n--- Summary ---")
+    print(f"Agents that stored ≥1 experience:           {n_stored_anything}/{n_agents}")
+    print(f"Agents whose buffer reached batch size 32:  {n_filled_batch}/{n_agents}")
+    print(f"Agents that ran ≥1 training gradient step:  {n_ever_trained}/{n_agents}")
+    print(f"Agents whose Q-net weights actually moved:  {n_weights_moved}/{n_agents}")
+    print("=" * 78)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--steps", type=int, default=100, help="Number of simulation steps")
+    parser.add_argument(
+        "--no-defer",
+        action="store_true",
+        help="Force defer_learning_training=False so each store_experience trains immediately",
+    )
+    parser.add_argument(
+        "--max-updates",
+        type=int,
+        default=None,
+        help="Override max_learning_updates_per_step",
+    )
+    parser.add_argument("--output", default="simulations/diagnostic", help="Output directory")
+    args = parser.parse_args()
+
+    install_instrumentation()
+
+    config = SimulationConfig.from_centralized_config(environment="development")
+    perf = getattr(config, "performance", None)
+    if perf is not None:
+        if args.no_defer:
+            perf.defer_learning_training = False
+        if args.max_updates is not None:
+            perf.max_learning_updates_per_step = int(args.max_updates)
+
+    print(
+        f"[diag] config: defer_learning_training={getattr(perf, 'defer_learning_training', None)}, "
+        f"max_learning_updates_per_step={getattr(perf, 'max_learning_updates_per_step', None)}, "
+        f"system_agents={config.population.system_agents}, "
+        f"independent_agents={config.population.independent_agents}, "
+        f"control_agents={config.population.control_agents}, "
+        f"steps={args.steps}"
+    )
+    print(
+        f"[diag] DecisionConfig defaults expected: rl_batch_size=32, rl_train_freq=4, rl_buffer_size=10000"
+    )
+
+    env = run_simulation(
+        num_steps=args.steps,
+        config=config,
+        path=args.output,
+        save_config=False,
+        disable_console_logging=True,
+    )
+
+    collect_final_state(env)
+    lifespans = harvest_lifespans(env)
+    report(args.steps, lifespans)
+
+    try:
+        env.cleanup()
+    except Exception:
+        pass
+
+    return 0
+
+
+if __name__ == "__main__":
+    if "PYTHONHASHSEED" not in os.environ or os.environ["PYTHONHASHSEED"] != "0":
+        os.environ["PYTHONHASHSEED"] = "0"
+        os.execv(sys.executable, [sys.executable] + sys.argv)
+    raise SystemExit(main())

--- a/scripts/diagnose_dqn_learning.py
+++ b/scripts/diagnose_dqn_learning.py
@@ -58,6 +58,9 @@ class AgentStats:
         "buffer_size_at_end",
         "epsilon_at_end",
         "rewards",
+        "actions",
+        "env_times",
+        "lifespan",
     )
 
     def __init__(self, agent_id: str) -> None:
@@ -75,6 +78,9 @@ class AgentStats:
         self.buffer_size_at_end: int = 0
         self.epsilon_at_end: Optional[float] = None
         self.rewards: list = []
+        self.actions: list = []
+        self.env_times: list = []
+        self.lifespan: int = 0
 
 
 _STATS: Dict[str, AgentStats] = defaultdict(lambda: AgentStats("?"))
@@ -115,6 +121,7 @@ def install_instrumentation() -> None:
     orig_should_train = TianshouWrapper.should_train
     orig_train_on_batch = TianshouWrapper.train_on_batch
     orig_decision_train_if_ready = DecisionModule.train_if_ready
+    orig_decision_update = DecisionModule.update
 
     def patched_store(self, state, action, reward, next_state, done, **kwargs):
         agent_id = getattr(self, "_diag_agent_id", "?")
@@ -124,6 +131,12 @@ def install_instrumentation() -> None:
             stats.rewards.append(float(reward))
         except (TypeError, ValueError):
             pass
+        try:
+            stats.actions.append(int(action))
+        except (TypeError, ValueError):
+            stats.actions.append(-1)
+        env_time = getattr(self, "_diag_env_time", None)
+        stats.env_times.append(int(env_time) if env_time is not None else -1)
         # Take an initial parameter sample on the very first store so that
         # comparisons later show real movement (or the absence of it).
         if stats.initial_param_sample is None and self.policy is not None:
@@ -155,10 +168,22 @@ def install_instrumentation() -> None:
         stats.train_ready_true += 1
         return orig_decision_train_if_ready(self)
 
+    def patched_decision_update(self, state, action, reward, next_state, done, **kwargs):
+        # Stash the current env time on the wrapper so patched_store can
+        # attach (env_time, action, reward) to its trajectory record.
+        if self.algorithm is not None:
+            try:
+                t = self.agent.services.time_service.current_time()
+                self.algorithm._diag_env_time = int(t)  # type: ignore[attr-defined]
+            except Exception:
+                self.algorithm._diag_env_time = None  # type: ignore[attr-defined]
+        return orig_decision_update(self, state, action, reward, next_state, done, **kwargs)
+
     TianshouWrapper.store_experience = patched_store  # type: ignore[assignment]
     TianshouWrapper.should_train = patched_should_train  # type: ignore[assignment]
     TianshouWrapper.train_on_batch = patched_train_on_batch  # type: ignore[assignment]
     DecisionModule.train_if_ready = patched_decision_train_if_ready  # type: ignore[assignment]
+    DecisionModule.update = patched_decision_update  # type: ignore[assignment]
 
     # Tag the wrapper with the agent id so the patched methods can attribute
     # their counts. We do this by patching DecisionModule.__init__ so that
@@ -243,7 +268,11 @@ def harvest_lifespans(env) -> Dict[str, int]:
         if death is None:
             # Some implementations don't set death_time on alive agents
             death = final_time
-        out[str(agent_id)] = max(0, int(death) - birth)
+        lifespan = max(0, int(death) - birth)
+        out[str(agent_id)] = lifespan
+        # Mirror onto the stats object so downstream analyses can filter
+        # (e.g., only consider agents that lived long enough to learn).
+        _stats_for(str(agent_id)).lifespan = lifespan
     return out
 
 
@@ -257,6 +286,139 @@ def _percentiles(values, qs=(0, 25, 50, 75, 100)) -> str:
         return "n/a"
     arr = np.asarray(values, dtype=float)
     return ", ".join(f"p{q}={np.percentile(arr, q):.1f}" for q in qs)
+
+
+def _entropy(counts: np.ndarray) -> float:
+    """Shannon entropy (nats) of a non-negative count vector."""
+    total = float(counts.sum())
+    if total <= 0:
+        return 0.0
+    p = counts.astype(np.float64) / total
+    p = p[p > 0]
+    return float(-(p * np.log(p)).sum())
+
+
+def decision_quality_analysis(min_lifespan: int = 100) -> None:
+    """Report whether agents make *better decisions* late in life than early.
+
+    Two complementary signals, both restricted to agents that lived long
+    enough to plausibly learn (lifespan >= ``min_lifespan``):
+
+    1. **Residualised reward late vs early.**  For every (env_time, reward)
+       tuple stored across all agents we compute the cohort-mean reward at
+       that env time.  An agent's *residual* reward at time t is its own
+       reward minus that cohort mean, so anything common to all agents at
+       that moment (food scarcity, density, weather) cancels out.  We then
+       split each long-lived agent's residuals into the first 25% and last
+       25% of their experience and compare the means.
+
+    2. **Action-distribution shift.**  Compare the entropy of the action
+       histogram in the first vs the last quartile of each agent's stored
+       experience and the share of the most-used action.  A policy that is
+       actually learning to commit should show lower entropy / higher
+       top-action share in late life than in early life.
+    """
+    print("\n--- Decision quality: late life vs early life "
+          f"(long-lived agents, lifespan >= {min_lifespan}) ---")
+
+    # ``lifespan`` only gets populated from ``harvest_lifespans`` for agents
+    # still in env.agent_objects at end of run. Fall back to store_calls as
+    # the lifespan estimate (~one store per step the agent acted) so agents
+    # that lived long and then died are still included.
+    long_lived = [
+        s for s in _STATS.values()
+        if max(s.lifespan, len(s.rewards)) >= min_lifespan and len(s.rewards) >= 8
+    ]
+    if not long_lived:
+        print("  (no agents survived long enough to evaluate)")
+        return
+
+    # ---- Build env_time -> cohort mean reward baseline ----
+    all_pairs = []
+    for s in _STATS.values():
+        for t, r in zip(s.env_times, s.rewards):
+            if t >= 0:
+                all_pairs.append((int(t), float(r)))
+    if not all_pairs:
+        print("  (no (env_time, reward) data was captured)")
+        return
+
+    times = np.array([p[0] for p in all_pairs], dtype=np.int64)
+    rewards = np.array([p[1] for p in all_pairs], dtype=np.float64)
+    unique_t = np.unique(times)
+    # Cohort mean reward at each env step (use a dict for O(1) lookup).
+    baseline = {}
+    for t in unique_t:
+        mask = times == t
+        baseline[int(t)] = float(rewards[mask].mean()) if mask.any() else 0.0
+
+    # ---- Per-agent residualised early-vs-late reward ----
+    early_residuals = []
+    late_residuals = []
+    per_agent_deltas = []
+    improved = 0
+    for s in long_lived:
+        ts = np.asarray(s.env_times, dtype=np.int64)
+        rs = np.asarray(s.rewards, dtype=np.float64)
+        valid = ts >= 0
+        ts, rs = ts[valid], rs[valid]
+        if len(rs) < 8:
+            continue
+        residuals = np.array([rs[i] - baseline.get(int(ts[i]), 0.0) for i in range(len(rs))])
+        q = max(1, len(residuals) // 4)
+        early = float(residuals[:q].mean())
+        late = float(residuals[-q:].mean())
+        early_residuals.append(early)
+        late_residuals.append(late)
+        per_agent_deltas.append(late - early)
+        if late > early:
+            improved += 1
+
+    print(f"  long-lived agents evaluated:                {len(per_agent_deltas)}")
+    if per_agent_deltas:
+        deltas = np.asarray(per_agent_deltas)
+        print(f"  mean early-life residualised reward:        {np.mean(early_residuals):+.5f}")
+        print(f"  mean late-life residualised reward:         {np.mean(late_residuals):+.5f}")
+        print(f"  mean Δ (late - early) per agent:            {deltas.mean():+.5f}")
+        print(f"  agents with positive Δ (improved):          {improved}/{len(per_agent_deltas)}")
+        # Simple paired t-statistic-ish summary (no scipy dependency).
+        n = len(deltas)
+        sd = float(deltas.std(ddof=1)) if n > 1 else 0.0
+        sem = sd / np.sqrt(n) if n > 1 and sd > 0 else float("nan")
+        t = deltas.mean() / sem if sem and not np.isnan(sem) else float("nan")
+        print(f"  one-sample t-stat for Δ > 0:                t={t:+.2f}  (n={n}, sd={sd:.5f})")
+
+    # ---- Action-distribution shift ----
+    early_entropies = []
+    late_entropies = []
+    early_top_share = []
+    late_top_share = []
+    for s in long_lived:
+        acts = np.asarray(s.actions, dtype=np.int64)
+        acts = acts[acts >= 0]
+        if len(acts) < 8:
+            continue
+        q = max(1, len(acts) // 4)
+        first_q = acts[:q]
+        last_q = acts[-q:]
+        n_actions = int(max(first_q.max(initial=0), last_q.max(initial=0)) + 1)
+        first_counts = np.bincount(first_q, minlength=n_actions)
+        last_counts = np.bincount(last_q, minlength=n_actions)
+        early_entropies.append(_entropy(first_counts))
+        late_entropies.append(_entropy(last_counts))
+        early_top_share.append(float(first_counts.max()) / max(1, len(first_q)))
+        late_top_share.append(float(last_counts.max()) / max(1, len(last_q)))
+
+    if early_entropies:
+        print(f"\n  mean action entropy   early -> late:      "
+              f"{np.mean(early_entropies):.3f} -> {np.mean(late_entropies):.3f} nats")
+        print(f"  mean top-action share early -> late:      "
+              f"{np.mean(early_top_share):.3f} -> {np.mean(late_top_share):.3f}")
+        ent_delta = np.mean(late_entropies) - np.mean(early_entropies)
+        share_delta = np.mean(late_top_share) - np.mean(early_top_share)
+        print(f"  Δ entropy: {ent_delta:+.3f} nats   "
+              f"Δ top-share: {share_delta:+.3f}   "
+              f"(negative entropy / positive top-share => policy committing)")
 
 
 def report(num_steps: int, lifespans: Dict[str, int]) -> None:
@@ -379,6 +541,13 @@ def report(num_steps: int, lifespans: Dict[str, int]) -> None:
                   f"{q_means[2]:+.4f}, {q_means[3]:+.4f}")
     else:
         print("  (insufficient reward data per agent)")
+
+    # Make sure ``lifespan`` is set on every stats record before the
+    # quality analysis filters by it; harvest_lifespans only updates entries
+    # for agents still present in env.agent_objects.
+    for agent_id, life in lifespans.items():
+        _stats_for(agent_id).lifespan = max(_stats_for(agent_id).lifespan, life)
+    decision_quality_analysis(min_lifespan=100)
     print("=" * 78)
 
 
@@ -402,6 +571,12 @@ def main() -> int:
         help="Override max_learning_updates_per_step",
     )
     parser.add_argument("--output", default="simulations/diagnostic", help="Output directory")
+    parser.add_argument(
+        "--train-freq",
+        type=int,
+        default=None,
+        help="Override DecisionConfig.rl_train_freq (lower = more gradient steps)",
+    )
     parser.add_argument(
         "--legacy",
         action="store_true",
@@ -431,6 +606,8 @@ def main() -> int:
             perf.defer_learning_training = False
         if args.max_updates is not None:
             perf.max_learning_updates_per_step = int(args.max_updates)
+    if args.train_freq is not None:
+        config.learning.training_frequency = int(args.train_freq)
 
     print(
         f"[diag] mode={'LEGACY (pre-fix)' if args.legacy else 'CURRENT (post-fix defaults)'} "

--- a/scripts/diagnose_dqn_learning.py
+++ b/scripts/diagnose_dqn_learning.py
@@ -57,6 +57,7 @@ class AgentStats:
         "param_change_l2",
         "buffer_size_at_end",
         "epsilon_at_end",
+        "rewards",
     )
 
     def __init__(self, agent_id: str) -> None:
@@ -73,9 +74,15 @@ class AgentStats:
         self.param_change_l2: float = 0.0
         self.buffer_size_at_end: int = 0
         self.epsilon_at_end: Optional[float] = None
+        self.rewards: list = []
 
 
 _STATS: Dict[str, AgentStats] = defaultdict(lambda: AgentStats("?"))
+
+
+def reset_stats() -> None:
+    """Clear the per-process stats container (useful for repeated runs)."""
+    _STATS.clear()
 
 
 def _stats_for(agent_id: str) -> AgentStats:
@@ -113,6 +120,10 @@ def install_instrumentation() -> None:
         agent_id = getattr(self, "_diag_agent_id", "?")
         stats = _stats_for(agent_id)
         stats.store_calls += 1
+        try:
+            stats.rewards.append(float(reward))
+        except (TypeError, ValueError):
+            pass
         # Take an initial parameter sample on the very first store so that
         # comparisons later show real movement (or the absence of it).
         if stats.initial_param_sample is None and self.policy is not None:
@@ -329,6 +340,45 @@ def report(num_steps: int, lifespans: Dict[str, int]) -> None:
     print(f"Agents whose buffer reached batch size 32:  {n_filled_batch}/{n_agents}")
     print(f"Agents that ran ≥1 training gradient step:  {n_ever_trained}/{n_agents}")
     print(f"Agents whose Q-net weights actually moved:  {n_weights_moved}/{n_agents}")
+
+    # ---- Reward-trend per agent (did learning *improve* behavior?) ----
+    print("\n--- Reward trend (per-agent first-half vs second-half mean reward) ---")
+    first_means = []
+    second_means = []
+    deltas = []
+    agents_improved = 0
+    agents_with_two_halves = 0
+    for s in _STATS.values():
+        rs = s.rewards
+        if len(rs) < 8:
+            continue
+        half = len(rs) // 2
+        first = float(np.mean(rs[:half]))
+        second = float(np.mean(rs[half:]))
+        first_means.append(first)
+        second_means.append(second)
+        deltas.append(second - first)
+        agents_with_two_halves += 1
+        if second > first:
+            agents_improved += 1
+    if first_means:
+        print(f"  agents with ≥8 stored rewards:      {agents_with_two_halves}")
+        print(f"  mean first-half reward (agg):       {np.mean(first_means):+.4f}")
+        print(f"  mean second-half reward (agg):      {np.mean(second_means):+.4f}")
+        print(f"  mean (second-first) Δ per agent:    {np.mean(deltas):+.4f}")
+        print(f"  agents whose Δ > 0 (improved):      {agents_improved}/{agents_with_two_halves}")
+        # Aggregate reward stream across all agents, ordered by store time.
+        all_rewards = []
+        for s in _STATS.values():
+            all_rewards.extend(s.rewards)
+        if len(all_rewards) >= 4:
+            quartiles = np.array_split(np.asarray(all_rewards, dtype=float), 4)
+            q_means = [float(np.mean(q)) for q in quartiles]
+            print(f"  aggregate quartile means (Q1..Q4): "
+                  f"{q_means[0]:+.4f}, {q_means[1]:+.4f}, "
+                  f"{q_means[2]:+.4f}, {q_means[3]:+.4f}")
+    else:
+        print("  (insufficient reward data per agent)")
     print("=" * 78)
 
 
@@ -352,12 +402,30 @@ def main() -> int:
         help="Override max_learning_updates_per_step",
     )
     parser.add_argument("--output", default="simulations/diagnostic", help="Output directory")
+    parser.add_argument(
+        "--legacy",
+        action="store_true",
+        help=(
+            "Reproduce the pre-fix behavior on the current code: cap deferred "
+            "training at 4 updates per step and disable epsilon-greedy by "
+            "setting epsilon_start=epsilon_min=0, epsilon_decay=1. Useful as "
+            "an A/B baseline."
+        ),
+    )
     args = parser.parse_args()
 
     install_instrumentation()
 
     config = SimulationConfig.from_centralized_config(environment="development")
     perf = getattr(config, "performance", None)
+    if args.legacy and perf is not None:
+        perf.defer_learning_training = True
+        perf.max_learning_updates_per_step = 4
+        # Disable the now-functional epsilon schedule so the policy is pure
+        # greedy on a near-random Q-net -- the pre-fix behavior.
+        config.learning.epsilon_start = 0.0
+        config.learning.epsilon_min = 0.0
+        config.learning.epsilon_decay = 1.0
     if perf is not None:
         if args.no_defer:
             perf.defer_learning_training = False
@@ -365,15 +433,14 @@ def main() -> int:
             perf.max_learning_updates_per_step = int(args.max_updates)
 
     print(
-        f"[diag] config: defer_learning_training={getattr(perf, 'defer_learning_training', None)}, "
+        f"[diag] mode={'LEGACY (pre-fix)' if args.legacy else 'CURRENT (post-fix defaults)'} "
+        f"defer_learning_training={getattr(perf, 'defer_learning_training', None)}, "
         f"max_learning_updates_per_step={getattr(perf, 'max_learning_updates_per_step', None)}, "
-        f"system_agents={config.population.system_agents}, "
-        f"independent_agents={config.population.independent_agents}, "
-        f"control_agents={config.population.control_agents}, "
+        f"epsilon_start={config.learning.epsilon_start}, "
+        f"epsilon_decay={config.learning.epsilon_decay}, "
+        f"system+independent+control_agents="
+        f"{config.population.system_agents + config.population.independent_agents + config.population.control_agents}, "
         f"steps={args.steps}"
-    )
-    print(
-        f"[diag] DecisionConfig defaults expected: rl_batch_size=32, rl_train_freq=4, rl_buffer_size=10000"
     )
 
     env = run_simulation(

--- a/tests/test_decision_config_wiring.py
+++ b/tests/test_decision_config_wiring.py
@@ -96,5 +96,122 @@ class TestEnsembleSizeWiring(unittest.TestCase):
         self.assertFalse(hasattr(module.algorithm.model, "n_estimators"))
 
 
+@unittest.skipUnless(TIANSHOU_AVAILABLE, "Tianshou required for DQN epsilon-greedy wiring tests")
+class TestEpsilonGreedyWiring(unittest.TestCase):
+    """`DecisionConfig.epsilon_*` must drive the live Tianshou DQN policy."""
+
+    def test_initial_eps_matches_epsilon_start(self):
+        cfg = DecisionConfig(
+            algorithm_type="dqn",
+            epsilon_start=0.7,
+            epsilon_min=0.05,
+            epsilon_decay=0.99,
+        )
+        module = _make_module(cfg)
+        # Before any action selection, ``policy.eps`` should reflect
+        # ``epsilon_start``; previously it stayed at the Tianshou default 0.0.
+        self.assertAlmostEqual(float(module.algorithm.policy.eps), 0.7, places=5)
+
+    def test_eps_decays_per_action_call(self):
+        cfg = DecisionConfig(
+            algorithm_type="dqn",
+            epsilon_start=0.7,
+            epsilon_min=0.05,
+            epsilon_decay=0.5,
+        )
+        module = _make_module(cfg)
+        algo = module.algorithm
+
+        import numpy as np
+
+        state = np.zeros((1, 8), dtype=np.float32)
+        mask = np.ones(4, dtype=bool)
+
+        algo.select_action_with_mask(state, mask)
+        first = float(algo.policy.eps)
+        algo.select_action_with_mask(state, mask)
+        second = float(algo.policy.eps)
+
+        self.assertAlmostEqual(first, 0.7 * 0.5, places=5)
+        self.assertAlmostEqual(second, 0.7 * 0.5 * 0.5, places=5)
+
+    def test_eps_floor_at_epsilon_min(self):
+        cfg = DecisionConfig(
+            algorithm_type="dqn",
+            epsilon_start=0.2,
+            epsilon_min=0.1,
+            epsilon_decay=0.5,
+        )
+        module = _make_module(cfg)
+        algo = module.algorithm
+
+        import numpy as np
+
+        state = np.zeros((1, 8), dtype=np.float32)
+        mask = np.ones(4, dtype=bool)
+        for _ in range(20):
+            algo.select_action_with_mask(state, mask)
+
+        self.assertAlmostEqual(float(algo.policy.eps), 0.1, places=5)
+
+    def test_eval_mode_uses_eps_test(self):
+        cfg = DecisionConfig(
+            algorithm_type="dqn",
+            epsilon_start=0.9,
+            epsilon_min=0.02,
+        )
+        module = _make_module(cfg)
+        module.algorithm.set_train_mode(False)
+        self.assertAlmostEqual(float(module.algorithm.policy.eps), 0.02, places=5)
+
+
+@unittest.skipUnless(TIANSHOU_AVAILABLE, "Tianshou required for DQN hidden-size wiring tests")
+class TestDqnHiddenSizeWiring(unittest.TestCase):
+    """`DecisionConfig.dqn_hidden_size` must control the Q-network width."""
+
+    def _hidden_widths(self, module: DecisionModule):
+        import torch.nn as nn
+
+        layers = list(module.algorithm.policy.model.q_layers)
+        widths = []
+        for layer in layers:
+            if isinstance(layer, nn.Linear):
+                widths.append((layer.in_features, layer.out_features))
+        return widths
+
+    def test_hidden_size_changes_layer_widths(self):
+        m_small = _make_module(DecisionConfig(algorithm_type="dqn", dqn_hidden_size=16))
+        m_large = _make_module(DecisionConfig(algorithm_type="dqn", dqn_hidden_size=64))
+        widths_small = self._hidden_widths(m_small)
+        widths_large = self._hidden_widths(m_large)
+        self.assertNotEqual(widths_small, widths_large)
+        # The narrowest hidden width should equal ``dqn_hidden_size`` (last
+        # FC layer's input dimension before the action head).
+        last_in_small = widths_small[-1][0]
+        last_in_large = widths_large[-1][0]
+        self.assertEqual(last_in_small, 16)
+        self.assertEqual(last_in_large, 64)
+
+
+@unittest.skipUnless(TIANSHOU_AVAILABLE, "Tianshou required for replay-buffer wiring tests")
+class TestReplayBufferWiring(unittest.TestCase):
+    """YAML ``learning.memory_size`` / ``batch_size`` must reach the Tianshou
+    DQN replay buffer (previously they were silently dropped)."""
+
+    def test_yaml_memory_size_drives_rl_buffer_size(self):
+        from farm.config import SimulationConfig
+        from farm.core.agent.config.component_configs import AgentComponentConfig
+
+        cfg = SimulationConfig.from_centralized_config(environment="development")
+        cfg.learning.memory_size = 1234
+        cfg.learning.batch_size = 17
+        decision_cfg = AgentComponentConfig.from_simulation_config(cfg).decision
+        self.assertEqual(decision_cfg.rl_buffer_size, 1234)
+        self.assertEqual(decision_cfg.rl_batch_size, 17)
+        # Legacy fields still receive the value too, for the legacy DQN module.
+        self.assertEqual(decision_cfg.memory_size, 1234)
+        self.assertEqual(decision_cfg.batch_size, 17)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rl_training_batching.py
+++ b/tests/test_rl_training_batching.py
@@ -1,11 +1,12 @@
 """Tests for simulation-level deferred RL training batching."""
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 from farm.config import SimulationConfig
-from farm.core.simulation import run_simulation
+from farm.core.simulation import _run_deferred_learning_updates, run_simulation
 
 
 class _StubAgent:
@@ -84,3 +85,33 @@ def test_run_simulation_limits_deferred_learning_updates_per_step(tmp_path):
         calls_this_step = step_total - previous_total
         assert calls_this_step <= config.performance.max_learning_updates_per_step
         previous_total = step_total
+
+
+@pytest.mark.unit
+def test_run_deferred_learning_updates_autoscale_zero_means_alive_count():
+    """``max_updates == 0`` should auto-scale to len(alive_agents).
+
+    Previously ``max_updates <= 0`` short-circuited and ran zero training
+    updates, which combined with the old default of 4 to throttle learning
+    to a tiny fraction of what agents could absorb in a typical run.
+    """
+    agents = [_StubAgent(f"a{i}", train_results=[True]) for i in range(7)]
+    env = SimpleNamespace(alive_agent_objects=agents)
+
+    updates = _run_deferred_learning_updates(env, max_updates=0, rr_cursor=0)
+
+    assert updates == len(agents)
+    for agent in agents:
+        assert agent.train_call_count == 1
+
+
+@pytest.mark.unit
+def test_run_deferred_learning_updates_negative_disables_training():
+    """A negative cap is treated as 'no training this step' (no auto-scale)."""
+    agents = [_StubAgent("a", train_results=[True])]
+    env = SimpleNamespace(alive_agent_objects=agents)
+
+    updates = _run_deferred_learning_updates(env, max_updates=-1, rr_cursor=0)
+
+    assert updates == 0
+    assert agents[0].train_call_count == 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigation found that under the default config, the median DQN agent ran only **2** gradient updates over a 100-step simulation (vs. ~18 with deferred training disabled), and several configured knobs were silently ignored. This PR fixes all five recommendations from the original investigation, adds a decision-quality analysis on top of the diagnostic, and ships a devlog walking through the whole thing.

### Before / after, default config, 100 steps

| Metric (per agent) | Before | After |
|---|---|---|
| Median `policy.learn()` calls | **2** | **18** |
| Median `\|Δw\|₂` of first Q-net param | ~0 | 0.1 |
| Final `policy.eps` | 0.000 (broken) | 0.606 (correctly decayed `1.0 × 0.995^100`) |
| Agents that trained ≥1 step | 54/63 | 52/58 |

[dqn_diagnostic_default.log](https://cursor.com/agents/bc-dba8fe0b-8c9e-4c74-908c-f1ab9268a451/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdqn_diagnostic_default.log)

[dqn_diagnostic_after_fixes.log](https://cursor.com/agents/bc-dba8fe0b-8c9e-4c74-908c-f1ab9268a451/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdqn_diagnostic_after_fixes.log)

### A/B at 300 steps (legacy throttle + broken eps vs new defaults, same code)

| Per-agent metric (median) | Legacy | Current | Δ |
|---|---:|---:|---:|
| `policy.learn()` calls | 5 | 34 | **6.8×** |
| `\|Δw\|₂` p75 | 0.1 | 0.2 | **2×** |
| Mean lifespan (steps) | 213 | 262 | **+23%** |

### Decision-quality analysis at 500 steps

Cohort-residualised reward late-life vs early-life across legacy / current / max-training (`rl_train_freq=1`):

| Long-lived agents (lifespan ≥ 100) | Legacy | Current | `--train-freq 1` |
|---|---:|---:|---:|
| Median `policy.learn()` calls | 7 | 33 | **117** |
| Mean Δ residualised reward (late − early) | +0.0082 | −0.0055 | **+0.0069** |
| t-stat for Δ > 0 | +1.15 | −0.79 | **+0.97** |
| Δ action entropy (nats) | +0.013 | +0.002 | **−0.024** |
| Mean lifespan (steps) | 306 | 355 | **391** |

Per-action reward improvement is **directionally positive but not statistically meaningful at 500 steps**. Action entropy *does* drop with enough gradient steps (`rl_train_freq=1`), which is the qualitative signature of a policy committing — the fixes unblock learning even if the simulation horizon isn't long enough to make it stat-significant.

Full write-up in `docs/devlog/2026-05-16-is-the-dqn-actually-learning.md`.

## Fixes

### 1. Auto-scale the deferred-training throttle (`farm/config/config.py`, `farm/config/default.yaml`, `farm/core/simulation.py`)
`max_learning_updates_per_step` now defaults to **0**, which is the auto-scale sentinel — every alive agent that is ready to train gets one gradient step per env step. A positive integer remains a hard cap; negative values are still rejected. The old default (`4`) silently throttled learning to 4 agents per step regardless of population.

### 2. Wire epsilon-greedy properly (`farm/core/decision/algorithms/tianshou.py`, `farm/core/decision/decision.py`)
Tianshou's `DQNPolicy.__init__` sets `policy.eps = 0.0` and the wrapper was never calling `set_eps`, so the configured `epsilon_start` / `epsilon_min` / `epsilon_decay` schedule had no effect — agents were purely greedy w.r.t. a near-random Q-network. The wrapper now:
- snapshots `eps_train` / `eps_train_final` / `eps_test` / `eps_decay` at init,
- calls `policy.set_eps(epsilon_start)` immediately,
- multiplicatively decays `policy.eps` on every `select_action_with_mask` call (training mode), floored at `epsilon_min`,
- exposes `set_train_mode(False)` to switch the policy to `eps_test` for evaluation.

### 3. Route YAML replay knobs to the active code path (`farm/core/agent/config/component_configs.py`)
`AgentComponentConfig.from_simulation_config` now maps `learning.memory_size` and `learning.batch_size` to **both** the legacy fields (`memory_size`, `batch_size`) and the Tianshou-facing fields (`rl_buffer_size`, `rl_batch_size`). Previously a YAML `learning.memory_size: 2000` produced a 10000-entry buffer because the Tianshou wrapper reads `rl_buffer_size` (default 10000) and ignores `memory_size`.

### 4. Plumb `dqn_hidden_size` through `AdaptiveQNet` (`farm/core/decision/algorithms/tianshou.py`)
The Q-network's FC widths were hard-coded to 512/256/128. They now derive from `dqn_hidden_size` as `h*4 → h*2 → h`, with a floor of 8. `dqn_hidden_size` is added to `_EXCLUDED_PARAMS` so it does not leak into the `DQNPolicy` constructor.

### 5. Surface silent failures in the agent step loop (`farm/core/agent/core.py`)
`AgentCore.step` no longer swallows exceptions from `decide_action` / `_execute_action` with `pass`; it logs them at warning level with the agent id, exception type, message, and traceback via structlog `exc_info=True`. Simulation flow is unchanged.

## Diagnostic

`scripts/diagnose_dqn_learning.py` now records per agent: replay-buffer stores, `should_train` outcomes, `policy.learn()` calls, `|Δw|₂` of the first Q-param, buffer size + `policy.eps` at end, lifespan, and `(env_time, action, reward)` per stored experience. The `decision_quality_analysis()` block runs a cohort-residualised reward delta + action-entropy / top-share shift restricted to long-lived agents. CLI flags `--legacy` (reproduce pre-fix behavior on current code), `--no-defer`, `--max-updates`, and `--train-freq` make it easy to A/B configurations on one binary.

## Tests

- `tests/test_decision_config_wiring.py`
  - `TestEpsilonGreedyWiring`: initial `policy.eps == epsilon_start`, multiplicative decay per action call, floor at `epsilon_min`, eval mode → `eps_test`.
  - `TestDqnHiddenSizeWiring`: changing `dqn_hidden_size` actually changes `Linear` widths.
  - `TestReplayBufferWiring`: YAML `learning.memory_size` / `batch_size` land in `rl_buffer_size` / `rl_batch_size`.
- `tests/test_rl_training_batching.py`
  - `test_run_deferred_learning_updates_autoscale_zero_means_alive_count`: `max_updates=0` runs one update per ready agent.
  - `test_run_deferred_learning_updates_negative_disables_training`: negative still means "no training this step".

## Devlog

`docs/devlog/2026-05-16-is-the-dqn-actually-learning.md` — full session walkthrough: hypothesis, instrumentation, four bugs found, fixes, before/after numbers, decision-quality analysis, honest take on what survived and what didn't, and follow-up experiments.

### Reproduction

```bash
PYTHONHASHSEED=0 python scripts/diagnose_dqn_learning.py --steps 100
PYTHONHASHSEED=0 python scripts/diagnose_dqn_learning.py --legacy --steps 300
PYTHONHASHSEED=0 python scripts/diagnose_dqn_learning.py --steps 500 --train-freq 1
```

### Testing
- ✅ `pytest -p no:cacheprovider` → **6492 passed, 0 failed**, 18 skipped (pre-existing CUDA/etc. skips)
- ✅ `pytest tests/test_decision_config_wiring.py tests/test_rl_training_batching.py -x -q` → all new tests green
- ✅ Diagnostic re-runs at 100/300/500 steps captured in `/opt/cursor/artifacts/`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dba8fe0b-8c9e-4c74-908c-f1ab9268a451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dba8fe0b-8c9e-4c74-908c-f1ab9268a451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

