### PR TITLE
Enhance Tianshou model state exposure and validation

### DIFF
--- a/farm/core/decision/algorithms/tianshou.py
+++ b/farm/core/decision/algorithms/tianshou.py
@@ -7,7 +7,7 @@ Windows-compatible alternative to other RL libraries.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Literal, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import gymnasium
 import numpy as np
@@ -41,6 +41,14 @@ class TianshouWrapper(RLAlgorithm):
         "eps_decay", "dqn_hidden_size",
         "repeat_per_collect", "max_batchsize",
     ])
+    _OPTIMIZER_ATTRS = (
+        "optim",
+        "actor_optim",
+        "critic_optim",
+        "critic1_optim",
+        "critic2_optim",
+        "alpha_optim",
+    )
 
     def __init__(
         self,
@@ -192,6 +200,144 @@ class TianshouWrapper(RLAlgorithm):
     def epsilon(self) -> float:
         """Current epsilon-greedy exploration rate (mirrors ``policy.eps``)."""
         return self._eps_current if self._train_mode else self._eps_test
+
+    def _get_policy_optimizers(self) -> Dict[str, Any]:
+        """Return the Tianshou policy optimizers exposed by the current wrapper."""
+        if self.policy is None:
+            return {}
+
+        optimizers: Dict[str, Any] = {}
+        for attr_name in self._OPTIMIZER_ATTRS:
+            optimizer = getattr(self.policy, attr_name, None)
+            if optimizer is None:
+                continue
+            if callable(getattr(optimizer, "state_dict", None)) and callable(
+                getattr(optimizer, "load_state_dict", None)
+            ):
+                optimizers[attr_name] = optimizer
+        return optimizers
+
+    def _get_learning_rates(self) -> Dict[str, float]:
+        """Snapshot the current learning rates for all exposed optimizers."""
+        learning_rates: Dict[str, float] = {}
+        for attr_name, optimizer in self._get_policy_optimizers().items():
+            param_groups = getattr(optimizer, "param_groups", None)
+            if not param_groups:
+                continue
+            lr = param_groups[0].get("lr")
+            if lr is None:
+                continue
+            learning_rates[attr_name] = float(lr)
+        return learning_rates
+
+    def _set_learning_rates(self, learning_rates: Dict[str, Any]) -> None:
+        """Apply learning rates to the matching optimizers when present."""
+        optimizers = self._get_policy_optimizers()
+        applied_rates: List[float] = []
+        for attr_name, raw_lr in learning_rates.items():
+            optimizer = optimizers.get(attr_name)
+            if optimizer is None:
+                continue
+            try:
+                lr = float(raw_lr)
+            except (TypeError, ValueError):
+                logger.warning("Skipping invalid learning rate for %s: %r", attr_name, raw_lr)
+                continue
+            for param_group in optimizer.param_groups:
+                param_group["lr"] = lr
+            applied_rates.append(lr)
+
+        if applied_rates:
+            self.algorithm_config["lr"] = applied_rates[0]
+
+    def _serialize_replay_value(self, value: Any) -> Any:
+        """Return a detached/copy-safe representation for replay payloads."""
+        if isinstance(value, np.ndarray):
+            return np.array(value, copy=True)
+        if torch.is_tensor(value):
+            return value.detach().cpu().numpy().copy()
+        if isinstance(value, np.generic):
+            return value.item()
+        return value
+
+    def _get_replay_buffer_state(self, limit: Optional[int] = None) -> Dict[str, Any]:
+        """Serialize a deterministic slice of the replay buffer."""
+        if self.replay_buffer is None:
+            return {"entries": [], "priorities": []}
+
+        entries = list(self.replay_buffer.buffer)
+        priorities = np.array(self.replay_buffer.priorities[: len(entries)], copy=True)
+
+        if len(entries) == self.replay_buffer.max_size and len(entries) > 0:
+            start_index = int(self.replay_buffer.position)
+            entries = entries[start_index:] + entries[:start_index]
+            priorities = np.concatenate((priorities[start_index:], priorities[:start_index]))
+
+        if limit is not None:
+            limit = max(0, int(limit))
+            entries = entries[-limit:]
+            priorities = priorities[-limit:]
+
+        return {
+            "entries": [
+                {
+                    key: self._serialize_replay_value(value)
+                    for key, value in experience.items()
+                }
+                for experience in entries
+            ],
+            "priorities": priorities.astype(np.float64).tolist(),
+            "beta": float(getattr(self.replay_buffer, "beta", 0.0)),
+            "beta_step_count": int(getattr(self.replay_buffer, "_beta_step_count", 0)),
+            "replay_strategy": getattr(self.replay_buffer, "replay_strategy", None),
+        }
+
+    def _load_replay_buffer_state(self, replay_state: Dict[str, Any]) -> None:
+        """Restore a previously serialized replay-buffer slice when compatible."""
+        entries = replay_state.get("entries")
+        if not isinstance(entries, list):
+            return
+
+        required_keys = {"state", "action", "reward", "next_state", "done"}
+        max_size = int(getattr(self.replay_buffer, "max_size", len(entries)))
+        capped_entries = entries[-max_size:]
+
+        normalized_entries: List[Dict[str, Any]] = []
+        for experience in capped_entries:
+            if not isinstance(experience, dict) or not required_keys.issubset(experience):
+                raise ValueError("Replay entry is missing required transition fields")
+            normalized_entries.append(dict(experience))
+
+        self.replay_buffer.clear()
+        for experience in normalized_entries:
+            extra_fields = {
+                key: value
+                for key, value in experience.items()
+                if key not in required_keys
+            }
+            self.replay_buffer.append(
+                experience["state"],
+                int(experience["action"]),
+                float(experience["reward"]),
+                experience["next_state"],
+                bool(experience["done"]),
+                **extra_fields,
+            )
+
+        raw_priorities = replay_state.get("priorities")
+        if isinstance(raw_priorities, list) and raw_priorities:
+            priorities = np.asarray(raw_priorities[-len(normalized_entries):], dtype=np.float64)
+            if priorities.shape[0] == len(normalized_entries):
+                self.replay_buffer.priorities[: len(normalized_entries)] = priorities
+                self.replay_buffer.priorities[len(normalized_entries):] = 0.0
+
+        beta = replay_state.get("beta")
+        if beta is not None:
+            self.replay_buffer.beta = float(beta)
+
+        beta_step_count = replay_state.get("beta_step_count")
+        if beta_step_count is not None:
+            self.replay_buffer._beta_step_count = int(beta_step_count)
 
     def _get_default_config(self, user_config: Dict[str, Any]) -> Dict[str, Any]:
         """Get default configuration for the algorithm."""
@@ -1325,14 +1471,23 @@ class TianshouWrapper(RLAlgorithm):
             and self.step_count % self.train_freq == 0
         )
 
