### PR TITLE
Implement experiment dashboard features and enhance testing coverage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -94,6 +94,7 @@ metrics = obs.get_metrics()
 ## 🔬 Research & Experiments
 
 - [Experiments](experiments.md) - Catalog of currently defined experiments (intrinsic evolution, hyperparameter convergence, cohort runner, memory agent, one of a kind, rabbit's foot)
+- [Dashboard experiment extension guide](experiments/dashboard_experiment_extension_guide.md) - How to add new dashboard-backed experiment types end-to-end
 - [ExperimentRunner](experiment_runner.md) - Generic multi-iteration simulation runner
 - Experiment case studies (see [Usage Examples](usage_examples.md))
 

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -120,6 +120,10 @@ dominant strategy.
 When introducing a new experiment, follow the structure used by the
 existing entries:
 
+- For dashboard-backed experiment types (manifest + adapter + view API),
+  follow the dedicated guide:
+  [Dashboard experiment extension guide](experiments/dashboard_experiment_extension_guide.md).
+
 1. **Create a runner** under `farm/runners/` (or extend an existing
    one). Mirror the patterns in
    [`intrinsic_evolution_experiment.py`](../farm/runners/intrinsic_evolution_experiment.py)

--- a/docs/experiments/dashboard_experiment_extension_guide.md
+++ b/docs/experiments/dashboard_experiment_extension_guide.md
@@ -1,0 +1,207 @@
+# Dashboard Experiment Extension Guide
+
+This guide explains how to add a new dashboard-backed experiment type
+without redesigning the API or editor flow.
+
+Use `intrinsic_evolution` as the reference implementation:
+
+- Adapter: `farm/experiments/intrinsic_dashboard.py`
+- Contract: `farm/experiments/interfaces.py`
+- Manifest schema: `farm/experiments/manifest.py`
+- API wiring: `farm/api/server.py`
+- Editor consumer: `farm/editor/components/sidebar.js` and
+  `farm/editor/components/experiment-dashboard.js`
+
+## What Exists Today
+
+The current dashboard experiment pipeline is:
+
+1. Editor builds a manifest and posts it to
+   `/api/experiments/manifests/validate`.
+2. API validates/normalizes via `validate_experiment_manifest()`.
+3. API resolves an adapter from `ExperimentRegistry`.
+4. API runs the adapter in background via `/api/experiments/run`.
+5. Editor loads available views from `/api/experiments/{run_id}/views`.
+6. Editor loads a specific payload from
+   `/api/experiments/{run_id}/views/{view_id}`.
+
+Any new experiment type should plug into this flow.
+
+## Manifest Schema and Versioning Rules
+
+The dashboard manifest shape is defined by `ExperimentManifest` in
+`farm/experiments/manifest.py`:
+
+```json
+{
+  "schema_version": 1,
+  "experiment_type": "intrinsic_evolution",
+  "experiment_name": "my-run",
+  "base_simulation_config": {},
+  "experiment_config": {},
+  "dashboard_preset": {
+    "default_views": [],
+    "default_gene_ids": [],
+    "step_window": null
+  }
+}
+```
+
+Rules:
+
+- `schema_version` is required and currently must equal
+  `SUPPORTED_SCHEMA_VERSION` (currently `1`).
+- `experiment_type` is required and must map to a registered adapter.
+- `experiment_name` is required and must be non-empty.
+- `base_simulation_config` and `experiment_config` are experiment-specific
+  payloads passed to the adapter.
+- `dashboard_preset` configures editor defaults, not simulation semantics.
+
+Versioning guidance:
+
+- Keep `schema_version` unchanged for additive, backward-compatible fields.
+- Bump `schema_version` for breaking contract changes (field rename/removal,
+  meaning changes, required-field changes).
+- When bumping, keep validation errors explicit about expected versions.
+- Add tests covering old/new schema behavior before changing API consumers.
+
+## Adapter Interface Contract and Registry Wiring
+
+Every experiment type must provide an adapter implementing
+`ExperimentAdapterProtocol` (`farm/experiments/interfaces.py`):
+
+- `experiment_type: str`
+- `validate_manifest(manifest) -> ManifestValidationResult`
+- `run_experiment(run_id, manifest, runtime_options) -> dict`
+- `list_views(run_context) -> List[ViewDescriptor]`
+- `get_view_data(run_context, view_id, filters) -> dict`
+
+`ViewDescriptor` contract:
+
+- `view_id` (stable identifier used by view-data endpoint)
+- `view_type` (renderer-level payload type)
+- `title`
+- `description`
+
+Registry wiring:
+
+1. Implement adapter, e.g. `farm/experiments/<your_type>_dashboard.py`.
+2. Export it from `farm/experiments/__init__.py` if desired for clean imports.
+3. Register it at API startup in `farm/api/server.py`:
+   `experiment_registry.register(YourAdapter())`.
+4. Ensure manifest validation accepts the new `experiment_type`.
+
+## API Expectations: View Descriptors and View Payloads
+
+The API endpoints used by the editor are in `farm/api/server.py`.
+
+### Validate manifest
+
+- **Endpoint:** `POST /api/experiments/manifests/validate`
+- **Body:** `{ "manifest": { ... } }`
+- **Response data shape:** `ManifestValidationResult`
+  - `is_valid: bool`
+  - `errors: list[str]`
+  - `warnings: list[str]`
+  - `normalized_manifest: dict | null`
+
+### Run experiment
+
+- **Endpoint:** `POST /api/experiments/run`
+- **Body:** `{ "manifest": { ... }, "runtime_options": { ... } }`
+- **Response:** accepted run with `run_id`
+
+### List views
+
+- **Endpoint:** `GET /api/experiments/{run_id}/views`
+- **Response data shape:** list of `ViewDescriptor.to_dict()` values
+
+Example item:
+
+```json
+{
+  "view_id": "summary_cards",
+  "view_type": "summary_cards",
+  "title": "Run Summary",
+  "description": "Resolved policy, completion stats, and final outcomes."
+}
+```
+
+### Fetch view payload
+
+- **Endpoint:** `POST /api/experiments/{run_id}/views/{view_id}`
+- **Body:** `{ "filters": { ... } }`
+- **Response data shape:** adapter-specific payload keyed by `view_type`
+
+Current editor renderers (`farm/editor/components/experiment-dashboard.js`)
+expect:
+
+- `summary_cards` with `cards`
+- `timeseries` with `series`
+- `distribution_over_time` with `snapshots`
+- `lineage_or_clusters` with `timeseries` and optional `clusters`
+
+If a view is listed, its payload must match its declared `view_type`.
+
+## End-to-End Checklist for Adding a New Experiment Type
+
+Use this as your implementation checklist:
+
+- [ ] Define the new type string (for example, `my_new_experiment`).
+- [ ] Implement adapter class following `ExperimentAdapterProtocol`.
+- [ ] Validate adapter-specific manifest content in `validate_manifest()`.
+- [ ] Build runnable config in `run_experiment()` and write artifacts to
+      stable output paths.
+- [ ] Implement `list_views()` returning only views that are truly available.
+- [ ] Implement `get_view_data()` for each `view_id` from `list_views()`.
+- [ ] Register adapter in `experiment_registry` in `farm/api/server.py`.
+- [ ] Update manifest validation to allow the new `experiment_type`.
+- [ ] Add editor-side defaults (`dashboard_preset.default_views`) if needed.
+- [ ] Add tests (manifest validation, registry lookup, adapter view list,
+      adapter payload shapes, endpoint-level smoke).
+- [ ] Add docs links in `docs/experiments.md` and `docs/README.md`.
+
+## Required Tests (Minimum)
+
+When adding a new type, include at least:
+
+- Manifest acceptance/rejection tests:
+  `tests/experiments/test_dashboard_manifest.py` pattern.
+- Adapter behavior tests:
+  follow `tests/experiments/test_intrinsic_dashboard_adapter.py`.
+- Registry error-path test for unsupported types (clear message with supported
+  set).
+- API smoke tests for:
+  - `/api/experiments/manifests/validate`
+  - `/api/experiments/{run_id}/views`
+  - `/api/experiments/{run_id}/views/{view_id}`
+- Editor test updates if you add a new `view_type` renderer in
+  `farm/editor/components/experiment-dashboard.js`.
+
+## Common Pitfalls
+
+- Artifact shape mismatch: `get_view_data()` payload does not match
+  `view_type` expected by the dashboard renderer.
+- Optional views listed unconditionally: `list_views()` should only include
+  views that can actually produce data (for example, speciation view only
+  when enabled/artifacts exist).
+- Incomplete manifest validation: generic validation passes but adapter
+  runtime fails due to missing experiment-specific fields.
+- Unregistered adapter: manifest validates but run fails because registry
+  cannot resolve `experiment_type`.
+- Non-stable `view_id`: changing IDs breaks bookmarked or preset view
+  selections.
+
+## Intrinsic Evolution as Reference
+
+`IntrinsicEvolutionAdapter` demonstrates all required parts:
+
+- manifest validation delegated plus adapter-specific config build
+- run execution and run summary output
+- conditional optional views (`speciation_index`) based on metadata
+- normalized payloads for summary, time series, distributions, and
+  cluster-oriented data
+
+Before introducing a new type, do a quick side-by-side comparison against
+`farm/experiments/intrinsic_dashboard.py` and confirm each protocol method
+is represented with equivalent test coverage.

--- a/farm/api/server.py
+++ b/farm/api/server.py
@@ -23,6 +23,12 @@ from farm.core.analysis import analyze_simulation
 from farm.core.services import EnvConfigService
 from farm.core.simulation import run_simulation
 from farm.database.database import SimulationDatabase
+from farm.experiments import (
+    ExperimentManifest,
+    ExperimentRegistry,
+    IntrinsicEvolutionAdapter,
+    validate_experiment_manifest,
+)
 from farm.utils.logging import configure_logging, get_logger
 
 # Configure structured logging
@@ -87,11 +93,27 @@ class SimulationStatus(BaseModel):
     message: Optional[str] = None
 
 
+class ExperimentManifestRequest(BaseModel):
+    manifest: Dict[str, Any]
+
+
+class ExperimentRunRequest(BaseModel):
+    manifest: Dict[str, Any]
+    runtime_options: Optional[Dict[str, Any]] = None
+
+
+class ViewDataRequest(BaseModel):
+    filters: Dict[str, Any] = {}
+
+
 # Store active simulations
 active_simulations = {}
 
 # Store active analyses
 active_analyses = {}
+
+# Store dashboard-backed experiment runs
+active_experiment_runs = {}
 
 # Configuration for analysis resource management
 MAX_COMPLETED_ANALYSES = 100
@@ -112,10 +134,12 @@ MAX_CONCURRENT_ANALYSES = 10
 # Async locks for use in async endpoints
 _active_simulations_async_lock = asyncio.Lock()
 _active_analyses_async_lock = asyncio.Lock()
+_active_experiment_runs_async_lock = asyncio.Lock()
 
 # Thread locks for use in background tasks (thread pool context)
 _active_simulations_thread_lock = threading.Lock()
 _active_analyses_thread_lock = threading.Lock()
+_active_experiment_runs_thread_lock = threading.Lock()
 
 # Semaphore for controlling concurrent analyses (threading-based)
 _analysis_semaphore = threading.Semaphore(MAX_CONCURRENT_ANALYSES)
@@ -180,6 +204,8 @@ class ConnectionManager:
 
 
 manager = ConnectionManager()
+experiment_registry = ExperimentRegistry()
+experiment_registry.register(IntrinsicEvolutionAdapter())
 
 
 def _public_simulation_summary(sim_id: str, entry: Dict[str, Any]) -> Dict[str, Any]:
@@ -225,6 +251,46 @@ def _run_simulation_background(sim_id, config, db_path):
                 active_simulations[sim_id]["status"] = "error"
                 # Store a generic message for the public API; full details are in the logs above.
                 active_simulations[sim_id]["error_message"] = "Simulation failed. Check server logs for details."
+
+
+def _run_experiment_background(
+    run_id: str,
+    manifest_payload: Dict[str, Any],
+    runtime_options: Dict[str, Any],
+) -> None:
+    """Execute a dashboard experiment in the background."""
+    try:
+        with ThreadLock(_active_experiment_runs_thread_lock):
+            if run_id in active_experiment_runs:
+                active_experiment_runs[run_id]["status"] = "running"
+
+        manifest = ExperimentManifest.parse_obj(manifest_payload)
+        adapter = experiment_registry.get(manifest.experiment_type)
+        run_summary = adapter.run_experiment(
+            run_id=run_id,
+            manifest=manifest,
+            runtime_options=runtime_options,
+        )
+
+        with ThreadLock(_active_experiment_runs_thread_lock):
+            if run_id in active_experiment_runs:
+                active_experiment_runs[run_id]["status"] = "completed"
+                active_experiment_runs[run_id]["ended_at"] = datetime.now().isoformat()
+                active_experiment_runs[run_id]["run_summary"] = run_summary
+                active_experiment_runs[run_id]["output_dir"] = run_summary.get("output_dir")
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "dashboard_experiment_failed",
+            run_id=run_id,
+            error_type=type(exc).__name__,
+            error_message=str(exc),
+            exc_info=True,
+        )
+        with ThreadLock(_active_experiment_runs_thread_lock):
+            if run_id in active_experiment_runs:
+                active_experiment_runs[run_id]["status"] = "error"
+                active_experiment_runs[run_id]["error_message"] = str(exc)
+                active_experiment_runs[run_id]["ended_at"] = datetime.now().isoformat()
 
 
 @app.post("/api/simulation/new", response_model=SimulationResponse)
@@ -281,6 +347,123 @@ async def create_simulation(
             exc_info=True,
         )
         raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@app.get("/api/experiments/types")
+async def list_dashboard_experiment_types():
+    """List supported experiment types for no-code builders."""
+    return {"status": "success", "data": experiment_registry.list_experiment_types()}
+
+
+@app.post("/api/experiments/manifests/validate")
+async def validate_dashboard_manifest(request_data: ExperimentManifestRequest):
+    """Validate and normalize a dashboard experiment manifest."""
+    generic_result = validate_experiment_manifest(request_data.manifest)
+    if not generic_result.is_valid:
+        return {"status": "success", "data": generic_result.dict()}
+
+    manifest = ExperimentManifest.parse_obj(generic_result.normalized_manifest)
+    adapter = experiment_registry.get(manifest.experiment_type)
+    adapter_result = adapter.validate_manifest(manifest)
+    return {"status": "success", "data": adapter_result.dict()}
+
+
+@app.post("/api/experiments/run")
+async def run_dashboard_experiment(
+    request_data: ExperimentRunRequest, background_tasks: BackgroundTasks
+):
+    """Launch a dashboard-backed experiment run in the background."""
+    generic_result = validate_experiment_manifest(request_data.manifest)
+    if not generic_result.is_valid or generic_result.normalized_manifest is None:
+        raise HTTPException(status_code=400, detail=generic_result.errors)
+
+    run_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{secrets.token_urlsafe(8)}"
+    normalized_manifest = generic_result.normalized_manifest
+    runtime_options = request_data.runtime_options or {}
+
+    async with AsyncLock(_active_experiment_runs_async_lock):
+        active_experiment_runs[run_id] = {
+            "status": "pending",
+            "created_at": datetime.now().isoformat(),
+            "manifest": normalized_manifest,
+            "runtime_options": runtime_options,
+            "run_summary": None,
+        }
+
+    background_tasks.add_task(
+        _run_experiment_background, run_id, normalized_manifest, runtime_options
+    )
+    return {
+        "status": "accepted",
+        "run_id": run_id,
+        "message": "Experiment run started",
+    }
+
+
+@app.get("/api/experiments/runs")
+async def list_dashboard_experiment_runs():
+    """List launched dashboard experiment runs and status."""
+    async with AsyncLock(_active_experiment_runs_async_lock):
+        runs = []
+        for run_id, value in active_experiment_runs.items():
+            runs.append(
+                {
+                    "run_id": run_id,
+                    "status": value.get("status"),
+                    "created_at": value.get("created_at"),
+                    "ended_at": value.get("ended_at"),
+                    "error_message": value.get("error_message"),
+                }
+            )
+    return {"status": "success", "data": runs}
+
+
+@app.get("/api/experiments/{run_id}/status")
+async def dashboard_experiment_status(run_id: str):
+    """Get a single dashboard experiment run status."""
+    async with AsyncLock(_active_experiment_runs_async_lock):
+        if run_id not in active_experiment_runs:
+            raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+        payload = active_experiment_runs[run_id].copy()
+    return {"status": "success", "data": payload}
+
+
+@app.get("/api/experiments/{run_id}/views")
+async def list_dashboard_views(run_id: str):
+    """List available dashboard views for the selected run."""
+    async with AsyncLock(_active_experiment_runs_async_lock):
+        run_context = active_experiment_runs.get(run_id)
+        if run_context is None:
+            raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+        manifest_payload = run_context.get("manifest")
+        if not manifest_payload:
+            raise HTTPException(status_code=400, detail="Run has no manifest payload")
+
+    manifest = ExperimentManifest.parse_obj(manifest_payload)
+    adapter = experiment_registry.get(manifest.experiment_type)
+    views = [view.to_dict() for view in adapter.list_views(run_context)]
+    return {"status": "success", "data": views}
+
+
+@app.post("/api/experiments/{run_id}/views/{view_id}")
+async def fetch_dashboard_view_data(run_id: str, view_id: str, request_data: ViewDataRequest):
+    """Fetch normalized payload for one dashboard view."""
+    async with AsyncLock(_active_experiment_runs_async_lock):
+        run_context = active_experiment_runs.get(run_id)
+        if run_context is None:
+            raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+        manifest_payload = run_context.get("manifest")
+        if not manifest_payload:
+            raise HTTPException(status_code=400, detail="Run has no manifest payload")
+
+    manifest = ExperimentManifest.parse_obj(manifest_payload)
+    adapter = experiment_registry.get(manifest.experiment_type)
+    data = adapter.get_view_data(
+        run_context=run_context,
+        view_id=view_id,
+        filters=request_data.filters,
+    )
+    return {"status": "success", "data": data}
 
 
 @app.get("/api/simulation/{sim_id}/step/{step}")

