### PR TITLE
Add lineage metrics helper for A/B analysis scripts

### DIFF
--- a/farm/analysis/lineage_metrics.py
+++ b/farm/analysis/lineage_metrics.py
@@ -1,0 +1,108 @@
+"""Per-run lineage summary helpers shared across A/B analyzer scripts.
+
+Both ``scripts/compare_crossover_arms.py`` and
+``scripts/compare_inheritance_arms.py`` need the same ``cluster_lineage.jsonl``
+parsing logic. Previously they reached across the script boundary via a
+name-mangled private import (``from scripts.compare_crossover_arms import
+_lineage_metrics``); promoting the helpers here gives both call sites a
+stable, documented surface and makes the parsing trivially unit-testable
+without standing up matplotlib.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List
+
+CLUSTER_LINEAGE_FILENAME = "cluster_lineage.jsonl"
+
+
+def _read_jsonl(path: Path) -> List[Dict[str, Any]]:
+    """Read a JSONL file into a list of dicts; silently skips malformed lines."""
+    rows: List[Dict[str, Any]] = []
+    if not path.is_file():
+        return rows
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return rows
+
+
+def _mean(values: List[float]) -> float:
+    """Arithmetic mean of ``values``; returns NaN on empty input.
+
+    Self-contained (no ``statistics`` import) so this module stays free of
+    optional dependencies and matches the previous behaviour exactly.
+    """
+    if not values:
+        return float("nan")
+    return sum(values) / len(values)
+
+
+def lineage_metrics(run_dir: Path) -> Dict[str, Any]:
+    """Per-run lineage summary from ``cluster_lineage.jsonl``.
+
+    Returns a dict with keys:
+
+    - ``cluster_count_trace``: ``[(step, k), ...]`` where ``k`` is the
+      number of distinct cluster IDs observed at that snapshot step.
+    - ``mean_k``: mean cluster count across snapshot steps (``nan`` when
+      no rows were recorded).
+    - ``churn_rate``: mean per-step fraction of cluster IDs at step ``t``
+      that do not survive to step ``t+1``. In ``[0, 1]``. ``nan`` when
+      fewer than two clustering steps were recorded.
+
+    Missing or unreadable lineage files yield the empty/NaN shape; callers
+    can then uniformly skip seeds with incomplete data.
+    """
+    rows = _read_jsonl(run_dir / CLUSTER_LINEAGE_FILENAME)
+    if not rows:
+        return {
+            "cluster_count_trace": [],
+            "mean_k": float("nan"),
+            "churn_rate": float("nan"),
+        }
+
+    steps_to_ids: Dict[int, set] = defaultdict(set)
+    for row in rows:
+        try:
+            step = int(row["step"])
+            cluster_id = row["cluster_id"]
+        except (KeyError, TypeError, ValueError):
+            continue
+        steps_to_ids[step].add(cluster_id)
+
+    sorted_steps = sorted(steps_to_ids.keys())
+    trace = [(s, len(steps_to_ids[s])) for s in sorted_steps]
+    mean_k = _mean([k for _, k in trace]) if trace else float("nan")
+
+    if len(sorted_steps) < 2:
+        churn = float("nan")
+    else:
+        churns: List[float] = []
+        for s_prev, s_next in zip(sorted_steps, sorted_steps[1:]):
+            prev = steps_to_ids[s_prev]
+            nxt = steps_to_ids[s_next]
+            if not prev:
+                continue
+            died = prev - nxt
+            churns.append(len(died) / len(prev))
+        churn = _mean(churns) if churns else float("nan")
+
+    return {
+        "cluster_count_trace": trace,
+        "mean_k": mean_k,
+        "churn_rate": churn if not math.isnan(churn) else float("nan"),
+    }
+
+
+__all__ = ["CLUSTER_LINEAGE_FILENAME", "lineage_metrics"]

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -468,7 +468,9 @@ class AgentCore:
         # Failures here used to be silently swallowed, which masked real
         # decision/execution bugs as "the agent simply isn't learning". Log
         # them at warning level (with the agent id and exception type) so they
-        # are visible without crashing the whole simulation.
+        # are visible without crashing the whole simulation, and also bump
+        # the per-run telemetry counter when one is attached so paired A/B
+        # comparisons can flag arms with elevated failure rates.
         try:
             action = self.behavior.decide_action(self, state_tensor, enabled_actions)
             self._execute_action(action, state_tensor)
@@ -480,6 +482,9 @@ class AgentCore:
                 error_message=str(exc),
                 exc_info=True,
             )
+            telemetry = getattr(self.environment, "inheritance_telemetry", None)
+            if isinstance(telemetry, InheritanceTelemetry):
+                telemetry.record_decide_action_failure(type(exc).__name__)
 
         # Call on_step_end on all components
         for component in self._components.values():

--- a/farm/core/decision/algorithms/tianshou.py
+++ b/farm/core/decision/algorithms/tianshou.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 from typing import Any, Dict, Literal, Optional, Tuple, Union
 
-import numpy as np
 import gymnasium
+import numpy as np
+import torch
 
 from .rl_base import PrioritizedReplayBuffer, RLAlgorithm
 
+from farm.core.decision.shape_utils import batch_observation
 from farm.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -914,49 +916,15 @@ class TianshouWrapper(RLAlgorithm):
             logger.error(f"Failed to initialize {self.algorithm_name} policy: {e}")
             raise
 
-    def _state_to_numpy(self, state: Union[np.ndarray, Any]) -> np.ndarray:
-        """Normalize an observation to a float32 numpy array."""
-        if isinstance(state, np.ndarray):
-            return state.astype(np.float32)
-        try:
-            import torch
-
-            if isinstance(state, torch.Tensor):
-                return state.detach().cpu().numpy().astype(np.float32)
-        except ImportError:
-            pass
-        return np.asarray(state, dtype=np.float32)
-
     def _state_to_batched_tensor(self, state: Union[np.ndarray, Any]):
         """Convert an observation to a batched float tensor on the policy device."""
-        import torch
-
-        state_np = self._state_to_numpy(state)
-        target_size = int(np.prod(self.observation_shape))
-
-        if state_np.ndim == 1:
-            if state_np.size == target_size and len(self.observation_shape) > 1:
-                state_np = state_np.reshape(1, *self.observation_shape)
-            else:
-                state_np = np.expand_dims(state_np, axis=0)
-        elif state_np.ndim == 2:
-            if state_np.shape == self.observation_shape:
-                state_np = np.expand_dims(state_np, axis=0)
-            elif state_np.size == target_size:
-                state_np = state_np.reshape(1, *self.observation_shape)
-            elif state_np.shape[0] != 1:
-                state_np = np.expand_dims(state_np, axis=0)
-        elif state_np.ndim == len(self.observation_shape):
-            state_np = np.expand_dims(state_np, axis=0)
-
+        state_np = batch_observation(state, self.observation_shape)
         device = self.algorithm_config.get("device", "cpu")
         return torch.from_numpy(state_np).float().to(device)
 
     @staticmethod
     def _tensor_to_1d_numpy(value: Any) -> np.ndarray:
         """Extract a 1D numpy vector from a model output tensor."""
-        import torch
-
         if isinstance(value, tuple):
             value = value[0]
         if isinstance(value, torch.Tensor):
@@ -965,28 +933,57 @@ class TianshouWrapper(RLAlgorithm):
             return value.detach().cpu().numpy().reshape(-1)
         return np.asarray(value, dtype=np.float64).reshape(-1)
 
-    def _continuous_actor_to_logits(self, action_out: Any) -> np.ndarray:
-        """Map a continuous actor output to discrete action logits."""
-        import torch
+    # Sharpness of the soft logits produced from a SAC/DDPG continuous actor
+    # output. Smaller values keep the implied distribution closer to uniform
+    # so the chromosome ``action_weights`` multiplier can still meaningfully
+    # shift sampling. ``CONTINUOUS_ACTOR_LOGIT_SCALE = 2.0`` corresponds to
+    # roughly an exp(2) ≈ 7.4× preference for the actor's chosen bin over a
+    # bin one unit away, which keeps the discrete approximation expressive
+    # without collapsing to a one-hot.
+    CONTINUOUS_ACTOR_LOGIT_SCALE = 2.0
 
+    def _continuous_actor_to_logits(self, action_out: Any) -> np.ndarray:
+        """Map a continuous actor output to discrete action logits.
+
+        SAC actors in Tianshou return ``(mean, log_std)``; DDPG actors return
+        a deterministic action mean. We treat the first scalar of either form
+        as the actor's preferred continuous action in ``[-1, 1]`` (post-tanh)
+        and project it onto the discrete action space with a soft, distance-
+        based logit profile. This is an approximation — see
+        ``docs/devlog/2026-05-21-baldwinian-vs-lamarckian-ab-harness.md`` for
+        the rationale and known limitations: continuous-actor algorithms
+        cannot natively express a full categorical distribution, so the
+        ``policy_probs × action_weights × mask`` composition in
+        :meth:`DecisionModule.decide_action` is necessarily less expressive
+        for SAC/DDPG than for DQN/PPO/A2C.
+        """
+        if isinstance(action_out, tuple):
+            # SAC: (mean, log_std) — use the deterministic mean for the
+            # discretization target. The log_std is intentionally discarded
+            # because the discrete softmax already supplies sampling noise.
+            action_out = action_out[0]
         if isinstance(action_out, torch.Tensor):
             raw = action_out.detach().cpu().numpy().reshape(-1)
         else:
             raw = np.asarray(action_out, dtype=np.float64).reshape(-1)
-        scalar = float(raw[0]) if raw.size > 0 else 0.0
-        discrete = int(
-            np.clip(np.round(scalar * (self.num_actions - 1)), 0, self.num_actions - 1)
-        )
-        logits = np.full(self.num_actions, -10.0, dtype=np.float64)
-        logits[discrete] = 10.0
-        return logits
+        if raw.size == 0:
+            return np.zeros(self.num_actions, dtype=np.float64)
+
+        # Map a scalar in [-1, 1] (post-tanh continuous action) to an index
+        # in [0, num_actions - 1] as a float so we can compute a distance
+        # profile rather than a one-hot.
+        scalar = float(np.clip(raw[0], -1.0, 1.0))
+        center = (scalar + 1.0) * 0.5 * (self.num_actions - 1)
+        bins = np.arange(self.num_actions, dtype=np.float64)
+        # Negative-squared-distance gives a smooth Gaussian-shaped preference
+        # around ``center``; scale controls how peaked the resulting softmax
+        # is. See ``CONTINUOUS_ACTOR_LOGIT_SCALE`` docstring for the choice.
+        return -self.CONTINUOUS_ACTOR_LOGIT_SCALE * (bins - center) ** 2
 
     def _policy_q_values(self, state: Union[np.ndarray, Any]) -> np.ndarray:
         """Return per-action logits or Q-values with shape ``(num_actions,)``."""
         if self.policy is None:
             return np.ones(self.num_actions, dtype=np.float64)
-
-        import torch
 
         state_tensor = self._state_to_batched_tensor(state)
         with torch.no_grad():
@@ -1098,15 +1095,20 @@ class TianshouWrapper(RLAlgorithm):
         return int(action)
 
     def predict_proba(self, state: np.ndarray) -> np.ndarray:
-        """Predict action probabilities from policy logits/Q-values."""
+        """Predict action probabilities from policy logits/Q-values.
+
+        Returns a length-``num_actions`` softmax over the policy's per-action
+        scores. No temperature scaling is applied — the raw logits/Q-values
+        are passed straight to ``_masked_softmax``. If a future caller needs
+        a hotter or colder distribution, route that through
+        :class:`DecisionConfig` so the knob is explicit and persisted in
+        experiment metadata.
+        """
         if self.policy is None:
             return np.full(self.num_actions, 1.0 / self.num_actions, dtype=float)
 
         logits = self._policy_q_values(state)
-        temperature = float(self.algorithm_config.get("policy_temperature", 1.0))
-        temperature = max(temperature, 1e-8)
-        scaled = logits / temperature
-        return self._masked_softmax(scaled, action_mask=None)
+        return self._masked_softmax(logits, action_mask=None)
 
     def store_experience(
         self,

--- a/farm/core/decision/decision.py
+++ b/farm/core/decision/decision.py
@@ -14,12 +14,14 @@ Key Features:
 """
 
 import os