-    def get_model_state(self) -> Dict[str, Any]:
-        """Get the current model state for saving."""
+    def get_model_state(
+        self,
+        include_optimizer_state: bool = False,
+        include_replay_buffer: bool = False,
+        replay_buffer_limit: Optional[int] = None,
+        include_plasticity_state: bool = False,
+    ) -> Dict[str, Any]:
+        """Get the current model state for saving.
+
+        Optional payloads are excluded by default so the existing
+        weights-only/Baldwinian paths keep their current behavior unless an
+        inheritance mode explicitly opts into richer module state.
+        """
         if self.policy is None:
             return {}
 
         try:
-            import torch
-
             state = {
                 "policy_state_dict": self.policy.state_dict(),
                 "step_count": self.step_count,
@@ -1340,6 +1495,31 @@ class TianshouWrapper(RLAlgorithm):
                 "algorithm_name": self.algorithm_name,
                 "algorithm_config": self.algorithm_config,
             }
+            if include_optimizer_state:
+                optimizer_state = {
+                    attr_name: optimizer.state_dict()
+                    for attr_name, optimizer in self._get_policy_optimizers().items()
+                }
+                if optimizer_state:
+                    state["optimizer_state"] = optimizer_state
+            if include_replay_buffer:
+                state["replay_buffer_state"] = self._get_replay_buffer_state(
+                    limit=replay_buffer_limit
+                )
+            if include_plasticity_state:
+                learning_rates = self._get_learning_rates()
+                state["plasticity_state"] = {
+                    "epsilon": float(self.epsilon),
+                    "eps_current": float(self._eps_current),
+                    "eps_test": float(self._eps_test),
+                    "train_mode": bool(self._train_mode),
+                    "learning_rate": (
+                        float(next(iter(learning_rates.values())))
+                        if learning_rates
+                        else float(self.algorithm_config.get("lr", 0.0))
+                    ),
+                    "learning_rates": learning_rates,
+                }
             return state
         except Exception as e:
             logger.warning(f"Failed to get model state: {e}")
@@ -1359,6 +1539,47 @@ class TianshouWrapper(RLAlgorithm):
 
         if "step_count" in state:
             self._step_count = state["step_count"]
+
+        optimizer_state = state.get("optimizer_state")
+        if isinstance(optimizer_state, dict):
+            for attr_name, optimizer_snapshot in optimizer_state.items():
+                optimizer = self._get_policy_optimizers().get(attr_name)
+                if optimizer is None:
+                    continue
+                try:
+                    optimizer.load_state_dict(optimizer_snapshot)
+                except Exception as e:
+                    logger.warning(f"Failed to load optimizer state for {attr_name}: {e}")
+
+        replay_buffer_state = state.get("replay_buffer_state")
+        if isinstance(replay_buffer_state, dict):
+            try:
+                self._load_replay_buffer_state(replay_buffer_state)
+            except Exception as e:
+                logger.warning(f"Failed to load replay buffer state: {e}")
+
+        plasticity_state = state.get("plasticity_state")
+        if isinstance(plasticity_state, dict):
+            if "train_mode" in plasticity_state:
+                self._train_mode = bool(plasticity_state["train_mode"])
+            if "eps_test" in plasticity_state:
+                self._eps_test = float(plasticity_state["eps_test"])
+            if "eps_current" in plasticity_state:
+                self._eps_current = float(plasticity_state["eps_current"])
+            elif "epsilon" in plasticity_state:
+                self._eps_current = float(plasticity_state["epsilon"])
+
+            learning_rates = plasticity_state.get("learning_rates")
+            if isinstance(learning_rates, dict) and learning_rates:
+                self._set_learning_rates(learning_rates)
+            elif "learning_rate" in plasticity_state:
+                self._set_learning_rates(
+                    {
+                        attr_name: plasticity_state["learning_rate"]
+                        for attr_name in self._get_policy_optimizers()
+                    }
+                )
+            self._apply_eps_to_policy()
 
     def train(self, batch: Any, **kwargs: Any) -> None:
         """Train method required by ActionAlgorithm interface."""

--- a/farm/core/decision/algorithms/tianshou.py
+++ b/farm/core/decision/algorithms/tianshou.py
@@ -280,9 +280,8 @@ class TianshouWrapper(RLAlgorithm):
                 limit = max(0, int(limit))
             except (ValueError, TypeError) as e:
                 logger.warning(f"Invalid replay_buffer_limit '{limit}': {e}. Ignoring limit.")