--- a/farm/api/server.py
+++ b/farm/api/server.py
@@ -14,7 +14,7 @@ from fastapi import (
     WebSocketDisconnect,
 )
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from farm.analysis.service import AnalysisRequest, AnalysisService
 from farm.api.analysis_controller import AnalysisController
@@ -103,7 +103,7 @@ class ExperimentRunRequest(BaseModel):
 
 
 class ViewDataRequest(BaseModel):
-    filters: Dict[str, Any] = {}
+    filters: Dict[str, Any] = Field(default_factory=dict)
 
 
 # Store active simulations
@@ -119,6 +119,8 @@ active_experiment_runs = {}
 MAX_COMPLETED_ANALYSES = 100
 ANALYSIS_RETENTION_HOURS = 24
 MAX_CONCURRENT_ANALYSES = 10
+MAX_COMPLETED_EXPERIMENT_RUNS = 100
+EXPERIMENT_RUN_RETENTION_HOURS = 24
 
 # IMPORTANT: Locking Strategy
 # ===========================
@@ -221,6 +223,58 @@ def _public_simulation_summary(sim_id: str, entry: Dict[str, Any]) -> Dict[str, 
     return summary
 
 
+def _public_experiment_summary(run_id: str, entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Return API-safe experiment run fields only."""
+    summary: Dict[str, Any] = {
+        "run_id": run_id,
+        "status": entry.get("status"),
+        "created_at": entry.get("created_at"),
+        "ended_at": entry.get("ended_at"),
+    }
+    if entry.get("status") == "error":
+        summary["error_message"] = entry.get("error_message")
+    return summary
+
+
+def _cleanup_old_experiment_runs() -> None:
+    """Remove old completed/error/stopped experiment runs to bound in-memory state."""
+    with ThreadLock(_active_experiment_runs_thread_lock):
+        now = datetime.now()
+        terminal_statuses = {"completed", "error", "stopped"}
+        to_remove = set()
+
+        for run_id, info in active_experiment_runs.items():
+            if info.get("status") not in terminal_statuses:
+                continue
+            ended_at_str = info.get("ended_at")
+            if not ended_at_str:
+                continue
+            try:
+                ended_at = datetime.fromisoformat(ended_at_str)
+            except (TypeError, ValueError):
+                continue
+            age_hours = (now - ended_at).total_seconds() / 3600
+            if age_hours > EXPERIMENT_RUN_RETENTION_HOURS:
+                to_remove.add(run_id)
+
+        completed_candidates = [
+            (
+                run_id,
+                info.get("ended_at") or info.get("created_at") or "",
+            )
+            for run_id, info in active_experiment_runs.items()
+            if info.get("status") in terminal_statuses and run_id not in to_remove
+        ]
+        if len(completed_candidates) > MAX_COMPLETED_EXPERIMENT_RUNS:
+            completed_candidates.sort(key=lambda item: item[1])
+            overflow = len(completed_candidates) - MAX_COMPLETED_EXPERIMENT_RUNS
+            for run_id, _ in completed_candidates[:overflow]:
+                to_remove.add(run_id)
+
+        for run_id in to_remove:
+            active_experiment_runs.pop(run_id, None)
+
+
 def _run_simulation_background(sim_id, config, db_path):
     try:
         with ThreadLock(_active_simulations_thread_lock):
@@ -264,7 +318,7 @@ def _run_experiment_background(
             if run_id in active_experiment_runs:
                 active_experiment_runs[run_id]["status"] = "running"
 
-        manifest = ExperimentManifest.parse_obj(manifest_payload)
+        manifest = ExperimentManifest.model_validate(manifest_payload)
         adapter = experiment_registry.get(manifest.experiment_type)
         run_summary = adapter.run_experiment(
             run_id=run_id,
@@ -291,6 +345,8 @@ def _run_experiment_background(
                 active_experiment_runs[run_id]["status"] = "error"
                 active_experiment_runs[run_id]["error_message"] = str(exc)
                 active_experiment_runs[run_id]["ended_at"] = datetime.now().isoformat()
+    finally:
+        _cleanup_old_experiment_runs()
 
 
 @app.post("/api/simulation/new", response_model=SimulationResponse)
@@ -360,12 +416,12 @@ async def validate_dashboard_manifest(request_data: ExperimentManifestRequest):
     """Validate and normalize a dashboard experiment manifest."""
     generic_result = validate_experiment_manifest(request_data.manifest)
     if not generic_result.is_valid:
-        return {"status": "success", "data": generic_result.dict()}
+        return {"status": "success", "data": generic_result.model_dump()}
 
-    manifest = ExperimentManifest.parse_obj(generic_result.normalized_manifest)
+    manifest = ExperimentManifest.model_validate(generic_result.normalized_manifest)
     adapter = experiment_registry.get(manifest.experiment_type)
     adapter_result = adapter.validate_manifest(manifest)
-    return {"status": "success", "data": adapter_result.dict()}
+    return {"status": "success", "data": adapter_result.model_dump()}
 
 
 @app.post("/api/experiments/run")
@@ -380,6 +436,8 @@ async def run_dashboard_experiment(
     run_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{secrets.token_urlsafe(8)}"
     normalized_manifest = generic_result.normalized_manifest
     runtime_options = request_data.runtime_options or {}
+
+    _cleanup_old_experiment_runs()
 
     async with AsyncLock(_active_experiment_runs_async_lock):
         active_experiment_runs[run_id] = {
@@ -403,28 +461,26 @@ async def run_dashboard_experiment(
 @app.get("/api/experiments/runs")
 async def list_dashboard_experiment_runs():
     """List launched dashboard experiment runs and status."""
+    _cleanup_old_experiment_runs()
     async with AsyncLock(_active_experiment_runs_async_lock):
-        runs = []
-        for run_id, value in active_experiment_runs.items():
-            runs.append(
-                {
-                    "run_id": run_id,
-                    "status": value.get("status"),
-                    "created_at": value.get("created_at"),
-                    "ended_at": value.get("ended_at"),
-                    "error_message": value.get("error_message"),
-                }
+        runs = [
+            _public_experiment_summary(run_id, value)
+            for run_id, value in sorted(
+                active_experiment_runs.items(),
+                key=lambda item: item[1].get("created_at") or "",
             )
+        ]
     return {"status": "success", "data": runs}
 
 
 @app.get("/api/experiments/{run_id}/status")
 async def dashboard_experiment_status(run_id: str):
     """Get a single dashboard experiment run status."""
+    _cleanup_old_experiment_runs()
     async with AsyncLock(_active_experiment_runs_async_lock):
         if run_id not in active_experiment_runs:
             raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
-        payload = active_experiment_runs[run_id].copy()
+        payload = _public_experiment_summary(run_id, active_experiment_runs[run_id])
     return {"status": "success", "data": payload}
 
 
@@ -438,13 +494,18 @@ async def list_dashboard_views(run_id: str):
     manifest_payload = run_context.get("manifest")
     if not manifest_payload:
         raise HTTPException(status_code=400, detail="Run has no manifest payload")
+    if run_context.get("status") != "completed":
+        raise HTTPException(
+            status_code=409,
+            detail="Experiment output is not available until the run has completed.",
+        )
     if not run_context.get("output_dir"):
         raise HTTPException(
             status_code=409,
             detail="Experiment output is not available for this run yet or the run failed.",
         )
 
-    manifest = ExperimentManifest.parse_obj(manifest_payload)
+    manifest = ExperimentManifest.model_validate(manifest_payload)
     adapter = experiment_registry.get(manifest.experiment_type)
     views = [view.to_dict() for view in adapter.list_views(run_context)]
     return {"status": "success", "data": views}
@@ -460,13 +521,18 @@ async def fetch_dashboard_view_data(run_id: str, view_id: str, request_data: Vie
     manifest_payload = run_context.get("manifest")
     if not manifest_payload:
         raise HTTPException(status_code=400, detail="Run has no manifest payload")
+    if run_context.get("status") != "completed":
+        raise HTTPException(
+            status_code=409,
+            detail="Experiment output is not available until the run has completed.",
+        )
     if not run_context.get("output_dir"):
         raise HTTPException(
             status_code=409,
             detail="Experiment output is not available for this run yet or the run failed.",
         )
 
-    manifest = ExperimentManifest.parse_obj(manifest_payload)
+    manifest = ExperimentManifest.model_validate(manifest_payload)
     adapter = experiment_registry.get(manifest.experiment_type)
     try:
         data = adapter.get_view_data(

--- a/farm/api/server.py
+++ b/farm/api/server.py
@@ -257,14 +257,19 @@ def _cleanup_old_experiment_runs() -> None:
             if age_hours > EXPERIMENT_RUN_RETENTION_HOURS:
                 to_remove.add(run_id)
 
-        completed_candidates = [
-            (
-                run_id,
-                info.get("ended_at") or info.get("created_at") or "",
-            )
-            for run_id, info in active_experiment_runs.items()
-            if info.get("status") in terminal_statuses and run_id not in to_remove
-        ]
+        completed_candidates = []
+        for run_id, info in active_experiment_runs.items():
+            if info.get("status") not in terminal_statuses or run_id in to_remove:
+                continue
+            sort_key = info.get("ended_at") or info.get("created_at")
+            if not sort_key:
+                logger.warning(
+                    "experiment_run_missing_timestamps",
+                    run_id=run_id,
+                    status=info.get("status"),
+                )
+                sort_key = ""
+            completed_candidates.append((run_id, sort_key))
         if len(completed_candidates) > MAX_COMPLETED_EXPERIMENT_RUNS:
             completed_candidates.sort(key=lambda item: item[1])
             overflow = len(completed_candidates) - MAX_COMPLETED_EXPERIMENT_RUNS

--- a/farm/api/server.py
+++ b/farm/api/server.py
@@ -458,11 +458,16 @@ async def fetch_dashboard_view_data(run_id: str, view_id: str, request_data: Vie
 
     manifest = ExperimentManifest.parse_obj(manifest_payload)
     adapter = experiment_registry.get(manifest.experiment_type)
-    data = adapter.get_view_data(
-        run_context=run_context,
-        view_id=view_id,
-        filters=request_data.filters,
-    )
+    try:
+        data = adapter.get_view_data(
+            run_context=run_context,
+            view_id=view_id,
+            filters=request_data.filters,
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"status": "success", "data": data}
 
 

--- a/farm/api/server.py
+++ b/farm/api/server.py
@@ -268,7 +268,7 @@ def _cleanup_old_experiment_runs() -> None:
                     run_id=run_id,
                     status=info.get("status"),
                 )
-                sort_key = datetime.min.isoformat()
+                sort_key = datetime.max.isoformat()
             completed_candidates.append((run_id, sort_key))
         if len(completed_candidates) > MAX_COMPLETED_EXPERIMENT_RUNS:
             completed_candidates.sort(key=lambda item: item[1])

--- a/farm/api/server.py
+++ b/farm/api/server.py
@@ -268,7 +268,7 @@ def _cleanup_old_experiment_runs() -> None:
                     run_id=run_id,
                     status=info.get("status"),
                 )
-                sort_key = ""
+                sort_key = datetime.min.isoformat()
             completed_candidates.append((run_id, sort_key))
         if len(completed_candidates) > MAX_COMPLETED_EXPERIMENT_RUNS:
             completed_candidates.sort(key=lambda item: item[1])

--- a/farm/api/server.py
+++ b/farm/api/server.py
@@ -432,12 +432,17 @@ async def dashboard_experiment_status(run_id: str):
 async def list_dashboard_views(run_id: str):
     """List available dashboard views for the selected run."""
     async with AsyncLock(_active_experiment_runs_async_lock):
-        run_context = active_experiment_runs.get(run_id)
-        if run_context is None:
+        if run_id not in active_experiment_runs:
             raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
-        manifest_payload = run_context.get("manifest")
-        if not manifest_payload:
-            raise HTTPException(status_code=400, detail="Run has no manifest payload")
+        run_context = active_experiment_runs[run_id].copy()
+    manifest_payload = run_context.get("manifest")
+    if not manifest_payload:
+        raise HTTPException(status_code=400, detail="Run has no manifest payload")
+    if not run_context.get("output_dir"):
+        raise HTTPException(
+            status_code=409,
+            detail="Experiment output is not available for this run yet or the run failed.",
+        )
 
     manifest = ExperimentManifest.parse_obj(manifest_payload)
     adapter = experiment_registry.get(manifest.experiment_type)
@@ -449,12 +454,17 @@ async def list_dashboard_views(run_id: str):
 async def fetch_dashboard_view_data(run_id: str, view_id: str, request_data: ViewDataRequest):
     """Fetch normalized payload for one dashboard view."""
     async with AsyncLock(_active_experiment_runs_async_lock):
-        run_context = active_experiment_runs.get(run_id)
-        if run_context is None:
+        if run_id not in active_experiment_runs:
             raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
-        manifest_payload = run_context.get("manifest")
-        if not manifest_payload:
-            raise HTTPException(status_code=400, detail="Run has no manifest payload")
+        run_context = active_experiment_runs[run_id].copy()
+    manifest_payload = run_context.get("manifest")
+    if not manifest_payload:
+        raise HTTPException(status_code=400, detail="Run has no manifest payload")
+    if not run_context.get("output_dir"):
+        raise HTTPException(
+            status_code=409,
+            detail="Experiment output is not available for this run yet or the run failed.",
+        )
 
     manifest = ExperimentManifest.parse_obj(manifest_payload)
     adapter = experiment_registry.get(manifest.experiment_type)

--- a/farm/editor/__tests__/experiment-dashboard.test.js
+++ b/farm/editor/__tests__/experiment-dashboard.test.js
@@ -121,4 +121,23 @@ describe('ExperimentDashboard', () => {
         expect(html).toContain('Cluster Records')
         expect(html).toContain('0')
     })
+
+    test('renders no renderer fallback for unknown view types', async () => {
+        const dashboard = await bootDashboard()
+        dashboard.renderViewData({ view_type: 'unknown_renderer' })
+        expect(document.getElementById('dashboard-body').textContent).toContain('No renderer available')
+    })
+
+    test('renders empty-state messages for branch payload gaps', async () => {
+        const dashboard = await bootDashboard()
+
+        dashboard.renderViewData({ view_type: 'summary_cards', cards: [] })
+        expect(document.getElementById('dashboard-body').textContent).toContain('No summary cards')
+
+        dashboard.renderViewData({ view_type: 'timeseries', series: [] })
+        expect(document.getElementById('dashboard-body').textContent).toContain('No time series data')
+
+        dashboard.renderViewData({ view_type: 'distribution_over_time', snapshots: [] })
+        expect(document.getElementById('dashboard-body').textContent).toContain('No distribution snapshots')
+    })
 })

--- a/farm/editor/__tests__/experiment-dashboard.test.js
+++ b/farm/editor/__tests__/experiment-dashboard.test.js
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 
 function injectHtml() {
-    document.body.innerHTML = '<div id="stats"></div>'
+    document.body.innerHTML = '<div id="stats">Simulation stats root</div><div id="experiment-dashboard"></div>'
 }
 
 function mockJsonResponse(payload, ok = true, status = 200) {
@@ -82,6 +82,11 @@ describe('ExperimentDashboard', () => {
         expect(document.getElementById('dashboard-body').textContent).toContain('Failed to load view data: HTTP 404')
     })
 
+    test('does not overwrite simulation stats container when rendering dashboard', async () => {
+        await bootDashboard()
+        expect(document.getElementById('stats').textContent).toContain('Simulation stats root')
+    })
+
     test('renders timeseries branch', async () => {
         const dashboard = await bootDashboard()
         dashboard.renderViewData({
@@ -139,5 +144,19 @@ describe('ExperimentDashboard', () => {
 
         dashboard.renderViewData({ view_type: 'distribution_over_time', snapshots: [] })
         expect(document.getElementById('dashboard-body').textContent).toContain('No distribution snapshots')
+    })
+
+    test('renders adapter values as text content to avoid HTML injection', async () => {
+        const dashboard = await bootDashboard()
+        dashboard.renderViewData({
+            view_type: 'summary_cards',
+            cards: [{ label: '<img src=x onerror=alert(1)>', value: '<b>42</b>' }],
+        })
+
+        const body = document.getElementById('dashboard-body')
+        expect(body.innerHTML).toContain('&lt;img src=x onerror=alert(1)&gt;')
+        expect(body.innerHTML).toContain('&lt;b&gt;42&lt;/b&gt;')
+        expect(body.querySelector('img')).toBeNull()
+        expect(body.querySelector('b')).toBeNull()
     })
 })

--- a/farm/editor/__tests__/experiment-dashboard.test.js
+++ b/farm/editor/__tests__/experiment-dashboard.test.js
@@ -1,0 +1,124 @@
+/** @jest-environment jsdom */
+
+function injectHtml() {
+    document.body.innerHTML = '<div id="stats"></div>'
+}
+
+function mockJsonResponse(payload, ok = true, status = 200) {
+    return Promise.resolve({
+        ok,
+        status,
+        json: async () => payload,
+    })
+}
+
+async function bootDashboard() {
+    await import('../components/experiment-dashboard.js')
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+    return window.experimentDashboard
+}
+
+describe('ExperimentDashboard', () => {
+    beforeEach(() => {
+        jest.resetModules()
+        injectHtml()
+        window.fetch = jest.fn()
+    })
+
+    test('loads run views and renders summary cards payload', async () => {
+        const dashboard = await bootDashboard()
+
+        window.fetch
+            .mockImplementationOnce(() => mockJsonResponse({
+                status: 'success',
+                data: [{ view_id: 'summary_cards', title: 'Run Summary' }],
+            }))
+            .mockImplementationOnce(() => mockJsonResponse({
+                status: 'success',
+                data: {
+                    view_type: 'summary_cards',
+                    cards: [{ label: 'Final Population', value: 42 }],
+                },
+            }))
+
+        await dashboard.loadRun('run123')
+
+        expect(document.getElementById('dashboard-run-id').textContent).toContain('run123')
+        expect(document.getElementById('dashboard-body').innerHTML).toContain('Final Population')
+        expect(document.getElementById('dashboard-body').innerHTML).toContain('42')
+    })
+
+    test('shows empty view list state', async () => {
+        await bootDashboard()
+
+        window.fetch.mockImplementationOnce(() => mockJsonResponse({ status: 'success', data: [] }))
+        await window.experimentDashboard.loadRun('run-empty')
+
+        expect(document.getElementById('dashboard-body').textContent).toContain('No dashboard views are available')
+        expect(document.getElementById('dashboard-view-select').disabled).toBe(true)
+        expect(document.getElementById('dashboard-load-view').disabled).toBe(true)
+    })
+
+    test('shows error when listing views fails', async () => {
+        await bootDashboard()
+
+        window.fetch.mockImplementationOnce(() => mockJsonResponse({ status: 'error' }, false, 500))
+        await window.experimentDashboard.loadRun('run-fail-views')
+
+        expect(document.getElementById('dashboard-body').textContent).toContain('Failed to load views: HTTP 500')
+    })
+
+    test('shows error when loading selected view fails', async () => {
+        await bootDashboard()
+
+        window.fetch
+            .mockImplementationOnce(() => mockJsonResponse({
+                status: 'success',
+                data: [{ view_id: 'summary_cards', title: 'Run Summary' }],
+            }))
+            .mockImplementationOnce(() => mockJsonResponse({ status: 'error' }, false, 404))
+
+        await window.experimentDashboard.loadRun('run-fail-view-data')
+        expect(document.getElementById('dashboard-body').textContent).toContain('Failed to load view data: HTTP 404')
+    })
+
+    test('renders timeseries branch', async () => {
+        const dashboard = await bootDashboard()
+        dashboard.renderViewData({
+            view_type: 'timeseries',
+            title: 'Gene trajectories',
+            series: [{ label: 'learning_rate mean', values: [0.1, 0.2] }],
+        })
+
+        expect(document.getElementById('dashboard-body').innerHTML).toContain('Gene trajectories')
+        expect(document.getElementById('dashboard-body').innerHTML).toContain('learning_rate mean')
+    })
+
+    test('renders distribution_over_time branch', async () => {
+        const dashboard = await bootDashboard()
+        dashboard.renderViewData({
+            view_type: 'distribution_over_time',
+            title: 'Gene distribution history',
+            snapshots: [{ step: 100, by_gene: { learning_rate: [0.1, 0.2] } }],
+        })
+
+        expect(document.getElementById('dashboard-body').innerHTML).toContain('Gene distribution history')
+        expect(document.getElementById('dashboard-body').innerHTML).toContain('100')
+    })
+
+    test('renders lineage_or_clusters branch and tolerates optional data', async () => {
+        const dashboard = await bootDashboard()
+        dashboard.renderViewData({
+            view_type: 'lineage_or_clusters',
+            title: 'Speciation index',
+            timeseries: { series: [{ values: [0.13] }] },
+            clusters: [],
+        })
+
+        const html = document.getElementById('dashboard-body').innerHTML
+        expect(html).toContain('Speciation index')
+        expect(html).toContain('0.13')
+        expect(html).toContain('Cluster Records')
+        expect(html).toContain('0')
+    })
+})

--- a/farm/editor/__tests__/sidebar-experiment-builder.test.js
+++ b/farm/editor/__tests__/sidebar-experiment-builder.test.js
@@ -1,0 +1,162 @@
+/** @jest-environment jsdom */
+
+function injectHtml() {
+    document.body.innerHTML = '<div id="sidebar"></div>'
+}
+
+function mockJsonResponse(payload, ok = true) {
+    return Promise.resolve({
+        ok,
+        json: async () => payload,
+        text: async () => JSON.stringify(payload),
+    })
+}
+
+async function bootSidebar() {
+    await import('../components/sidebar.js')
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+    return window.sidebar
+}
+
+describe('Sidebar intrinsic experiment builder', () => {
+    beforeEach(() => {
+        jest.resetModules()
+        jest.useRealTimers()
+        injectHtml()
+        localStorage.clear()
+        window.fetch = jest.fn()
+    })
+
+    test('serializes intrinsic manifest from sidebar controls', async () => {
+        const sidebar = await bootSidebar()
+
+        document.getElementById('env-width').value = '120'
+        document.getElementById('env-height').value = '80'
+        document.getElementById('init-resources').value = '900'
+        document.getElementById('exp-name').value = 'intrinsic-test-run'
+        document.getElementById('exp-steps').value = '600'
+        document.getElementById('exp-snapshot-interval').value = '30'
+        document.getElementById('exp-selection-pressure').value = 'high'
+        document.getElementById('exp-enable-speciation').checked = false
+
+        const manifest = sidebar.buildIntrinsicManifest()
+        expect(manifest.schema_version).toBe(1)
+        expect(manifest.experiment_type).toBe('intrinsic_evolution')
+        expect(manifest.experiment_name).toBe('intrinsic-test-run')
+        expect(manifest.base_simulation_config).toEqual({
+            'environment.width': 120,
+            'environment.height': 80,
+            'resources.initial_resources': 900,
+        })
+        expect(manifest.experiment_config).toMatchObject({
+            num_steps: 600,
+            snapshot_interval: 30,
+            policy: { selection_pressure: 'high' },
+            speciation: { enabled: false },
+        })
+    })
+
+    test('deserializes saved preset back into controls', async () => {
+        const sidebar = await bootSidebar()
+        localStorage.setItem(
+            'intrinsic-dashboard-preset',
+            JSON.stringify({
+                experiment_name: 'loaded-preset',
+                experiment_config: {
+                    num_steps: 777,
+                    snapshot_interval: 11,
+                    policy: { selection_pressure: 'low' },
+                    speciation: { enabled: true },
+                },
+            })
+        )
+
+        sidebar.loadExperimentPreset()
+
+        expect(document.getElementById('exp-name').value).toBe('loaded-preset')
+        expect(document.getElementById('exp-steps').value).toBe('777')
+        expect(document.getElementById('exp-snapshot-interval').value).toBe('11')
+        expect(document.getElementById('exp-selection-pressure').value).toBe('low')
+        expect(document.getElementById('exp-enable-speciation').checked).toBe(true)
+        expect(document.getElementById('exp-status').textContent).toContain('Loaded saved experiment preset.')
+    })
+
+    test('validate action posts manifest and shows success status', async () => {
+        const sidebar = await bootSidebar()
+        window.fetch.mockImplementation((url) => {
+            if (url.endsWith('/api/experiments/manifests/validate')) {
+                return mockJsonResponse({ status: 'success', data: { is_valid: true } })
+            }
+            throw new Error(`Unexpected fetch url: ${url}`)
+        })
+
+        await sidebar.validateExperimentManifest()
+
+        expect(window.fetch).toHaveBeenCalledTimes(1)
+        const [url, options] = window.fetch.mock.calls[0]
+        expect(url).toContain('/api/experiments/manifests/validate')
+        const body = JSON.parse(options.body)
+        expect(body.manifest.experiment_type).toBe('intrinsic_evolution')
+        expect(document.getElementById('exp-status').textContent).toBe('Manifest is valid.')
+    })
+
+    test('run action updates lifecycle status pending running completed', async () => {
+        jest.useFakeTimers()
+        const sidebar = await bootSidebar()
+
+        let statusPollCount = 0
+        window.fetch.mockImplementation((url) => {
+            if (url.endsWith('/api/experiments/run')) {
+                return mockJsonResponse({ status: 'accepted', run_id: 'run123' })
+            }
+            if (url.endsWith('/api/experiments/run123/status')) {
+                statusPollCount += 1
+                if (statusPollCount === 1) {
+                    return mockJsonResponse({ status: 'success', data: { status: 'pending' } })
+                }
+                if (statusPollCount === 2) {
+                    return mockJsonResponse({ status: 'success', data: { status: 'running' } })
+                }
+                return mockJsonResponse({ status: 'success', data: { status: 'completed' } })
+            }
+            throw new Error(`Unexpected fetch url: ${url}`)
+        })
+
+        await sidebar.runExperimentFromBuilder()
+        expect(document.getElementById('exp-status').textContent).toBe('Run run123 started.')
+
+        await jest.advanceTimersByTimeAsync(2000)
+        expect(document.getElementById('exp-status').textContent).toBe('Run run123: pending')
+
+        await jest.advanceTimersByTimeAsync(2000)
+        expect(document.getElementById('exp-status').textContent).toBe('Run run123: running')
+
+        await jest.advanceTimersByTimeAsync(2000)
+        expect(document.getElementById('exp-status').textContent).toBe('Run run123: completed')
+    })
+
+    test('new simulation control remains wired (regression)', async () => {
+        const sidebar = await bootSidebar()
+        window.fetch.mockImplementation((url) => {
+            if (url.endsWith('/api/simulation/new')) {
+                return mockJsonResponse({ status: 'accepted', sim_id: 'sim123', message: 'Simulation started' })
+            }
+            throw new Error(`Unexpected fetch url: ${url}`)
+        })
+
+        document.getElementById('env-width').value = '140'
+        document.getElementById('env-height').value = '90'
+        document.getElementById('init-resources').value = '700'
+        await sidebar.createNewSimulation()
+
+        expect(window.fetch).toHaveBeenCalledTimes(1)
+        const [url, options] = window.fetch.mock.calls[0]
+        expect(url).toContain('/api/simulation/new')
+        expect(JSON.parse(options.body)).toEqual({
+            width: 140,
+            height: 90,
+            initialResources: 700,
+        })
+    })
+})
+

--- a/farm/editor/__tests__/sidebar-experiment-builder.test.js
+++ b/farm/editor/__tests__/sidebar-experiment-builder.test.js
@@ -135,6 +135,21 @@ describe('Sidebar intrinsic experiment builder', () => {
         expect(document.getElementById('exp-status').textContent).toBe('Run run123: completed')
     })
 
+    test('starting a second poll loop clears the first interval', async () => {
+        jest.useFakeTimers()
+        const sidebar = await bootSidebar()
+        const clearIntervalSpy = jest.spyOn(global, 'clearInterval')
+
+        window.fetch.mockImplementation(() => mockJsonResponse({ status: 'success', data: { status: 'running' } }))
+
+        await sidebar.pollExperimentRun('run-first')
+        const firstInterval = sidebar.experimentPollInterval
+        await sidebar.pollExperimentRun('run-second')
+
+        expect(clearIntervalSpy).toHaveBeenCalledWith(firstInterval)
+        expect(sidebar.experimentPollInterval).not.toBe(firstInterval)
+    })
+
     test('new simulation control remains wired (regression)', async () => {
         const sidebar = await bootSidebar()
         window.fetch.mockImplementation((url) => {
@@ -159,4 +174,3 @@ describe('Sidebar intrinsic experiment builder', () => {
         })
     })
 })
-

--- a/farm/editor/components/editor.js
+++ b/farm/editor/components/editor.js
@@ -166,7 +166,7 @@ class Editor {
         this.currentSimId = data.sim_id;
         this.currentStep = 0;
         socketService.subscribeToSimulation(this.currentSimId);
-        this.updateVisualization(data.data);
+        this.updateVisualization(data.data || {});
         this.hideLoading();
     }
 
@@ -189,12 +189,14 @@ class Editor {
     }
 
     async handleSimulationUpdated(data) {
-        this.updateVisualization(data);
-        this.updateStats(data);
-        this.updateCharts(data);
+        this.updateVisualization(data || {});
+        this.updateStats(data || {});
+        this.updateCharts(data || {});
     }
 
     updateVisualization(data) {
+        const frame = this.normalizeFrameData(data);
+
         // Clear canvas
         this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
 
@@ -202,22 +204,22 @@ class Editor {
         this.drawGrid();
 
         // Draw resources
-        if (data.resources) {
-            data.resources.forEach(resource => {
+        if (frame.resources) {
+            frame.resources.forEach(resource => {
                 this.drawResource(resource);
             });
         }
 
         // Draw agents
-        if (data.agents) {
-            data.agents.forEach(agent => {
+        if (frame.agents) {
+            frame.agents.forEach(agent => {
                 this.drawAgent(agent);
             });
         }
 
         // Draw interactions if any
-        if (data.interactions) {
-            data.interactions.forEach(interaction => {
+        if (frame.interactions) {
+            frame.interactions.forEach(interaction => {
                 this.drawInteraction(interaction);
             });
         }
@@ -519,6 +521,97 @@ class Editor {
                 ${this.renderBehaviorAnalysis(data.behavior)}
             </div>
         `;
+    }
+
+    setupStats() {
+        this.stats.innerHTML = `
+            <div class="dashboard-shell">
+                <div><strong>Step:</strong> <span id="sim-step">0</span></div>
+                <div><strong>Agents:</strong> <span id="sim-agents">0</span></div>
+                <div><strong>Resources:</strong> <span id="sim-resources">0</span></div>
+            </div>
+        `;
+    }
+
+    normalizeFrameData(data) {
+        const agents = data.agents || data.agent_states || [];
+        const resources = data.resources || data.resource_states || [];
+        const interactions = data.interactions || [];
+        return { agents, resources, interactions };
+    }
+
+    updateStats(data) {
+        const frame = this.normalizeFrameData(data);
+        const stepEl = document.getElementById('sim-step');
+        const agentsEl = document.getElementById('sim-agents');
+        const resourcesEl = document.getElementById('sim-resources');
+        if (stepEl) {
+            stepEl.textContent = `${this.currentStep}`;
+        }
+        if (agentsEl) {
+            agentsEl.textContent = `${frame.agents.length}`;
+        }
+        if (resourcesEl) {
+            resourcesEl.textContent = `${frame.resources.length}`;
+        }
+    }
+
+    updateCharts(data) {
+        const frame = this.normalizeFrameData(data);
+        const metrics = data.metrics || {};
+        const popChart = this.charts.population;
+        const resourceChart = this.charts.resources;
+        if (!popChart || !resourceChart) {
+            return;
+        }
+
+        popChart.data.labels.push(this.currentStep);
+        popChart.data.datasets[0].data.push(metrics.system_agents || 0);
+        popChart.data.datasets[1].data.push(metrics.independent_agents || 0);
+        popChart.data.datasets[2].data.push(metrics.control_agents || 0);
+        popChart.update();
+
+        resourceChart.data.labels.push(this.currentStep);
+        resourceChart.data.datasets[0].data.push(
+            metrics.total_resources || frame.resources.reduce((sum, item) => sum + (item.amount || 0), 0)
+        );
+        resourceChart.update();
+    }
+
+    renderPopulationAnalysis(population = {}) {
+        return `<pre>${JSON.stringify(population, null, 2)}</pre>`;
+    }
+
+    renderResourceAnalysis(resources = {}) {
+        return `<pre>${JSON.stringify(resources, null, 2)}</pre>`;
+    }
+
+    renderBehaviorAnalysis(behavior = {}) {
+        return `<pre>${JSON.stringify(behavior, null, 2)}</pre>`;
+    }
+
+    attachAnalysisEventListeners(modal) {
+        const close = modal.querySelector('.close');
+        if (close) {
+            close.addEventListener('click', () => modal.remove());
+        }
+        modal.addEventListener('click', (event) => {
+            if (event.target === modal) {
+                modal.remove();
+            }
+        });
+        modal.querySelectorAll('.tab-btn').forEach((button) => {
+            button.addEventListener('click', () => {
+                modal.querySelectorAll('.tab-btn').forEach((candidate) => candidate.classList.remove('active'));
+                button.classList.add('active');
+                const tabId = button.dataset.tab;
+                modal.querySelectorAll('.tab-panel').forEach((panel) => panel.classList.remove('active'));
+                const panel = modal.querySelector(`#${tabId}`);
+                if (panel) {
+                    panel.classList.add('active');
+                }
+            });
+        });
     }
 
     // Helper methods

--- a/farm/editor/components/experiment-dashboard.js
+++ b/farm/editor/components/experiment-dashboard.js
@@ -1,0 +1,148 @@
+class ExperimentDashboard {
+    constructor() {
+        this.statsRoot = document.getElementById('stats');
+        this.currentRunId = null;
+        this.currentViews = [];
+        this.init();
+    }
+
+    init() {
+        this.statsRoot.innerHTML = `
+            <div class="dashboard-shell">
+                <div class="dashboard-header">
+                    <h3>Experiment Dashboard</h3>
+                    <div id="dashboard-run-id">No run selected</div>
+                </div>
+                <div class="dashboard-controls">
+                    <label for="dashboard-view-select">View:</label>
+                    <select id="dashboard-view-select"></select>
+                    <button id="dashboard-load-view">Load View</button>
+                </div>
+                <div id="dashboard-body">Run an experiment from the builder to load views.</div>
+            </div>
+        `;
+
+        document.getElementById('dashboard-load-view').addEventListener('click', () => {
+            this.loadSelectedView();
+        });
+
+        window.addEventListener('experiment-run-completed', (event) => {
+            this.loadRun(event.detail.run_id);
+        });
+    }
+
+    async loadRun(runId) {
+        this.currentRunId = runId;
+        document.getElementById('dashboard-run-id').textContent = `Run: ${runId}`;
+        const body = document.getElementById('dashboard-body');
+        body.textContent = 'Loading views...';
+        try {
+            const response = await fetch(`http://localhost:5000/api/experiments/${runId}/views`);
+            const payload = await response.json();
+            this.currentViews = payload?.data || [];
+            this.renderViewOptions();
+            await this.loadSelectedView();
+        } catch (error) {
+            body.textContent = `Failed to load views: ${error.message}`;
+        }
+    }
+
+    renderViewOptions() {
+        const select = document.getElementById('dashboard-view-select');
+        select.innerHTML = '';
+        this.currentViews.forEach((view) => {
+            const option = document.createElement('option');
+            option.value = view.view_id;
+            option.textContent = view.title;
+            select.appendChild(option);
+        });
+    }
+
+    async loadSelectedView() {
+        if (!this.currentRunId) {
+            return;
+        }
+        const select = document.getElementById('dashboard-view-select');
+        const viewId = select.value;
+        if (!viewId) {
+            return;
+        }
+        const body = document.getElementById('dashboard-body');
+        body.textContent = 'Loading view data...';
+        try {
+            const response = await fetch(
+                `http://localhost:5000/api/experiments/${this.currentRunId}/views/${viewId}`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ filters: {} })
+                }
+            );
+            const payload = await response.json();
+            this.renderViewData(payload?.data || {});
+        } catch (error) {
+            body.textContent = `Failed to load view data: ${error.message}`;
+        }
+    }
+
+    renderViewData(data) {
+        const body = document.getElementById('dashboard-body');
+        if (data.view_type === 'summary_cards') {
+            const cards = (data.cards || [])
+                .map((card) => `<div class="dashboard-card"><strong>${card.label}</strong><span>${card.value}</span></div>`)
+                .join('');
+            body.innerHTML = `<div class="dashboard-card-grid">${cards}</div>`;
+            return;
+        }
+
+        if (data.view_type === 'timeseries') {
+            const rows = (data.series || [])
+                .map((series) => `<tr><td>${series.label}</td><td>${(series.values || []).slice(-1)[0] ?? 'n/a'}</td><td>${(series.values || []).length}</td></tr>`)
+                .join('');
+            body.innerHTML = `
+                <h4>${data.title || 'Time series'}</h4>
+                <table class="dashboard-table">
+                    <thead><tr><th>Series</th><th>Latest</th><th>Samples</th></tr></thead>
+                    <tbody>${rows}</tbody>
+                </table>
+            `;
+            return;
+        }
+
+        if (data.view_type === 'distribution_over_time') {
+            const rows = (data.snapshots || [])
+                .map((snapshot) => {
+                    const genes = Object.keys(snapshot.by_gene || {}).length;
+                    return `<tr><td>${snapshot.step}</td><td>${genes}</td></tr>`;
+                })
+                .join('');
+            body.innerHTML = `
+                <h4>${data.title || 'Distribution over time'}</h4>
+                <table class="dashboard-table">
+                    <thead><tr><th>Step</th><th>Genes tracked</th></tr></thead>
+                    <tbody>${rows}</tbody>
+                </table>
+            `;
+            return;
+        }
+
+        if (data.view_type === 'lineage_or_clusters') {
+            const clusterCount = (data.clusters || []).length;
+            const latestIndex = data?.timeseries?.series?.[0]?.values?.slice(-1)[0] ?? 'n/a';
+            body.innerHTML = `
+                <h4>${data.title || 'Lineage and clusters'}</h4>
+                <div class="dashboard-card-grid">
+                    <div class="dashboard-card"><strong>Latest Speciation Index</strong><span>${latestIndex}</span></div>
+                    <div class="dashboard-card"><strong>Cluster Records</strong><span>${clusterCount}</span></div>
+                </div>
+            `;
+            return;
+        }
+
+        body.textContent = 'No renderer available for this view.';
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    window.experimentDashboard = new ExperimentDashboard();
+});

--- a/farm/editor/components/experiment-dashboard.js
+++ b/farm/editor/components/experiment-dashboard.js
@@ -1,6 +1,9 @@
 class ExperimentDashboard {
     constructor() {
-        this.statsRoot = document.getElementById('experiment-dashboard') || document.getElementById('stats');
+        this.statsRoot = document.getElementById('experiment-dashboard');
+        if (!this.statsRoot) {
+            return;
+        }
         this.currentRunId = null;
         this.currentViews = [];
         this.isLoadingView = false;

--- a/farm/editor/components/experiment-dashboard.js
+++ b/farm/editor/components/experiment-dashboard.js
@@ -1,6 +1,6 @@
 class ExperimentDashboard {
     constructor() {
-        this.statsRoot = document.getElementById('stats');
+        this.statsRoot = document.getElementById('experiment-dashboard') || document.getElementById('stats');
         this.currentRunId = null;
         this.currentViews = [];
         this.isLoadingView = false;
@@ -114,14 +114,25 @@ class ExperimentDashboard {
 
     renderViewData(data) {
         if (data.view_type === 'summary_cards') {
-            const cards = (data.cards || [])
-                .map((card) => `<div class="dashboard-card"><strong>${card.label}</strong><span>${card.value}</span></div>`)
-                .join('');
-            if (!cards) {
+            const cards = data.cards || [];
+            if (!cards.length) {
                 this.body.textContent = 'No summary cards are available for this run.';
                 return;
             }
-            this.body.innerHTML = `<div class="dashboard-card-grid">${cards}</div>`;
+            const grid = document.createElement('div');
+            grid.className = 'dashboard-card-grid';
+            cards.forEach((card) => {
+                const cardElement = document.createElement('div');
+                cardElement.className = 'dashboard-card';
+                const label = document.createElement('strong');
+                label.textContent = String(card.label ?? '');
+                const value = document.createElement('span');
+                value.textContent = String(card.value ?? '');
+                cardElement.appendChild(label);
+                cardElement.appendChild(value);
+                grid.appendChild(cardElement);
+            });
+            this.body.replaceChildren(grid);
             return;
         }
 
@@ -130,16 +141,27 @@ class ExperimentDashboard {
                 this.body.textContent = 'No time series data is available for this run.';
                 return;
             }
-            const rows = (data.series || [])
-                .map((series) => `<tr><td>${series.label}</td><td>${(series.values || []).slice(-1)[0] ?? 'n/a'}</td><td>${(series.values || []).length}</td></tr>`)
-                .join('');
-            this.body.innerHTML = `
-                <h4>${data.title || 'Time series'}</h4>
-                <table class="dashboard-table">
-                    <thead><tr><th>Series</th><th>Latest</th><th>Samples</th></tr></thead>
-                    <tbody>${rows}</tbody>
-                </table>
-            `;
+            const title = document.createElement('h4');
+            title.textContent = data.title || 'Time series';
+            const table = document.createElement('table');
+            table.className = 'dashboard-table';
+            table.innerHTML = '<thead><tr><th>Series</th><th>Latest</th><th>Samples</th></tr></thead>';
+            const body = document.createElement('tbody');
+            (data.series || []).forEach((series) => {
+                const row = document.createElement('tr');
+                const label = document.createElement('td');
+                label.textContent = String(series.label ?? '');
+                const latest = document.createElement('td');
+                latest.textContent = String((series.values || []).slice(-1)[0] ?? 'n/a');
+                const samples = document.createElement('td');
+                samples.textContent = String((series.values || []).length);
+                row.appendChild(label);
+                row.appendChild(latest);
+                row.appendChild(samples);
+                body.appendChild(row);
+            });
+            table.appendChild(body);
+            this.body.replaceChildren(title, table);
             return;
         }
 
@@ -148,32 +170,53 @@ class ExperimentDashboard {
                 this.body.textContent = 'No distribution snapshots are available for this run.';
                 return;
             }
-            const rows = (data.snapshots || [])
-                .map((snapshot) => {
-                    const genes = Object.keys(snapshot.by_gene || {}).length;
-                    return `<tr><td>${snapshot.step}</td><td>${genes}</td></tr>`;
-                })
-                .join('');
-            this.body.innerHTML = `
-                <h4>${data.title || 'Distribution over time'}</h4>
-                <table class="dashboard-table">
-                    <thead><tr><th>Step</th><th>Genes tracked</th></tr></thead>
-                    <tbody>${rows}</tbody>
-                </table>
-            `;
+            const title = document.createElement('h4');
+            title.textContent = data.title || 'Distribution over time';
+            const table = document.createElement('table');
+            table.className = 'dashboard-table';
+            table.innerHTML = '<thead><tr><th>Step</th><th>Genes tracked</th></tr></thead>';
+            const body = document.createElement('tbody');
+            (data.snapshots || []).forEach((snapshot) => {
+                const row = document.createElement('tr');
+                const step = document.createElement('td');
+                step.textContent = String(snapshot.step ?? '');
+                const genes = document.createElement('td');
+                genes.textContent = String(Object.keys(snapshot.by_gene || {}).length);
+                row.appendChild(step);
+                row.appendChild(genes);
+                body.appendChild(row);
+            });
+            table.appendChild(body);
+            this.body.replaceChildren(title, table);
             return;
         }
 
         if (data.view_type === 'lineage_or_clusters') {
             const clusterCount = (data.clusters || []).length;
             const latestIndex = data?.timeseries?.series?.[0]?.values?.slice(-1)[0] ?? 'n/a';
-            this.body.innerHTML = `
-                <h4>${data.title || 'Lineage and clusters'}</h4>
-                <div class="dashboard-card-grid">
-                    <div class="dashboard-card"><strong>Latest Speciation Index</strong><span>${latestIndex}</span></div>
-                    <div class="dashboard-card"><strong>Cluster Records</strong><span>${clusterCount}</span></div>
-                </div>
-            `;
+            const title = document.createElement('h4');
+            title.textContent = data.title || 'Lineage and clusters';
+            const grid = document.createElement('div');
+            grid.className = 'dashboard-card-grid';
+            const indexCard = document.createElement('div');
+            indexCard.className = 'dashboard-card';
+            const indexLabel = document.createElement('strong');
+            indexLabel.textContent = 'Latest Speciation Index';
+            const indexValue = document.createElement('span');
+            indexValue.textContent = String(latestIndex);
+            indexCard.appendChild(indexLabel);
+            indexCard.appendChild(indexValue);
+            const clusterCard = document.createElement('div');
+            clusterCard.className = 'dashboard-card';
+            const clusterLabel = document.createElement('strong');
+            clusterLabel.textContent = 'Cluster Records';
+            const clusterValue = document.createElement('span');
+            clusterValue.textContent = String(clusterCount);
+            clusterCard.appendChild(clusterLabel);
+            clusterCard.appendChild(clusterValue);
+            grid.appendChild(indexCard);
+            grid.appendChild(clusterCard);
+            this.body.replaceChildren(title, grid);
             return;
         }
 

--- a/farm/editor/components/experiment-dashboard.js
+++ b/farm/editor/components/experiment-dashboard.js
@@ -1,12 +1,12 @@
 class ExperimentDashboard {
     constructor() {
+        this.currentRunId = null;
+        this.currentViews = [];
+        this.isLoadingView = false;
         this.statsRoot = document.getElementById('experiment-dashboard');
         if (!this.statsRoot) {
             return;
         }
-        this.currentRunId = null;
-        this.currentViews = [];
-        this.isLoadingView = false;
         this.init();
     }
 

--- a/farm/editor/components/experiment-dashboard.js
+++ b/farm/editor/components/experiment-dashboard.js
@@ -3,6 +3,7 @@ class ExperimentDashboard {
         this.statsRoot = document.getElementById('stats');
         this.currentRunId = null;
         this.currentViews = [];
+        this.isLoadingView = false;
         this.init();
     }
 
@@ -15,14 +16,19 @@ class ExperimentDashboard {
                 </div>
                 <div class="dashboard-controls">
                     <label for="dashboard-view-select">View:</label>
-                    <select id="dashboard-view-select"></select>
-                    <button id="dashboard-load-view">Load View</button>
+                    <select id="dashboard-view-select" disabled></select>
+                    <button id="dashboard-load-view" disabled>Load View</button>
                 </div>
                 <div id="dashboard-body">Run an experiment from the builder to load views.</div>
             </div>
         `;
 
-        document.getElementById('dashboard-load-view').addEventListener('click', () => {
+        this.viewSelect = document.getElementById('dashboard-view-select');
+        this.loadButton = document.getElementById('dashboard-load-view');
+        this.runLabel = document.getElementById('dashboard-run-id');
+        this.body = document.getElementById('dashboard-body');
+
+        this.loadButton.addEventListener('click', () => {
             this.loadSelectedView();
         });
 
@@ -33,42 +39,57 @@ class ExperimentDashboard {
 
     async loadRun(runId) {
         this.currentRunId = runId;
-        document.getElementById('dashboard-run-id').textContent = `Run: ${runId}`;
-        const body = document.getElementById('dashboard-body');
-        body.textContent = 'Loading views...';
+        this.runLabel.textContent = `Run: ${runId}`;
+        this.body.textContent = 'Loading views...';
+        this.viewSelect.disabled = true;
+        this.loadButton.disabled = true;
         try {
             const response = await fetch(`http://localhost:5000/api/experiments/${runId}/views`);
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
             const payload = await response.json();
             this.currentViews = payload?.data || [];
             this.renderViewOptions();
+            if (this.currentViews.length === 0) {
+                this.body.textContent = 'No dashboard views are available for this run.';
+                return;
+            }
             await this.loadSelectedView();
         } catch (error) {
-            body.textContent = `Failed to load views: ${error.message}`;
+            this.body.textContent = `Failed to load views: ${error.message}`;
         }
     }
 
     renderViewOptions() {
-        const select = document.getElementById('dashboard-view-select');
-        select.innerHTML = '';
+        const previousSelection = this.viewSelect.value;
+        this.viewSelect.innerHTML = '';
         this.currentViews.forEach((view) => {
             const option = document.createElement('option');
             option.value = view.view_id;
             option.textContent = view.title;
-            select.appendChild(option);
+            this.viewSelect.appendChild(option);
         });
+        if (previousSelection && this.currentViews.some((view) => view.view_id === previousSelection)) {
+            this.viewSelect.value = previousSelection;
+        }
+        const hasViews = this.currentViews.length > 0;
+        this.viewSelect.disabled = !hasViews;
+        this.loadButton.disabled = !hasViews;
     }
 
     async loadSelectedView() {
-        if (!this.currentRunId) {
+        if (!this.currentRunId || this.isLoadingView) {
             return;
         }
-        const select = document.getElementById('dashboard-view-select');
-        const viewId = select.value;
+        const viewId = this.viewSelect.value;
         if (!viewId) {
+            this.body.textContent = 'Select a dashboard view to load.';
             return;
         }
-        const body = document.getElementById('dashboard-body');
-        body.textContent = 'Loading view data...';
+        this.isLoadingView = true;
+        this.body.textContent = 'Loading view data...';
+        this.loadButton.disabled = true;
         try {
             const response = await fetch(
                 `http://localhost:5000/api/experiments/${this.currentRunId}/views/${viewId}`,
@@ -78,28 +99,41 @@ class ExperimentDashboard {
                     body: JSON.stringify({ filters: {} })
                 }
             );
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
             const payload = await response.json();
             this.renderViewData(payload?.data || {});
         } catch (error) {
-            body.textContent = `Failed to load view data: ${error.message}`;
+            this.body.textContent = `Failed to load view data: ${error.message}`;
+        } finally {
+            this.isLoadingView = false;
+            this.loadButton.disabled = this.currentViews.length === 0;
         }
     }
 
     renderViewData(data) {
-        const body = document.getElementById('dashboard-body');
         if (data.view_type === 'summary_cards') {
             const cards = (data.cards || [])
                 .map((card) => `<div class="dashboard-card"><strong>${card.label}</strong><span>${card.value}</span></div>`)
                 .join('');
-            body.innerHTML = `<div class="dashboard-card-grid">${cards}</div>`;
+            if (!cards) {
+                this.body.textContent = 'No summary cards are available for this run.';
+                return;
+            }
+            this.body.innerHTML = `<div class="dashboard-card-grid">${cards}</div>`;
             return;
         }
 
         if (data.view_type === 'timeseries') {
+            if (!data.series?.length) {
+                this.body.textContent = 'No time series data is available for this run.';
+                return;
+            }
             const rows = (data.series || [])
                 .map((series) => `<tr><td>${series.label}</td><td>${(series.values || []).slice(-1)[0] ?? 'n/a'}</td><td>${(series.values || []).length}</td></tr>`)
                 .join('');
-            body.innerHTML = `
+            this.body.innerHTML = `
                 <h4>${data.title || 'Time series'}</h4>
                 <table class="dashboard-table">
                     <thead><tr><th>Series</th><th>Latest</th><th>Samples</th></tr></thead>
@@ -110,13 +144,17 @@ class ExperimentDashboard {
         }
 
         if (data.view_type === 'distribution_over_time') {
+            if (!data.snapshots?.length) {
+                this.body.textContent = 'No distribution snapshots are available for this run.';
+                return;
+            }
             const rows = (data.snapshots || [])
                 .map((snapshot) => {
                     const genes = Object.keys(snapshot.by_gene || {}).length;
                     return `<tr><td>${snapshot.step}</td><td>${genes}</td></tr>`;
                 })
                 .join('');
-            body.innerHTML = `
+            this.body.innerHTML = `
                 <h4>${data.title || 'Distribution over time'}</h4>
                 <table class="dashboard-table">
                     <thead><tr><th>Step</th><th>Genes tracked</th></tr></thead>
@@ -129,7 +167,7 @@ class ExperimentDashboard {
         if (data.view_type === 'lineage_or_clusters') {
             const clusterCount = (data.clusters || []).length;
             const latestIndex = data?.timeseries?.series?.[0]?.values?.slice(-1)[0] ?? 'n/a';
-            body.innerHTML = `
+            this.body.innerHTML = `
                 <h4>${data.title || 'Lineage and clusters'}</h4>
                 <div class="dashboard-card-grid">
                     <div class="dashboard-card"><strong>Latest Speciation Index</strong><span>${latestIndex}</span></div>
@@ -139,7 +177,7 @@ class ExperimentDashboard {
             return;
         }
 
-        body.textContent = 'No renderer available for this view.';
+        this.body.textContent = 'No renderer available for this view.';
     }
 }
 

--- a/farm/editor/components/sidebar.js
+++ b/farm/editor/components/sidebar.js
@@ -16,6 +16,42 @@ class Sidebar {
                 <button id="open-sim">Open Simulation</button>
                 <button id="export-data">Export Data</button>
                 <div class="config-section">
+                    <h3>Experiment Builder</h3>
+                    <div class="config-item">
+                        <label>Experiment Name:</label>
+                        <input type="text" id="exp-name" value="intrinsic-dashboard-run">
+                    </div>
+                    <div class="config-item">
+                        <label>Steps:</label>
+                        <input type="number" id="exp-steps" value="400" min="1">
+                    </div>
+                    <div class="config-item">
+                        <label>Snapshot Interval:</label>
+                        <input type="number" id="exp-snapshot-interval" value="25" min="1">
+                    </div>
+                    <div class="config-item">
+                        <label>Selection Pressure:</label>
+                        <select id="exp-selection-pressure">
+                            <option value="none">none</option>
+                            <option value="low">low</option>
+                            <option value="medium" selected>medium</option>
+                            <option value="high">high</option>
+                        </select>
+                    </div>
+                    <div class="config-item">
+                        <label>Enable Speciation:</label>
+                        <input type="checkbox" id="exp-enable-speciation" checked>
+                    </div>
+                    <div class="builder-actions">
+                        <button id="validate-exp">Validate Manifest</button>
+                        <button id="run-exp">Run Experiment</button>
+                        <button id="save-exp-preset">Save Preset</button>
+                        <button id="load-exp-preset">Load Preset</button>
+                        <button id="load-latest-exp">Load Latest</button>
+                    </div>
+                    <div id="exp-status" class="exp-status">No experiment run yet.</div>
+                </div>
+                <div class="config-section">
                     <h3>Configuration</h3>
                     <div class="config-item">
                         <label>Environment Width:</label>
@@ -69,6 +105,21 @@ class Sidebar {
         document.getElementById('export-data').addEventListener('click', () => {
             this.exportData();
         });
+        document.getElementById('validate-exp').addEventListener('click', () => {
+            this.validateExperimentManifest();
+        });
+        document.getElementById('run-exp').addEventListener('click', () => {
+            this.runExperimentFromBuilder();
+        });
+        document.getElementById('save-exp-preset').addEventListener('click', () => {
+            this.saveExperimentPreset();
+        });
+        document.getElementById('load-exp-preset').addEventListener('click', () => {
+            this.loadExperimentPreset();
+        });
+        document.getElementById('load-latest-exp').addEventListener('click', () => {
+            this.loadLatestExperimentRun();
+        });
     }
 
     async createNewSimulation() {
@@ -105,6 +156,168 @@ class Sidebar {
 
     async exportData() {
         // Implementation for exporting data
+    }
+
+    buildIntrinsicManifest() {
+        const width = parseInt(document.getElementById('env-width').value, 10);
+        const height = parseInt(document.getElementById('env-height').value, 10);
+        const initialResources = parseInt(document.getElementById('init-resources').value, 10);
+        const experimentName = document.getElementById('exp-name').value.trim() || 'intrinsic-dashboard-run';
+        const steps = parseInt(document.getElementById('exp-steps').value, 10);
+        const snapshotInterval = parseInt(document.getElementById('exp-snapshot-interval').value, 10);
+        const selectionPressure = document.getElementById('exp-selection-pressure').value;
+        const speciationEnabled = document.getElementById('exp-enable-speciation').checked;
+
+        return {
+            schema_version: 1,
+            experiment_type: 'intrinsic_evolution',
+            experiment_name: experimentName,
+            base_simulation_config: {
+                'environment.width': width,
+                'environment.height': height,
+                'resources.initial_resources': initialResources
+            },
+            experiment_config: {
+                num_steps: steps,
+                snapshot_interval: snapshotInterval,
+                initial_conditions: {
+                    profile: 'stable'
+                },
+                policy: {
+                    selection_pressure: selectionPressure
+                },
+                speciation: {
+                    enabled: speciationEnabled
+                }
+            },
+            dashboard_preset: {
+                default_views: ['summary_cards', 'gene_trajectories', 'population_dynamics']
+            }
+        };
+    }
+
+    updateExperimentStatus(message, isError = false) {
+        const status = document.getElementById('exp-status');
+        status.textContent = message;
+        status.classList.toggle('error', isError);
+    }
+
+    async validateExperimentManifest() {
+        const manifest = this.buildIntrinsicManifest();
+        this.updateExperimentStatus('Validating manifest...');
+        try {
+            const response = await fetch('http://localhost:5000/api/experiments/manifests/validate', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ manifest })
+            });
+            const data = await response.json();
+            const result = data.data || {};
+            if (!result.is_valid) {
+                this.updateExperimentStatus(`Manifest invalid: ${(result.errors || []).join('; ')}`, true);
+                return;
+            }
+            this.updateExperimentStatus('Manifest is valid.');
+        } catch (error) {
+            this.updateExperimentStatus(`Validation failed: ${error.message}`, true);
+        }
+    }
+
+    async runExperimentFromBuilder() {
+        const manifest = this.buildIntrinsicManifest();
+        this.updateExperimentStatus('Starting experiment run...');
+        try {
+            const response = await fetch('http://localhost:5000/api/experiments/run', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ manifest })
+            });
+            if (!response.ok) {
+                const failure = await response.text();
+                throw new Error(failure || 'Failed to start experiment');
+            }
+            const data = await response.json();
+            const runId = data.run_id;
+            this.updateExperimentStatus(`Run ${runId} started.`);
+            window.dispatchEvent(new CustomEvent('experiment-run-created', { detail: { run_id: runId } }));
+            this.pollExperimentRun(runId);
+        } catch (error) {
+            this.updateExperimentStatus(`Run failed to start: ${error.message}`, true);
+        }
+    }
+
+    async pollExperimentRun(runId) {
+        const interval = setInterval(async () => {
+            try {
+                const response = await fetch(`http://localhost:5000/api/experiments/${runId}/status`);
+                const payload = await response.json();
+                const status = payload?.data?.status;
+                window.dispatchEvent(new CustomEvent('experiment-run-status', { detail: payload.data }));
+                this.updateExperimentStatus(`Run ${runId}: ${status}`);
+                if (status === 'completed') {
+                    clearInterval(interval);
+                    window.dispatchEvent(new CustomEvent('experiment-run-completed', { detail: { run_id: runId } }));
+                }
+                if (status === 'error') {
+                    clearInterval(interval);
+                    const message = payload?.data?.error_message || 'Unknown error';
+                    this.updateExperimentStatus(`Run ${runId} errored: ${message}`, true);
+                }
+            } catch (error) {
+                clearInterval(interval);
+                this.updateExperimentStatus(`Run polling failed: ${error.message}`, true);
+            }
+        }, 2000);
+    }
+
+    async loadLatestExperimentRun() {
+        this.updateExperimentStatus('Loading latest completed run...');
+        try {
+            const response = await fetch('http://localhost:5000/api/experiments/runs');
+            const payload = await response.json();
+            const runs = payload?.data || [];
+            const completed = runs.filter(run => run.status === 'completed');
+            if (completed.length === 0) {
+                this.updateExperimentStatus('No completed experiment runs found.', true);
+                return;
+            }
+            const latest = completed[completed.length - 1];
+            this.updateExperimentStatus(`Loaded run ${latest.run_id}.`);
+            window.dispatchEvent(new CustomEvent('experiment-run-completed', { detail: { run_id: latest.run_id } }));
+        } catch (error) {
+            this.updateExperimentStatus(`Failed to load run: ${error.message}`, true);
+        }
+    }
+
+    saveExperimentPreset() {
+        try {
+            const manifest = this.buildIntrinsicManifest();
+            localStorage.setItem('intrinsic-dashboard-preset', JSON.stringify(manifest));
+            this.updateExperimentStatus('Saved experiment preset locally.');
+        } catch (error) {
+            this.updateExperimentStatus(`Failed to save preset: ${error.message}`, true);
+        }
+    }
+
+    loadExperimentPreset() {
+        try {
+            const raw = localStorage.getItem('intrinsic-dashboard-preset');
+            if (!raw) {
+                this.updateExperimentStatus('No saved preset found.', true);
+                return;
+            }
+            const manifest = JSON.parse(raw);
+            document.getElementById('exp-name').value = manifest.experiment_name || 'intrinsic-dashboard-run';
+            document.getElementById('exp-steps').value = manifest.experiment_config?.num_steps || 400;
+            document.getElementById('exp-snapshot-interval').value = manifest.experiment_config?.snapshot_interval || 25;
+            document.getElementById('exp-selection-pressure').value = manifest.experiment_config?.policy?.selection_pressure || 'medium';
+            document.getElementById('exp-enable-speciation').checked = Boolean(
+                manifest.experiment_config?.speciation?.enabled
+            );
+            this.updateExperimentStatus('Loaded saved experiment preset.');
+        } catch (error) {
+            this.updateExperimentStatus(`Failed to load preset: ${error.message}`, true);
+        }
     }
 }
 

--- a/farm/editor/components/sidebar.js
+++ b/farm/editor/components/sidebar.js
@@ -1,6 +1,7 @@
 class Sidebar {
     constructor() {
         this.element = document.getElementById('sidebar');
+        this.experimentPollInterval = null;
         this.init();
     }
 
@@ -247,7 +248,10 @@ class Sidebar {
     }
 
     async pollExperimentRun(runId) {
-        const interval = setInterval(async () => {
+        if (this.experimentPollInterval) {
+            clearInterval(this.experimentPollInterval);
+        }
+        this.experimentPollInterval = setInterval(async () => {
             try {
                 const response = await fetch(`http://localhost:5000/api/experiments/${runId}/status`);
                 const payload = await response.json();
@@ -255,16 +259,19 @@ class Sidebar {
                 window.dispatchEvent(new CustomEvent('experiment-run-status', { detail: payload.data }));
                 this.updateExperimentStatus(`Run ${runId}: ${status}`);
                 if (status === 'completed') {
-                    clearInterval(interval);
+                    clearInterval(this.experimentPollInterval);
+                    this.experimentPollInterval = null;
                     window.dispatchEvent(new CustomEvent('experiment-run-completed', { detail: { run_id: runId } }));
                 }
                 if (status === 'error') {
-                    clearInterval(interval);
+                    clearInterval(this.experimentPollInterval);
+                    this.experimentPollInterval = null;
                     const message = payload?.data?.error_message || 'Unknown error';
                     this.updateExperimentStatus(`Run ${runId} errored: ${message}`, true);
                 }
             } catch (error) {
-                clearInterval(interval);
+                clearInterval(this.experimentPollInterval);
+                this.experimentPollInterval = null;
                 this.updateExperimentStatus(`Run polling failed: ${error.message}`, true);
             }
         }, 2000);

--- a/farm/editor/index.html
+++ b/farm/editor/index.html
@@ -11,6 +11,7 @@
             <div id="visualization"></div>
             <div id="controls"></div>
             <div id="stats"></div>
+            <div id="experiment-dashboard"></div>
         </div>
     </div>
 

--- a/farm/editor/index.html
+++ b/farm/editor/index.html
@@ -28,6 +28,7 @@
 
     <script src="components/sidebar.js"></script>
     <script src="components/editor.js"></script>
+    <script src="components/experiment-dashboard.js"></script>
     <script src="services/schema.js"></script>
     <script src="services/dialog.js"></script>
     <script src="components/config-explorer/SplitPane.js"></script>

--- a/farm/editor/styles/main.css
+++ b/farm/editor/styles/main.css
@@ -322,3 +322,96 @@ body.grayscale #config-explorer {
 .section-item { text-align: left; padding: 10px 12px; background: #34495e; border: none; color: #ecf0f1; border-radius: 4px; cursor: pointer; }
 .section-item:hover { background: #3b5672; }
 .section-item.active { background: #3498db; }
+
+.config-item select {
+    width: 100%;
+    padding: 6px;
+    border-radius: 4px;
+    border: none;
+}
+
+.builder-actions {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 6px;
+    margin-top: 10px;
+}
+
+.builder-actions button {
+    background-color: #2ecc71;
+    border: none;
+    color: white;
+    padding: 8px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.builder-actions button:hover {
+    background-color: #27ae60;
+}
+
+.exp-status {
+    margin-top: 10px;
+    font-size: 12px;
+    line-height: 1.4;
+    color: #ecf0f1;
+}
+
+.exp-status.error {
+    color: #ffb3a7;
+}
+
+.dashboard-shell {
+    margin-top: 14px;
+    background-color: #34495e;
+    border-radius: 8px;
+    padding: 12px;
+    color: #ecf0f1;
+}
+
+.dashboard-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.dashboard-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 8px 0;
+}
+
+.dashboard-controls select,
+.dashboard-controls button {
+    padding: 6px;
+    border-radius: 4px;
+    border: none;
+}
+
+.dashboard-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 10px;
+}
+
+.dashboard-card {
+    background-color: #2c3e50;
+    border-radius: 6px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.dashboard-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.dashboard-table th,
+.dashboard-table td {
+    border-bottom: 1px solid rgba(236, 240, 241, 0.15);
+    text-align: left;
+    padding: 6px;
+}

--- a/farm/experiments/__init__.py
+++ b/farm/experiments/__init__.py
@@ -1,0 +1,23 @@
+"""Experiment dashboard interfaces and adapters."""
+
+from farm.experiments.intrinsic_dashboard import IntrinsicEvolutionAdapter
+from farm.experiments.interfaces import (
+    ExperimentAdapterProtocol,
+    ExperimentRegistry,
+    ViewDescriptor,
+)
+from farm.experiments.manifest import (
+    ExperimentManifest,
+    ManifestValidationResult,
+    validate_experiment_manifest,
+)
+
+__all__ = [
+    "ExperimentAdapterProtocol",
+    "ExperimentManifest",
+    "ExperimentRegistry",
+    "IntrinsicEvolutionAdapter",
+    "ManifestValidationResult",
+    "ViewDescriptor",
+    "validate_experiment_manifest",
+]

--- a/farm/experiments/interfaces.py
+++ b/farm/experiments/interfaces.py
@@ -1,0 +1,75 @@
+"""Common interface for dashboard-backed experiment adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Protocol
+
+from farm.experiments.manifest import ExperimentManifest, ManifestValidationResult
+
+
+@dataclass(frozen=True)
+class ViewDescriptor:
+    """Metadata describing a dashboard view exposed by an experiment adapter."""
+
+    view_id: str
+    view_type: str
+    title: str
+    description: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "view_id": self.view_id,
+            "view_type": self.view_type,
+            "title": self.title,
+            "description": self.description,
+        }
+
+
+class ExperimentAdapterProtocol(Protocol):
+    """Contract implemented by each experiment type adapter."""
+
+    experiment_type: str
+
+    def validate_manifest(self, manifest: ExperimentManifest) -> ManifestValidationResult:
+        """Validate adapter-specific sections of a normalized manifest."""
+
+    def run_experiment(
+        self,
+        run_id: str,
+        manifest: ExperimentManifest,
+        runtime_options: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Execute the experiment and return a run summary."""
+
+    def list_views(self, run_context: Dict[str, Any]) -> List[ViewDescriptor]:
+        """List available dashboard views for a completed/in-progress run."""
+
+    def get_view_data(
+        self,
+        run_context: Dict[str, Any],
+        view_id: str,
+        filters: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Return normalized payload for a single dashboard view."""
+
+
+class ExperimentRegistry:
+    """In-memory experiment type -> adapter registry."""
+
+    def __init__(self) -> None:
+        self._adapters: Dict[str, ExperimentAdapterProtocol] = {}
+
+    def register(self, adapter: ExperimentAdapterProtocol) -> None:
+        self._adapters[adapter.experiment_type] = adapter
+
+    def get(self, experiment_type: str) -> ExperimentAdapterProtocol:
+        if experiment_type not in self._adapters:
+            supported = ", ".join(sorted(self._adapters.keys()))
+            raise KeyError(
+                f"Unsupported experiment_type={experiment_type!r}. Supported: {supported}"
+            )
+        return self._adapters[experiment_type]
+
+    def list_experiment_types(self) -> List[str]:
+        return sorted(self._adapters.keys())

--- a/farm/experiments/intrinsic_dashboard.py
+++ b/farm/experiments/intrinsic_dashboard.py
@@ -1,0 +1,324 @@
+"""Intrinsic evolution adapter for the dashboard experiment interface."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Iterable, List, Optional
+
+from farm.config import SimulationConfig
+from farm.experiments.interfaces import ExperimentAdapterProtocol, ViewDescriptor
+from farm.experiments.manifest import (
+    ExperimentManifest,
+    INTRINSIC_EVOLUTION_EXPERIMENT_TYPE,
+    ManifestValidationResult,
+)
+from farm.runners.intrinsic_evolution_experiment import (
+    InitialConditionsConfig,
+    IntrinsicEvolutionExperiment,
+    IntrinsicEvolutionExperimentConfig,
+    IntrinsicEvolutionPolicy,
+    SpeciationConfig,
+)
+
+
+def _read_json(path: str, default: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    if not os.path.exists(path):
+        return default or {}
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _read_jsonl(path: str) -> List[Dict[str, Any]]:
+    if not os.path.exists(path):
+        return []
+    rows: List[Dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            rows.append(json.loads(stripped))
+    return rows
+
+
+def _to_series_payload(
+    x_axis: List[int],
+    series: Iterable[Dict[str, Any]],
+    title: str,
+) -> Dict[str, Any]:
+    return {
+        "view_type": "timeseries",
+        "title": title,
+        "x": x_axis,
+        "series": list(series),
+    }
+
+
+class IntrinsicEvolutionAdapter(ExperimentAdapterProtocol):
+    """Adapter between intrinsic-evolution artifacts and dashboard payloads."""
+
+    experiment_type = INTRINSIC_EVOLUTION_EXPERIMENT_TYPE
+
+    def validate_manifest(self, manifest: ExperimentManifest) -> ManifestValidationResult:
+        try:
+            self._build_config(manifest, output_dir="results/validation_only")
+        except Exception as exc:  # noqa: BLE001
+            return ManifestValidationResult(is_valid=False, errors=[str(exc)])
+        return ManifestValidationResult(is_valid=True, normalized_manifest=manifest.dict())
+
+    def run_experiment(
+        self,
+        run_id: str,
+        manifest: ExperimentManifest,
+        runtime_options: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        output_dir = runtime_options.get("output_dir") or os.path.join(
+            "results", "intrinsic_dashboard_runs", run_id
+        )
+        os.makedirs(output_dir, exist_ok=True)
+        base_config, experiment_config = self._build_config(manifest, output_dir=output_dir)
+
+        experiment = IntrinsicEvolutionExperiment(
+            base_config=base_config,
+            config=experiment_config,
+        )
+        result = experiment.run()
+        return {
+            "run_id": run_id,
+            "experiment_type": self.experiment_type,
+            "output_dir": output_dir,
+            "num_steps_completed": result.num_steps_completed,
+            "final_population": result.final_population,
+            "startup_transient_metrics": result.startup_transient_metrics,
+        }
+
+    def list_views(self, run_context: Dict[str, Any]) -> List[ViewDescriptor]:
+        output_dir = run_context["output_dir"]
+        metadata = _read_json(os.path.join(output_dir, "intrinsic_evolution_metadata.json"))
+        views = [
+            ViewDescriptor(
+                view_id="summary_cards",
+                view_type="summary_cards",
+                title="Run Summary",
+                description="Resolved policy, completion stats, and final outcomes.",
+            ),
+            ViewDescriptor(
+                view_id="gene_trajectories",
+                view_type="timeseries",
+                title="Gene Trajectories",
+                description="Per-gene mean and variability over simulation steps.",
+            ),
+            ViewDescriptor(
+                view_id="population_dynamics",
+                view_type="timeseries",
+                title="Population Dynamics",
+                description="Population plus realized birth/death and selection pressure.",
+            ),
+            ViewDescriptor(
+                view_id="gene_distributions",
+                view_type="distribution_over_time",
+                title="Gene Distributions",
+                description="Snapshot-based per-gene distribution values.",
+            ),
+        ]
+        if metadata.get("speciation", {}).get("enabled"):
+            views.append(
+                ViewDescriptor(
+                    view_id="speciation_index",
+                    view_type="lineage_or_clusters",
+                    title="Speciation Index",
+                    description="Cluster separation and lineage-oriented speciation tracking.",
+                )
+            )
+        return views
+
+    def get_view_data(
+        self,
+        run_context: Dict[str, Any],
+        view_id: str,
+        filters: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        output_dir = run_context["output_dir"]
+        trajectory = _read_jsonl(os.path.join(output_dir, "intrinsic_gene_trajectory.jsonl"))
+        snapshots = _read_jsonl(os.path.join(output_dir, "intrinsic_gene_snapshots.jsonl"))
+        metadata = _read_json(os.path.join(output_dir, "intrinsic_evolution_metadata.json"))
+        clusters = _read_jsonl(os.path.join(output_dir, "cluster_lineage.jsonl"))
+
+        if view_id == "summary_cards":
+            return self._summary_cards(metadata, trajectory)
+        if view_id == "gene_trajectories":
+            return self._gene_trajectories(trajectory, filters)
+        if view_id == "population_dynamics":
+            return self._population_dynamics(trajectory)
+        if view_id == "gene_distributions":
+            return self._gene_distributions(snapshots, filters)
+        if view_id == "speciation_index":
+            return self._speciation_index(trajectory, clusters)
+        raise KeyError(f"Unknown view_id={view_id!r}")
+
+    def _build_config(
+        self,
+        manifest: ExperimentManifest,
+        *,
+        output_dir: str,
+    ) -> tuple[SimulationConfig, IntrinsicEvolutionExperimentConfig]:
+        base_config = SimulationConfig.from_dict(manifest.base_simulation_config)
+        config_payload = dict(manifest.experiment_config)
+
+        policy_payload = config_payload.pop("policy", {})
+        initial_conditions_payload = config_payload.pop("initial_conditions", {})
+        speciation_payload = config_payload.pop("speciation", {})
+        config_payload["output_dir"] = config_payload.get("output_dir") or output_dir
+
+        experiment_config = IntrinsicEvolutionExperimentConfig(
+            policy=IntrinsicEvolutionPolicy(**policy_payload),
+            initial_conditions=InitialConditionsConfig(**initial_conditions_payload),
+            speciation=SpeciationConfig(**speciation_payload),
+            **config_payload,
+        )
+        return base_config, experiment_config
+
+    def _summary_cards(
+        self,
+        metadata: Dict[str, Any],
+        trajectory_rows: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        cards = [
+            {"id": "steps", "label": "Steps Completed", "value": metadata.get("num_steps_completed")},
+            {"id": "population", "label": "Final Population", "value": metadata.get("final_population")},
+            {
+                "id": "snapshot_interval",
+                "label": "Snapshot Interval",
+                "value": metadata.get("snapshot_interval"),
+            },
+            {
+                "id": "selection_pressure",
+                "label": "Selection Pressure",
+                "value": metadata.get("policy", {}).get("selection_pressure"),
+            },
+            {
+                "id": "speciation_enabled",
+                "label": "Speciation Enabled",
+                "value": metadata.get("speciation", {}).get("enabled", False),
+            },
+        ]
+        if trajectory_rows:
+            cards.append(
+                {
+                    "id": "samples",
+                    "label": "Trajectory Samples",
+                    "value": len(trajectory_rows),
+                }
+            )
+        return {"view_type": "summary_cards", "cards": cards, "metadata": metadata}
+
+    def _gene_trajectories(
+        self,
+        trajectory_rows: List[Dict[str, Any]],
+        filters: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        selected_genes = set(filters.get("genes", []))
+        x_axis = [int(row.get("step", index + 1)) for index, row in enumerate(trajectory_rows)]
+        by_gene: Dict[str, Dict[str, List[float]]] = {}
+
+        for row in trajectory_rows:
+            stats = row.get("gene_stats", {})
+            for gene_name, gene_stats in stats.items():
+                if selected_genes and gene_name not in selected_genes:
+                    continue
+                slot = by_gene.setdefault(
+                    gene_name,
+                    {"mean": [], "std": [], "min": [], "max": []},
+                )
+                slot["mean"].append(float(gene_stats.get("mean", 0.0)))
+                slot["std"].append(float(gene_stats.get("std", 0.0)))
+                slot["min"].append(float(gene_stats.get("min", 0.0)))
+                slot["max"].append(float(gene_stats.get("max", 0.0)))
+
+        series: List[Dict[str, Any]] = []
+        for gene_name, values in sorted(by_gene.items()):
+            series.append(
+                {
+                    "id": f"{gene_name}_mean",
+                    "label": f"{gene_name} mean",
+                    "values": values["mean"],
+                    "bands": {
+                        "std": values["std"],
+                        "min": values["min"],
+                        "max": values["max"],
+                    },
+                }
+            )
+        return _to_series_payload(x_axis, series, "Gene trajectories")
+
+    def _population_dynamics(self, trajectory_rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+        x_axis = [int(row.get("step", index + 1)) for index, row in enumerate(trajectory_rows)]
+        population = [
+            int(row.get("n_alive", row.get("population", row.get("n_with_chromosome", 0))))
+            for row in trajectory_rows
+        ]
+        births = [float(row.get("realized_birth_rate", 0.0)) for row in trajectory_rows]
+        deaths = [float(row.get("realized_death_rate", 0.0)) for row in trajectory_rows]
+        selection = [
+            float(row.get("effective_selection_strength", 0.0)) for row in trajectory_rows
+        ]
+        series = [
+            {"id": "population", "label": "Population", "values": population},
+            {"id": "birth_rate", "label": "Birth Rate", "values": births},
+            {"id": "death_rate", "label": "Death Rate", "values": deaths},
+            {
+                "id": "selection_strength",
+                "label": "Selection Strength",
+                "values": selection,
+            },
+        ]
+        return _to_series_payload(x_axis, series, "Population dynamics")
+
+    def _gene_distributions(
+        self,
+        snapshot_rows: List[Dict[str, Any]],
+        filters: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        max_snapshots = int(filters.get("max_snapshots", 25))
+        reduced_rows = snapshot_rows[-max_snapshots:] if max_snapshots > 0 else snapshot_rows
+        payload: List[Dict[str, Any]] = []
+        for row in reduced_rows:
+            step = int(row.get("step", 0))
+            by_gene: Dict[str, List[float]] = {}
+            for agent in row.get("agents", []):
+                chromosome = agent.get("chromosome", {})
+                for gene_name, value in chromosome.items():
+                    by_gene.setdefault(gene_name, []).append(float(value))
+            payload.append({"step": step, "by_gene": by_gene})
+        return {
+            "view_type": "distribution_over_time",
+            "title": "Gene distribution history",
+            "snapshots": payload,
+        }
+
+    def _speciation_index(
+        self,
+        trajectory_rows: List[Dict[str, Any]],
+        cluster_rows: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        x_axis = [int(row.get("step", index + 1)) for index, row in enumerate(trajectory_rows)]
+        speciation_values = [float(row.get("speciation_index", 0.0)) for row in trajectory_rows]
+        cluster_sizes = [
+            {
+                "step": int(row.get("step", 0)),
+                "cluster_id": row.get("cluster_id"),
+                "size": int(row.get("size", 0)),
+            }
+            for row in cluster_rows
+        ]
+        return {
+            "view_type": "lineage_or_clusters",
+            "title": "Speciation index",
+            "timeseries": _to_series_payload(
+                x_axis,
+                [{"id": "speciation_index", "label": "Speciation Index", "values": speciation_values}],
+                "Speciation index",
+            ),
+            "clusters": cluster_sizes,
+        }

--- a/farm/experiments/intrinsic_dashboard.py
+++ b/farm/experiments/intrinsic_dashboard.py
@@ -65,7 +65,9 @@ class IntrinsicEvolutionAdapter(ExperimentAdapterProtocol):
             self._build_config(manifest, output_dir="results/validation_only")
         except Exception as exc:  # noqa: BLE001
             return ManifestValidationResult(is_valid=False, errors=[str(exc)])
-        return ManifestValidationResult(is_valid=True, normalized_manifest=manifest.dict())
+        return ManifestValidationResult(
+            is_valid=True, normalized_manifest=manifest.model_dump()
+        )
 
     def run_experiment(
         self,

--- a/farm/experiments/manifest.py
+++ b/farm/experiments/manifest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, ValidationError, root_validator
+from pydantic import BaseModel, Field, ValidationError, model_validator
 
 
 SUPPORTED_SCHEMA_VERSION = 1
@@ -29,22 +29,22 @@ class ExperimentManifest(BaseModel):
     experiment_config: Dict[str, Any] = Field(default_factory=dict)
     dashboard_preset: DashboardPreset = Field(default_factory=DashboardPreset)
 
-    @root_validator(skip_on_failure=True)
-    def _validate_supported_values(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        schema_version = values.get("schema_version")
+    @model_validator(mode="after")
+    def _validate_supported_values(self) -> "ExperimentManifest":
+        schema_version = self.schema_version
         if schema_version != SUPPORTED_SCHEMA_VERSION:
             raise ValueError(
                 f"Unsupported schema_version={schema_version}. "
                 f"Expected {SUPPORTED_SCHEMA_VERSION}."
             )
 
-        experiment_type = values.get("experiment_type")
+        experiment_type = self.experiment_type
         if experiment_type != INTRINSIC_EVOLUTION_EXPERIMENT_TYPE:
             raise ValueError(
                 f"Unsupported experiment_type={experiment_type!r}. "
                 f"Supported values: [{INTRINSIC_EVOLUTION_EXPERIMENT_TYPE!r}]"
             )
-        return values
+        return self
 
 
 class ManifestValidationResult(BaseModel):
@@ -59,7 +59,7 @@ class ManifestValidationResult(BaseModel):
 def validate_experiment_manifest(payload: Dict[str, Any]) -> ManifestValidationResult:
     """Validate and normalize a manifest payload."""
     try:
-        manifest = ExperimentManifest.parse_obj(payload)
+        manifest = ExperimentManifest.model_validate(payload)
     except ValidationError as exc:
         errors: List[str] = []
         for issue in exc.errors():
@@ -71,5 +71,5 @@ def validate_experiment_manifest(payload: Dict[str, Any]) -> ManifestValidationR
 
     return ManifestValidationResult(
         is_valid=True,
-        normalized_manifest=manifest.dict(),
+        normalized_manifest=manifest.model_dump(),
     )

--- a/farm/experiments/manifest.py
+++ b/farm/experiments/manifest.py
@@ -1,0 +1,75 @@
+"""Versioned experiment manifest schema used by the dashboard APIs."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, ValidationError, root_validator
+
+
+SUPPORTED_SCHEMA_VERSION = 1
+INTRINSIC_EVOLUTION_EXPERIMENT_TYPE = "intrinsic_evolution"
+
+
+class DashboardPreset(BaseModel):
+    """View-level defaults selected by the no-code editor."""
+
+    default_views: List[str] = Field(default_factory=list)
+    default_gene_ids: List[str] = Field(default_factory=list)
+    step_window: Optional[Dict[str, int]] = None
+
+
+class ExperimentManifest(BaseModel):
+    """Top-level, versioned experiment descriptor."""
+
+    schema_version: int = Field(default=SUPPORTED_SCHEMA_VERSION)
+    experiment_type: str
+    experiment_name: str = Field(min_length=1)
+    base_simulation_config: Dict[str, Any] = Field(default_factory=dict)
+    experiment_config: Dict[str, Any] = Field(default_factory=dict)
+    dashboard_preset: DashboardPreset = Field(default_factory=DashboardPreset)
+
+    @root_validator(skip_on_failure=True)
+    def _validate_supported_values(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        schema_version = values.get("schema_version")
+        if schema_version != SUPPORTED_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported schema_version={schema_version}. "
+                f"Expected {SUPPORTED_SCHEMA_VERSION}."
+            )
+
+        experiment_type = values.get("experiment_type")
+        if experiment_type != INTRINSIC_EVOLUTION_EXPERIMENT_TYPE:
+            raise ValueError(
+                f"Unsupported experiment_type={experiment_type!r}. "
+                f"Supported values: [{INTRINSIC_EVOLUTION_EXPERIMENT_TYPE!r}]"
+            )
+        return values
+
+
+class ManifestValidationResult(BaseModel):
+    """Validation response shape returned by backend endpoints."""
+
+    is_valid: bool
+    errors: List[str] = Field(default_factory=list)
+    warnings: List[str] = Field(default_factory=list)
+    normalized_manifest: Optional[Dict[str, Any]] = None
+
+
+def validate_experiment_manifest(payload: Dict[str, Any]) -> ManifestValidationResult:
+    """Validate and normalize a manifest payload."""
+    try:
+        manifest = ExperimentManifest.parse_obj(payload)
+    except ValidationError as exc:
+        errors: List[str] = []
+        for issue in exc.errors():
+            location = ".".join(str(part) for part in issue.get("loc", []))
+            errors.append(f"{location}: {issue.get('msg')}")
+        return ManifestValidationResult(is_valid=False, errors=errors)
+    except ValueError as exc:
+        return ManifestValidationResult(is_valid=False, errors=[str(exc)])
+
+    return ManifestValidationResult(
+        is_valid=True,
+        normalized_manifest=manifest.dict(),
+    )

--- a/tests/api/test_server.py
+++ b/tests/api/test_server.py
@@ -141,6 +141,19 @@ class TestFastAPIServer:
         assert payload["data"]["is_valid"] is True
         assert payload["data"]["normalized_manifest"]["experiment_type"] == "intrinsic_evolution"
 
+    def test_validate_dashboard_manifest_invalid_payload(self, client):
+        """POST /api/experiments/manifests/validate returns validation errors for bad manifests."""
+        response = client.post(
+            "/api/experiments/manifests/validate",
+            json={"manifest": {"schema_version": 999, "experiment_type": "intrinsic_evolution"}},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["status"] == "success"
+        assert payload["data"]["is_valid"] is False
+        assert payload["data"]["errors"]
+
     def test_dashboard_experiment_status_unknown_run_id(self, client):
         """GET /api/experiments/{run_id}/status returns 404 for unknown run id."""
         with _active_experiment_runs_thread_lock:
@@ -151,6 +164,73 @@ class TestFastAPIServer:
         assert response.status_code == 404
         payload = response.json()
         assert "not found" in payload["detail"]
+
+    def test_dashboard_experiment_run_rejects_bad_manifest(self, client):
+        """POST /api/experiments/run returns 400 for invalid manifests."""
+        response = client.post(
+            "/api/experiments/run",
+            json={"manifest": {"schema_version": 999, "experiment_type": "intrinsic_evolution"}},
+        )
+
+        assert response.status_code == 400
+        payload = response.json()
+        assert payload["detail"]
+
+    def test_dashboard_experiment_views_unknown_run_id(self, client):
+        """GET /api/experiments/{run_id}/views returns 404 for unknown run id."""
+        response = client.get("/api/experiments/unknown-run/views")
+        assert response.status_code == 404
+        payload = response.json()
+        assert "not found" in payload["detail"]
+
+    def test_dashboard_experiment_view_data_unknown_run_id(self, client):
+        """POST /api/experiments/{run_id}/views/{view_id} returns 404 for unknown run id."""
+        response = client.post(
+            "/api/experiments/unknown-run/views/summary_cards",
+            json={"filters": {}},
+        )
+        assert response.status_code == 404
+        payload = response.json()
+        assert "not found" in payload["detail"]
+
+    def test_dashboard_experiment_views_missing_manifest(self, client):
+        """GET /api/experiments/{run_id}/views returns 400 when manifest is missing."""
+        run_id = "run_missing_manifest"
+        with _active_experiment_runs_thread_lock:
+            active_experiment_runs.clear()
+            active_experiment_runs[run_id] = {
+                "status": "completed",
+                "created_at": datetime.now().isoformat(),
+                "manifest": None,
+                "runtime_options": {},
+                "run_summary": {"run_id": run_id},
+            }
+
+        response = client.get(f"/api/experiments/{run_id}/views")
+        assert response.status_code == 400
+        payload = response.json()
+        assert "no manifest payload" in payload["detail"]
+
+    def test_dashboard_experiment_view_data_missing_manifest(self, client):
+        """POST /api/experiments/{run_id}/views/{view_id} returns 400 when manifest is missing."""
+        run_id = "run_missing_manifest_data"
+        with _active_experiment_runs_thread_lock:
+            active_experiment_runs.clear()
+            active_experiment_runs[run_id] = {
+                "status": "completed",
+                "created_at": datetime.now().isoformat(),
+                "manifest": None,
+                "runtime_options": {},
+                "run_summary": {"run_id": run_id},
+            }
+
+        response = client.post(
+            f"/api/experiments/{run_id}/views/summary_cards",
+            json={"filters": {}},
+        )
+        assert response.status_code == 400
+        payload = response.json()
+        assert "no manifest payload" in payload["detail"]
 
     def test_dashboard_experiment_unknown_view_id(self, client):
         """POST /api/experiments/{run_id}/views/{view_id} returns 404 for unknown views."""

--- a/tests/api/test_server.py
+++ b/tests/api/test_server.py
@@ -13,6 +13,7 @@ import pytest
 from fastapi import WebSocket
 from fastapi.testclient import TestClient
 
+from farm.experiments.interfaces import ViewDescriptor
 from farm.api.server import (
     AnalysisRequestModel,
     AnalysisResponse,
@@ -139,6 +140,128 @@ class TestFastAPIServer:
         assert payload["status"] == "success"
         assert payload["data"]["is_valid"] is True
         assert payload["data"]["normalized_manifest"]["experiment_type"] == "intrinsic_evolution"
+
+    def test_dashboard_experiment_status_unknown_run_id(self, client):
+        """GET /api/experiments/{run_id}/status returns 404 for unknown run id."""
+        with _active_experiment_runs_thread_lock:
+            active_experiment_runs.clear()
+
+        response = client.get("/api/experiments/unknown-run/status")
+
+        assert response.status_code == 404
+        payload = response.json()
+        assert "not found" in payload["detail"]
+
+    def test_dashboard_experiment_unknown_view_id(self, client):
+        """POST /api/experiments/{run_id}/views/{view_id} returns 404 for unknown views."""
+        manifest = {
+            "schema_version": 1,
+            "experiment_type": "intrinsic_evolution",
+            "experiment_name": "intrinsic-smoke",
+            "base_simulation_config": {"environment.width": 100},
+            "experiment_config": {"num_steps": 10, "snapshot_interval": 2},
+            "dashboard_preset": {"default_views": ["summary_cards"]},
+        }
+        run_id = "run_unknown_view"
+
+        with _active_experiment_runs_thread_lock:
+            active_experiment_runs.clear()
+            active_experiment_runs[run_id] = {
+                "status": "completed",
+                "created_at": datetime.now().isoformat(),
+                "manifest": manifest,
+                "runtime_options": {},
+                "run_summary": {"run_id": run_id},
+                "output_dir": "results/fake",
+            }
+
+        mock_adapter = Mock()
+        mock_adapter.get_view_data.side_effect = KeyError("Unknown view_id='does-not-exist'")
+
+        with patch("farm.api.server.experiment_registry.get", return_value=mock_adapter):
+            response = client.post(
+                f"/api/experiments/{run_id}/views/does-not-exist",
+                json={"filters": {}},
+            )
+
+        assert response.status_code == 404
+        payload = response.json()
+        assert "Unknown view_id" in payload["detail"]
+
+    def test_dashboard_experiment_run_status_views_smoke(self, client):
+        """Run intrinsic manifest, verify status lifecycle, list views, and fetch one payload."""
+        with _active_experiment_runs_thread_lock:
+            active_experiment_runs.clear()
+
+        manifest = {
+            "schema_version": 1,
+            "experiment_type": "intrinsic_evolution",
+            "experiment_name": "intrinsic-smoke",
+            "base_simulation_config": {"environment.width": 100},
+            "experiment_config": {"num_steps": 10, "snapshot_interval": 2},
+            "dashboard_preset": {"default_views": ["summary_cards"]},
+        }
+
+        mock_adapter = Mock()
+        mock_adapter.list_views.return_value = [
+            ViewDescriptor(
+                view_id="summary_cards",
+                view_type="summary_cards",
+                title="Run Summary",
+                description="Summary cards",
+            )
+        ]
+        mock_adapter.get_view_data.return_value = {
+            "view_type": "summary_cards",
+            "cards": [{"id": "steps", "label": "Steps Completed", "value": 10}],
+        }
+
+        def _mock_background_run(run_id, manifest_payload, runtime_options):
+            with _active_experiment_runs_thread_lock:
+                assert active_experiment_runs[run_id]["status"] == "pending"
+                active_experiment_runs[run_id]["status"] = "running"
+                active_experiment_runs[run_id]["status"] = "completed"
+                active_experiment_runs[run_id]["output_dir"] = "results/fake"
+                active_experiment_runs[run_id]["run_summary"] = {
+                    "run_id": run_id,
+                    "output_dir": "results/fake",
+                }
+                active_experiment_runs[run_id]["ended_at"] = datetime.now().isoformat()
+
+        with patch("farm.api.server.experiment_registry.get", return_value=mock_adapter), patch(
+            "farm.api.server._run_experiment_background",
+            side_effect=_mock_background_run,
+        ):
+            run_response = client.post(
+                "/api/experiments/run",
+                json={"manifest": manifest, "runtime_options": {"output_dir": "results/fake"}},
+            )
+
+            assert run_response.status_code == 200
+            run_payload = run_response.json()
+            assert run_payload["status"] == "accepted"
+            run_id = run_payload["run_id"]
+
+            status_response = client.get(f"/api/experiments/{run_id}/status")
+            assert status_response.status_code == 200
+            status_payload = status_response.json()
+            assert status_payload["status"] == "success"
+            assert status_payload["data"]["status"] == "completed"
+
+            views_response = client.get(f"/api/experiments/{run_id}/views")
+            assert views_response.status_code == 200
+            views_payload = views_response.json()
+            assert views_payload["status"] == "success"
+            assert views_payload["data"][0]["view_id"] == "summary_cards"
+
+            view_data_response = client.post(
+                f"/api/experiments/{run_id}/views/summary_cards",
+                json={"filters": {}},
+            )
+            assert view_data_response.status_code == 200
+            view_data_payload = view_data_response.json()
+            assert view_data_payload["status"] == "success"
+            assert view_data_payload["data"]["view_type"] == "summary_cards"
 
     def test_get_step_success(self, client, temp_db_path):
         """Test successful step retrieval."""

--- a/tests/api/test_server.py
+++ b/tests/api/test_server.py
@@ -4,7 +4,7 @@ import json
 import os
 import tempfile
 import threading
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict
 from unittest.mock import MagicMock, Mock, patch
@@ -176,6 +176,58 @@ class TestFastAPIServer:
         payload = response.json()
         assert payload["detail"]
 
+    def test_dashboard_experiment_runs_list_returns_summaries_in_created_order(self, client):
+        """GET /api/experiments/runs returns safe run summaries in created_at order."""
+        now = datetime.now().replace(microsecond=0)
+        with _active_experiment_runs_thread_lock:
+            active_experiment_runs.clear()
+            active_experiment_runs["run_late"] = {
+                "status": "completed",
+                "created_at": (now + timedelta(seconds=1)).isoformat(),
+                "ended_at": (now + timedelta(seconds=2)).isoformat(),
+                "manifest": {"experiment_name": "late"},
+                "runtime_options": {"output_dir": "/tmp/late"},
+            }
+            active_experiment_runs["run_early"] = {
+                "status": "running",
+                "created_at": now.isoformat(),
+                "manifest": {"experiment_name": "early"},
+                "runtime_options": {"output_dir": "/tmp/early"},
+            }
+
+        response = client.get("/api/experiments/runs")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["status"] == "success"
+        assert [run["run_id"] for run in payload["data"]] == ["run_early", "run_late"]
+        assert payload["data"][0]["status"] == "running"
+        assert payload["data"][0].get("manifest") is None
+        assert payload["data"][0].get("runtime_options") is None
+
+    def test_dashboard_experiment_status_hides_internal_manifest_and_runtime_options(self, client):
+        """GET /api/experiments/{run_id}/status returns sanitized fields only."""
+        run_id = "run_status_safe"
+        with _active_experiment_runs_thread_lock:
+            active_experiment_runs.clear()
+            active_experiment_runs[run_id] = {
+                "status": "completed",
+                "created_at": datetime.now().isoformat(),
+                "ended_at": datetime.now().isoformat(),
+                "manifest": {"experiment_name": "private"},
+                "runtime_options": {"output_dir": "/tmp/private"},
+                "output_dir": "/tmp/private",
+            }
+
+        response = client.get(f"/api/experiments/{run_id}/status")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["status"] == "success"
+        assert payload["data"]["run_id"] == run_id
+        assert payload["data"]["status"] == "completed"
+        assert payload["data"].get("manifest") is None
+        assert payload["data"].get("runtime_options") is None
+        assert payload["data"].get("output_dir") is None
+
     def test_dashboard_experiment_views_unknown_run_id(self, client):
         """GET /api/experiments/{run_id}/views returns 404 for unknown run id."""
         response = client.get("/api/experiments/unknown-run/views")
@@ -211,6 +263,26 @@ class TestFastAPIServer:
         payload = response.json()
         assert "no manifest payload" in payload["detail"]
 
+    def test_dashboard_experiment_views_pending_run_returns_409(self, client):
+        """GET /api/experiments/{run_id}/views returns 409 until run is completed."""
+        run_id = "run_pending_views"
+        with _active_experiment_runs_thread_lock:
+            active_experiment_runs.clear()
+            active_experiment_runs[run_id] = {
+                "status": "running",
+                "created_at": datetime.now().isoformat(),
+                "manifest": {
+                    "schema_version": 1,
+                    "experiment_type": "intrinsic_evolution",
+                    "experiment_name": "intrinsic-smoke",
+                },
+            }
+
+        response = client.get(f"/api/experiments/{run_id}/views")
+        assert response.status_code == 409
+        payload = response.json()
+        assert "until the run has completed" in payload["detail"]
+
     def test_dashboard_experiment_view_data_missing_manifest(self, client):
         """POST /api/experiments/{run_id}/views/{view_id} returns 400 when manifest is missing."""
         run_id = "run_missing_manifest_data"
@@ -231,6 +303,29 @@ class TestFastAPIServer:
         assert response.status_code == 400
         payload = response.json()
         assert "no manifest payload" in payload["detail"]
+
+    def test_dashboard_experiment_view_data_pending_run_returns_409(self, client):
+        """POST /api/experiments/{run_id}/views/{view_id} returns 409 until run is completed."""
+        run_id = "run_pending_view_data"
+        with _active_experiment_runs_thread_lock:
+            active_experiment_runs.clear()
+            active_experiment_runs[run_id] = {
+                "status": "pending",
+                "created_at": datetime.now().isoformat(),
+                "manifest": {
+                    "schema_version": 1,
+                    "experiment_type": "intrinsic_evolution",
+                    "experiment_name": "intrinsic-smoke",
+                },
+            }
+
+        response = client.post(
+            f"/api/experiments/{run_id}/views/summary_cards",
+            json={"filters": {}},
+        )
+        assert response.status_code == 409
+        payload = response.json()
+        assert "until the run has completed" in payload["detail"]
 
     def test_dashboard_experiment_unknown_view_id(self, client):
         """POST /api/experiments/{run_id}/views/{view_id} returns 404 for unknown views."""

--- a/tests/api/test_server.py
+++ b/tests/api/test_server.py
@@ -19,7 +19,9 @@ from farm.api.server import (
     SimulationCreateRequest,
     SimulationResponse,
     SimulationStatus,
+    _active_experiment_runs_thread_lock,
     _active_simulations_thread_lock,
+    active_experiment_runs,
     active_simulations,
     app,
     manager,
@@ -112,6 +114,31 @@ class TestFastAPIServer:
             assert response.status_code == 500
             data = response.json()
             assert data["detail"] == "Config error"
+
+    def test_validate_dashboard_manifest_smoke(self, client):
+        """POST /api/experiments/manifests/validate returns a valid normalized payload."""
+        with _active_experiment_runs_thread_lock:
+            active_experiment_runs.clear()
+
+        manifest = {
+            "schema_version": 1,
+            "experiment_type": "intrinsic_evolution",
+            "experiment_name": "intrinsic-smoke",
+            "base_simulation_config": {"environment.width": 100},
+            "experiment_config": {"num_steps": 10, "snapshot_interval": 2},
+            "dashboard_preset": {"default_views": ["summary_cards"]},
+        }
+
+        response = client.post(
+            "/api/experiments/manifests/validate",
+            json={"manifest": manifest},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["status"] == "success"
+        assert payload["data"]["is_valid"] is True
+        assert payload["data"]["normalized_manifest"]["experiment_type"] == "intrinsic_evolution"
 
     def test_get_step_success(self, client, temp_db_path):
         """Test successful step retrieval."""

--- a/tests/experiments/test_dashboard_manifest.py
+++ b/tests/experiments/test_dashboard_manifest.py
@@ -1,0 +1,35 @@
+from farm.experiments.manifest import (
+    INTRINSIC_EVOLUTION_EXPERIMENT_TYPE,
+    SUPPORTED_SCHEMA_VERSION,
+    validate_experiment_manifest,
+)
+
+
+def test_validate_manifest_accepts_intrinsic_payload():
+    payload = {
+        "schema_version": SUPPORTED_SCHEMA_VERSION,
+        "experiment_type": INTRINSIC_EVOLUTION_EXPERIMENT_TYPE,
+        "experiment_name": "intrinsic-smoke",
+        "base_simulation_config": {"environment.width": 100},
+        "experiment_config": {"num_steps": 10, "snapshot_interval": 2},
+        "dashboard_preset": {"default_views": ["summary_cards"]},
+    }
+
+    result = validate_experiment_manifest(payload)
+    assert result.is_valid is True
+    assert result.normalized_manifest is not None
+    assert result.normalized_manifest["experiment_type"] == INTRINSIC_EVOLUTION_EXPERIMENT_TYPE
+
+
+def test_validate_manifest_rejects_unsupported_type():
+    payload = {
+        "schema_version": SUPPORTED_SCHEMA_VERSION,
+        "experiment_type": "unsupported_experiment",
+        "experiment_name": "bad-run",
+        "base_simulation_config": {},
+        "experiment_config": {},
+    }
+
+    result = validate_experiment_manifest(payload)
+    assert result.is_valid is False
+    assert result.errors

--- a/tests/experiments/test_dashboard_manifest.py
+++ b/tests/experiments/test_dashboard_manifest.py
@@ -1,8 +1,11 @@
+import pytest
+
 from farm.experiments.manifest import (
     INTRINSIC_EVOLUTION_EXPERIMENT_TYPE,
     SUPPORTED_SCHEMA_VERSION,
     validate_experiment_manifest,
 )
+from farm.experiments.interfaces import ExperimentRegistry
 
 
 def test_validate_manifest_accepts_intrinsic_payload():
@@ -33,3 +36,19 @@ def test_validate_manifest_rejects_unsupported_type():
     result = validate_experiment_manifest(payload)
     assert result.is_valid is False
     assert result.errors
+
+
+def test_registry_get_rejects_unsupported_experiment_type_with_clear_error():
+    registry = ExperimentRegistry()
+
+    class _KnownAdapter:
+        experiment_type = INTRINSIC_EVOLUTION_EXPERIMENT_TYPE
+
+    registry.register(_KnownAdapter())
+
+    with pytest.raises(KeyError) as exc_info:
+        registry.get("unknown_experiment_type")
+
+    message = str(exc_info.value)
+    assert "Unsupported experiment_type='unknown_experiment_type'" in message
+    assert INTRINSIC_EVOLUTION_EXPERIMENT_TYPE in message

--- a/tests/experiments/test_intrinsic_dashboard_adapter.py
+++ b/tests/experiments/test_intrinsic_dashboard_adapter.py
@@ -1,0 +1,84 @@
+import json
+
+from farm.experiments.intrinsic_dashboard import IntrinsicEvolutionAdapter
+
+
+def _write_jsonl(path, rows):
+    with open(path, "w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+
+def test_adapter_views_and_payloads(tmp_path):
+    output_dir = tmp_path / "intrinsic-run"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    metadata = {
+        "num_steps_completed": 2,
+        "final_population": 7,
+        "snapshot_interval": 1,
+        "policy": {"selection_pressure": "medium"},
+        "speciation": {"enabled": True},
+    }
+    with open(output_dir / "intrinsic_evolution_metadata.json", "w", encoding="utf-8") as handle:
+        json.dump(metadata, handle)
+
+    _write_jsonl(
+        output_dir / "intrinsic_gene_trajectory.jsonl",
+        [
+            {
+                "step": 1,
+                "n_alive": 6,
+                "gene_stats": {"learning_rate": {"mean": 0.1, "std": 0.01, "min": 0.08, "max": 0.12}},
+                "realized_birth_rate": 0.2,
+                "realized_death_rate": 0.1,
+                "effective_selection_strength": 0.05,
+                "speciation_index": 0.1,
+            },
+            {
+                "step": 2,
+                "n_alive": 7,
+                "gene_stats": {"learning_rate": {"mean": 0.11, "std": 0.02, "min": 0.07, "max": 0.13}},
+                "realized_birth_rate": 0.3,
+                "realized_death_rate": 0.05,
+                "effective_selection_strength": 0.06,
+                "speciation_index": 0.12,
+            },
+        ],
+    )
+
+    _write_jsonl(
+        output_dir / "intrinsic_gene_snapshots.jsonl",
+        [
+            {"step": 1, "agents": [{"chromosome": {"learning_rate": 0.1}}]},
+            {"step": 2, "agents": [{"chromosome": {"learning_rate": 0.12}}]},
+        ],
+    )
+    _write_jsonl(
+        output_dir / "cluster_lineage.jsonl",
+        [{"step": 2, "cluster_id": 1, "size": 3}],
+    )
+
+    adapter = IntrinsicEvolutionAdapter()
+    run_context = {"output_dir": str(output_dir)}
+    views = adapter.list_views(run_context)
+    view_ids = [item.view_id for item in views]
+    assert "summary_cards" in view_ids
+    assert "gene_trajectories" in view_ids
+    assert "speciation_index" in view_ids
+
+    summary = adapter.get_view_data(run_context, "summary_cards", {})
+    assert summary["view_type"] == "summary_cards"
+    assert summary["cards"]
+
+    trajectories = adapter.get_view_data(
+        run_context,
+        "gene_trajectories",
+        {"genes": ["learning_rate"]},
+    )
+    assert trajectories["view_type"] == "timeseries"
+    assert trajectories["series"][0]["id"] == "learning_rate_mean"
+
+    distributions = adapter.get_view_data(run_context, "gene_distributions", {})
+    assert distributions["view_type"] == "distribution_over_time"
+    assert len(distributions["snapshots"]) == 2


### PR DESCRIPTION
This pull request introduces a new dashboard-backed experiment API and supporting documentation, along with a comprehensive test suite for the dashboard UI. The main changes include the addition of a detailed extension guide for dashboard-backed experiments, new API endpoints and background task management for experiment runs, and frontend test coverage for dashboard rendering logic.

**API and Backend Enhancements:**

* Added a new set of API endpoints in `farm/api/server.py` to support dashboard-backed experiment types, including manifest validation, experiment run management, view listing, and view data retrieval. This includes background task execution and in-memory run tracking. [[1]](diffhunk://#diff-8fce827ec902b043dfd9184d7ed1daa832d31bd337845bd500a9aa8d36f0a7f3R26-R31) [[2]](diffhunk://#diff-8fce827ec902b043dfd9184d7ed1daa832d31bd337845bd500a9aa8d36f0a7f3R96-R117) [[3]](diffhunk://#diff-8fce827ec902b043dfd9184d7ed1daa832d31bd337845bd500a9aa8d36f0a7f3R137-R142) [[4]](diffhunk://#diff-8fce827ec902b043dfd9184d7ed1daa832d31bd337845bd500a9aa8d36f0a7f3R207-R208) [[5]](diffhunk://#diff-8fce827ec902b043dfd9184d7ed1daa832d31bd337845bd500a9aa8d36f0a7f3R256-R295) [[6]](diffhunk://#diff-8fce827ec902b043dfd9184d7ed1daa832d31bd337845bd500a9aa8d36f0a7f3R352-R473)
* Introduced thread and async locks for safe concurrent access to experiment run state.

**Documentation Improvements:**

* Added a new, in-depth "Dashboard Experiment Extension Guide" (`docs/experiments/dashboard_experiment_extension_guide.md`) that explains how to implement and register new dashboard-backed experiment types, including manifest schema, adapter contract, API wiring, and required tests.
* Updated `docs/README.md` and `docs/experiments.md` to reference the new extension guide and clarify the process for adding dashboard experiment types. [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R97) [[2]](diffhunk://#diff-b1f8a4f198e4e3283e6be5c4e2312fd055b4c4bf1855e51b4aa35977001c7d4dR123-R126)

**Frontend and Testing:**

* Added a Jest test suite (`farm/editor/__tests__/experiment-dashboard.test.js`) that verifies the dashboard UI's ability to load experiment views, handle various payloads, display errors, and render different view types and empty states.

These changes provide a robust framework for extending the platform with new dashboard experiment types, with clear guidance, API support, and frontend test coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new FastAPI endpoints and background execution/state tracking for experiment runs, which can affect API stability and concurrency behavior; also introduces filesystem-backed view payload loading that could surface runtime errors if artifacts are missing/malformed.
> 
> **Overview**
> Adds a **dashboard-backed experiments** flow end-to-end: a versioned `ExperimentManifest`, adapter protocol + `ExperimentRegistry`, and an `IntrinsicEvolutionAdapter` that runs the intrinsic experiment and exposes normalized dashboard views (`summary_cards`, time series, distributions, optional speciation).
> 
> Extends `farm/api/server.py` with new `/api/experiments/*` endpoints to **list types, validate manifests, launch background runs, track run status in-memory, list views, and fetch view payloads**, including new async/thread locks around `active_experiment_runs`.
> 
> Updates the editor to include an **Experiment Builder** in `sidebar.js` (manifest build/validate/run/poll/save+load preset/load-latest) and a new `experiment-dashboard.js` renderer, plus small robustness fixes in `editor.js` to tolerate missing frame data. Adds CSS for the new UI and comprehensive Jest + pytest coverage for manifest validation, registry errors, adapter payloads, and API/UI smoke paths, along with docs linking a new dashboard extension guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c71b860c844d366730d33b2e8c34e9fbc6048a5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->