+import pickle
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
 
 from farm.core.decision.config import DecisionConfig
+from farm.core.decision.shape_utils import batch_observation
 from farm.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -556,34 +558,7 @@ class DecisionModule:
         self, state: Union[torch.Tensor, np.ndarray]
     ) -> np.ndarray:
         """Convert and batch an observation for algorithm ``predict_proba`` calls."""
-        if isinstance(state, torch.Tensor):
-            state_np = state.detach().cpu().numpy()
-        else:
-            state_np = np.array(state, dtype=np.float32)
-
-        target_size = int(np.prod(self.observation_shape))
-
-        if state_np.ndim == 1:
-            if state_np.size == target_size and len(self.observation_shape) > 1:
-                state_np = state_np.reshape(1, *self.observation_shape)
-            else:
-                state_np = state_np.reshape(1, -1)
-        elif state_np.ndim == 2:
-            if state_np.shape == self.observation_shape:
-                state_np = state_np[np.newaxis, ...]
-            elif state_np.size == target_size:
-                state_np = state_np.reshape(1, *self.observation_shape)
-            elif state_np.shape[0] == 1:
-                pass
-            else:
-                state_np = state_np.reshape(1, -1)
-        elif state_np.ndim == len(self.observation_shape):
-            state_np = state_np[np.newaxis, ...]
-        elif state_np.ndim == len(self.observation_shape) + 1:
-            pass
-        else:
-            state_np = state_np.reshape(1, -1)
-        return state_np
+        return batch_observation(state, self.observation_shape)
 
     def _policy_probs(self, state_np: np.ndarray) -> np.ndarray:
         """Return a normalized policy probability vector over the action space."""