-                limit = None
-            
-            if limit is not None:
+            else:
+                # Only apply limit if conversion succeeded
                 if limit == 0:
                     entries = []
                     priorities = priorities[:0]

--- a/farm/core/decision/algorithms/tianshou.py
+++ b/farm/core/decision/algorithms/tianshou.py
@@ -276,13 +276,19 @@ class TianshouWrapper(RLAlgorithm):
             priorities = np.concatenate((priorities[start_index:], priorities[:start_index]))
 
         if limit is not None:
-            limit = max(0, int(limit))
-            if limit == 0:
-                entries = []
-                priorities = priorities[:0]
-            else:
-                entries = entries[-limit:]
-                priorities = priorities[-limit:]
+            try:
+                limit = max(0, int(limit))
+            except (ValueError, TypeError) as e:
+                logger.warning(f"Invalid replay_buffer_limit '{limit}': {e}. Ignoring limit.")
+                limit = None
+            
+            if limit is not None:
+                if limit == 0:
+                    entries = []
+                    priorities = priorities[:0]
+                else:
+                    entries = entries[-limit:]
+                    priorities = priorities[-limit:]
 
         return {
             "entries": [
@@ -1580,11 +1586,20 @@ class TianshouWrapper(RLAlgorithm):
             if "train_mode" in plasticity_state:
                 self._train_mode = bool(plasticity_state["train_mode"])
             if "eps_test" in plasticity_state:
-                self._eps_test = float(plasticity_state["eps_test"])
+                try:
+                    self._eps_test = float(plasticity_state["eps_test"])
+                except (ValueError, TypeError) as e:
+                    logger.warning(f"Invalid eps_test value: {e}. Skipping.")
             if "eps_current" in plasticity_state:
-                self._eps_current = float(plasticity_state["eps_current"])
+                try:
+                    self._eps_current = float(plasticity_state["eps_current"])
+                except (ValueError, TypeError) as e:
+                    logger.warning(f"Invalid eps_current value: {e}. Skipping.")
             elif "epsilon" in plasticity_state:
-                self._eps_current = float(plasticity_state["epsilon"])
+                try:
+                    self._eps_current = float(plasticity_state["epsilon"])
+                except (ValueError, TypeError) as e:
+                    logger.warning(f"Invalid epsilon value: {e}. Skipping.")
 
             learning_rates = plasticity_state.get("learning_rates")
             if isinstance(learning_rates, dict) and learning_rates:

--- a/farm/core/decision/algorithms/tianshou.py
+++ b/farm/core/decision/algorithms/tianshou.py
@@ -270,7 +270,7 @@ class TianshouWrapper(RLAlgorithm):
         # so slicing to ``len(entries)`` always stays within bounds.
         priorities = np.array(self.replay_buffer.priorities[: len(entries)], copy=True)
 
-        if len(entries) == self.replay_buffer.max_size and len(entries) > 0:
+        if len(entries) == self.replay_buffer.max_size:
             start_index = int(self.replay_buffer.position)
             entries = entries[start_index:] + entries[:start_index]
             priorities = np.concatenate((priorities[start_index:], priorities[:start_index]))
@@ -296,6 +296,9 @@ class TianshouWrapper(RLAlgorithm):
 
     def _load_replay_buffer_state(self, replay_state: Dict[str, Any]) -> None:
         """Restore a previously serialized replay-buffer slice when compatible."""
+        if self.replay_buffer is None:
+            return
+
         entries = replay_state.get("entries")
         if not isinstance(entries, list):
             return

--- a/farm/core/decision/algorithms/tianshou.py
+++ b/farm/core/decision/algorithms/tianshou.py
@@ -266,6 +266,8 @@ class TianshouWrapper(RLAlgorithm):
             return {"entries": [], "priorities": []}
 
         entries = list(self.replay_buffer.buffer)
+        # ``PrioritizedReplayBuffer.priorities`` is preallocated to ``max_size``,
+        # so slicing to ``len(entries)`` always stays within bounds.
         priorities = np.array(self.replay_buffer.priorities[: len(entries)], copy=True)
 
         if len(entries) == self.replay_buffer.max_size and len(entries) > 0:
@@ -303,9 +305,12 @@ class TianshouWrapper(RLAlgorithm):
         capped_entries = entries[-max_size:]
 
         normalized_entries: List[Dict[str, Any]] = []
-        for experience in capped_entries:
+        for index, experience in enumerate(capped_entries):
             if not isinstance(experience, dict) or not required_keys.issubset(experience):
-                raise ValueError("Replay entry is missing required transition fields")
+                missing_keys = sorted(required_keys.difference(experience) if isinstance(experience, dict) else required_keys)
+                raise ValueError(
+                    f"Replay entry at index {index} is missing required fields: {missing_keys}"
+                )
             normalized_entries.append(dict(experience))
 
         self.replay_buffer.clear()
@@ -1508,9 +1513,8 @@ class TianshouWrapper(RLAlgorithm):
                 )
             if include_plasticity_state:
                 learning_rates = self._get_learning_rates()
-                state["plasticity_state"] = {
-                    "epsilon": float(self.epsilon),
-                    "eps_current": float(self._eps_current),
+                plasticity_state = {
+                    "epsilon": float(self._eps_current),
                     "eps_test": float(self._eps_test),
                     "train_mode": bool(self._train_mode),
                     "learning_rate": (
@@ -1518,8 +1522,10 @@ class TianshouWrapper(RLAlgorithm):
                         if learning_rates
                         else float(self.algorithm_config.get("lr", 0.0))
                     ),
-                    "learning_rates": learning_rates,
                 }
+                if len(learning_rates) > 1:
+                    plasticity_state["learning_rates"] = learning_rates
+                state["plasticity_state"] = plasticity_state
             return state
         except Exception as e:
             logger.warning(f"Failed to get model state: {e}")

--- a/farm/core/decision/algorithms/tianshou.py
+++ b/farm/core/decision/algorithms/tianshou.py
@@ -277,8 +277,12 @@ class TianshouWrapper(RLAlgorithm):
 
         if limit is not None:
             limit = max(0, int(limit))
-            entries = entries[-limit:]
-            priorities = priorities[-limit:]
+            if limit == 0:
+                entries = []
+                priorities = priorities[:0]
+            else:
+                entries = entries[-limit:]
+                priorities = priorities[-limit:]
 
         return {
             "entries": [
@@ -346,6 +350,10 @@ class TianshouWrapper(RLAlgorithm):
         beta_step_count = replay_state.get("beta_step_count")
         if beta_step_count is not None:
             self.replay_buffer._beta_step_count = int(beta_step_count)
+
+        replay_strategy = replay_state.get("replay_strategy")
+        if replay_strategy in ("uniform", "prioritized"):
+            self.replay_buffer.replay_strategy = replay_strategy
 
     def _get_default_config(self, user_config: Dict[str, Any]) -> Dict[str, Any]:
         """Get default configuration for the algorithm."""

--- a/farm/core/decision/algorithms/tianshou.py
+++ b/farm/core/decision/algorithms/tianshou.py
@@ -201,6 +201,21 @@ class TianshouWrapper(RLAlgorithm):
         """Current epsilon-greedy exploration rate (mirrors ``policy.eps``)."""
         return self._eps_current if self._train_mode else self._eps_test
 
+    @staticmethod
+    def _coerce_float(source: Dict[str, Any], key: str) -> Optional[float]:
+        """Return ``source[key]`` as a float, or ``None`` if absent/invalid.
+
+        Invalid values are logged and skipped so a malformed plasticity payload
+        leaves the existing attribute untouched rather than raising.
+        """
+        if key not in source:
+            return None
+        try:
+            return float(source[key])
+        except (ValueError, TypeError) as e:
+            logger.warning(f"Invalid {key} value: {e}. Skipping.")
+            return None
+
     def _get_policy_optimizers(self) -> Dict[str, Any]:
         """Return the Tianshou policy optimizers exposed by the current wrapper."""
         if self.policy is None:
@@ -359,6 +374,9 @@ class TianshouWrapper(RLAlgorithm):
         replay_strategy = replay_state.get("replay_strategy")
         if replay_strategy in ("uniform", "prioritized"):
             self.replay_buffer.replay_strategy = replay_strategy
+            # Keep the wrapper-level attribute in sync with the buffer so any
+            # reader of ``wrapper.replay_strategy`` does not observe a stale value.
+            self.replay_strategy = replay_strategy
 
     def _get_default_config(self, user_config: Dict[str, Any]) -> Dict[str, Any]:
         """Get default configuration for the algorithm."""
@@ -1516,18 +1534,38 @@ class TianshouWrapper(RLAlgorithm):
                 "algorithm_name": self.algorithm_name,
                 "algorithm_config": self.algorithm_config,
             }
-            if include_optimizer_state:
+        except Exception as e:
+            logger.warning(f"Failed to get model state: {e}")
+            return {
+                "step_count": self.step_count,
+                "buffer_size": len(self.replay_buffer),
+                "algorithm_name": self.algorithm_name,
+            }
+
+        # Optional payloads are isolated so a failure serializing any of them
+        # degrades to "core weights only" instead of discarding the policy
+        # state that warmstart/inheritance depends on.
+        if include_optimizer_state:
+            try:
                 optimizer_state = {
                     attr_name: optimizer.state_dict()
                     for attr_name, optimizer in self._get_policy_optimizers().items()
                 }
                 if optimizer_state:
                     state["optimizer_state"] = optimizer_state
-            if include_replay_buffer:
+            except Exception as e:
+                logger.warning(f"Failed to serialize optimizer state: {e}")
+
+        if include_replay_buffer:
+            try:
                 state["replay_buffer_state"] = self._get_replay_buffer_state(
                     limit=replay_buffer_limit
                 )
-            if include_plasticity_state:
+            except Exception as e:
+                logger.warning(f"Failed to serialize replay buffer state: {e}")
+
+        if include_plasticity_state:
+            try:
                 learning_rates = self._get_learning_rates()
                 plasticity_state = {
                     "epsilon": float(self._eps_current),
@@ -1542,14 +1580,10 @@ class TianshouWrapper(RLAlgorithm):
                 if len(learning_rates) > 1:
                     plasticity_state["learning_rates"] = learning_rates
                 state["plasticity_state"] = plasticity_state
-            return state
-        except Exception as e:
-            logger.warning(f"Failed to get model state: {e}")
-            return {
-                "step_count": self.step_count,
-                "buffer_size": len(self.replay_buffer),
-                "algorithm_name": self.algorithm_name,
-            }
+            except Exception as e:
+                logger.warning(f"Failed to serialize plasticity state: {e}")
+
+        return state
 
     def load_model_state(self, state: Dict[str, Any]) -> None:
         """Load a saved model state."""
@@ -1584,22 +1618,21 @@ class TianshouWrapper(RLAlgorithm):
         if isinstance(plasticity_state, dict):
             if "train_mode" in plasticity_state:
                 self._train_mode = bool(plasticity_state["train_mode"])
-            if "eps_test" in plasticity_state:
-                try:
-                    self._eps_test = float(plasticity_state["eps_test"])
-                except (ValueError, TypeError) as e:
-                    logger.warning(f"Invalid eps_test value: {e}. Skipping.")
-            if "eps_current" in plasticity_state:
-                try:
-                    self._eps_current = float(plasticity_state["eps_current"])
-                except (ValueError, TypeError) as e:
-                    logger.warning(f"Invalid eps_current value: {e}. Skipping.")
-            elif "epsilon" in plasticity_state:
-                try:
-                    self._eps_current = float(plasticity_state["epsilon"])
-                except (ValueError, TypeError) as e:
-                    logger.warning(f"Invalid epsilon value: {e}. Skipping.")
 
+            eps_test = self._coerce_float(plasticity_state, "eps_test")
+            if eps_test is not None:
+                self._eps_test = eps_test
+            # ``eps_current`` is the canonical key; fall back to ``epsilon`` for
+            # payloads produced by ``get_model_state`` (which emits ``epsilon``).
+            eps_current = self._coerce_float(plasticity_state, "eps_current")
+            if eps_current is None:
+                eps_current = self._coerce_float(plasticity_state, "epsilon")
+            if eps_current is not None:
+                self._eps_current = eps_current
+
+            # Plasticity learning rate is the evolvable gene, so it is applied
+            # after any restored optimizer state and intentionally overrides the
+            # optimizer's restored param-group LR.
             learning_rates = plasticity_state.get("learning_rates")
             if isinstance(learning_rates, dict) and learning_rates:
                 self._set_learning_rates(learning_rates)

--- a/tests/decision/test_tianshou_wrapper.py
+++ b/tests/decision/test_tianshou_wrapper.py
@@ -661,6 +661,91 @@ class TestTianshouWrapperModelPersistence(unittest.TestCase):
         self.assertAlmostEqual(self.dqn_wrapper._eps_current, 0.321)
         self.assertAlmostEqual(self.dqn_wrapper.policy.optim.param_groups[0]["lr"], 1e-3)
 
+    def test_get_model_state_preserves_weights_on_optional_failure(self):
+        """A failing optional payload must not discard the core policy weights."""
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("replay serialization failed")
+
+        self.dqn_wrapper._get_replay_buffer_state = _boom
+
+        state = self.dqn_wrapper.get_model_state(
+            include_replay_buffer=True,
+            include_plasticity_state=True,
+        )
+
+        self.assertIn("policy_state_dict", state)
+        self.assertTrue(state["policy_state_dict"])
+        self.assertNotIn("replay_buffer_state", state)
+        self.assertIn("plasticity_state", state)
+
+    def test_load_model_state_wrapped_replay_buffer_preserves_order(self):
+        """A full/wrapped buffer round-trips in logical (oldest-first) order."""
+        from farm.core.decision.algorithms.tianshou import DQNWrapper
+
+        wrapper = DQNWrapper(
+            num_actions=self.num_actions,
+            state_dim=self.state_dim,
+            observation_shape=self.observation_shape,
+            buffer_size=4,
+        )
+        for i in range(6):
+            state = self._make_state(i)
+            wrapper.store_experience(state, i % self.num_actions, float(i), state + 1, False)
+
+        self.assertEqual(len(wrapper.replay_buffer), 4)
+        self.assertGreater(wrapper.replay_buffer.position, 0)
+
+        saved_state = wrapper.get_model_state(include_replay_buffer=True)
+
+        new_wrapper = DQNWrapper(
+            num_actions=self.num_actions,
+            state_dim=self.state_dim,
+            observation_shape=self.observation_shape,
+            buffer_size=4,
+        )
+        new_wrapper.load_model_state(saved_state)
+
+        self.assertEqual(
+            [entry["reward"] for entry in new_wrapper.replay_buffer.buffer],
+            [2.0, 3.0, 4.0, 5.0],
+        )
+
+    def test_load_model_state_prioritized_replay_roundtrip(self):
+        """Prioritized replay state (priorities/beta/strategy) round-trips."""
+        from farm.core.decision.algorithms.tianshou import DQNWrapper
+
+        wrapper = DQNWrapper(
+            num_actions=self.num_actions,
+            state_dim=self.state_dim,
+            observation_shape=self.observation_shape,
+            replay_strategy="prioritized",
+        )
+        for i in range(5):
+            state = self._make_state(i)
+            wrapper.store_experience(state, i % self.num_actions, float(i), state + 1, False)
+        wrapper.replay_buffer.priorities[:5] = np.array([0.5, 1.5, 2.5, 3.5, 4.5])
+        wrapper.replay_buffer.beta = 0.77
+
+        saved_state = wrapper.get_model_state(include_replay_buffer=True)
+        self.assertEqual(saved_state["replay_buffer_state"]["replay_strategy"], "prioritized")
+
+        new_wrapper = DQNWrapper(
+            num_actions=self.num_actions,
+            state_dim=self.state_dim,
+            observation_shape=self.observation_shape,
+            replay_strategy="uniform",
+        )
+        new_wrapper.load_model_state(saved_state)
+
+        self.assertEqual(new_wrapper.replay_strategy, "prioritized")
+        self.assertEqual(new_wrapper.replay_buffer.replay_strategy, "prioritized")
+        self.assertAlmostEqual(new_wrapper.replay_buffer.beta, 0.77)
+        np.testing.assert_allclose(
+            new_wrapper.replay_buffer.priorities[:5],
+            np.array([0.5, 1.5, 2.5, 3.5, 4.5]),
+        )
+
     def test_save_load_roundtrip(self):
         """Test saving and loading model state in a roundtrip."""
         # Add some experiences

--- a/tests/decision/test_tianshou_wrapper.py
+++ b/tests/decision/test_tianshou_wrapper.py
@@ -559,7 +559,7 @@ class TestTianshouWrapperModelPersistence(unittest.TestCase):
             [entry["reward"] for entry in state["replay_buffer_state"]["entries"]],
             [29.0, 30.0, 31.0],
         )
-        self.assertAlmostEqual(state["plasticity_state"]["eps_current"], 0.123)
+        self.assertAlmostEqual(state["plasticity_state"]["epsilon"], 0.123)
         self.assertAlmostEqual(state["plasticity_state"]["learning_rate"], 1e-3)
 
     def test_load_model_state_restores_optimizer_and_plasticity(self):
@@ -652,7 +652,11 @@ class TestTianshouWrapperModelPersistence(unittest.TestCase):
         """Test malformed optional payloads are ignored without breaking load."""
         state = {
             "step_count": 7,
-            "plasticity_state": {"learning_rate": "bad-value", "epsilon": 0.321},
+            "plasticity_state": {
+                "learning_rate": "bad-value",
+                "learning_rates": {"optim": "bad-value"},
+                "epsilon": 0.321,
+            },
             "replay_buffer_state": {
                 "entries": [{"reward": 1.0}],
                 "priorities": [1.0],

--- a/tests/decision/test_tianshou_wrapper.py
+++ b/tests/decision/test_tianshou_wrapper.py
@@ -36,7 +36,7 @@ class TestTianshouWrapperInitialization(unittest.TestCase):
 
     def test_ppo_wrapper_initialization(self):
         """Test PPOWrapper initialization."""
-        from farm.core.decision.algorithms.tianshou import PPOWrapper
+        from farm.core.decision.algorithms.tianshou import DQNWrapper, PPOWrapper
 
         wrapper = PPOWrapper(
             num_actions=self.num_actions,
@@ -115,7 +115,7 @@ class TestTianshouWrapperInitialization(unittest.TestCase):
 
     def test_custom_algorithm_config(self):
         """Test initialization with custom algorithm configuration."""
-        from farm.core.decision.algorithms.tianshou import PPOWrapper
+        from farm.core.decision.algorithms.tianshou import DQNWrapper, PPOWrapper
 
         custom_config = {
             "lr": 1e-4,
@@ -207,7 +207,7 @@ class TestTianshouWrapperActionSelection(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from farm.core.decision.algorithms.tianshou import PPOWrapper
+        from farm.core.decision.algorithms.tianshou import DQNWrapper, PPOWrapper
 
         self.num_actions = 4
         self.state_dim = 13
@@ -218,6 +218,15 @@ class TestTianshouWrapperActionSelection(unittest.TestCase):
             state_dim=self.state_dim,
             observation_shape=self.observation_shape,
         )
+        self.dqn_wrapper = DQNWrapper(
+            num_actions=self.num_actions,
+            state_dim=self.state_dim,
+            observation_shape=self.observation_shape,
+        )
+
+    def _make_state(self, value):
+        """Create a deterministic observation tensor for replay-buffer tests."""
+        return np.full(self.observation_shape, value, dtype=np.float32)
 
     def test_select_action_1d_state(self):
         """Test action selection with 1D state on a flat DQN policy."""
@@ -303,7 +312,7 @@ class TestTianshouWrapperExperienceReplay(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from farm.core.decision.algorithms.tianshou import PPOWrapper
+        from farm.core.decision.algorithms.tianshou import DQNWrapper, PPOWrapper
 
         self.num_actions = 4
         self.state_dim = 13
@@ -467,7 +476,7 @@ class TestTianshouWrapperModelPersistence(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from farm.core.decision.algorithms.tianshou import PPOWrapper
+        from farm.core.decision.algorithms.tianshou import DQNWrapper, PPOWrapper
 
         self.num_actions = 4
         self.state_dim = 13
@@ -478,6 +487,15 @@ class TestTianshouWrapperModelPersistence(unittest.TestCase):
             state_dim=self.state_dim,
             observation_shape=self.observation_shape,
         )
+        self.dqn_wrapper = DQNWrapper(
+            num_actions=self.num_actions,
+            state_dim=self.state_dim,
+            observation_shape=self.observation_shape,
+        )
+
+    def _make_state(self, value):
+        """Create a deterministic observation tensor for replay-buffer tests."""
+        return np.full(self.observation_shape, value, dtype=np.float32)
 
     def test_get_model_state(self):
         """Test getting model state for saving."""
@@ -513,6 +531,140 @@ class TestTianshouWrapperModelPersistence(unittest.TestCase):
         self.wrapper.load_model_state(initial_state)
 
         self.assertEqual(self.wrapper.step_count, 100)
+
+    def test_get_model_state_opt_in_fields(self):
+        """Test opt-in serialization of optimizer, replay, and plasticity state."""
+        for i in range(self.dqn_wrapper.batch_size):
+            state = self._make_state(i)
+            self.dqn_wrapper.store_experience(state, i % self.num_actions, float(i), state + 1, False)
+
+        self.dqn_wrapper.train_on_batch({})
+        self.dqn_wrapper._eps_current = 0.123
+        self.dqn_wrapper._apply_eps_to_policy()
+
+        state = self.dqn_wrapper.get_model_state(
+            include_optimizer_state=True,
+            include_replay_buffer=True,
+            replay_buffer_limit=3,
+            include_plasticity_state=True,
+        )
+
+        self.assertIn("optimizer_state", state)
+        self.assertIn("replay_buffer_state", state)
+        self.assertIn("plasticity_state", state)
+        self.assertIn("optim", state["optimizer_state"])
+        self.assertTrue(state["optimizer_state"]["optim"]["state"])
+        self.assertEqual(len(state["replay_buffer_state"]["entries"]), 3)
+        self.assertEqual(
+            [entry["reward"] for entry in state["replay_buffer_state"]["entries"]],
+            [29.0, 30.0, 31.0],
+        )
+        self.assertAlmostEqual(state["plasticity_state"]["eps_current"], 0.123)
+        self.assertAlmostEqual(state["plasticity_state"]["learning_rate"], 1e-3)
+
+    def test_load_model_state_restores_optimizer_and_plasticity(self):
+        """Test loading optimizer/plasticity state when present."""
+        for i in range(self.dqn_wrapper.batch_size):
+            state = self._make_state(i)
+            self.dqn_wrapper.store_experience(state, i % self.num_actions, float(i), state + 1, False)
+
+        self.dqn_wrapper.train_on_batch({})
+        self.dqn_wrapper._eps_current = 0.222
+        self.dqn_wrapper._eps_test = 0.111
+        self.dqn_wrapper._apply_eps_to_policy()
+        self.dqn_wrapper.policy.optim.param_groups[0]["lr"] = 2.5e-4
+
+        saved_state = self.dqn_wrapper.get_model_state(
+            include_optimizer_state=True,
+            include_plasticity_state=True,
+        )
+
+        from farm.core.decision.algorithms.tianshou import DQNWrapper
+
+        new_wrapper = DQNWrapper(
+            num_actions=self.num_actions,
+            state_dim=self.state_dim,
+            observation_shape=self.observation_shape,
+        )
+        new_wrapper.policy.optim.param_groups[0]["lr"] = 9.9e-4
+        new_wrapper._eps_current = 0.9
+        new_wrapper._eps_test = 0.8
+
+        new_wrapper.load_model_state(saved_state)
+
+        self.assertAlmostEqual(new_wrapper._eps_current, 0.222)
+        self.assertAlmostEqual(new_wrapper._eps_test, 0.111)
+        self.assertAlmostEqual(float(new_wrapper.policy.eps), 0.222)
+        self.assertAlmostEqual(new_wrapper.policy.optim.param_groups[0]["lr"], 2.5e-4)
+
+        saved_optimizer_state = saved_state["optimizer_state"]["optim"]["state"]
+        loaded_optimizer_state = new_wrapper.policy.optim.state_dict()["state"]
+        self.assertEqual(set(loaded_optimizer_state), set(saved_optimizer_state))
+
+        first_slot_key = next(iter(saved_optimizer_state))
+        for slot_name, saved_value in saved_optimizer_state[first_slot_key].items():
+            loaded_value = loaded_optimizer_state[first_slot_key][slot_name]
+            if hasattr(saved_value, "detach"):
+                np.testing.assert_allclose(
+                    loaded_value.detach().cpu().numpy(),
+                    saved_value.detach().cpu().numpy(),
+                )
+            else:
+                self.assertEqual(loaded_value, saved_value)
+
+    def test_load_model_state_restores_bounded_replay_buffer(self):
+        """Test loading a capped replay-buffer slice when present."""
+        for i in range(6):
+            state = self._make_state(i)
+            self.dqn_wrapper.store_experience(
+                state,
+                i % self.num_actions,
+                float(i),
+                state + 1,
+                bool(i % 2),
+            )
+
+        saved_state = self.dqn_wrapper.get_model_state(
+            include_replay_buffer=True,
+            replay_buffer_limit=3,
+        )
+
+        from farm.core.decision.algorithms.tianshou import DQNWrapper
+
+        new_wrapper = DQNWrapper(
+            num_actions=self.num_actions,
+            state_dim=self.state_dim,
+            observation_shape=self.observation_shape,
+        )
+        new_wrapper.load_model_state(saved_state)
+
+        self.assertEqual(len(new_wrapper.replay_buffer), 3)
+        self.assertEqual(
+            [entry["reward"] for entry in new_wrapper.replay_buffer.buffer],
+            [3.0, 4.0, 5.0],
+        )
+        self.assertEqual(
+            [entry["done"] for entry in new_wrapper.replay_buffer.buffer],
+            [True, False, True],
+        )
+
+    def test_load_model_state_skips_malformed_optional_payloads(self):
+        """Test malformed optional payloads are ignored without breaking load."""
+        state = {
+            "step_count": 7,
+            "plasticity_state": {"learning_rate": "bad-value", "epsilon": 0.321},
+            "replay_buffer_state": {
+                "entries": [{"reward": 1.0}],
+                "priorities": [1.0],
+            },
+        }
+
+        self.dqn_wrapper.load_model_state(state)
+
+        self.assertEqual(self.dqn_wrapper.step_count, 7)
+        self.assertEqual(len(self.dqn_wrapper.replay_buffer), 0)
+        self.assertAlmostEqual(self.dqn_wrapper._eps_current, 0.321)
+        self.assertAlmostEqual(self.dqn_wrapper.policy.optim.param_groups[0]["lr"], 1e-3)
 
     def test_save_load_roundtrip(self):
         """Test saving and loading model state in a roundtrip."""
@@ -650,4 +802,3 @@ class TestTianshouWrapperAlgorithmSpecific(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/decision/test_tianshou_wrapper.py
+++ b/tests/decision/test_tianshou_wrapper.py
@@ -36,7 +36,7 @@ class TestTianshouWrapperInitialization(unittest.TestCase):
 
     def test_ppo_wrapper_initialization(self):
         """Test PPOWrapper initialization."""
-        from farm.core.decision.algorithms.tianshou import DQNWrapper, PPOWrapper
+        from farm.core.decision.algorithms.tianshou import PPOWrapper
 
         wrapper = PPOWrapper(
             num_actions=self.num_actions,
@@ -115,7 +115,7 @@ class TestTianshouWrapperInitialization(unittest.TestCase):
 
     def test_custom_algorithm_config(self):
         """Test initialization with custom algorithm configuration."""
-        from farm.core.decision.algorithms.tianshou import DQNWrapper, PPOWrapper
+        from farm.core.decision.algorithms.tianshou import PPOWrapper
 
         custom_config = {
             "lr": 1e-4,
@@ -207,7 +207,7 @@ class TestTianshouWrapperActionSelection(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from farm.core.decision.algorithms.tianshou import DQNWrapper, PPOWrapper
+        from farm.core.decision.algorithms.tianshou import PPOWrapper
 
         self.num_actions = 4
         self.state_dim = 13
@@ -218,15 +218,6 @@ class TestTianshouWrapperActionSelection(unittest.TestCase):
             state_dim=self.state_dim,
             observation_shape=self.observation_shape,
         )
-        self.dqn_wrapper = DQNWrapper(
-            num_actions=self.num_actions,
-            state_dim=self.state_dim,
-            observation_shape=self.observation_shape,
-        )
-
-    def _make_state(self, value):
-        """Create a deterministic observation tensor for replay-buffer tests."""
-        return np.full(self.observation_shape, value, dtype=np.float32)
 
     def test_select_action_1d_state(self):
         """Test action selection with 1D state on a flat DQN policy."""
@@ -312,7 +303,7 @@ class TestTianshouWrapperExperienceReplay(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from farm.core.decision.algorithms.tianshou import DQNWrapper, PPOWrapper
+        from farm.core.decision.algorithms.tianshou import PPOWrapper
 
         self.num_actions = 4
         self.state_dim = 13


### PR DESCRIPTION
This pull request adds robust opt-in serialization and restoration of optimizer state, replay buffer contents, and plasticity parameters to the `TianshouWrapper` reinforcement learning algorithm. These enhancements allow for more comprehensive model checkpointing and recovery, supporting richer forms of RL model persistence and transfer. The test suite is also extended to cover these new behaviors and edge cases.

**Enhancements to model persistence and restoration:**

* Added methods to serialize and restore optimizer state, replay buffer contents, and plasticity parameters (such as epsilon and learning rates) in `TianshouWrapper`, with optional inclusion via new parameters in `get_model_state` and `load_model_state`. [[1]](diffhunk://#diff-13e3fcdf63bc2f739042c5709315aa9cebf62d5590d210e88e4696d25bccd934R44-R51) [[2]](diffhunk://#diff-13e3fcdf63bc2f739042c5709315aa9cebf62d5590d210e88e4696d25bccd934R204-R349) [[3]](diffhunk://#diff-13e3fcdf63bc2f739042c5709315aa9cebf62d5590d210e88e4696d25bccd934L1328-R1531) [[4]](diffhunk://#diff-13e3fcdf63bc2f739042c5709315aa9cebf62d5590d210e88e4696d25bccd934R1552-R1592)
* Implemented helper methods for safe serialization/deserialization of replay buffer entries and optimizer learning rates, supporting partial or malformed payloads gracefully.

**Test suite improvements:**

* Added new tests in `test_tianshou_wrapper.py` to verify opt-in serialization of optimizer, replay buffer, and plasticity state, as well as correct restoration and error handling of these payloads. [[1]](diffhunk://#diff-416c09c6d284f3d106811f9f826504e82eed83e3b41675c441f5d4b91c258000L470-R470) [[2]](diffhunk://#diff-416c09c6d284f3d106811f9f826504e82eed83e3b41675c441f5d4b91c258000R481-R489) [[3]](diffhunk://#diff-416c09c6d284f3d106811f9f826504e82eed83e3b41675c441f5d4b91c258000R526-R663)
* Expanded coverage to include DQNWrapper alongside PPOWrapper in the test setup.

These changes make RL model checkpointing more flexible and robust, enabling advanced research and production workflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect RL training continuity (optimizer moments, replay contents, exploration schedule) when inheritance modes opt in; defaults preserve prior behavior but restored state can alter learning dynamics if mis-serialized or mismatched across algorithms.
> 
> **Overview**
> **`TianshouWrapper`** now supports richer checkpoints without changing the default weights-only save path. **`get_model_state`** accepts optional flags to include policy optimizers (across known Tianshou optimizer attrs), a bounded replay-buffer slice (with circular-buffer ordering, PER metadata, and **`replay_buffer_limit`**), and **plasticity** fields (epsilon, train mode, learning rates). **`load_model_state`** restores those sections when present, logging and skipping on optimizer/replay failures and tolerating bad learning-rate or malformed replay payloads.
> 
> Helper logic covers optimizer discovery, LR get/set, and copy-safe replay serialization. **`test_tianshou_wrapper`** adds DQN-focused coverage for opt-in serialization, round-trip restore, capped replay load, and malformed optional payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74ff1b6170875b7d26a62bb777bbafbd981be72d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->