### PR TITLE
Update devlog entry for Baldwinian vs Lamarckian A/B harness

### DIFF
--- a/docs/devlog/2026-05-21-baldwinian-vs-lamarckian-ab-harness.md
+++ b/docs/devlog/2026-05-21-baldwinian-vs-lamarckian-ab-harness.md
@@ -1,126 +1,195 @@
 ---
 layout: page
-title: "Baldwinian vs Lamarckian A/B harness landed (with first smoke run)"
+title: "Baldwinian vs Lamarckian: policy warm-start across three resource regimes"
 ---
 
-Issue [#849](https://github.com/Dooders/AgentFarm/issues/849) asked for an explicit,
-matched Baldwinian-vs-Lamarckian experiment path so we can quantify when
-offspring warm-starting helps and when it destabilizes runs.
+Issue [#849](https://github.com/Dooders/AgentFarm/issues/849) asked for a matched
+A/B path to quantify when offspring policy warm-starting helps and when it
+destabilizes intrinsic-evolution runs. This post reports the full matrix:
+36 paired simulations, one aggregate comparison, and a clear answer on whether
+Lamarckian inheritance is worth turning on under the stable-profile regimes we
+already use elsewhere.
 
-This post is the implementation log plus a first smoke-run snapshot. The full
-36-run matrix is intentionally deferred.
+## What we tested
 
-## What shipped
+Two inheritance modes on the same intrinsic-evolution stack:
 
-The core inheritance toggle is now implemented in the intrinsic evolution path:
+- **Baldwinian** (baseline): offspring inherit the hyperparameter chromosome
+  and start with a fresh decision policy.
+- **Lamarckian** (treatment): same chromosome inheritance, plus a compatible
+  policy warm-start copied from the parent at reproduction.
 
-- `IntrinsicEvolutionPolicy` now supports `inheritance_mode` with:
-  - `baldwinian` (default): child gets fresh decision policy
-  - `lamarckian`: child attempts policy warm-start from parent
-- Reproduction now applies warm-start only when `inheritance_mode=lamarckian`.
-- Warm-start telemetry is persisted in metadata:
-  - `policy_inheritance_metrics.lamarckian_warmstart_applied`
-  - `policy_inheritance_metrics.lamarckian_warmstart_skipped`
+Everything else is held fixed across arms — see the
+[protocol doc](../experiments/intrinsic_evolution/inheritance_mode_ab.md)
+for the full parameter list. Highlights:
 
-New experiment scripts:
+| Knob | Value |
+| --- | --- |
+| Profiles | `conservative`, `balanced`, `buffered` |
+| Seeds | `42`, `7`, `19`, `101`, `137`, `256` |
+| Logged steps | 1000 (200-step warmup) |
+| Crossover | off (isolates inheritance mode) |
+| Selection pressure | low |
+| Speciation | GMM, `max_k=4` |
 
-- `scripts/run_inheritance_mode_ab.py` (arm orchestrator)
-- `scripts/compare_inheritance_arms.py` (paired treatment-vs-baseline analyzer)
+Matrix size: **2 arms × 3 profiles × 6 seeds = 36 runs**.
 
-Runner wiring updates:
+Runner: `scripts/run_inheritance_mode_ab.py`.
+Comparator: `scripts/compare_inheritance_arms.py`.
+Outputs: `experiments/inheritance_ab/` (manifest, per-arm sweeps, aggregate
+summary and plots).
 
-- `scripts/run_stable_profile_seed_sweep.py` now accepts
-  `--inheritance-mode {baldwinian,lamarckian}` and records it in manifests.
+## Headline result
 
-Protocol doc:
+**No robust effect in any profile.** Under the protocol's acceptance gate
+(paired 95% CI excludes zero *and* sign agreement ≥ 75%), Lamarckian
+warm-starting does not earn a regime-wide recommendation — not as a win, not
+as a stability loss, not as a speciation-collapse risk.
 
-- `docs/experiments/intrinsic_evolution/inheritance_mode_ab.md`
+| Profile | Verdict |
+| --- | --- |
+| conservative | no robust effect |
+| balanced | no robust effect |
+| buffered | no robust effect |
 
-## First smoke run (initial result, not a conclusion)
+That is not the same as "nothing happened." Warm-start executed at scale and
+paired runs diverged on population counts. The treatment just did not clear a
+strict small-sample bar on the ecological readouts we score for recommendations.
 
-I ran a minimal A/B smoke to verify behavior and data plumbing:
+## Mechanism coverage
 
-- profiles: `balanced`
-- seeds: `42`
-- steps: `200` (with warmup `200`)
-- total runs: `2` (one per arm)
-- output dir: `experiments/inheritance_ab_smoke/`
+Lamarckian warm-start was active throughout the Lamarckian arm:
 
-Command:
+| Profile | Mean success rate | 95% CI | Applied | Skipped |
+| --- | --- | --- | --- | --- |
+| conservative | 0.852 | [0.838, 0.867] | 3118 | 538 |
+| balanced | 0.849 | [0.836, 0.862] | 3837 | 681 |
+| buffered | 0.849 | [0.835, 0.863] | 3773 | 671 |
 
-```bash
-PYTHONHASHSEED=0 python scripts/run_inheritance_mode_ab.py \
-  --profiles balanced --seeds 42 --num-steps 200 \
-  --output-dir experiments/inheritance_ab_smoke \
-  --disk-database --resume
-```
+Every skip was `incompatible_state` — parent and child policy shapes did not
+match at reproduction time, so those offspring fell back to a cold start.
+`decide_action_failures` were zero in both arms across all 36 runs.
 
-Paired compare command:
+Wall-clock: ~5.5 h per arm (~19.7k s Baldwinian, ~20.2k s Lamarckian). All
+36 runs completed without error.
 
-```bash
-python scripts/compare_inheritance_arms.py \
-  --baseline-dir experiments/inheritance_ab_smoke/baldwinian \
-  --treatment-dir experiments/inheritance_ab_smoke/lamarckian \
-  --arm-labels lamarckian \
-  --output-dir experiments/inheritance_ab_smoke/aggregate
-```
+## Paired deltas (Lamarckian − Baldwinian)
 
-### Observed smoke outputs
+### Performance
 
-- Both runs completed successfully (`1/1` per arm).
-- Runtime:
-  - Baldwinian arm: `341.965s`
-  - Lamarckian arm: `362.731s`
-- Lamarckian inheritance telemetry (seed 42, balanced):
-  - `applied = 182`
-  - `skipped = 39`
-  - warm-start attempt success among recorded outcomes: `~82.4%`
-- Final population at step 200:
-  - Baldwinian: `101`
-  - Lamarckian: `101`
-- Startup transient metrics at this smoke scale were identical in this single
-  seed run (`peak_birth_rate=0.054`, `peak_death_rate=0.0`,
-  `oscillation_amplitude=41`).
+Population is the primary performance readout. Effects are seed-noisy and
+profile-dependent:
+
+**Conservative** — mildly negative on average, mixed by seed:
+
+| Metric | Mean Δ | 95% CI | Sign agreement |
+| --- | --- | --- | --- |
+| population mean | −8.2 | [−19.5, 3.1] | 67% |
+| population final | −6.2 | [−21.5, 9.2] | 67% |
+
+Per-seed final population (Baldwinian → Lamarckian): 74→76 (+2), 64→76 (+12),
+63→31 (−32), 67→62 (−5), 75→67 (−8), 67→61 (−6). Seed 42 alone accounts for
+most of the negative mean.
+
+**Balanced** — the strongest directional signal, still not robust:
+
+| Metric | Mean Δ | 95% CI | Sign agreement |
+| --- | --- | --- | --- |
+| population mean | +6.2 | [−0.4, 12.8] | 83% |
+| population final | +11.8 | [−2.1, 25.8] | 83% |
+
+Five of six seeds gained population (+6 to +27 agents). Seed 7 lost nine
+agents, widening the CI enough to include zero.
+
+Per-seed final population: 97→88 (−9), 72→88 (+16), 67→94 (+27), 60→67 (+7),
+67→91 (+24), 74→80 (+6).
+
+**Buffered** — flat:
+
+| Metric | Mean Δ | 95% CI | Sign agreement |
+| --- | --- | --- | --- |
+| population mean | −3.8 | [−16.8, 9.2] | 50% |
+| population final | 0.0 | [−9.0, 9.0] | 67% |
+
+Per-seed final population: 99→98, 88→86, 105→104, 93→102, 74→83, 95→81 —
+small swings in both directions.
+
+### Stability
+
+Startup death rate was **0.0** in every run for both arms, so the stability-loss
+path never fired. Oscillation amplitude deltas were small and CI-wide in all
+profiles (conservative +3.3, balanced −2.2, buffered −0.3; none robust).
+
+### Diversity
+
+Speciation slope moved slightly positive under conservative (+0.007/100 steps,
+83% sign agreement, CI barely excludes zero) but that metric alone does not
+trigger a recommendation — and the classifier treats *negative* slope as
+collapse risk, not positive. Buffered and balanced speciation deltas were
+essentially flat.
 
 ## How to read this
 
-This smoke run is only a harness check:
+Three layers stack on top of each other:
 
-- It confirms Lamarckian wiring executes in live reproduction and records
-  non-zero warm-start counts.
-- It does **not** support any performance/stability claim yet.
-- Single-seed, single-profile parity is expected to be noisy and underpowered.
+1. **The mechanism works.** ~85% of reproduction events in the Lamarckian arm
+   successfully copied parent policy weights. Arms are not equivalent at the
+   action-selection layer.
 
-## Next step
+2. **Ecological outcomes are a second-order perturbation.** Both arms share
+   the same chromosome inheritance path; decisions combine policy probabilities
+   with chromosome action weights multiplicatively. Inherited weights nudge
+   behavior, but population and speciation are emergent, high-variance
+   summaries — especially with only six paired seeds.
 
-Run the full matched matrix described in the experiment doc:
+3. **The verdict gate is conservative.** Balanced came closest to a Lamarckian
+   performance win (83% sign agreement, mean +12 final population) but one
+   dissenting seed kept the 95% CI straddling zero. Conservative and buffered
+   never approached a clean call.
 
-- 2 arms × 3 profiles × 6 seeds = 36 runs
-- then use `scripts/compare_inheritance_arms.py` on the full outputs.
+Practical takeaway for now: **keep Baldwinian as the default.** Lamarckian
+warm-start adds ~2% wall-clock overhead and ~15% cold-start fallbacks without
+a demonstrated regime-wide payoff on the metrics we care about at this scale.
 
-That full run is where we decide whether warm-starting offspring is worth the
-stability trade-off by regime.
+## What shipped (harness)
 
-## Followup: decision-path defect found and fixed (2026-05-22)
+The experiment path that produced these numbers:
 
-The first full 36-run matrix (`experiments/inheritance_ab_pre_fix/`) completed
-cleanly but produced **byte-identical** Baldwinian and Lamarckian outcomes:
-same metadata, gene trajectories, lineage logs, and all 236k `agent_actions`
-rows per paired seed.
+- `IntrinsicEvolutionPolicy.inheritance_mode`: `baldwinian` | `lamarckian`
+- Reproduction applies warm-start only in Lamarckian mode via
+  `apply_lamarckian_policy_warmstart`
+- Telemetry in run metadata:
+  `policy_inheritance_metrics.lamarckian_warmstart_applied/skipped`
+- `scripts/run_inheritance_mode_ab.py` — orchestrates both arms
+- `scripts/compare_inheritance_arms.py` — paired-seed deltas and verdicts
+- `scripts/run_stable_profile_seed_sweep.py` accepts `--inheritance-mode`
 
-Root cause: `DecisionModule.decide_action` silently swallowed Tianshou
-`predict_proba` failures and fell back to chromosome-only
-`_weighted_random_action`, so copied policy weights never influenced actions.
+To reproduce:
 
-Fix (this change):
+```bash
+PYTHONHASHSEED=0 python scripts/run_inheritance_mode_ab.py \
+  --output-dir experiments/inheritance_ab \
+  --disk-database \
+  --resume
 
-- [`farm/core/decision/algorithms/tianshou.py`](../../farm/core/decision/algorithms/tianshou.py):
-  query `policy.model` / `policy.actor` directly; real softmax `predict_proba`.
-- [`farm/core/decision/decision.py`](../../farm/core/decision/decision.py):
-  always compose `policy_probs × action_weights × enabled_mask`; propagate
-  algorithm errors instead of silent fallback.
-- Regression tests in
-  [`tests/decision/test_decision_policy_sensitivity.py`](../../tests/decision/test_decision_policy_sensitivity.py).
+python scripts/compare_inheritance_arms.py \
+  --baseline-dir experiments/inheritance_ab/baldwinian \
+  --baseline-label baldwinian \
+  --treatment-dir experiments/inheritance_ab/lamarckian \
+  --arm-labels lamarckian \
+  --output-dir experiments/inheritance_ab/aggregate
+```
 
-**The pre-fix aggregate verdict (`no robust effect` across all profiles) is
-invalid.** Re-run the matrix into `experiments/inheritance_ab/` after this fix.
+## Open questions
+
+- **Balanced near-miss:** with more seeds or a longer horizon, does the +12
+  mean final-population delta on balanced consolidate into a robust win?
+- **Conservative seed sensitivity:** is the seed-42 collapse (−32 agents) a
+  genuine Lamarckian failure mode or run noise?
+- **Mechanism-proximal metrics:** offspring fitness in the first *N* steps after
+  birth may show a Lamarckian advantage even when whole-population summaries
+  do not.
+
+Those are follow-ups, not revisions to this aggregate. At n=6 per profile, the
+honest read is: warm-start runs, sometimes helps individual seeds, and does not
+yet justify flipping the default inheritance mode.

--- a/docs/devlog/index.md
+++ b/docs/devlog/index.md
@@ -8,11 +8,11 @@ subtitle: Build notes, design decisions, and experiment outcomes from AgentFarm 
   <li>
     <a class="post-card" href="{{ '/devlog/2026-05-21-baldwinian-vs-lamarckian-ab-harness/' | relative_url }}">
       <span class="post-card__date">2026-05-21</span>
-      <h3 class="post-card__title">Baldwinian vs Lamarckian A/B harness landed</h3>
+      <h3 class="post-card__title">Baldwinian vs Lamarckian: policy warm-start across three resource regimes</h3>
       <p class="post-card__excerpt">
-        Added explicit inheritance mode control to intrinsic evolution, plus
-        new A/B runner and comparator scripts. First smoke run confirms
-        Lamarckian warm-start events are recorded end-to-end.
+        Full 36-run matched matrix (2 arms × 3 profiles × 6 seeds). Lamarckian
+        warm-start applied ~85% of the time and paired runs diverged, but no
+        profile cleared the robustness gate — keep Baldwinian as default for now.
       </p>
       <span class="post-card__more">Read the post</span>
     </a>


### PR DESCRIPTION
- Revised title to reflect focus on policy warm-start across resource regimes.
- Expanded content to include detailed results from a full 36-run matrix, highlighting the lack of robust effects from Lamarckian warm-starting across profiles.
- Updated experiment scripts and telemetry details, confirming warm-start application rates and outcomes.
- Adjusted the devlog index to match the new title and summary of findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only devlog and index copy; no runtime, API, or experiment code changes.
> 
> **Overview**
> **Reframes the Baldwinian vs Lamarckian devlog from a harness/smoke-run log into a full experiment write-up** after the completed **36-run** matched matrix (`experiments/inheritance_ab/`), with a new title focused on policy warm-start across **conservative**, **balanced**, and **buffered** profiles.
> 
> **Adds** protocol context (arms, seeds, steps, crossover off), a **headline verdict** (no profile passes the robustness gate; keep Baldwinian default), **mechanism coverage** (~85% warm-start success, skips as `incompatible_state`), **paired deltas** by profile (population, stability, diversity), interpretation layers, reproduction commands, and **open questions**. **Removes** the 2-run smoke narrative, the “next step: run 36 runs” call, and the long **2026-05-22 decision-path defect / pre-fix invalidation** section (that story stays in the experiment protocol doc, not this post).
> 
> **Updates** the devlog index card title and excerpt to match the new headline and takeaway.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ea82047a2c733a81ce0ed86b75a9d6784b70949. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->