### PR TITLE
Harden determinism test suite

### DIFF
--- a/.github/workflows/deterministic-simulation.yml
+++ b/.github/workflows/deterministic-simulation.yml
@@ -50,6 +50,14 @@ jobs:
         run: |
           timeout 10m python -m pytest -vv -o addopts='' \
             tests/test_deterministic_pytest.py::test_determinism_regression_critical \
+            tests/test_deterministic_pytest.py::test_different_seeds_produce_different_results \
+            --tb=short \
+            --durations=10
+
+      - name: Run cross-process determinism tests
+        run: |
+          timeout 15m python -m pytest -vv -o addopts='' \
+            tests/test_cross_process_determinism.py \
             --tb=short \
             --durations=10
 

--- a/docs/deterministic_simulations.md
+++ b/docs/deterministic_simulations.md
@@ -81,13 +81,19 @@ np.random.seed(42)
 
 ### Testing for Determinism
 
-Use the `deterministic_test.py` script to verify that your simulations are deterministic:
+Use the `tests/test_deterministic.py` script to verify that your simulations are deterministic:
 
 ```bash
-python deterministic_test.py --environment testing --steps 100 --seed 42
+python tests/test_deterministic.py --environment testing --steps 100 --seed 42
 ```
 
-This script runs two identical simulations with the same seed and compares their final states to verify determinism.
+This script runs two identical simulations with the same seed and compares their intermediate state snapshots, final states, and persisted database contents to verify determinism.
+
+For cross-process reproducibility (verifying that results do not depend on per-process state such as `PYTHONHASHSEED`), run:
+
+```bash
+pytest -o addopts='' tests/test_cross_process_determinism.py
+```
 
 ## Common Issues and Solutions
 
@@ -113,7 +119,7 @@ Sometimes enforcing determinism can reduce performance:
 
 1. **Version Your Seeds**: Keep track of which seed was used for which experiment
 2. **Document Dependencies**: Record all external dependencies that might affect determinism
-3. **Test Determinism Regularly**: Use the deterministic_test.py script to verify determinism
+3. **Test Determinism Regularly**: Use the `tests/test_deterministic.py` script to verify determinism
 4. **Save Initial Conditions**: Save the complete initial state to allow future reproduction
 
 ## Advanced Topics
@@ -164,9 +170,9 @@ We recently made several important improvements to ensure complete determinism i
 
 ### 5. Testing for Determinism
 
-We've added a new script `deterministic_test.py` that:
+We've added a script `tests/test_deterministic.py` that:
 - Runs two identical simulations with the same seed
-- Compares their final states to verify determinism
+- Compares intermediate state snapshots, final states, and database contents to verify determinism
 - Provides detailed comparison of any differences
 
 ## Implementation Details
@@ -226,12 +232,12 @@ def update(self):
 You can validate that your changes maintain determinism by running:
 
 ```bash
-python deterministic_test.py --steps 100 --seed 42
+python tests/test_deterministic.py --steps 100 --seed 42
 ```
 
 This script will:
 1. Run two identical simulations with the same seed
-2. Compare their final states
+2. Compare their intermediate snapshots, final states, and database contents
 3. Report whether they are identical
 
 ## Conclusion

--- a/tests/helpers/run_sim_snapshot.py
+++ b/tests/helpers/run_sim_snapshot.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""
+Subprocess helper for cross-process determinism tests.
+
+Runs one simulation with the given seed (relying solely on production seeding via
+``run_simulation(seed=...)``) and writes a JSON snapshot of the final state to the
+given output path. Invoked in a fresh interpreter so that per-process state
+(PYTHONHASHSEED, import order, module caches) cannot be shared between runs.
+"""
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run one simulation and snapshot its final state")
+    parser.add_argument("--environment", type=str, default="testing")
+    parser.add_argument("--steps", type=int, required=True)
+    parser.add_argument("--seed", type=int, required=True)
+    parser.add_argument("--output", type=str, required=True, help="Path to write the JSON state snapshot")
+    args = parser.parse_args()
+
+    from farm.config import SimulationConfig
+    from farm.core.simulation import run_simulation
+    from tests.test_deterministic import capture_simulation_state
+
+    config = SimulationConfig.from_centralized_config(environment=args.environment)
+    config.seed = args.seed
+    config.database.use_in_memory_db = True
+    config.database.persist_db_on_completion = False
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        environment = run_simulation(
+            num_steps=args.steps,
+            config=config,
+            path=temp_dir,
+            save_config=False,
+            seed=args.seed,
+        )
+        try:
+            state = capture_simulation_state(environment)
+        finally:
+            environment.cleanup()
+
+    Path(args.output).write_text(json.dumps(state, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_component_determinism.py
+++ b/tests/test_component_determinism.py
@@ -31,6 +31,20 @@ from farm.config import SimulationConfig
 from tests.conftest import seed_all_rngs, capture_component_state
 
 
+def create_mock_db():
+    """
+    Create a mock simulation database whose genome-id lookups report "not found".
+
+    A bare ``Mock()`` returns truthy Mock objects from ``_execute_in_transaction``,
+    which sends ``Identity.genome_id``'s uniqueness loop into infinite counter
+    probing (and unbounded mock-call recording) once an agent successfully
+    reproduces.
+    """
+    mock_db = Mock()
+    mock_db._execute_in_transaction.return_value = False
+    return mock_db
+
+
 def run_seeded_trajectory(seed, create_agent, steps, record, prepare=None):
     """
     Seed all RNGs once, create an agent, and step it while recording observations.
@@ -148,7 +162,7 @@ class TestResourceComponentDeterminism:
             seed=seed
         )
         with patch("farm.database.utilities.setup_db") as mock_setup_db:
-            mock_setup_db.return_value = Mock()
+            mock_setup_db.return_value = create_mock_db()
             env = Environment(width=50, height=50, resource_distribution={"amount": 10}, config=config)
             
             # Create services from environment
@@ -221,7 +235,7 @@ class TestReproductionComponentDeterminism:
             seed=seed
         )
         with patch("farm.database.utilities.setup_db") as mock_setup_db:
-            mock_setup_db.return_value = Mock()
+            mock_setup_db.return_value = create_mock_db()
             env = Environment(width=50, height=50, resource_distribution={"amount": 10}, config=config)
             
             # Create services from environment
@@ -283,7 +297,7 @@ class TestMovementComponentDeterminism:
             seed=seed
         )
         with patch("farm.database.utilities.setup_db") as mock_setup_db:
-            mock_setup_db.return_value = Mock()
+            mock_setup_db.return_value = create_mock_db()
             env = Environment(width=50, height=50, resource_distribution={"amount": 10}, config=config)
             
             # Create services from environment
@@ -342,7 +356,7 @@ class TestComponentIntegrationDeterminism:
             seed=seed
         )
         with patch("farm.database.utilities.setup_db") as mock_setup_db:
-            mock_setup_db.return_value = Mock()
+            mock_setup_db.return_value = create_mock_db()
             env = Environment(width=50, height=50, resource_distribution={"amount": 10}, config=config)
             
             # Create services from environment

--- a/tests/test_component_determinism.py
+++ b/tests/test_component_determinism.py
@@ -31,6 +31,43 @@ from farm.config import SimulationConfig
 from tests.conftest import seed_all_rngs, capture_component_state
 
 
