### PR TITLE
Enhance warm-start coverage metrics in A/B comparison scripts

### DIFF
--- a/scripts/compare_inheritance_arms.py
+++ b/scripts/compare_inheritance_arms.py
@@ -16,6 +16,7 @@ import argparse
 import json
 import math
 import sys
+from collections import Counter
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
@@ -176,6 +177,8 @@ def _extract_metadata_metrics(run_dir: Path) -> Dict[str, Any]:
             "peak_death_rate": float(startup.get("peak_death_rate", float("nan"))),
             "oscillation_amplitude": float(startup.get("oscillation_amplitude", float("nan"))),
         },
+        "lamarckian_warmstart_applied": applied,
+        "lamarckian_warmstart_skipped": skipped,
         "lamarckian_warmstart_rate": warmstart_rate,
         "lamarckian_warmstart_skipped_reasons": skipped_reasons,
         "decide_action_failures": decide_failures,
@@ -488,6 +491,78 @@ def _plot_startup_transient(
     plt.close(fig)
 
 
+def _warmstart_rate_from_run(run: Dict[str, Any]) -> Optional[float]:
+    applied = int(run.get("lamarckian_warmstart_applied", 0))
+    skipped = int(run.get("lamarckian_warmstart_skipped", 0))
+    denom = applied + skipped
+    if denom <= 0:
+        return None
+    return float(applied / denom)
+
+
+def _summarize_warmstart_coverage(
+    treatment_runs: Dict[int, Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Aggregate Lamarckian warm-start coverage for one (profile, arm) pair."""
+    per_seed: Dict[str, Dict[str, Any]] = {}
+    rates: List[float] = []
+    total_applied = 0
+    total_skipped = 0
+    skip_reasons: Counter = Counter()
+
+    for seed in sorted(treatment_runs):
+        run = treatment_runs[seed]
+        applied = int(run.get("lamarckian_warmstart_applied", 0))
+        skipped = int(run.get("lamarckian_warmstart_skipped", 0))
+        rate = _warmstart_rate_from_run(run)
+        per_seed[str(seed)] = {
+            "applied": applied,
+            "skipped": skipped,
+            "rate": rate,
+            "skip_reasons": dict(run.get("lamarckian_warmstart_skipped_reasons", {}) or {}),
+        }
+        total_applied += applied
+        total_skipped += skipped
+        for reason, count in (run.get("lamarckian_warmstart_skipped_reasons", {}) or {}).items():
+            skip_reasons[str(reason)] += int(count)
+        if rate is not None:
+            rates.append(rate)
+
+    lo, hi = _t_ci(rates) if rates else (None, None)
+    return {
+        "n": len(rates),
+        "mean_rate": _mean(rates) if rates else None,
+        "rate_ci95": [lo, hi],
+        "total_applied": total_applied,
+        "total_skipped": total_skipped,
+        "skip_reasons": dict(skip_reasons),
+        "per_seed": per_seed,
+    }
+
+
+def _compute_mechanism_coverage(
+    treatments: Dict[str, Dict[str, Dict[int, Dict[str, Any]]]],
+    profiles: Sequence[str],
+    arm_labels: Sequence[str],
+) -> Dict[str, Dict[str, Dict[str, Any]]]:
+    """Treatment-only mechanism stats (not paired against baseline)."""
+    out: Dict[str, Dict[str, Dict[str, Any]]] = {}
+    for profile in profiles:
+        out[profile] = {}
+        for arm in arm_labels:
+            treatment_runs = treatments.get(arm, {}).get(profile, {})
+            out[profile][arm] = {
+                "lamarckian_warmstart": _summarize_warmstart_coverage(treatment_runs),
+            }
+    return out
+
+
+def _fmt_skip_reasons(reasons: Dict[str, int]) -> str:
+    if not reasons:
+        return "none"
+    return ", ".join(f"{reason}={count}" for reason, count in sorted(reasons.items()))
+
+
 def _fmt(value: Any, places: int = 3) -> str:
     if value is None:
         return "n/a"
@@ -505,6 +580,7 @@ def _build_markdown(
     verdicts: Dict[str, Dict[str, str]],
     arm_labels: Sequence[str],
     baseline_label: str,
+    mechanism_coverage: Optional[Dict[str, Dict[str, Dict[str, Any]]]] = None,
 ) -> str:
     lines: List[str] = [
         "# Inheritance-mode A/B comparison",
@@ -534,13 +610,44 @@ def _build_markdown(
         "",
     ]
 
+    if mechanism_coverage:
+        lines += [
+            "## Mechanism coverage (treatment only)",
+            "",
+            (
+                "Lamarckian warm-start rate is an absolute treatment-arm statistic. "
+                f"The `{baseline_label}` baseline performs no warm-start attempts, "
+                "so paired deltas are undefined."
+            ),
+            "",
+            "| Profile | Arm | Mean rate | 95% CI | Applied | Skipped | Skip reasons | n |",
+            "| --- | --- | --- | --- | --- | --- | --- | --- |",
+        ]
+        for profile in PROFILE_ORDER:
+            if profile not in mechanism_coverage:
+                continue
+            for arm in arm_labels:
+                warmstart = mechanism_coverage.get(profile, {}).get(arm, {}).get(
+                    "lamarckian_warmstart", {}
+                )
+                if not warmstart:
+                    continue
+                lines.append(
+                    f"| {profile} | {arm} | {_fmt(warmstart.get('mean_rate'))} "
+                    f"| {_fmt(warmstart.get('rate_ci95'))} "
+                    f"| {warmstart.get('total_applied', 0)} "
+                    f"| {warmstart.get('total_skipped', 0)} "
+                    f"| {_fmt_skip_reasons(warmstart.get('skip_reasons', {}))} "
+                    f"| {warmstart.get('n', 0)} |"
+                )
+        lines.append("")
+
     headline_keys = [
         ("population_mean", "population mean"),
         ("population_final", "population final"),
         ("speciation_slope", "speciation slope/100"),
         ("startup_transient.peak_death_rate", "startup peak death rate"),
         ("startup_transient.oscillation_amplitude", "startup oscillation amplitude"),
-        ("lamarckian_warmstart_rate", "warmstart rate delta"),
         ("decide_action_failures", "decide_action failures delta"),
     ]
     lines += ["## Paired deltas (treatment - baseline)", ""]
@@ -607,6 +714,8 @@ def main() -> int:
                 baseline_label=baseline_label,
             )
 
+    mechanism_coverage = _compute_mechanism_coverage(treatments, profiles, arm_labels)
+
     summary = {
         "comparison_type": "inheritance_mode_ab",
         "baseline_dir": str(baseline_dir),
@@ -616,6 +725,7 @@ def main() -> int:
         "deltas": deltas,
         "verdicts": verdicts,
         "paired_seeds": paired_seeds,
+        "mechanism_coverage": mechanism_coverage,
     }
 
     json_path = output_dir / "inheritance_ab_summary.json"
@@ -624,7 +734,13 @@ def main() -> int:
 
     md_path = output_dir / "inheritance_ab_summary.md"
     md_path.write_text(
-        _build_markdown(deltas, verdicts, arm_labels, baseline_label),
+        _build_markdown(
+            deltas,
+            verdicts,
+            arm_labels,
+            baseline_label,
+            mechanism_coverage=mechanism_coverage,
+        ),
         encoding="utf-8",
     )
 

--- a/tests/scripts/test_compare_inheritance_arms.py
+++ b/tests/scripts/test_compare_inheritance_arms.py
@@ -9,6 +9,7 @@ import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Optional
 
 _repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 if _repo_root not in sys.path:
@@ -16,12 +17,16 @@ if _repo_root not in sys.path:
 
 from scripts.compare_inheritance_arms import (  # noqa: E402
     ALL_METRIC_KEYS,
+    _build_markdown,
     _ci_excludes_zero,
     _classify_regime_verdict,
+    _compute_mechanism_coverage,
     _extract_metadata_metrics,
     _paired_delta_summary,
     _paired_metric_deltas,
     _resolve_metric_value,
+    _summarize_warmstart_coverage,
+    _warmstart_rate_from_run,
 )
 
 
@@ -271,6 +276,8 @@ class TestExtractMetadataMetrics(unittest.TestCase):
             )
             metrics = _extract_metadata_metrics(run_dir)
         self.assertAlmostEqual(metrics["lamarckian_warmstart_rate"], 0.8)
+        self.assertEqual(metrics["lamarckian_warmstart_applied"], 8)
+        self.assertEqual(metrics["lamarckian_warmstart_skipped"], 2)
         self.assertEqual(
             metrics["lamarckian_warmstart_skipped_reasons"], {"incompatible_state": 2}
         )
@@ -283,6 +290,66 @@ class TestExtractMetadataMetrics(unittest.TestCase):
     def test_missing_metadata_returns_empty(self):
         with TemporaryDirectory() as tmp:
             self.assertEqual(_extract_metadata_metrics(Path(tmp)), {})
+
+
+class TestWarmstartCoverage(unittest.TestCase):
+    def _run(self, applied: int, skipped: int, reasons: Optional[dict] = None):
+        return {
+            "lamarckian_warmstart_applied": applied,
+            "lamarckian_warmstart_skipped": skipped,
+            "lamarckian_warmstart_skipped_reasons": reasons or {},
+        }
+
+    def test_rate_from_run(self):
+        self.assertAlmostEqual(_warmstart_rate_from_run(self._run(8, 2)), 0.8)
+        self.assertIsNone(_warmstart_rate_from_run(self._run(0, 0)))
+
+    def test_summarize_warmstart_coverage(self):
+        runs = {
+            42: self._run(8, 2, {"incompatible_state": 2}),
+            7: self._run(9, 1, {"incompatible_state": 1}),
+        }
+        summary = _summarize_warmstart_coverage(runs)
+        self.assertEqual(summary["n"], 2)
+        self.assertAlmostEqual(summary["mean_rate"], 0.85)
+        self.assertEqual(summary["total_applied"], 17)
+        self.assertEqual(summary["total_skipped"], 3)
+        self.assertEqual(summary["skip_reasons"], {"incompatible_state": 3})
+        self.assertEqual(summary["per_seed"]["42"]["applied"], 8)
+
+    def test_compute_mechanism_coverage(self):
+        treatments = {
+            "lamarckian": {
+                "conservative": {
+                    42: self._run(8, 2, {"incompatible_state": 2}),
+                }
+            }
+        }
+        coverage = _compute_mechanism_coverage(treatments, ["conservative"], ["lamarckian"])
+        warmstart = coverage["conservative"]["lamarckian"]["lamarckian_warmstart"]
+        self.assertAlmostEqual(warmstart["mean_rate"], 0.8)
+        self.assertEqual(warmstart["total_applied"], 8)
+
+    def test_markdown_includes_mechanism_coverage(self):
+        coverage = {
+            "conservative": {
+                "lamarckian": {
+                    "lamarckian_warmstart": {
+                        "n": 1,
+                        "mean_rate": 0.8,
+                        "rate_ci95": [0.8, 0.8],
+                        "total_applied": 8,
+                        "total_skipped": 2,
+                        "skip_reasons": {"incompatible_state": 2},
+                        "per_seed": {},
+                    }
+                }
+            }
+        }
+        md = _build_markdown({}, {}, ["lamarckian"], "baldwinian", mechanism_coverage=coverage)
+        self.assertIn("## Mechanism coverage (treatment only)", md)
+        self.assertIn("Lamarckian warm-start rate is an absolute treatment-arm statistic", md)
+        self.assertNotIn("| lamarckian | warmstart rate delta |", md)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Introduced functions to compute and summarize Lamarckian warm-start coverage, including rates and reasons for skips.
- Updated the `_build_markdown` function to include a new section for mechanism coverage in the output.
- Added unit tests to validate the new warm-start coverage calculations and ensure proper integration with existing functionality.
- Enhanced metadata extraction to include warm-start application and skip counts for better telemetry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analysis and reporting changes only; no runtime experiment or production paths modified.
> 
> **Overview**
> The inheritance A/B comparison script now reports **Lamarckian warm-start** as **treatment-only mechanism coverage** instead of a misleading paired delta against the Baldwinian baseline (which does not attempt warm-starts).
> 
> Run metadata extraction adds **`lamarckian_warmstart_applied`** and **`lamarckian_warmstart_skipped`** counts. New helpers aggregate per-seed rates, 95% CIs, totals, and skip-reason histograms into **`mechanism_coverage`** on the JSON summary and a **Mechanism coverage (treatment only)** markdown table. The paired-deltas section **drops** the warmstart rate delta row.
> 
> Unit tests cover rate calculation, aggregation, JSON wiring, and markdown content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68be9e1f8e5f344aa61205dc5a5b5025dcd0186b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->