@@ -642,7 +617,15 @@ class DecisionModule:
             return int(full_action)
         if full_action in enabled_actions:
             return enabled_actions.index(full_action)
-        return 0
+        # ``decide_action`` masks the sampling distribution to ``enabled_actions``
+        # before drawing, so a sampled index outside the enabled set indicates
+        # the upstream mask/distribution invariant has been violated. Surface
+        # it loudly rather than silently snapping to the first enabled slot,
+        # which previously hid logic regressions.
+        raise AssertionError(
+            f"Sampled action {full_action!r} is not in enabled_actions={enabled_actions!r} "
+            f"for agent {self.agent_id!r}; action_mask sampling invariant violated."
+        )
 
     def decide_action(
         self,
@@ -968,8 +951,6 @@ class DecisionModule:
             ):
                 # For Tianshou algorithms, get model state and save
                 model_state = self.algorithm.get_model_state()
-                import pickle
-
                 with open(f"{path}.pkl", "wb") as f:
                     pickle.dump(
                         {
@@ -990,8 +971,6 @@ class DecisionModule:
                 self.algorithm.save(path)
             else:
                 # For fallback algorithm, save basic info
-                import pickle
-
                 with open(f"{path}.pkl", "wb") as f:
                     pickle.dump(
                         {
@@ -1015,8 +994,6 @@ class DecisionModule:
         """
         try:
             # Try to load pickle file first (for Tianshou models)
-            import pickle
-
             pickle_path = f"{path}.pkl"
 
             if os.path.exists(pickle_path):

--- a/farm/core/decision/shape_utils.py
+++ b/farm/core/decision/shape_utils.py
@@ -1,0 +1,78 @@
+"""Shared observation-shape normalization for the decision pipeline.
+
+Both :class:`farm.core.decision.decision.DecisionModule` and
+:class:`farm.core.decision.algorithms.tianshou.TianshouWrapper` need to coerce
+an incoming observation (1D vector, raw spatial tensor, already-batched
+tensor, etc.) into a single canonical batched-numpy form before calling the
+underlying policy network.  Keeping that logic in one place prevents the two
+sites from drifting on edge cases like ``(C, H, W)`` vs ``(N, C, H, W)`` or
+flat ``(D,)`` vs already-batched ``(1, D)``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence, Tuple
+
+import numpy as np
+
+
+def _to_float32_numpy(state: Any) -> np.ndarray:
+    """Coerce ``state`` to a ``float32`` numpy array without unnecessary copies.
+
+    Handles torch tensors lazily so this helper can be imported without
+    requiring torch to be installed at module-load time.
+    """
+    if isinstance(state, np.ndarray):
+        return state.astype(np.float32, copy=False)
+    try:
+        import torch  # local import keeps torch optional at import time
+
+        if isinstance(state, torch.Tensor):
+            return state.detach().cpu().numpy().astype(np.float32, copy=False)
+    except ImportError:
+        pass
+    return np.asarray(state, dtype=np.float32)
+
+
+def batch_observation(
+    state: Any,
+    observation_shape: Sequence[int] | Tuple[int, ...],
+) -> np.ndarray:
+    """Return ``state`` reshaped to ``(1, *observation_shape)``-style batched form.
+
+    Args:
+        state: Raw observation as a numpy array, torch tensor, or array-like.
+        observation_shape: Per-sample shape the policy network expects.
+
+    Returns:
+        Float32 numpy array with a leading batch dimension.  The function is
+        intentionally tolerant of common input shapes:
+
+        * 1D vector matching ``prod(observation_shape)`` reshapes into the
+          full multi-dimensional layout when ``observation_shape`` has rank
+          > 1.
+        * 2D input matching ``observation_shape`` exactly gets a batch axis
+          prepended.
+        * Already-batched inputs (leading singleton dim) pass through.
+    """
+    state_np = _to_float32_numpy(state)
+    obs_shape = tuple(observation_shape)
+    target_size = int(np.prod(obs_shape)) if obs_shape else state_np.size
+
+    if state_np.ndim == 1:
+        if state_np.size == target_size and len(obs_shape) > 1:
+            return state_np.reshape(1, *obs_shape)
+        return state_np.reshape(1, -1)
+    if state_np.ndim == 2:
+        if state_np.shape == obs_shape:
+            return state_np[np.newaxis, ...]
+        if state_np.size == target_size:
+            return state_np.reshape(1, *obs_shape)
+        if state_np.shape[0] == 1:
+            return state_np
+        return state_np.reshape(1, -1)
+    if state_np.ndim == len(obs_shape):
+        return state_np[np.newaxis, ...]
+    if state_np.ndim == len(obs_shape) + 1:
+        return state_np
+    return state_np.reshape(1, -1)

--- a/farm/core/decision/shape_utils.py
+++ b/farm/core/decision/shape_utils.py
@@ -30,6 +30,7 @@ def _to_float32_numpy(state: Any) -> np.ndarray:
         if isinstance(state, torch.Tensor):
             return state.detach().cpu().numpy().astype(np.float32, copy=False)
     except ImportError:
+        # Torch is optional; if unavailable, fall back to generic numpy coercion.
         pass
     return np.asarray(state, dtype=np.float32)
 

--- a/farm/core/inheritance_telemetry.py
+++ b/farm/core/inheritance_telemetry.py
@@ -1,10 +1,11 @@
-"""Per-run counters for offspring policy-inheritance events.
+"""Per-run telemetry counters for policy inheritance and decision failures.
 
 The intrinsic-evolution runner attaches one :class:`InheritanceTelemetry`
 instance to the live :class:`farm.core.environment.Environment` for the
-duration of a run.  Reproduction code paths in
-:mod:`farm.core.agent.core` record warm-start outcomes through it, and the
-runner serialises the resulting counts into the per-run metadata JSON
+duration of a run.  Reproduction code paths in :mod:`farm.core.agent.core`
+record warm-start outcomes through it, and the agent step records
+``decide_action`` failures through :meth:`record_decide_action_failure`.
+The runner serialises the resulting counts into the per-run metadata JSON
 (``policy_inheritance_metrics``).
 """
 
@@ -23,11 +24,21 @@ class InheritanceTelemetry:
     ``WARMSTART_REASON_*`` strings from
     :mod:`farm.core.policy_inheritance`, so downstream analysis can split
     "skipped because architecture mutated" from genuine missing-API cases.
+
+    ``decide_action_failures`` counts agent-step decision failures so
+    experiment harnesses can detect a silent degradation regime (the
+    decision module now propagates errors instead of falling back to a
+    chromosome-only sampler — see the 2026-05-22 dev-log entry).
+    ``decide_action_failure_reasons`` is a multiset keyed by the offending
+    exception class name so common failure modes are easy to triage from
+    the persisted metadata.
     """
 
     lamarckian_warmstart_applied: int = 0
     lamarckian_warmstart_skipped: int = 0
     lamarckian_warmstart_skipped_reasons: Counter = field(default_factory=Counter)
+    decide_action_failures: int = 0
+    decide_action_failure_reasons: Counter = field(default_factory=Counter)
 
     def record_applied(self) -> None:
         self.lamarckian_warmstart_applied += 1
@@ -36,6 +47,11 @@ class InheritanceTelemetry:
         self.lamarckian_warmstart_skipped += 1
         self.lamarckian_warmstart_skipped_reasons[reason] += 1
 
+    def record_decide_action_failure(self, error_type: str = "Exception") -> None:
+        """Record one agent-step decision failure attributed to ``error_type``."""
+        self.decide_action_failures += 1
+        self.decide_action_failure_reasons[error_type] += 1
+
     def to_dict(self) -> Dict[str, Any]:
         """Render as a JSON-friendly dict for run metadata."""
         return {
@@ -43,5 +59,9 @@ class InheritanceTelemetry:
             "lamarckian_warmstart_skipped": int(self.lamarckian_warmstart_skipped),
             "lamarckian_warmstart_skipped_reasons": dict(
                 self.lamarckian_warmstart_skipped_reasons
+            ),
+            "decide_action_failures": int(self.decide_action_failures),
+            "decide_action_failure_reasons": dict(
+                self.decide_action_failure_reasons
             ),
         }

--- a/farm/utils/logging/config.py
+++ b/farm/utils/logging/config.py
@@ -616,6 +616,10 @@ def configure_logging(
     if enable_metrics:
         _metrics_manager.set_processor(MetricsProcessor())
 
+    # ``dict_tracebacks`` emits structured exception data (a list) that
+    # ``ConsoleRenderer`` cannot render; reserve it for JSON output only.
+    use_json_renderer = not disable_console and (environment == "production" or json_logs)
+
     # Build optimized processor chain
     processors: list[Processor] = [
         # PHASE 1: Context merging (cheap)
@@ -634,7 +638,7 @@ def configure_logging(
         structlog.processors.TimeStamper(fmt="iso", utc=True, key="timestamp"),
         # PHASE 7: Stack and exception info
         structlog.processors.StackInfoRenderer(),
-        structlog.processors.dict_tracebacks,
+        *([structlog.processors.dict_tracebacks] if use_json_renderer else []),
         # PHASE 8: Security
         censor_sensitive_data,
         # PHASE 9: Custom processors

--- a/scripts/compare_crossover_arms.py
+++ b/scripts/compare_crossover_arms.py
@@ -36,7 +36,6 @@ import argparse
 import json
 import math
 import sys
-from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
@@ -50,6 +49,9 @@ _repo_root = Path(__file__).resolve().parent.parent
 if str(_repo_root) not in sys.path:
     sys.path.insert(0, str(_repo_root))
 
+from farm.analysis.lineage_metrics import (  # noqa: E402
+    lineage_metrics as _lineage_metrics,
+)
 from scripts.analyze_stable_profile_seed_sweep import (  # noqa: E402
     CONVERGENT_GENES,
     PROFILE_COLORS,
@@ -63,78 +65,6 @@ from scripts.analyze_stable_profile_seed_sweep import (  # noqa: E402
     _t_ci,
     _variance,
 )
-
-# ── Lineage-file parsing ──────────────────────────────────────────────────────
-
-CLUSTER_LINEAGE_FILENAME = "cluster_lineage.jsonl"
-
-
-def _read_jsonl(path: Path) -> List[Dict[str, Any]]:
-    rows: List[Dict[str, Any]] = []
-    if not path.is_file():
-        return rows
-    with path.open(encoding="utf-8") as fh:
-        for line in fh:
-            line = line.strip()
-            if line:
-                try:
-                    rows.append(json.loads(line))
-                except json.JSONDecodeError:
-                    continue
-    return rows
-
-
-def _lineage_metrics(run_dir: Path) -> Dict[str, Any]:
-    """Per-run lineage summary from ``cluster_lineage.jsonl``.
-
-    Returns
-    -------
-    dict with keys:
-      - ``cluster_count_trace``: list of (step, k) tuples (k = #clusters at step)
-      - ``mean_k``: mean cluster count across clustering steps (NaN if absent)
-      - ``churn_rate``: mean per-step fraction of cluster IDs at step t that
-        do NOT survive to step t+1.  In [0, 1].  NaN if fewer than two
-        clustering steps were recorded.
-    """
-    rows = _read_jsonl(run_dir / CLUSTER_LINEAGE_FILENAME)
-    if not rows:
-        return {
-            "cluster_count_trace": [],
-            "mean_k": float("nan"),
-            "churn_rate": float("nan"),
-        }
-
-    steps_to_ids: Dict[int, set] = defaultdict(set)
-    for r in rows:
-        try:
-            step = int(r["step"])
-            cid = r["cluster_id"]
-        except (KeyError, TypeError, ValueError):
-            continue
-        steps_to_ids[step].add(cid)
-
-    sorted_steps = sorted(steps_to_ids.keys())
-    trace = [(s, len(steps_to_ids[s])) for s in sorted_steps]
-    mean_k = _mean([k for _, k in trace]) if trace else float("nan")
-
-    if len(sorted_steps) < 2:
-        churn = float("nan")
-    else:
-        churns: List[float] = []
-        for s_prev, s_next in zip(sorted_steps, sorted_steps[1:]):
-            prev = steps_to_ids[s_prev]
-            nxt = steps_to_ids[s_next]
-            if not prev:
-                continue
-            died = prev - nxt
-            churns.append(len(died) / len(prev))
-        churn = _mean(churns) if churns else float("nan")
-
-    return {
-        "cluster_count_trace": trace,
-        "mean_k": mean_k,
-        "churn_rate": churn,
-    }
 
 
 # ── Paired-delta stats ────────────────────────────────────────────────────────

--- a/scripts/compare_inheritance_arms.py
+++ b/scripts/compare_inheritance_arms.py
@@ -29,6 +29,9 @@ _repo_root = Path(__file__).resolve().parent.parent
 if str(_repo_root) not in sys.path:
     sys.path.insert(0, str(_repo_root))
 
+from farm.analysis.lineage_metrics import (  # noqa: E402
+    lineage_metrics as _lineage_metrics,
+)
 from scripts.analyze_stable_profile_seed_sweep import (  # noqa: E402
     PROFILE_ORDER,
     SIGN_AGREEMENT_THRESHOLD,
@@ -38,7 +41,6 @@ from scripts.analyze_stable_profile_seed_sweep import (  # noqa: E402
     _t_ci,
     _variance,
 )
-from scripts.compare_crossover_arms import _lineage_metrics  # noqa: E402
 
 METRIC_KEYS: List[str] = [
     "speciation_final",
@@ -53,7 +55,7 @@ STABILITY_KEYS: List[str] = [
     "startup_transient.peak_death_rate",
     "startup_transient.oscillation_amplitude",
 ]
-INFO_KEYS: List[str] = ["lamarckian_warmstart_rate"]
+INFO_KEYS: List[str] = ["lamarckian_warmstart_rate", "decide_action_failures"]
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -108,11 +110,15 @@ def _build_parser() -> argparse.ArgumentParser:
 def _paired_delta_summary(values: Sequence[float]) -> Dict[str, Any]:
     clean = [float(v) for v in values if not math.isnan(v)]
     if not clean:
+        # Empty summaries use ``None`` rather than ``float("nan")`` so that
+        # ``json.dump`` emits valid JSON (``"null"``) instead of the
+        # JavaScript-only ``NaN`` token; downstream tools that consume the
+        # summary file should treat ``None`` as "no data".
         return {
-            "mean_delta": float("nan"),
-            "variance": float("nan"),
-            "ci95": [float("nan"), float("nan")],
-            "sign_agreement": float("nan"),
+            "mean_delta": None,
+            "variance": None,
+            "ci95": [None, None],
+            "sign_agreement": None,
             "n": 0,
         }
 
@@ -157,6 +163,13 @@ def _extract_metadata_metrics(run_dir: Path) -> Dict[str, Any]:
     )
     denom = applied + skipped
     warmstart_rate = float(applied / denom) if denom > 0 else float("nan")
+    # ``decide_action_failures`` was added so paired A/B comparisons can flag
+    # arms where the new fail-loud decision path is degrading silently
+    # (see ``InheritanceTelemetry`` and the 2026-05-22 dev-log entry).
+    decide_failures = float(inheritance.get("decide_action_failures", 0))
+    decide_failure_reasons = dict(
+        inheritance.get("decide_action_failure_reasons", {}) or {}
+    )
     return {
         "startup_transient": {
             "peak_birth_rate": float(startup.get("peak_birth_rate", float("nan"))),
@@ -165,6 +178,8 @@ def _extract_metadata_metrics(run_dir: Path) -> Dict[str, Any]:
         },
         "lamarckian_warmstart_rate": warmstart_rate,
         "lamarckian_warmstart_skipped_reasons": skipped_reasons,
+        "decide_action_failures": decide_failures,
+        "decide_action_failure_reasons": decide_failure_reasons,
     }
 
 
@@ -474,9 +489,11 @@ def _plot_startup_transient(
 
 
 def _fmt(value: Any, places: int = 3) -> str:
+    if value is None:
+        return "n/a"
     if isinstance(value, (int, float)):
         if isinstance(value, float) and math.isnan(value):
-            return "nan"
+            return "n/a"
         return f"{value:.{places}f}"
     if isinstance(value, list) and len(value) == 2:
         return f"[{_fmt(value[0], places)}, {_fmt(value[1], places)}]"
@@ -524,6 +541,7 @@ def _build_markdown(
         ("startup_transient.peak_death_rate", "startup peak death rate"),
         ("startup_transient.oscillation_amplitude", "startup oscillation amplitude"),
         ("lamarckian_warmstart_rate", "warmstart rate delta"),
+        ("decide_action_failures", "decide_action failures delta"),
     ]
     lines += ["## Paired deltas (treatment - baseline)", ""]
     for profile in PROFILE_ORDER:

--- a/scripts/compare_inheritance_arms.py
+++ b/scripts/compare_inheritance_arms.py
@@ -423,8 +423,8 @@ def _plot_paired_delta_heatmap(
             row = []
             arm_d = deltas.get(profile, {}).get(arm, {})
             for col in columns:
-                value = arm_d.get(col, {}).get("mean_delta", float("nan"))
-                row.append(float(value))
+                raw = arm_d.get(col, {}).get("mean_delta", float("nan"))
+                row.append(float("nan") if raw is None else float(raw))
             matrix.append(row)
     if not matrix:
         return

--- a/tests/analysis/test_lineage_metrics.py
+++ b/tests/analysis/test_lineage_metrics.py
@@ -1,0 +1,96 @@
+"""Unit tests for the shared lineage-metrics helper.
+
+The helper used to live as a private function in
+``scripts/compare_crossover_arms.py`` and was reached across the script
+boundary via name-mangled private import; promoting it required a stable
+contract.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from farm.analysis.lineage_metrics import (
+    CLUSTER_LINEAGE_FILENAME,
+    lineage_metrics,
+)
+
+
+def _write_lineage(run_dir: Path, rows):
+    path = run_dir / CLUSTER_LINEAGE_FILENAME
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+
+
+class TestLineageMetrics(unittest.TestCase):
+    def test_missing_file_returns_empty_shape(self):
+        with TemporaryDirectory() as tmp:
+            metrics = lineage_metrics(Path(tmp))
+        self.assertEqual(metrics["cluster_count_trace"], [])
+        self.assertTrue(math.isnan(metrics["mean_k"]))
+        self.assertTrue(math.isnan(metrics["churn_rate"]))
+
+    def test_single_step_returns_nan_churn(self):
+        with TemporaryDirectory() as tmp:
+            run_dir = Path(tmp)
+            _write_lineage(
+                run_dir,
+                [
+                    {"step": 0, "cluster_id": "a"},
+                    {"step": 0, "cluster_id": "b"},
+                ],
+            )
+            metrics = lineage_metrics(run_dir)
+        self.assertEqual(metrics["cluster_count_trace"], [(0, 2)])
+        self.assertEqual(metrics["mean_k"], 2.0)
+        self.assertTrue(math.isnan(metrics["churn_rate"]))
+
+    def test_churn_rate_counts_disappearing_clusters(self):
+        with TemporaryDirectory() as tmp:
+            run_dir = Path(tmp)
+            _write_lineage(
+                run_dir,
+                [
+                    # Step 0: clusters {a, b, c, d}.
+                    {"step": 0, "cluster_id": "a"},
+                    {"step": 0, "cluster_id": "b"},
+                    {"step": 0, "cluster_id": "c"},
+                    {"step": 0, "cluster_id": "d"},
+                    # Step 1: clusters {b, c} survive; {a, d} died (50% churn).
+                    {"step": 1, "cluster_id": "b"},
+                    {"step": 1, "cluster_id": "c"},
+                ],
+            )
+            metrics = lineage_metrics(run_dir)
+        self.assertEqual(metrics["cluster_count_trace"], [(0, 4), (1, 2)])
+        self.assertAlmostEqual(metrics["mean_k"], 3.0)
+        self.assertAlmostEqual(metrics["churn_rate"], 0.5)
+
+    def test_malformed_lines_are_skipped(self):
+        with TemporaryDirectory() as tmp:
+            run_dir = Path(tmp)
+            path = run_dir / CLUSTER_LINEAGE_FILENAME
+            path.write_text(
+                "\n".join(
+                    [
+                        json.dumps({"step": 0, "cluster_id": "a"}),
+                        "{not valid json",
+                        json.dumps({"step": 0, "cluster_id": "b"}),
+                        "",
+                        json.dumps({"step": 1}),  # missing cluster_id
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            metrics = lineage_metrics(run_dir)
+        self.assertEqual(metrics["cluster_count_trace"], [(0, 2)])
+        self.assertEqual(metrics["mean_k"], 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/decision/test_decision_policy_sensitivity.py
+++ b/tests/decision/test_decision_policy_sensitivity.py
@@ -56,7 +56,8 @@ class TestDecisionPolicySensitivity(unittest.TestCase):
 
     def test_decide_action_responds_to_policy_weights(self):
         state = torch.randn(8)
-        uniform_weights = np.ones(get_action_count(), dtype=np.float64) / get_action_count()
+        num_actions = get_action_count()
+        uniform_weights = np.ones(num_actions, dtype=np.float64) / num_actions
 
         module_a = _make_decision_module(seed=11)
         module_b = _make_decision_module(seed=22)
@@ -69,14 +70,33 @@ class TestDecisionPolicySensitivity(unittest.TestCase):
         self.assertFalse(np.array_equal(hist_a, hist_b))
 
         np.random.seed(456)
-        weighted_a = np.zeros(get_action_count(), dtype=np.int64)
+        weighted_a = np.zeros(num_actions, dtype=np.int64)
         for _ in range(2000):
             weighted_a[module_a.decide_action(state, action_weights=uniform_weights)] += 1
         np.random.seed(456)
-        weighted_b = np.zeros(get_action_count(), dtype=np.int64)
+        weighted_b = np.zeros(num_actions, dtype=np.int64)
         for _ in range(2000):
             weighted_b[module_b.decide_action(state, action_weights=uniform_weights)] += 1
         self.assertFalse(np.array_equal(weighted_a, weighted_b))
+
+        # Holding the module fixed, switching from uniform weights to a
+        # heavily-skewed weight vector must actually shift the sampling
+        # distribution; otherwise the multiplicative composition in
+        # decide_action is silently dropping action_weights.
+        skewed_weights = np.full(num_actions, 0.01, dtype=np.float64)
+        skewed_weights[0] = 1.0
+        skewed_weights /= skewed_weights.sum()
+        np.random.seed(789)
+        skewed_hist = np.zeros(num_actions, dtype=np.int64)
+        for _ in range(2000):
+            skewed_hist[
+                module_a.decide_action(state, action_weights=skewed_weights)
+            ] += 1
+        self.assertFalse(np.array_equal(weighted_a, skewed_hist))
+        # Action 0 should dominate under the skewed weights (the policy
+        # could still pull it away from a strict argmax, so we only require
+        # that action 0 is the most-sampled action by a comfortable margin).
+        self.assertEqual(int(np.argmax(skewed_hist)), 0)
 
     def test_lamarckian_warmstart_matches_parent_distribution(self):
         parent_module = _make_decision_module(seed=101)
@@ -192,3 +212,42 @@ class TestTianshouPredictProbaShapes(unittest.TestCase):
         for _ in range(50):
             action = wrapper.select_action_with_mask(state, mask)
             self.assertIn(action, [0, 1])
+
+    def test_continuous_actor_to_logits_handles_tuple(self):
+        """SAC actors return ``(mean, log_std)``; the helper must unpack the mean."""
+        from farm.core.decision.algorithms.tianshou import SACWrapper
+
+        # SAC's actor in this codebase is CNN-based, so the wrapper requires
+        # a spatial observation shape at construction time. The helper under
+        # test only depends on ``num_actions``, so we just need a wrapper
+        # that initialises successfully.
+        spatial_shape = (13, 13, 13)
+        wrapper = SACWrapper(
+            num_actions=4,
+            state_dim=int(np.prod(spatial_shape)),
+            observation_shape=spatial_shape,
+        )
+        # Build a fake "SAC actor output" as a (mean, log_std) tuple of
+        # tensors with mean = +1.0 (post-tanh top of the action range).
+        mean = torch.tensor([1.0])
+        log_std = torch.tensor([0.0])
+        logits = wrapper._continuous_actor_to_logits((mean, log_std))
+        self.assertEqual(logits.shape, (wrapper.num_actions,))
+        # The center of the distance profile sits at num_actions - 1, so
+        # the last bin must carry the highest logit (smallest squared
+        # distance).
+        self.assertEqual(int(np.argmax(logits)), wrapper.num_actions - 1)
+
+        # Bare-tensor inputs (DDPG-style deterministic mean) must still work.
+        deterministic = torch.tensor([-1.0])
+        ddpg_logits = wrapper._continuous_actor_to_logits(deterministic)
+        self.assertEqual(int(np.argmax(ddpg_logits)), 0)
+
+        # The resulting softmax must be soft enough that chromosome weights
+        # can still shift the distribution — i.e. not a degenerate one-hot.
+        # We expect the top-bin probability to be well below 1.0 so that
+        # multiplying by per-action weights can meaningfully reweight other
+        # bins.
+        probs = wrapper._masked_softmax(logits, action_mask=None)
+        self.assertLess(float(np.max(probs)), 0.95)
+        self.assertGreater(float(np.min(probs)), 0.0)

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -297,6 +297,10 @@ class TestRunnerOrchestration(unittest.TestCase):
             self.assertEqual(
                 inheritance_metrics["lamarckian_warmstart_skipped_reasons"], {}
             )
+            self.assertEqual(inheritance_metrics["decide_action_failures"], 0)
+            self.assertEqual(
+                inheritance_metrics["decide_action_failure_reasons"], {}
+            )
             # Initial-diversity defaults installed by the runner are
             # surfaced in the metadata for reproducibility.
             self.assertIn("initial_diversity", metadata)

--- a/tests/scripts/test_compare_inheritance_arms.py
+++ b/tests/scripts/test_compare_inheritance_arms.py
@@ -29,7 +29,19 @@ class TestPairedDeltaSummary(unittest.TestCase):
     def test_empty(self):
         out = _paired_delta_summary([])
         self.assertEqual(out["n"], 0)
-        self.assertTrue(math.isnan(out["mean_delta"]))
+        # Empty summaries must use ``None`` (valid JSON ``null``), not NaN
+        # (which json.dump emits as the non-standard ``NaN`` token).
+        self.assertIsNone(out["mean_delta"])
+        self.assertEqual(out["ci95"], [None, None])
+
+    def test_empty_summary_is_json_serializable(self):
+        out = _paired_delta_summary([])
+        # Strict mode rejects NaN/Infinity tokens, so this exercises the
+        # contract that empty summaries round-trip through valid JSON.
+        encoded = json.dumps(out, allow_nan=False)
+        decoded = json.loads(encoded)
+        self.assertEqual(decoded["n"], 0)
+        self.assertIsNone(decoded["mean_delta"])
 
     def test_non_empty(self):
         out = _paired_delta_summary([1.0, 2.0, 3.0])
@@ -247,6 +259,11 @@ class TestExtractMetadataMetrics(unittest.TestCase):
                             "lamarckian_warmstart_skipped_reasons": {
                                 "incompatible_state": 2,
                             },
+                            "decide_action_failures": 4,
+                            "decide_action_failure_reasons": {
+                                "RuntimeError": 3,
+                                "ValueError": 1,
+                            },
                         },
                     }
                 ),
@@ -256,6 +273,11 @@ class TestExtractMetadataMetrics(unittest.TestCase):
         self.assertAlmostEqual(metrics["lamarckian_warmstart_rate"], 0.8)
         self.assertEqual(
             metrics["lamarckian_warmstart_skipped_reasons"], {"incompatible_state": 2}
+        )
+        self.assertEqual(metrics["decide_action_failures"], 4.0)
+        self.assertEqual(
+            metrics["decide_action_failure_reasons"],
+            {"RuntimeError": 3, "ValueError": 1},
         )
 
     def test_missing_metadata_returns_empty(self):

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -162,6 +162,33 @@ def test_reproduce_lamarckian_policy_applies_warmstart_and_tracks_counter():
     offspring.behavior.decision_module.algorithm.load_model_state.assert_called_once()
 
 
+def test_step_records_decide_action_failure_in_telemetry():
+    """A ``decide_action`` exception during ``step`` must bump the failure counter."""
+    parent = _build_parent_agent_for_reproduction()
+    parent.alive = True
+    parent._invalidate_obs_cache = Mock()
+    parent.behavior = Mock()
+    parent.behavior.decide_action.side_effect = RuntimeError("predict_proba boom")
+    parent._create_observation = Mock(return_value=Mock())
+    parent._get_enabled_actions = Mock(return_value=None)
+    parent._execute_action = Mock()
+    # Resource component on the parent has a starvation counter below the
+    # threshold so the early-return path isn't triggered.
+    resource_comp = parent._components["resource"]
+    resource_comp.starvation_counter = 0
+    resource_comp.config = SimpleNamespace(starvation_threshold=100)
+
+    telemetry = parent.environment.inheritance_telemetry
+
+    with patch("farm.core.agent.core.logger.warning") as warn:
+        AgentCore.step(parent)
+
+    warn.assert_called_once()
+    assert telemetry.decide_action_failures == 1
+    assert telemetry.decide_action_failure_reasons["RuntimeError"] == 1
+    parent._execute_action.assert_not_called()
+
+
 def test_reproduce_lamarckian_incompatible_policy_counts_as_skipped():
     """Shape/key mismatch should skip warm-start without failing reproduction."""
     parent = _build_parent_agent_for_reproduction()

--- a/tests/test_decision_config_wiring.py
+++ b/tests/test_decision_config_wiring.py
@@ -149,19 +149,36 @@ class TestEpsilonGreedyWiring(unittest.TestCase):
         import numpy as np
         import torch
 
+        # After the 2026-05-22 decision-path fix, ``select_action_with_mask``
+        # reads Q-values through ``policy.model(state_tensor)`` for DQN
+        # rather than calling the policy directly. The spy therefore exposes
+        # a callable ``model`` that returns a length-``num_actions`` tensor
+        # and records the epsilon value it observed at call time.
         class _EpsilonSpyPolicy:
-            def __init__(self):
+            def __init__(self, num_actions: int):
                 self.eps = 0.0
                 self.eps_seen: list[float] = []
+                self._num_actions = num_actions
 
             def set_eps(self, value: float) -> None:
                 self.eps = float(value)
 
-            def __call__(self, *_args, **_kwargs):
+            def _record(self) -> None:
                 self.eps_seen.append(float(self.eps))
-                return torch.tensor([0]), None
 
-        spy = _EpsilonSpyPolicy()
+            class _Model:
+                def __init__(self, outer):
+                    self._outer = outer
+
+                def __call__(self, state_tensor):
+                    self._outer._record()
+                    return torch.zeros((1, self._outer._num_actions))
+
+            @property
+            def model(self):
+                return self._Model(self)
+
+        spy = _EpsilonSpyPolicy(algo.num_actions)
         algo.policy = spy
         algo._apply_eps_to_policy(initial=True)
 
@@ -203,7 +220,15 @@ class TestEpsilonGreedyWiring(unittest.TestCase):
         module.algorithm.set_train_mode(False)
         self.assertAlmostEqual(float(module.algorithm.policy.eps), 0.02, places=5)
 
-    def test_eps_decays_on_weighted_decision_fallback_path(self):
+    def test_predict_proba_failure_propagates_without_decaying_eps(self):
+        """``predict_proba`` failures now surface as exceptions (no silent fallback).
+
+        After the 2026-05-22 decision-path fix, :meth:`DecisionModule.decide_action`
+        no longer catches algorithm errors and falls through to a weighted
+        random sampler. Errors propagate so they can be counted in
+        ``InheritanceTelemetry.decide_action_failures`` and triaged; epsilon
+        must not advance because no real decision was committed.
+        """
         cfg = DecisionConfig(
             algorithm_type="dqn",
             epsilon_start=1.0,
@@ -217,13 +242,12 @@ class TestEpsilonGreedyWiring(unittest.TestCase):
         state = np.zeros(8, dtype=np.float32)
         action_weights = np.ones(4, dtype=np.float64) / 4.0
 
-        # Simulate a probability-prediction failure so DecisionModule falls
-        # back to weighted random action selection. Epsilon should still decay
-        # once for this real decision.
+        eps_before = float(module.algorithm.policy.eps)
         with patch.object(module.algorithm, "predict_proba", side_effect=RuntimeError("boom")):
-            module.decide_action(state, action_weights=action_weights)
+            with self.assertRaises(RuntimeError):
+                module.decide_action(state, action_weights=action_weights)
 
-        self.assertAlmostEqual(float(module.algorithm.policy.eps), 0.5, places=5)
+        self.assertAlmostEqual(float(module.algorithm.policy.eps), eps_before, places=5)
 
     def test_weighted_decision_predict_proba_sees_initial_eps(self):
         cfg = DecisionConfig(

--- a/tests/test_policy_inheritance.py
+++ b/tests/test_policy_inheritance.py
@@ -226,3 +226,45 @@ def test_inheritance_telemetry_records_applied_and_skipped():
         WARMSTART_REASON_INCOMPATIBLE_STATE: 2,
         WARMSTART_REASON_NO_POLICY_STATE: 1,
     }
+
+
+def test_inheritance_telemetry_records_decide_action_failures():
+    telemetry = InheritanceTelemetry()
+    telemetry.record_decide_action_failure("ValueError")
+    telemetry.record_decide_action_failure("ValueError")
+    telemetry.record_decide_action_failure("RuntimeError")
+
+    payload = telemetry.to_dict()
+    assert payload["decide_action_failures"] == 3
+    assert payload["decide_action_failure_reasons"] == {
+        "ValueError": 2,
+        "RuntimeError": 1,
+    }
+
+
+def test_apply_skips_when_parent_behavior_is_none():
+    """Missing ``parent.behavior`` must surface as NO_DECISION_MODULE, not raise."""
+    parent = SimpleNamespace(behavior=None)
+    offspring = SimpleNamespace(
+        behavior=SimpleNamespace(
+            decision_module=SimpleNamespace(algorithm=SimpleNamespace())
+        )
+    )
+    assert (
+        apply_lamarckian_policy_warmstart(parent, offspring)
+        == WARMSTART_REASON_NO_DECISION_MODULE
+    )
+
+
+def test_apply_skips_when_offspring_behavior_is_none():
+    """Symmetric guard: missing ``offspring.behavior`` is also NO_DECISION_MODULE."""
+    parent = SimpleNamespace(
+        behavior=SimpleNamespace(
+            decision_module=SimpleNamespace(algorithm=SimpleNamespace())
+        )
+    )
+    offspring = SimpleNamespace(behavior=None)
+    assert (
+        apply_lamarckian_policy_warmstart(parent, offspring)
+        == WARMSTART_REASON_NO_DECISION_MODULE
+    )


### PR DESCRIPTION
- Introduced `lineage_metrics` function in `farm.analysis.lineage_metrics.py` to provide a per-run summary of lineage data from `cluster_lineage.jsonl`.
- Replaced private lineage parsing logic in `compare_crossover_arms.py` and `compare_inheritance_arms.py` with a stable, documented interface for improved testability and maintainability.
- Enhanced `InheritanceTelemetry` to track `decide_action` failures, allowing for better monitoring of decision-making issues during experiments.
- Updated relevant scripts and tests to utilize the new lineage metrics helper and telemetry features.
- Added unit tests for the new lineage metrics functionality to ensure robustness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core decision/action-selection code paths (observation batching, SAC/DDPG discretization, and stricter enabled-action invariants) and adds new telemetry wiring, which could change runtime behavior and experiment outcomes if edge cases regress.
> 
> **Overview**
> Adds `farm.analysis.lineage_metrics.lineage_metrics` as a shared, unit-tested parser for `cluster_lineage.jsonl`, and updates the A/B comparison scripts to use it instead of duplicating/private-importing lineage logic.
> 
> Extends `InheritanceTelemetry` and `AgentCore.step` to count and persist `decide_action` failures (with per-exception breakdown), and updates `compare_inheritance_arms.py` to surface these deltas while ensuring empty summaries serialize as JSON `null` (not `NaN`).
> 
> Refactors decision-state batching into `farm.core.decision.shape_utils.batch_observation`, makes `DecisionModule` fail loudly when sampling violates `enabled_actions`, and adjusts the Tianshou wrapper to (a) use the shared batching helper, (b) produce *soft* logits for SAC/DDPG continuous actors (including tuple outputs), and (c) remove `predict_proba` temperature scaling; tests were updated/added accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eafad7098ad509458c53638f4e332f0059bac50f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->