+def run_seeded_trajectory(seed, create_agent, steps, record, prepare=None):
+    """
+    Seed all RNGs once, create an agent, and step it while recording observations.
+
+    Seeding only once per trajectory (instead of before every step) ensures the
+    test exercises sequential RNG consumption - the way randomness is actually
+    used in a simulation run.
+
+    Parameters
+    ----------
+    seed : int
+        Seed applied once before agent creation
+    create_agent : callable
+        Factory receiving the seed and returning the agent under test
+    steps : int
+        Number of steps to execute
+    record : callable
+        Function mapping the agent to the per-step observation to record
+    prepare : callable, optional
+        Hook invoked with the agent after creation, before stepping
+
+    Returns
+    -------
+    list
+        Per-step observations
+    """
+    seed_all_rngs(seed)
+    agent = create_agent(seed)
+    if prepare is not None:
+        prepare(agent)
+    observations = []
+    for _ in range(steps):
+        agent.step()
+        observations.append(record(agent))
+    return observations
+
+
 @pytest.mark.determinism
 class TestDefaultAgentBehaviorDeterminism:
     """Test deterministic behavior of DefaultAgentBehavior."""
@@ -55,28 +92,21 @@ class TestDefaultAgentBehaviorDeterminism:
         mock_core = Mock()
         mock_core.actions = actions
         
-        # Test with same seed multiple times
+        # Seed once per run so sequential RNG consumption is actually exercised;
+        # re-seeding before every draw would just repeat the same draw 20 times.
         seed_all_rngs(deterministic_seed)
         behavior1 = DefaultAgentBehavior()
-        
+        actions1 = [behavior1.decide_action(mock_core, None, None).name for _ in range(20)]
+
         seed_all_rngs(deterministic_seed)
         behavior2 = DefaultAgentBehavior()
-        
-        # Generate action sequences
-        actions1 = []
-        actions2 = []
-        
-        for _ in range(20):
-            seed_all_rngs(deterministic_seed)
-            action1 = behavior1.decide_action(mock_core, None, None)
-            actions1.append(action1.name)
-            
-            seed_all_rngs(deterministic_seed)
-            action2 = behavior2.decide_action(mock_core, None, None)
-            actions2.append(action2.name)
-        
+        actions2 = [behavior2.decide_action(mock_core, None, None).name for _ in range(20)]
+
         # Action sequences should be identical (weighted selection is deterministic with same seed)
         assert actions1 == actions2, "DefaultAgentBehavior action selection is not deterministic"
+        # Sanity check: the sequence should contain multiple distinct actions, otherwise
+        # this test would pass trivially for a constant-action behavior.
+        assert len(set(actions1)) > 1, "Expected a varied action sequence from weighted selection"
     
     def test_action_history_consistency(self, deterministic_seed):
         """Test that action history is consistent across runs."""
@@ -90,23 +120,17 @@ class TestDefaultAgentBehaviorDeterminism:
             Action("attack", 0.3, Mock()),
         ]
         
-        # Create two behaviors with same seed
+        # Seed once per run so sequential RNG consumption is actually exercised.
         seed_all_rngs(deterministic_seed)
         behavior1 = DefaultAgentBehavior()
-        
+        for _ in range(10):
+            behavior1.decide_action(None, None, actions)
+
         seed_all_rngs(deterministic_seed)
         behavior2 = DefaultAgentBehavior()
-        
-        # Execute same sequence of actions
         for _ in range(10):
-            seed_all_rngs(deterministic_seed)
-            action1 = behavior1.decide_action(None, None, actions)
-            
-            seed_all_rngs(deterministic_seed)
-            action2 = behavior2.decide_action(None, None, actions)
-            
-            assert action1 == action2, "Actions should be identical with same seed"
-        
+            behavior2.decide_action(None, None, actions)
+
         # Action histories should be identical
         assert behavior1.action_history == behavior2.action_history, "Action histories should be identical"
 
@@ -157,54 +181,31 @@ class TestResourceComponentDeterminism:
     
     def test_resource_consumption_determinism(self, deterministic_seed):
         """Test that resource consumption is deterministic."""
-        # Create two agents with same seed
-        seed_all_rngs(deterministic_seed)
-        agent1 = self.create_test_agent(deterministic_seed)
-        
-        seed_all_rngs(deterministic_seed)
-        agent2 = self.create_test_agent(deterministic_seed)
-        
-        # Execute same number of steps
-        for _ in range(10):
-            seed_all_rngs(deterministic_seed)
-            agent1.step()
-            
-            seed_all_rngs(deterministic_seed)
-            agent2.step()
-        
-        # Resource levels should be identical
-        resource_comp1 = agent1.get_component("resource")
-        resource_comp2 = agent2.get_component("resource")
-        
-        assert resource_comp1.level == resource_comp2.level, "Resource levels should be identical"
-        assert resource_comp1.starvation_counter == resource_comp2.starvation_counter, "Starvation counters should be identical"
-    
+        def record(agent):
+            resource = agent.get_component("resource")
+            return (resource.level, resource.starvation_counter)
+
+        series1 = run_seeded_trajectory(deterministic_seed, self.create_test_agent, 10, record)
+        series2 = run_seeded_trajectory(deterministic_seed, self.create_test_agent, 10, record)
+
+        assert series1 == series2, "Resource consumption should be deterministic"
+
     def test_starvation_counter_determinism(self, deterministic_seed):
         """Test that starvation counter updates are deterministic."""
-        # Create agents with low initial resources
-        seed_all_rngs(deterministic_seed)
-        agent1 = self.create_test_agent(deterministic_seed)
-        agent1.get_component("resource").level = 1.0  # Low resources
-        
-        seed_all_rngs(deterministic_seed)
-        agent2 = self.create_test_agent(deterministic_seed)
-        agent2.get_component("resource").level = 1.0  # Low resources
-        
-        # Execute steps and track starvation counter
-        starvation_counts1 = []
-        starvation_counts2 = []
-        
-        for _ in range(15):
-            seed_all_rngs(deterministic_seed)
-            agent1.step()
-            starvation_counts1.append(agent1.get_component("resource").starvation_counter)
-            
-            seed_all_rngs(deterministic_seed)
-            agent2.step()
-            starvation_counts2.append(agent2.get_component("resource").starvation_counter)
-        
-        # Starvation counters should be identical
-        assert starvation_counts1 == starvation_counts2, "Starvation counter updates should be deterministic"
+        def set_low_resources(agent):
+            agent.get_component("resource").level = 1.0
+
+        def record(agent):
+            return agent.get_component("resource").starvation_counter
+
+        series1 = run_seeded_trajectory(
+            deterministic_seed, self.create_test_agent, 15, record, prepare=set_low_resources
+        )
+        series2 = run_seeded_trajectory(
+            deterministic_seed, self.create_test_agent, 15, record, prepare=set_low_resources
+        )
+
+        assert series1 == series2, "Starvation counter updates should be deterministic"
 
 
 @pytest.mark.determinism
@@ -250,53 +251,23 @@ class TestReproductionComponentDeterminism:
     
     def test_offspring_creation_determinism(self, deterministic_seed):
         """Test that offspring creation is deterministic."""
-        # Create two agents with same seed
-        seed_all_rngs(deterministic_seed)
-        agent1 = self.create_test_agent(deterministic_seed)
-        
-        seed_all_rngs(deterministic_seed)
-        agent2 = self.create_test_agent(deterministic_seed)
-        
-        # Execute same number of steps
-        offspring_counts1 = []
-        offspring_counts2 = []
-        
-        for _ in range(20):
-            seed_all_rngs(deterministic_seed)
-            agent1.step()
-            offspring_counts1.append(agent1.get_component("reproduction").offspring_created)
-            
-            seed_all_rngs(deterministic_seed)
-            agent2.step()
-            offspring_counts2.append(agent2.get_component("reproduction").offspring_created)
-        
-        # Offspring counts should be identical
-        assert offspring_counts1 == offspring_counts2, "Offspring creation should be deterministic"
-    
+        def record(agent):
+            return agent.get_component("reproduction").offspring_created
+
+        series1 = run_seeded_trajectory(deterministic_seed, self.create_test_agent, 20, record)
+        series2 = run_seeded_trajectory(deterministic_seed, self.create_test_agent, 20, record)
+
+        assert series1 == series2, "Offspring creation should be deterministic"
+
     def test_reproduction_cooldown_determinism(self, deterministic_seed):
         """Test that reproduction cooldown is deterministic."""
