### PR TITLE
docs(AGENTS.md): dedupe entries and refresh cloud notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,21 +64,17 @@ When changing behavior, locate the closest existing patterns in `farm/` and mirr
 
 | Service | How to run | Notes |
 |---------|-----------|-------|
-| Simulation (CLI) | `source venv/bin/activate && python run_simulation.py --environment development --steps N` | Produces a `.db` file in `simulations/` |
-| API server | `source venv/bin/activate && uvicorn farm.api.server:app --host 0.0.0.0 --port 5000` | Do **not** use `python -m farm.api.server` — the `reload=True` flag in `__main__` requires import-string mode and may crash. Use the `uvicorn` command directly. |
-| Pytest | `source venv/bin/activate && pytest` | See `AGENTS.md > Commands` table for variants. |
-| Jest (editor) | `cd farm/editor && npm test -- --runInBand` | Requires Node 20 (`nvm use 20`). |
-| Lint | `source venv/bin/activate && ruff check .` | Ruff/Pylint may need to be installed separately if not in your env. |
-| Pytest | `source venv/bin/activate && pytest` | See `AGENTS.md > Commands` table for variants. 2 pre-existing failures in `tests/analysis/test_dominance.py` (pandas `LossySetitemError`). |
-| Jest (editor) | `cd farm/editor && npm test -- --runInBand` | Requires Node 20 (`nvm use 20`). |
-| Lint | `source venv/bin/activate && ruff check .` | 136 pre-existing warnings; these are in the repo, not regressions. |
+| Simulation (CLI) | `source venv/bin/activate && python run_simulation.py --environment development --steps N` | Produces a `.db` file in `simulations/`. |
+| API server | `source venv/bin/activate && uvicorn farm.api.server:app --host 0.0.0.0 --port 5000` | Do **not** use `python -m farm.api.server` — the `reload=True` flag in `__main__` requires an import string and exits with `WARNING: You must pass the application as an import string …`. Use the `uvicorn` command directly. |
+| Pytest | `source venv/bin/activate && pytest` | See `AGENTS.md > Commands` table for variants. Default suite currently passes cleanly (≈6.5k tests; CUDA/optional-dep tests are skipped). |
+| Jest (editor) | `cd farm/editor && npm test -- --runInBand` | Requires Node 20. Run `source /home/ubuntu/.nvm/nvm.sh && nvm use 20` first. |
+| Lint | `source venv/bin/activate && ruff check .` | ≈163 pre-existing warnings; these are in the repo, not regressions. Ruff/Pylint may need to be `pip install`-ed separately if not in your env. |
 
 ### Gotchas
 
 - **API server startup**: Always use `uvicorn farm.api.server:app` instead of `python -m farm.api.server`. The latter's `reload=True` flag causes `WARNING: You must pass the application as an import string to enable 'reload' or 'workers'` and silently exits.
-- **Node version**: The editor tests require Node 20. Use `nvm use 20` (or your Node 20 install) before `npm test`.
 - **Node version**: The editor tests require Node 20. Run `source /home/ubuntu/.nvm/nvm.sh && nvm use 20` before `npm test`.
-- **`python3.12-venv` and `python3-tk`**: Must be installed via `apt` — they are not in `requirements.txt`. The update script handles this.
+- **`python3.12-venv` and `python3-tk`**: Must be installed via `apt` — they are not in `requirements.txt`. The update script handles this. The pre-provisioned `venv/` in Cursor Cloud uses Python 3.12.
 - **Ruff/Pylint not in `requirements.txt`**: `ruff` and `pylint` must be `pip install`-ed separately; the update script handles this.
 - **Simulation determinism**: `run_simulation.py` automatically restarts itself with `PYTHONHASHSEED=0` if not set. This is normal behavior, not an error.
 - **Pytest logging noise**: Some tests trigger `structlog` memory-monitor warnings on stderr (`CRITICAL: Memory usage at …`). This is cosmetic and does not indicate test failure — check the actual pass/fail summary line.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited `AGENTS.md` against the current repo state and fixed the items that were either duplicated or no longer accurate.

### Fixes

- **Removed duplicate rows** in the *Services overview* table (`Pytest`, `Jest (editor)`, and `Lint` were each listed twice with conflicting notes).
- **Removed duplicate** `Node version` bullet in *Gotchas* — kept the more specific one with the `source /home/ubuntu/.nvm/nvm.sh && nvm use 20` command.
- **Pytest note**: dropped the stale claim about "2 pre-existing failures in `tests/analysis/test_dominance.py` (pandas `LossySetitemError`)" — those tests now pass. Default suite currently reports `6496 passed, 18 skipped, 51 deselected` on the Cursor Cloud venv.
- **Lint note**: updated the pre-existing-warning count from `136` to the current `~163` (output of `ruff check .`).
- **Python version**: clarified that the pre-provisioned `venv/` in Cursor Cloud is Python 3.12 (the rest of the file still documents 3.8+ / CI 3.10).

### Verified against the repo

- `pytest` → `6496 passed, 18 skipped, 51 deselected` (no failures).
- `ruff check .` → `Found 163 errors.`
- `uvicorn farm.api.server:app --host 0.0.0.0 --port 5000` → `/docs` returns `HTTP 200`.
- `python -m farm.api.server` → still emits `WARNING: You must pass the application as an import string to enable 'reload' or 'workers'` and exits, confirming the existing gotcha.
- `cd farm/editor && npm test -- --runInBand` (Node 20) → `Tests: 16 passed, 16 total`.

No code or behavior changes; documentation-only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ae5c4f8-b4eb-4174-a87b-b1d4251fa61e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ae5c4f8-b4eb-4174-a87b-b1d4251fa61e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