-        # Create agents
-        seed_all_rngs(deterministic_seed)
-        agent1 = self.create_test_agent(deterministic_seed)
-        
-        seed_all_rngs(deterministic_seed)
-        agent2 = self.create_test_agent(deterministic_seed)
-        
-        # Track cooldown values
-        cooldowns1 = []
-        cooldowns2 = []
-        
-        for _ in range(15):
-            seed_all_rngs(deterministic_seed)
-            agent1.step()
-            cooldowns1.append(getattr(agent1.get_component("reproduction"), "reproduction_cooldown", 0))
-            
-            seed_all_rngs(deterministic_seed)
-            agent2.step()
-            cooldowns2.append(getattr(agent2.get_component("reproduction"), "reproduction_cooldown", 0))
-        
-        # Cooldown values should be identical
-        assert cooldowns1 == cooldowns2, "Reproduction cooldown should be deterministic"
+        def record(agent):
+            return getattr(agent.get_component("reproduction"), "reproduction_cooldown", 0)
+
+        series1 = run_seeded_trajectory(deterministic_seed, self.create_test_agent, 15, record)
+        series2 = run_seeded_trajectory(deterministic_seed, self.create_test_agent, 15, record)
+
+        assert series1 == series2, "Reproduction cooldown should be deterministic"
 
 
 @pytest.mark.determinism
@@ -342,52 +313,19 @@ class TestMovementComponentDeterminism:
     
     def test_movement_target_selection_determinism(self, deterministic_seed):
         """Test that movement target selection is deterministic."""
-        # Create two agents with same seed
-        seed_all_rngs(deterministic_seed)
-        agent1 = self.create_test_agent(deterministic_seed)
-        
-        seed_all_rngs(deterministic_seed)
-        agent2 = self.create_test_agent(deterministic_seed)
-        
-        # Track positions over time
-        positions1 = []
-        positions2 = []
-        
-        for _ in range(15):
-            seed_all_rngs(deterministic_seed)
-            agent1.step()
-            positions1.append(agent1.position)
-            
-            seed_all_rngs(deterministic_seed)
-            agent2.step()
-            positions2.append(agent2.position)
-        
-        # Positions should be identical
+        positions1 = run_seeded_trajectory(deterministic_seed, self.create_test_agent, 15, lambda a: a.position)
+        positions2 = run_seeded_trajectory(deterministic_seed, self.create_test_agent, 15, lambda a: a.position)
+
         assert positions1 == positions2, "Movement should be deterministic"
-    
+
     def test_movement_component_state_determinism(self, deterministic_seed):
         """Test that movement component internal state is deterministic."""
-        # Create agents
-        seed_all_rngs(deterministic_seed)
-        agent1 = self.create_test_agent(deterministic_seed)
-        
-        seed_all_rngs(deterministic_seed)
-        agent2 = self.create_test_agent(deterministic_seed)
-        
-        # Execute steps and capture component states
-        states1 = []
-        states2 = []
-        
-        for _ in range(10):
-            seed_all_rngs(deterministic_seed)
-            agent1.step()
-            states1.append(capture_component_state(agent1.get_component("movement")))
-            
-            seed_all_rngs(deterministic_seed)
-            agent2.step()
-            states2.append(capture_component_state(agent2.get_component("movement")))
-        
-        # Component states should be identical
+        def record(agent):
+            return capture_component_state(agent.get_component("movement"))
+
+        states1 = run_seeded_trajectory(deterministic_seed, self.create_test_agent, 10, record)
+        states2 = run_seeded_trajectory(deterministic_seed, self.create_test_agent, 10, record)
+
         assert states1 == states2, "Movement component states should be deterministic"
 
 
@@ -440,51 +378,20 @@ class TestComponentIntegrationDeterminism:
     
     def test_multi_component_determinism(self, deterministic_seed):
         """Test that multiple components work deterministically together."""
-        # Create two agents with same seed
-        seed_all_rngs(deterministic_seed)
-        agent1 = self.create_full_agent(deterministic_seed)
-        
-        seed_all_rngs(deterministic_seed)
-        agent2 = self.create_full_agent(deterministic_seed)
-        
-        # Track comprehensive state over time
-        states1 = []
-        states2 = []
-        
-        for step in range(20):
-            seed_all_rngs(deterministic_seed)
-            agent1.step()
-            
-            # Capture comprehensive state
-            state1 = {
-                "position": agent1.position,
-                "resource_level": agent1.resource_level,
-                "alive": agent1.alive,
-                "components": {}
+        def record(agent):
+            return {
+                "position": agent.position,
+                "resource_level": agent.resource_level,
+                "alive": agent.alive,
+                "components": {
+                    name: capture_component_state(component)
+                    for name, component in agent._components.items()
+                },
             }
-            
-            for name, component in agent1._components.items():
-                state1["components"][name] = capture_component_state(component)
-            
-            states1.append(state1)
-            
-            seed_all_rngs(deterministic_seed)
-            agent2.step()
-            
-            # Capture comprehensive state
-            state2 = {
-                "position": agent2.position,
-                "resource_level": agent2.resource_level,
-                "alive": agent2.alive,
-                "components": {}
-            }
-            
-            for name, component in agent2._components.items():
-                state2["components"][name] = capture_component_state(component)
-            
-            states2.append(state2)
-        
-        # States should be identical
+
+        states1 = run_seeded_trajectory(deterministic_seed, self.create_full_agent, 20, record)
+        states2 = run_seeded_trajectory(deterministic_seed, self.create_full_agent, 20, record)
+
         assert states1 == states2, "Multi-component integration should be deterministic"
 
 

--- a/tests/test_cross_process_determinism.py
+++ b/tests/test_cross_process_determinism.py
@@ -1,0 +1,82 @@
+"""
+Cross-process determinism tests.
+
+In-process A/B comparisons cannot detect nondeterminism that depends on
+per-process interpreter state: both runs share the same hash randomization seed
+(PYTHONHASHSEED), import order, and warmed caches. These tests run each
+simulation in a fresh subprocess - deliberately with *different* PYTHONHASHSEED
+values - so that any dependence on dict/set hash ordering or other per-process
+state shows up as a state mismatch.
+
+The subprocesses do not pre-seed RNGs; reproducibility must come entirely from
+``run_simulation(seed=...)``.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.determinism]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HELPER_SCRIPT = REPO_ROOT / "tests" / "helpers" / "run_sim_snapshot.py"
+SUBPROCESS_TIMEOUT_SECONDS = 300
+
+
+def _run_simulation_in_subprocess(output_path: Path, seed: int, steps: int, hash_seed: str) -> dict:
+    """Run one simulation in a fresh interpreter and return its final state snapshot."""
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = hash_seed
+    env["PYTHONPATH"] = str(REPO_ROOT)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(HELPER_SCRIPT),
+            "--environment", "testing",
+            "--steps", str(steps),
+            "--seed", str(seed),
+            "--output", str(output_path),
+        ],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=SUBPROCESS_TIMEOUT_SECONDS,
+    )
+    assert result.returncode == 0, (
+        f"Simulation subprocess failed (PYTHONHASHSEED={hash_seed}):\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    return json.loads(output_path.read_text())
+
+
+def test_cross_process_repeatability_under_hash_randomization(tmp_path):
+    """Same seed in two fresh processes with different PYTHONHASHSEED must match."""
+    seed = 42
+    steps = 25
+
+    state1 = _run_simulation_in_subprocess(tmp_path / "run1.json", seed=seed, steps=steps, hash_seed="1")
+    state2 = _run_simulation_in_subprocess(tmp_path / "run2.json", seed=seed, steps=steps, hash_seed="2")
+
+    assert state1 == state2, (
+        "Simulation results differ across processes with different PYTHONHASHSEED values - "
+        "behavior likely depends on dict/set hash ordering or other per-process state"
+    )
+
+
+def test_cross_process_seed_sensitivity(tmp_path):
+    """Different seeds in fresh processes must produce different results."""
+    steps = 25
+
+    state1 = _run_simulation_in_subprocess(tmp_path / "seed_a.json", seed=42, steps=steps, hash_seed="0")
+    state2 = _run_simulation_in_subprocess(tmp_path / "seed_b.json", seed=1042, steps=steps, hash_seed="0")
+
+    assert state1 != state2, (
+        "Two different seeds produced identical final states - "
+        "the seed is likely not plumbed through to the simulation"
+    )

--- a/tests/test_deterministic.py
+++ b/tests/test_deterministic.py
@@ -442,8 +442,11 @@ def run_determinism_test(environment, num_steps, seed=42, snapshot_steps=None):
 
     state_deterministic = hash1 == hash2
 
-    # Compare intermediate snapshots
-    snapshots_deterministic = snapshots1 == snapshots2
+    # Compare intermediate snapshots (require every requested step to be captured)
+    snapshots_deterministic = all(
+        step in snapshots1 and step in snapshots2 and snapshots1[step] == snapshots2[step]
+        for step in snapshot_steps
+    )
     if not snapshots_deterministic:
         print("\n❌ Intermediate state snapshots diverge:")
         for step in snapshot_steps:

--- a/tests/test_deterministic.py
+++ b/tests/test_deterministic.py
@@ -4,56 +4,65 @@ Script to test determinism in the AgentFarm simulation.
 This will run two identical simulations and compare their outcomes to validate determinism.
 
 This module can be used both as a standalone CLI script and imported by pytest tests.
+
+Note: this harness deliberately does NOT pre-seed any RNGs itself. Reproducibility
+must come entirely from ``run_simulation(seed=...)`` so that a regression in the
+production seeding path (``init_random_seeds`` / ``Environment`` seeding) is caught
+here instead of being masked by test-side seeding.
 """
 
 import argparse
 import hashlib
 import json
-import numpy as np
 import os
-import random
-import torch
 from datetime import datetime
 
 from farm.config import SimulationConfig
 from farm.core.simulation import run_simulation
-from tests.conftest import seed_all_rngs
+
+# Columns whose values are allowed to differ between two otherwise identical runs.
+# module_id: object references can vary; simulation_db_path: absolute path to this run's DB file.
+ACCEPTABLE_DIFFERENCE_COLUMNS = frozenset(
+    {"start_time", "end_time", "created_at", "updated_at", "timestamp", "module_id", "simulation_db_path"}
+)
+
+# Number of rows fetched per chunk when comparing database tables.
+ROW_CHUNK_SIZE = 5000
 
 
-def get_simulation_state_hash(environment, debug=False):
+def capture_simulation_state(environment):
     """
-    Generate a hash of the current simulation state to check for equality.
+    Capture a deterministic, JSON-serializable snapshot of the simulation state.
 
     Parameters
     ----------
     environment : Environment
-        The simulation environment to hash
-    debug : bool, optional
-        Whether to print detailed debug information, by default False
+        The simulation environment to snapshot
 
     Returns
     -------
-    str
-        Hash of the state as a hex string
+    dict
+        Serializable state snapshot
     """
-    # Dictionary to hold all relevant state
     state = {
         "time": environment.time,
         "agents": [],
         "resources": [],
-        "spatial_index_state": None
+        "spatial_index_state": None,
     }
 
     # Capture spatial index state if available
-    if hasattr(environment, 'spatial_index') and environment.spatial_index:
+    if hasattr(environment, "spatial_index") and environment.spatial_index:
         try:
             # Get all agent positions in sorted order for deterministic spatial state
             agent_positions = []
             for agent in sorted(environment._agent_objects.values(), key=lambda a: a.agent_id):
-                agent_positions.append({
-                    "agent_id": agent.agent_id,
-                    "position": agent.position
-                })
+                agent_positions.append(
+                    {
+                        "agent_id": agent.agent_id,
+                        "position": agent.position,
+                    }
+                )
             state["spatial_index_state"] = agent_positions
         except Exception:
             state["spatial_index_state"] = None
@@ -68,185 +77,201 @@ def get_simulation_state_hash(environment, debug=False):
             "alive": agent.alive,
             "generation": agent.generation,
             "components": {},
-            "action_history": []
+            "action_history": [],
         }
 
         # Capture component states for high-risk components
-        if hasattr(agent, '_components'):
+        if hasattr(agent, "_components"):
             for name, component in agent._components.items():
-                if name in ["movement", "resource", "reproduction"]:
-                    component_state = {}
-                    
-                    # Resource component state
-                    if name == "resource":
-                        component_state.update({
-                            "level": getattr(component, "level", None),
-                            "starvation_counter": getattr(component, "starvation_counter", None),
-                        })
-                    
-                    # Movement component state
-                    elif name == "movement":
-                        component_state.update({
-                            "target_position": getattr(component, "target_position", None),
-                            "last_position": getattr(component, "last_position", None),
-                        })
-                    
-                    # Reproduction component state
-                    elif name == "reproduction":
-                        component_state.update({
-                            "offspring_created": getattr(component, "offspring_created", None),
-                            "reproduction_cooldown": getattr(component, "reproduction_cooldown", None),
-                        })
-                    
-                    agent_state["components"][name] = component_state
+                if name == "resource":
+                    agent_state["components"][name] = {
+                        "level": getattr(component, "level", None),
+                        "starvation_counter": getattr(component, "starvation_counter", None),
+                    }
+                elif name == "movement":
+                    agent_state["components"][name] = {
+                        "target_position": getattr(component, "target_position", None),
+                        "last_position": getattr(component, "last_position", None),
+                    }
+                elif name == "reproduction":
+                    agent_state["components"][name] = {
+                        "offspring_created": getattr(component, "offspring_created", None),
+                        "reproduction_cooldown": getattr(component, "reproduction_cooldown", None),
+                    }
 
-        # Capture behavior action history
-        if hasattr(agent, 'behavior') and hasattr(agent.behavior, 'action_history'):
-            # Keep last 10 actions for determinism testing
+        # Capture behavior action history (last 10 actions)
+        if hasattr(agent, "behavior") and hasattr(agent.behavior, "action_history"):
             agent_state["action_history"] = agent.behavior.action_history[-10:]
 
         state["agents"].append(agent_state)
 
     # Sort resources by ID for consistency
     for resource in sorted(environment.resources, key=lambda r: r.resource_id):
-        resource_state = {
-            "id": resource.resource_id,
-            "position": resource.position,
-            "amount": resource.amount
-        }
-        state["resources"].append(resource_state)
+        state["resources"].append(
+            {
+                "id": resource.resource_id,
+                "position": resource.position,
+                "amount": resource.amount,
+            }
+        )
 
-    # Convert to JSON and hash it
+    return state
+
+
+def hash_simulation_state(state):
+    """Hash a state snapshot produced by :func:`capture_simulation_state`."""
     state_json = json.dumps(state, sort_keys=True)
-    state_hash = hashlib.sha256(state_json.encode()).hexdigest()
+    return hashlib.sha256(state_json.encode()).hexdigest()
 
-    if debug:
-        print(f"Time: {state['time']}")
-        print(f"Number of agents: {len(state['agents'])}")
-        print(f"Number of resources: {len(state['resources'])}")
-        print(f"Spatial index state captured: {state['spatial_index_state'] is not None}")
-        # Print the first agent and resource for debugging
-        if state['agents']:
-            print(f"First agent: {state['agents'][0]}")
-        if state['resources']:
-            print(f"First resource: {state['resources'][0]}")
 
-    return state_hash, state if debug else state_hash
+def get_simulation_state_hash(environment):
+    """
+    Generate a hash of the current simulation state to check for equality.
+
+    Parameters
+    ----------
+    environment : Environment
+        The simulation environment to hash
+
+    Returns
+    -------
+    str
+        SHA-256 hash of the state as a hex string
+    """
+    return hash_simulation_state(capture_simulation_state(environment))
+
+
+def _print_state_summary(state):
+    """Print a short summary of a captured state snapshot."""
+    print(f"Time: {state['time']}")
+    print(f"Number of agents: {len(state['agents'])}")
+    print(f"Number of resources: {len(state['resources'])}")
+    print(f"Spatial index state captured: {state['spatial_index_state'] is not None}")
+    if state["agents"]:
+        print(f"First agent: {state['agents'][0]}")
+    if state["resources"]:
+        print(f"First resource: {state['resources'][0]}")
+
+
+def _rows_match(row1, row2, col_names):
+    """
+    Compare two table rows, tolerating differences in acceptable columns.
+
+    Returns
+    -------
+    tuple
+        (match, differences) where differences lists (col_name, val1, val2)
+        for non-acceptable mismatches.
+    """
+    differences = []
+    for j, (col1, col2) in enumerate(zip(row1, row2)):
+        if col1 != col2:
+            col_name = col_names[j] if j < len(col_names) else f"column_{j}"
+            if col_name not in ACCEPTABLE_DIFFERENCE_COLUMNS:
+                differences.append((col_name, col1, col2))
+    return not differences, differences
+
+
+def _compare_table(session1, session2, table):
+    """
+    Compare one table between two databases, chunk by chunk.
+
+    Returns True if the tables match (ignoring acceptable columns), False otherwise.
+    """
+    from sqlalchemy import text
+
+    count1 = session1.execute(text(f"SELECT COUNT(*) FROM {table}")).scalar()
+    count2 = session2.execute(text(f"SELECT COUNT(*) FROM {table}")).scalar()
+
+    if count1 != count2:
+        print(f"Row count mismatch in {table}: {count1} vs {count2}")
+        return False
+
+    col_info = session1.execute(text(f"PRAGMA table_info({table})")).fetchall()
+    col_names = [row[1] for row in col_info]  # Column name is in index 1
+
+    mismatches_reported = 0
+    table_matches = True
+    for offset in range(0, count1, ROW_CHUNK_SIZE):
+        chunk_query = text(f"SELECT * FROM {table} ORDER BY rowid LIMIT :limit OFFSET :offset")
+        params = {"limit": ROW_CHUNK_SIZE, "offset": offset}
+        data1 = session1.execute(chunk_query, params).fetchall()
+        data2 = session2.execute(chunk_query, params).fetchall()
+
+        if data1 == data2:
+            continue
+
+        for i, (row1, row2) in enumerate(zip(data1, data2)):
+            if row1 == row2:
+                continue
+            match, differences = _rows_match(row1, row2, col_names)
+            if not match:
+                table_matches = False
+                mismatches_reported += 1
+                if mismatches_reported <= 5:
+                    print(f"  Row {offset + i}: Non-acceptable differences found:")
+                    for col_name, val1, val2 in differences:
+                        print(f"    {col_name}: {val1} vs {val2}")
+                else:
+                    print("  ... further differences suppressed")
+                    return False
+
+    return table_matches
 
 
 def compare_database_contents(db1_path, db2_path):
     """
     Compare database contents between two simulation runs.
     Ignores timestamp differences in simulation records as these are expected.
-    
+
     Parameters
     ----------
     db1_path : str
         Path to first simulation database
     db2_path : str
         Path to second simulation database
-        
+
     Returns
     -------
     bool
-        True if databases are mostly identical (ignoring timestamps), False otherwise
+        True if databases are identical (ignoring acceptable columns), False otherwise
     """
     try:
         from sqlalchemy import create_engine, text
         from sqlalchemy.orm import sessionmaker
-        
-        # Create database connections
+
         engine1 = create_engine(f"sqlite:///{db1_path}")
         engine2 = create_engine(f"sqlite:///{db2_path}")
-        
+
         Session1 = sessionmaker(bind=engine1)
         Session2 = sessionmaker(bind=engine2)
-        
+
         with Session1() as session1, Session2() as session2:
-            # Get list of tables
             tables_query = text("SELECT name FROM sqlite_master WHERE type='table'")
             tables1 = [row[0] for row in session1.execute(tables_query).fetchall()]
             tables2 = [row[0] for row in session2.execute(tables_query).fetchall()]
-            
+
             if set(tables1) != set(tables2):
                 print(f"Table mismatch: {set(tables1)} vs {set(tables2)}")
                 return False
-            
-            # Compare each table
+
             for table in tables1:
-                if table.startswith('sqlite_'):
+                if table.startswith("sqlite_"):
                     continue  # Skip system tables
-                    
-                # Get row counts
-                count1 = session1.execute(text(f"SELECT COUNT(*) FROM {table}")).scalar()
-                count2 = session2.execute(text(f"SELECT COUNT(*) FROM {table}")).scalar()
-                
-                if count1 != count2:
-                    print(f"Row count mismatch in {table}: {count1} vs {count2}")
+                if not _compare_table(session1, session2, table):
+                    print(f"❌ Table {table} differs between runs")
                     return False
-                
-                # Compare actual data (for smaller tables)
-                if count1 < 10000:  # Only compare small tables to avoid memory issues
-                    data1 = session1.execute(text(f"SELECT * FROM {table} ORDER BY rowid")).fetchall()
-                    data2 = session2.execute(text(f"SELECT * FROM {table} ORDER BY rowid")).fetchall()
-                    
-                    if data1 != data2:
-                        print(f"Data mismatch in table {table} (checking if only timestamps differ)...")
-                        # Get column names once
-                        col_info = session1.execute(text(f"PRAGMA table_info({table})")).fetchall()
-                        col_names = [row[1] for row in col_info]  # Column name is in index 1
-                        timestamp_cols = {'start_time', 'end_time', 'created_at', 'updated_at', 'timestamp'}
-                        # module_id: object references can vary; simulation_db_path: absolute path to this run's DB file
-                        acceptable_difference_cols = timestamp_cols | {'module_id', 'simulation_db_path'}
-                        
-                        # Check each row for differences
-                        all_timestamp_diffs = True
-                        for i, (row1, row2) in enumerate(zip(data1, data2)):
-                            if row1 != row2:
-                                # Check if the only difference is in timestamp columns
-                                differences = []
-                                for j, (col1, col2) in enumerate(zip(row1, row2)):
-                                    if col1 != col2:
-                                        col_name = col_names[j] if j < len(col_names) else f"column_{j}"
-                                        differences.append((col_name, col1, col2))
-                                
-                                # Check if all differences are acceptable (timestamps or module_id)
-                                if differences:
-                                    if all(col_name in acceptable_difference_cols for col_name, _, _ in differences):
-                                        print(
-                                            f"  Row {i}: Only acceptable differences detected "
-                                            "(timestamps, module_id, simulation_db_path)"
-                                        )
-                                    else:
-                                        print(f"  Row {i}: Non-acceptable differences found:")
-                                        for col_name, val1, val2 in differences:
-                                            print(f"    {col_name}: {val1} vs {val2}")
-                                        all_timestamp_diffs = False
-                                        if i > 5:  # Limit output
-                                            print(f"  ... and {len(data1) - i - 1} more differences")
-                                            break
-                        
-                        if all_timestamp_diffs:
-                            print(
-                                f"✅ Table {table} differences are only acceptable "
-                                "(timestamps, module_id, simulation_db_path)"
-                            )
-                            # Continue to next table - don't return False
-                        else:
-                            return False
-                else:
-                    print(f"Skipping large table {table} ({count1} rows) - using row count only")
-            
-            print("✅ Database contents are mostly identical (timestamp differences ignored)")
+
+            print("✅ Database contents are identical (acceptable column differences ignored)")
             return True
-            
+
     except Exception as e:
         print(f"Error comparing databases: {e}")
         return False
     finally:
-        if 'engine1' in locals():
+        if "engine1" in locals():
             engine1.dispose()
-        if 'engine2' in locals():
+        if "engine2" in locals():
             engine2.dispose()
 
 
@@ -308,9 +333,33 @@ def compare_states(state1, state2):
         print(f"... and {resource_diffs - 3} more resource differences")
 
 
-def run_determinism_test(environment, num_steps, seed=42, use_snapshot_steps=None):
+def _make_snapshot_recorder(snapshot_steps, snapshots):
+    """
+    Build an ``on_step_end`` hook that records state hashes at the given step numbers.
+
+    Parameters
+    ----------
+    snapshot_steps : list of int
+        1-based step numbers at which to record a state hash
+    snapshots : dict
+        Output mapping of step number -> state hash, filled in during the run
+    """
+    target_steps = set(snapshot_steps)
+
+    def on_step_end(environment, step_index):
+        step_number = step_index + 1
+        if step_number in target_steps:
+            snapshots[step_number] = get_simulation_state_hash(environment)
+
+    return on_step_end
+
+
+def run_determinism_test(environment, num_steps, seed=42, snapshot_steps=None):
     """
     Run two identical simulations with the same seed and compare their results.
+
+    Reproducibility relies solely on ``run_simulation(seed=...)``; this harness
+    intentionally performs no RNG seeding of its own.
 
     Parameters
     ----------
@@ -320,8 +369,9 @@ def run_determinism_test(environment, num_steps, seed=42, use_snapshot_steps=Non
         Number of simulation steps to run
     seed : int
         Seed value to use for both simulations
-    use_snapshot_steps : list, optional
-        List of step numbers to take snapshots at for comparison
+    snapshot_steps : list, optional
+        1-based step numbers at which to compare intermediate state hashes.
+        Defaults to the start, middle, and end of the simulation.
 
     Returns
     -------
@@ -329,9 +379,6 @@ def run_determinism_test(environment, num_steps, seed=42, use_snapshot_steps=Non
         True if the simulations were deterministic, False otherwise
     """
     print(f"Starting determinism test with seed {seed}")
-
-    # Set fixed seeds for all random generators
-    seed_all_rngs(seed)
 
     # Load configuration
     config = SimulationConfig.from_centralized_config(environment=environment)
@@ -345,32 +392,28 @@ def run_determinism_test(environment, num_steps, seed=42, use_snapshot_steps=Non
     # Increase memory limit for longer simulations to avoid memory warnings
     config.database.in_memory_db_memory_limit_mb = 5000  # 5GB limit
 
-    # Snapshot steps for comparison
-    if use_snapshot_steps is None:
+    if snapshot_steps is None:
         # Take snapshots at the start, middle, and end of the simulation
         snapshot_steps = [1, num_steps // 2, num_steps]
-    else:
-        snapshot_steps = use_snapshot_steps
+    snapshot_steps = sorted({step for step in snapshot_steps if 1 <= step <= num_steps})
 
     # Use fixed simulation IDs for both runs to ensure database files have predictable names
     fixed_simulation_id = f"determinism_test_{seed}_{num_steps}"
-    
+
     # Run first simulation
     print("Running first simulation...")
     sim_dir_1 = f"simulations/determinism_test_{datetime.now().strftime('%Y%m%d_%H%M%S')}_1"
     os.makedirs(sim_dir_1, exist_ok=True)
 
-    # Reset seeds again to ensure same initial state
-    seed_all_rngs(seed)
-
-    # Run first simulation and capture state snapshots
+    snapshots1 = {}
     env1 = run_simulation(
         num_steps=num_steps,
         config=config,
         path=sim_dir_1,
         save_config=True,
         seed=seed,
-        simulation_id=fixed_simulation_id
+        simulation_id=fixed_simulation_id,
+        on_step_end=_make_snapshot_recorder(snapshot_steps, snapshots1),
     )
 
     # Run second simulation
@@ -378,52 +421,61 @@ def run_determinism_test(environment, num_steps, seed=42, use_snapshot_steps=Non
     sim_dir_2 = f"simulations/determinism_test_{datetime.now().strftime('%Y%m%d_%H%M%S')}_2"
     os.makedirs(sim_dir_2, exist_ok=True)
 
-    # Reset seeds again
-    seed_all_rngs(seed)
-
-    # Run second simulation with the same simulation ID
+    snapshots2 = {}
     env2 = run_simulation(
         num_steps=num_steps,
         config=config,
         path=sim_dir_2,
         save_config=True,
         seed=seed,
-        simulation_id=fixed_simulation_id
+        simulation_id=fixed_simulation_id,
+        on_step_end=_make_snapshot_recorder(snapshot_steps, snapshots2),
     )
 
     # Compare final states
-    hash1, state1 = get_simulation_state_hash(env1, debug=True)
-    hash2, state2 = get_simulation_state_hash(env2, debug=True)
+    state1 = capture_simulation_state(env1)
+    state2 = capture_simulation_state(env2)
+    _print_state_summary(state1)
+    _print_state_summary(state2)
+    hash1 = hash_simulation_state(state1)
+    hash2 = hash_simulation_state(state2)
 
     state_deterministic = hash1 == hash2
 
-    # Compare database contents if databases were persisted
-    db_deterministic = True
-    if config.database.persist_db_on_completion:
-        print("\nComparing database contents...")
-        # Use the fixed simulation ID for both database paths
-        db1_path = os.path.join(sim_dir_1, f"simulation_{fixed_simulation_id}.db")
-        db2_path = os.path.join(sim_dir_2, f"simulation_{fixed_simulation_id}.db")
-        
-        # Debug: List files in simulation directories
-        print("Looking for database files:")
-        print(f"  DB1 path: {db1_path}")
-        print(f"  DB2 path: {db2_path}")
+    # Compare intermediate snapshots
+    snapshots_deterministic = snapshots1 == snapshots2
+    if not snapshots_deterministic:
+        print("\n❌ Intermediate state snapshots diverge:")
+        for step in snapshot_steps:
+            h1 = snapshots1.get(step)
+            h2 = snapshots2.get(step)
+            marker = "==" if h1 == h2 else "!="
+            print(f"  Step {step}: {h1} {marker} {h2}")
+
+    # Compare database contents (persistence is enabled above, so missing files are a failure)
+    print("\nComparing database contents...")
+    db1_path = os.path.join(sim_dir_1, f"simulation_{fixed_simulation_id}.db")
+    db2_path = os.path.join(sim_dir_2, f"simulation_{fixed_simulation_id}.db")
+
+    print("Looking for database files:")
+    print(f"  DB1 path: {db1_path}")
+    print(f"  DB2 path: {db2_path}")
+
+    if os.path.exists(db1_path) and os.path.exists(db2_path):
+        db_deterministic = compare_database_contents(db1_path, db2_path)
+    else:
+        print("❌ Database files not found - persistence failed, treating as non-deterministic")
         print(f"  Sim dir 1 contents: {os.listdir(sim_dir_1) if os.path.exists(sim_dir_1) else 'Directory not found'}")
         print(f"  Sim dir 2 contents: {os.listdir(sim_dir_2) if os.path.exists(sim_dir_2) else 'Directory not found'}")
-        
-        if os.path.exists(db1_path) and os.path.exists(db2_path):
-            db_deterministic = compare_database_contents(db1_path, db2_path)
-        else:
-            print("⚠️  Database files not found - skipping database comparison")
-            db_deterministic = True  # Don't fail if DBs weren't created
+        db_deterministic = False
 
-    is_deterministic = state_deterministic and db_deterministic
+    is_deterministic = state_deterministic and snapshots_deterministic and db_deterministic
 
     print("\nDeterminism Test Results:")
     print(f"  - First simulation state hash: {hash1}")
     print(f"  - Second simulation state hash: {hash2}")
     print(f"  - State deterministic: {state_deterministic}")
+    print(f"  - Intermediate snapshots deterministic: {snapshots_deterministic} (steps {snapshot_steps})")
     print(f"  - Database deterministic: {db_deterministic}")
     print(f"  - Overall deterministic: {is_deterministic}")
 
@@ -432,18 +484,13 @@ def run_determinism_test(environment, num_steps, seed=42, use_snapshot_steps=Non
         compare_states(state1, state2)
 
     if not is_deterministic:
-        if not state_deterministic:
-            print("\n❌ The simulation has non-deterministic elements.")
-            print("This could be due to:")
-            print("  - Uncontrolled random number generation")
-            print("  - Floating point instability")
-            print("  - Parallelism/threading issues")
-            print("  - External state affecting the simulation")
-            print("  - Non-deterministic database logging")
-        else:
-            print("\n⚠️  The simulation state is deterministic, but database has minor differences.")
-            print("This is likely due to timestamp differences, which is expected and acceptable.")
-            print("✅ The core simulation behavior is fully deterministic.")
+        print("\n❌ The simulation has non-deterministic elements.")
+        print("This could be due to:")
+        print("  - Uncontrolled random number generation")
+        print("  - Floating point instability")
+        print("  - Parallelism/threading issues")
+        print("  - External state affecting the simulation")
+        print("  - Non-deterministic database logging")
     else:
         print("\n✅ The simulation is fully deterministic with the given seed.")
         print("Both simulation state and database contents are identical.")
@@ -487,4 +534,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/tests/test_deterministic_pytest.py
+++ b/tests/test_deterministic_pytest.py
@@ -4,6 +4,9 @@ Pytest-compatible deterministic testing suite for AgentFarm simulation.
 
 This module provides comprehensive deterministic testing using pytest framework
 with proper fixtures, markers, and parametrized tests for multi-seed validation.
+
+None of these tests pre-seed RNGs themselves: reproducibility must come entirely
+from ``run_simulation(seed=...)`` so regressions in production seeding are caught.
 """
 
 import os
@@ -49,9 +52,20 @@ def test_determinism_step_by_step(deterministic_seed):
         environment="testing",
         num_steps=50,
         seed=deterministic_seed,
-        use_snapshot_steps=snapshot_steps
+        snapshot_steps=snapshot_steps
     )
     assert result, f"Step-by-step determinism test failed with seed {deterministic_seed}"
+
+
+@pytest.mark.determinism
+def test_different_seeds_produce_different_results(deterministic_seed):
+    """Different seeds must produce different outcomes (the seed is actually wired through)."""
+    hash_a = run_single_simulation_hash("testing", seed=deterministic_seed, steps=30)
+    hash_b = run_single_simulation_hash("testing", seed=deterministic_seed + 1000, steps=30)
+    assert hash_a != hash_b, (
+        "Two different seeds produced identical final states - "
+        "the seed is likely not plumbed through to the simulation"
+    )
 
 
 @pytest.mark.determinism
@@ -64,9 +78,9 @@ def test_determinism_different_agent_counts(agent_count, deterministic_seed):
     config.population.independent_agents = agent_count // 3
     config.population.control_agents = agent_count - 2 * (agent_count // 3)
     config.seed = deterministic_seed
-    config.use_in_memory_db = True
-    config.persist_db_on_completion = False
-    
+    config.database.use_in_memory_db = True
+    config.database.persist_db_on_completion = False
+
     # Run deterministic test with custom config
     result = run_deterministic_simulation_pair(config, deterministic_seed, 30)
     assert result, f"Determinism test failed with {agent_count} agents"
@@ -77,15 +91,15 @@ def test_determinism_different_agent_counts(agent_count, deterministic_seed):
 def test_determinism_different_world_sizes(world_size, deterministic_seed):
     """Test determinism with varying world sizes."""
     width, height = world_size
-    
+
     # Create custom config with specific world size
     config = SimulationConfig.from_centralized_config(environment="testing")
     config.environment.width = width
     config.environment.height = height
     config.seed = deterministic_seed
-    config.use_in_memory_db = True
-    config.persist_db_on_completion = False
-    
+    config.database.use_in_memory_db = True
+    config.database.persist_db_on_completion = False
+
     # Run deterministic test with custom config
     result = run_deterministic_simulation_pair(config, deterministic_seed, 30)
     assert result, f"Determinism test failed with world size {world_size}"
@@ -114,10 +128,31 @@ def test_determinism_long_simulation(deterministic_seed):
     assert result, f"Long simulation determinism test failed with seed {deterministic_seed}"
 
 
+def run_single_simulation_hash(environment_name: str, seed: int, steps: int) -> str:
+    """Run one simulation with the given seed and return its final state hash."""
+    config = SimulationConfig.from_centralized_config(environment=environment_name)
+    config.seed = seed
+    config.database.use_in_memory_db = True
+    config.database.persist_db_on_completion = False
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        env = run_simulation(
+            num_steps=steps,
+            config=config,
+            path=temp_dir,
+            save_config=False,
+            seed=seed
+        )
+        try:
+            return get_simulation_state_hash(env)
+        finally:
+            env.cleanup()
+
+
 def run_deterministic_simulation_pair(config: SimulationConfig, seed: int, steps: int) -> bool:
     """
     Run two identical simulations with the same seed and compare their results.
-    
+
     Parameters
     ----------
     config : SimulationConfig
@@ -126,27 +161,19 @@ def run_deterministic_simulation_pair(config: SimulationConfig, seed: int, steps
         Seed value to use for both simulations
     steps : int
         Number of simulation steps to run
-        
+
     Returns
     -------
     bool
         True if the simulations were deterministic, False otherwise
     """
-    from tests.conftest import seed_all_rngs
-    
-    # Set fixed seeds for all random generators
-    seed_all_rngs(seed)
-    
     # Create temporary directories for simulations
     with tempfile.TemporaryDirectory() as temp_dir:
         sim_dir_1 = os.path.join(temp_dir, "sim_1")
         sim_dir_2 = os.path.join(temp_dir, "sim_2")
         os.makedirs(sim_dir_1, exist_ok=True)
         os.makedirs(sim_dir_2, exist_ok=True)
-        
-        # Reset seeds again to ensure same initial state
-        seed_all_rngs(seed)
-        
+
         # Run first simulation
         env1 = run_simulation(
             num_steps=steps,
@@ -155,10 +182,7 @@ def run_deterministic_simulation_pair(config: SimulationConfig, seed: int, steps
             save_config=True,
             seed=seed
         )
-        
-        # Reset seeds again
-        seed_all_rngs(seed)
-        
+
         # Run second simulation
         env2 = run_simulation(
             num_steps=steps,
@@ -167,28 +191,23 @@ def run_deterministic_simulation_pair(config: SimulationConfig, seed: int, steps
             save_config=True,
             seed=seed
         )
-        
+
         # Compare final states
-        hash1 = get_simulation_state_hash(env1, debug=False)
-        hash2 = get_simulation_state_hash(env2, debug=False)
-        
+        hash1 = get_simulation_state_hash(env1)
+        hash2 = get_simulation_state_hash(env2)
+
         return hash1 == hash2
 
 
 @pytest.mark.determinism
 def test_state_hash_consistency(deterministic_seed):
     """Test that state hash generation is consistent."""
-    from tests.conftest import seed_all_rngs
-    
-    # Set seed
-    seed_all_rngs(deterministic_seed)
-    
     # Create config
     config = SimulationConfig.from_centralized_config(environment="testing")
     config.seed = deterministic_seed
-    config.use_in_memory_db = True
-    config.persist_db_on_completion = False
-    
+    config.database.use_in_memory_db = True
+    config.database.persist_db_on_completion = False
+
     with tempfile.TemporaryDirectory() as temp_dir:
         # Run simulation
         env = run_simulation(
@@ -198,20 +217,21 @@ def test_state_hash_consistency(deterministic_seed):
             save_config=True,
             seed=deterministic_seed
         )
-        
+
         # Generate hash multiple times - should be identical
-        hash1 = get_simulation_state_hash(env, debug=False)
-        hash2 = get_simulation_state_hash(env, debug=False)
-        hash3 = get_simulation_state_hash(env, debug=False)
-        
+        hash1 = get_simulation_state_hash(env)
+        hash2 = get_simulation_state_hash(env)
+        hash3 = get_simulation_state_hash(env)
+
         assert hash1 == hash2 == hash3, "State hash generation is not consistent"
+        assert isinstance(hash1, str), "State hash must be a hex string"
 
 
 @pytest.mark.determinism
 def test_determinism_with_different_environments(deterministic_seed):
     """Test determinism across different configuration environments."""
     environments = ["testing", "development"]
-    
+
     for env_name in environments:
         result = run_determinism_test(
             environment=env_name,

--- a/tests/test_simulation_determinism_regression.py
+++ b/tests/test_simulation_determinism_regression.py
@@ -12,7 +12,6 @@ from farm.config.config import (
     ResourceConfig,
 )
 from farm.core.simulation import run_simulation
-from tests.conftest import seed_all_rngs
 
 
 def _capture_final_state(environment) -> dict:
@@ -69,7 +68,7 @@ def _run_deterministic_trial(tmp_path, seed: int, trial_name: str) -> dict:
     output_dir = tmp_path / trial_name
     output_dir.mkdir()
 
-    seed_all_rngs(seed)
+    # No external RNG seeding here: reproducibility must come from run_simulation(seed=...).
     environment = run_simulation(
         num_steps=8,
         config=config,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes structural flaws in the deterministic reproducibility tests so they actually verify that `run_simulation(seed=...)` is reproducible on its own:

- **Remove test-side RNG pre-seeding** (`seed_all_rngs` before each run) from `tests/test_deterministic.py`, `tests/test_deterministic_pytest.py`, and `tests/test_simulation_determinism_regression.py`. Previously a regression in the production seeding path (`init_random_seeds`) would have been masked by the harness seeding the RNGs itself.
- **Add cross-process determinism tests** (`tests/test_cross_process_determinism.py` + `tests/helpers/run_sim_snapshot.py`): each simulation runs in a fresh subprocess with a *different* `PYTHONHASHSEED`, catching nondeterminism that depends on dict/set hash ordering or other per-process state — invisible to in-process A/B comparisons.
- **Add seed-sensitivity tests** (in-process and cross-process) asserting that different seeds produce different results, catching a seed that is silently no longer plumbed through.
- **Implement intermediate snapshot comparison** via the existing `on_step_end` hook. The old `use_snapshot_steps` parameter was dead code, making `test_determinism_step_by_step` a no-op duplicate of the single-seed test.
- **Fail loudly when persisted DB files are missing** instead of silently passing the database comparison.
- **Compare large DB tables chunk-by-chunk** (5k rows per chunk) instead of degrading to row-count-only above 10k rows.
- **Fix `get_simulation_state_hash` tuple-return bug** (`return state_hash, state if debug else state_hash` always returned a tuple due to operator precedence); split into `capture_simulation_state` + `hash_simulation_state`.
- **Fix dead config attributes** in `test_deterministic_pytest.py` — `config.use_in_memory_db` set on the top-level `SimulationConfig` was unread; the real fields are `config.database.*` (worked only by coincidence with `testing.yaml` defaults).
- **Seed once per trajectory in component determinism tests** — they previously re-seeded before every step/draw, so "sequences" were one draw repeated and sequential RNG consumption was never exercised. Added shared `run_seeded_trajectory` helper.
- **Fix infinite genome-id probing in component tests**: with sequential RNG consumption, the multi-component agent now actually reproduces; `add_agent`'s genome-id uniqueness check queried the bare-`Mock` DB, whose truthy `Mock` returns sent `Identity.genome_id`'s counter loop into infinite probing with unbounded mock-call recording (11+ GB RSS). The mocked DB now reports genome ids as "not found". This also cut the component suite from ~10 min to ~7 s.
- Wire the new tests into `.github/workflows/deterministic-simulation.yml` and fix stale `deterministic_test.py` references in `docs/deterministic_simulations.md`.

## Testing

All run locally (Python 3.12 venv):

- ✅ `pytest -o addopts='' tests/test_cross_process_determinism.py` — 2 passed (cross-process repeatability under differing `PYTHONHASHSEED`, cross-process seed sensitivity)
- ✅ `pytest -o addopts='' tests/test_component_determinism.py` — 9 passed in 6.6s
- ✅ `pytest -o addopts='' tests/test_simulation_determinism_regression.py` — 1 passed (no pre-seeding)
- ✅ `pytest -o addopts='' tests/test_deterministic_pytest.py::test_determinism_single_seed ::test_determinism_step_by_step ::test_different_seeds_produce_different_results ::test_state_hash_consistency` — 4 passed
- ✅ `pytest -o addopts='' tests/test_deterministic_pytest.py::test_determinism_regression_critical` — 1 passed (100 steps)
- ✅ `python tests/test_deterministic.py --environment testing --steps 50 --seed 42` — fully deterministic, intermediate snapshots at steps 1/25/50 compared
- ✅ Negative validation of `compare_database_contents`: detects differing rows and row-count mismatches; tolerates timestamp-only differences
- ✅ `ruff check` on all changed files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a98bf257-ccaf-4aff-b06e-f0b481009c84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a98bf257-ccaf-4aff-b06e-f0b481009c84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

