### PR TITLE
Add P2-P4 inheritance_mode values for enhanced payload variants

### DIFF
--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -32,7 +32,12 @@ from farm.core.hyperparameter_chromosome import (
 )
 from farm.core.environment import _AgentList
 from farm.core.inheritance_telemetry import InheritanceTelemetry
-from farm.core.policy_inheritance import apply_lamarckian_policy_warmstart
+from farm.core.policy_inheritance import (
+    apply_lamarckian_policy_warmstart,
+    apply_p2_policy_warmstart,
+    apply_p3_policy_warmstart,
+    apply_p4_policy_warmstart,
+)
 from farm.core.state import AgentState, AgentStateManager
 from farm.utils.logging import get_logger
 
@@ -1199,7 +1204,15 @@ class AgentCore:
         return True
 
     def _apply_lamarckian_inheritance_if_enabled(self, offspring: "AgentCore") -> None:
-        """Apply optional Lamarckian policy warm-start from parent to child.
+        """Apply optional policy warm-start from parent to child.
+
+        Dispatches to the appropriate variant hook based on the runner's
+        configured ``inheritance_mode``:
+
+        - ``"lamarckian"`` (P1): copy policy weights.
+        - ``"p2"``: weights + plasticity damping (lower child LR/ε).
+        - ``"p3"``: weights + optimizer state + bounded replay slice.
+        - ``"p4"``: gated/blended transfer (fitness gate + weight blend).
 
         When the runner has attached an :class:`InheritanceTelemetry` to the
         environment, outcome counters are updated through it (one applied or
@@ -1212,10 +1225,22 @@ class AgentCore:
         policy = getattr(self.environment, "intrinsic_evolution_policy", None)
         if policy is None or not getattr(policy, "enabled", False):
             return
-        if getattr(policy, "inheritance_mode", "baldwinian") != "lamarckian":
+
+        inheritance_mode = getattr(policy, "inheritance_mode", "baldwinian")
+        if inheritance_mode == "baldwinian":
             return
 
-        skip_reason = apply_lamarckian_policy_warmstart(self, offspring)
+        if inheritance_mode == "lamarckian":
+            skip_reason = apply_lamarckian_policy_warmstart(self, offspring)
+        elif inheritance_mode == "p2":
+            skip_reason = apply_p2_policy_warmstart(self, offspring)
+        elif inheritance_mode == "p3":
+            skip_reason = apply_p3_policy_warmstart(self, offspring)
+        elif inheritance_mode == "p4":
+            skip_reason = apply_p4_policy_warmstart(self, offspring)
+        else:
+            return
+
         telemetry = getattr(self.environment, "inheritance_telemetry", None)
         if not isinstance(telemetry, InheritanceTelemetry):
             return

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -48,6 +48,16 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+# Maps a configured ``inheritance_mode`` to its warm-start hook. ``baldwinian``
+# is intentionally absent (cold-start: no warm-start is applied).
+_WARMSTART_DISPATCH = {
+    "lamarckian": apply_lamarckian_policy_warmstart,
+    "p2": apply_p2_policy_warmstart,
+    "p3": apply_p3_policy_warmstart,
+    "p4": apply_p4_policy_warmstart,
+}
+
+
 def compute_effective_reproduction_cost(agent: Any, base_cost: float) -> float:
     """Return the density-adjusted reproduction cost for *agent*.
 
@@ -1136,7 +1146,7 @@ class AgentCore:
             # Optional Lamarckian step: copy parent policy weights into the
             # already-constructed offspring before the env sees the child, so
             # the first decide() call uses warm-started weights.
-            self._apply_lamarckian_inheritance_if_enabled(offspring)
+            self._apply_policy_inheritance_if_enabled(offspring)
 
             # Add offspring to environment with immediate flush to ensure it's in database
             # Genome ID will be generated in add_agent() using parent info
@@ -1203,7 +1213,7 @@ class AgentCore:
             )
         return True
 
-    def _apply_lamarckian_inheritance_if_enabled(self, offspring: "AgentCore") -> None:
+    def _apply_policy_inheritance_if_enabled(self, offspring: "AgentCore") -> None:
         """Apply optional policy warm-start from parent to child.
 
         Dispatches to the appropriate variant hook based on the runner's
@@ -1227,19 +1237,12 @@ class AgentCore:
             return
 
         inheritance_mode = getattr(policy, "inheritance_mode", "baldwinian")
-        if inheritance_mode == "baldwinian":
+        warmstart_hook = _WARMSTART_DISPATCH.get(inheritance_mode)
+        if warmstart_hook is None:
+            # ``baldwinian`` (cold start) and any unrecognized mode are no-ops.
             return
 
-        if inheritance_mode == "lamarckian":
-            skip_reason = apply_lamarckian_policy_warmstart(self, offspring)
-        elif inheritance_mode == "p2":
-            skip_reason = apply_p2_policy_warmstart(self, offspring)
-        elif inheritance_mode == "p3":
-            skip_reason = apply_p3_policy_warmstart(self, offspring)
-        elif inheritance_mode == "p4":
-            skip_reason = apply_p4_policy_warmstart(self, offspring)
-        else:
-            return
+        skip_reason = warmstart_hook(self, offspring)
 
         telemetry = getattr(self.environment, "inheritance_telemetry", None)
         if not isinstance(telemetry, InheritanceTelemetry):

--- a/farm/core/policy_inheritance.py
+++ b/farm/core/policy_inheritance.py
@@ -28,9 +28,16 @@ P2–P4 variant hooks are also provided here (see the variant ladder in
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+import inspect
+from typing import Any, Callable, Dict, Optional, Tuple
 
 from farm.utils.logging import get_logger
+
+try:  # torch is an optional dependency at import time; the P4 blend degrades
+    # gracefully (copies parent weights) when it is unavailable.
+    import torch
+except ImportError:  # pragma: no cover - exercised only in torch-less envs
+    torch = None  # type: ignore[assignment]
 
 logger = get_logger(__name__)
 
@@ -49,6 +56,12 @@ WARMSTART_REASON_LOAD_FAILED = "load_failed"
 
 # P4-specific: parent did not clear the fitness gate.
 WARMSTART_REASON_GATE_NOT_CLEARED = "gate_not_cleared"
+
+# P2/P3: the parent algorithm cannot supply the richer module state these
+# variants require (its ``get_model_state`` does not accept the extended
+# kwargs). Surfaced as a distinct skip so a misconfigured arm shows up as
+# all-skipped instead of silently masquerading as a successful transfer.
+WARMSTART_REASON_EXTENDED_STATE_UNSUPPORTED = "extended_state_unsupported"
 
 # Default plasticity damping factor applied by the P2 variant.
 # The child's inherited LR and ε are scaled by this factor so the
@@ -108,43 +121,14 @@ def apply_lamarckian_policy_warmstart(parent: Any, offspring: Any) -> Optional[s
     enough to run on long simulations without a noticeable wall-clock
     penalty.
     """
-    parent_behavior = getattr(parent, "behavior", None)
-    child_behavior = getattr(offspring, "behavior", None)
-    parent_module = getattr(parent_behavior, "decision_module", None)
-    child_module = getattr(child_behavior, "decision_module", None)
-    if parent_module is None or child_module is None:
-        return WARMSTART_REASON_NO_DECISION_MODULE
+    _, child_algorithm, parent_state, skip_reason = _get_parent_algorithm_state(
+        parent, offspring
+    )
+    if skip_reason is not None:
+        return skip_reason
 
-    parent_algorithm = getattr(parent_module, "algorithm", None)
-    child_algorithm = getattr(child_module, "algorithm", None)
-    if parent_algorithm is None or child_algorithm is None:
-        return WARMSTART_REASON_NO_ALGORITHM
-
-    get_model_state = getattr(parent_algorithm, "get_model_state", None)
+    policy_state = parent_state["policy_state_dict"]
     load_model_state = getattr(child_algorithm, "load_model_state", None)
-    if not callable(get_model_state) or not callable(load_model_state):
-        return WARMSTART_REASON_NO_WARMSTART_API
-
-    try:
-        parent_state = get_model_state()
-    except Exception:
-        logger.exception(
-            "lamarckian_warmstart_parent_state_failed",
-            parent_id=getattr(parent, "agent_id", None),
-            offspring_id=getattr(offspring, "agent_id", None),
-        )
-        return WARMSTART_REASON_PARENT_STATE_FAILED
-
-    if not isinstance(parent_state, dict):
-        return WARMSTART_REASON_NO_POLICY_STATE
-    policy_state = parent_state.get("policy_state_dict")
-    if not isinstance(policy_state, dict) or not policy_state:
-        return WARMSTART_REASON_NO_POLICY_STATE
-
-    child_policy = getattr(child_algorithm, "policy", None)
-    if not _policy_state_is_compatible(policy_state, child_policy):
-        return WARMSTART_REASON_INCOMPATIBLE_STATE
-
     try:
         load_model_state({"policy_state_dict": policy_state})
     except Exception:
@@ -157,6 +141,35 @@ def apply_lamarckian_policy_warmstart(parent: Any, offspring: Any) -> Optional[s
     return None
 
 
+_EXTENDED_STATE_PARAMS = (
+    "include_optimizer_state",
+    "include_replay_buffer",
+    "replay_buffer_limit",
+    "include_plasticity_state",
+)
+
+
+def _supports_extended_state(get_model_state: Callable) -> bool:
+    """Return whether ``get_model_state`` accepts the extended-payload kwargs.
+
+    We inspect the signature explicitly instead of catching ``TypeError`` from
+    the call: a ``TypeError`` raised *inside* a conforming implementation must
+    not be silently misread as "this algorithm doesn't support extended state",
+    which would downgrade a P2/P3 arm to a weights-only transfer without any
+    observable signal.
+    """
+    try:
+        signature = inspect.signature(get_model_state)
+    except (TypeError, ValueError):
+        # Builtins / C-callables without an introspectable signature: assume the
+        # documented API surface is present rather than guessing.
+        return True
+    params = signature.parameters
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
+        return True
+    return all(name in params for name in _EXTENDED_STATE_PARAMS)
+
+
 def _get_parent_algorithm_state(
     parent: Any,
     offspring: Any,
@@ -165,12 +178,17 @@ def _get_parent_algorithm_state(
     include_replay_buffer: bool = False,
     replay_buffer_limit: Optional[int] = None,
     include_plasticity_state: bool = False,
-) -> tuple:
+) -> Tuple[Any, Any, Optional[Dict[str, Any]], Optional[str]]:
     """Extract the parent's algorithm objects and model state.
 
     Returns a 4-tuple ``(parent_algorithm, child_algorithm, parent_state, skip_reason)``.
     If ``skip_reason`` is not ``None`` the caller should propagate it immediately;
     the other three elements will be ``None``.
+
+    When a caller requests extended payloads (optimizer/replay/plasticity) but
+    the parent algorithm's ``get_model_state`` cannot supply them, the skip
+    reason is :data:`WARMSTART_REASON_EXTENDED_STATE_UNSUPPORTED` so the outcome
+    is recorded rather than silently degrading to a weights-only transfer.
     """
     parent_behavior = getattr(parent, "behavior", None)
     child_behavior = getattr(offspring, "behavior", None)
@@ -189,26 +207,30 @@ def _get_parent_algorithm_state(
     if not callable(get_model_state) or not callable(load_model_state):
         return None, None, None, WARMSTART_REASON_NO_WARMSTART_API
 
-    try:
-        parent_state = get_model_state(
-            include_optimizer_state=include_optimizer_state,
-            include_replay_buffer=include_replay_buffer,
-            replay_buffer_limit=replay_buffer_limit,
-            include_plasticity_state=include_plasticity_state,
+    wants_extended = (
+        include_optimizer_state
+        or include_replay_buffer
+        or include_plasticity_state
+        or replay_buffer_limit is not None
+    )
+    if wants_extended and not _supports_extended_state(get_model_state):
+        logger.warning(
+            "warmstart_extended_state_unsupported",
+            parent_id=getattr(parent, "agent_id", None),
+            offspring_id=getattr(offspring, "agent_id", None),
         )
-    except TypeError:
-        # Fallback: the implementation does not accept extended kwargs (e.g. in
-        # tests or older algorithm versions).  Call without arguments and accept
-        # the core policy state without the optional payloads.
-        try:
-            parent_state = get_model_state()
-        except Exception:
-            logger.exception(
-                "warmstart_parent_state_failed",
-                parent_id=getattr(parent, "agent_id", None),
-                offspring_id=getattr(offspring, "agent_id", None),
+        return None, None, None, WARMSTART_REASON_EXTENDED_STATE_UNSUPPORTED
+
+    try:
+        if wants_extended:
+            parent_state = get_model_state(
+                include_optimizer_state=include_optimizer_state,
+                include_replay_buffer=include_replay_buffer,
+                replay_buffer_limit=replay_buffer_limit,
+                include_plasticity_state=include_plasticity_state,
             )
-            return None, None, None, WARMSTART_REASON_PARENT_STATE_FAILED
+        else:
+            parent_state = get_model_state()
     except Exception:
         logger.exception(
             "warmstart_parent_state_failed",
@@ -255,36 +277,39 @@ def apply_p2_policy_warmstart(
     if skip_reason is not None:
         return skip_reason
 
-    policy_state = parent_state["policy_state_dict"]
-    plasticity_state = parent_state.get("plasticity_state", {})
-    step_count = parent_state.get("step_count")
-
-    # Build the child payload: weights + damped plasticity parameters.
-    child_payload: Dict[str, Any] = {"policy_state_dict": policy_state}
-
-    if step_count is not None:
-        child_payload["step_count"] = step_count
-
-    if plasticity_state:
-        damped: Dict[str, Any] = {}
-        if "learning_rate" in plasticity_state:
-            damped["learning_rate"] = float(plasticity_state["learning_rate"]) * plasticity_damping
-        if "learning_rates" in plasticity_state:
-            damped["learning_rates"] = {
-                k: float(v) * plasticity_damping
-                for k, v in plasticity_state["learning_rates"].items()
-            }
-        if "epsilon" in plasticity_state:
-            damped["epsilon"] = float(plasticity_state["epsilon"]) * plasticity_damping
-        if "eps_test" in plasticity_state:
-            damped["eps_test"] = float(plasticity_state["eps_test"]) * plasticity_damping
-        if "train_mode" in plasticity_state:
-            damped["train_mode"] = plasticity_state["train_mode"]
-        if damped:
-            child_payload["plasticity_state"] = damped
-
+    # Payload construction and load are both treated as non-fatal: any failure
+    # returns a skip reason so reproduction continues with a cold-start child,
+    # matching the Lamarckian (P1) contract that warm-start never aborts a
+    # birth event.
     load_model_state = getattr(child_algorithm, "load_model_state", None)
     try:
+        policy_state = parent_state["policy_state_dict"]
+        plasticity_state = parent_state.get("plasticity_state", {})
+        step_count = parent_state.get("step_count")
+
+        child_payload: Dict[str, Any] = {"policy_state_dict": policy_state}
+
+        if step_count is not None:
+            child_payload["step_count"] = step_count
+
+        if plasticity_state:
+            damped: Dict[str, Any] = {}
+            if "learning_rate" in plasticity_state:
+                damped["learning_rate"] = float(plasticity_state["learning_rate"]) * plasticity_damping
+            if "learning_rates" in plasticity_state:
+                damped["learning_rates"] = {
+                    k: float(v) * plasticity_damping
+                    for k, v in plasticity_state["learning_rates"].items()
+                }
+            if "epsilon" in plasticity_state:
+                damped["epsilon"] = float(plasticity_state["epsilon"]) * plasticity_damping
+            if "eps_test" in plasticity_state:
+                damped["eps_test"] = float(plasticity_state["eps_test"]) * plasticity_damping
+            if "train_mode" in plasticity_state:
+                damped["train_mode"] = plasticity_state["train_mode"]
+            if damped:
+                child_payload["plasticity_state"] = damped
+
         load_model_state(child_payload)
     except Exception:
         logger.exception(
@@ -331,25 +356,26 @@ def apply_p3_policy_warmstart(
     if skip_reason is not None:
         return skip_reason
 
-    policy_state = parent_state["policy_state_dict"]
-
-    # Build the child payload: weights + optional continuation machinery.
-    child_payload: Dict[str, Any] = {"policy_state_dict": policy_state}
-
-    step_count = parent_state.get("step_count")
-    if step_count is not None:
-        child_payload["step_count"] = step_count
-
-    optimizer_state = parent_state.get("optimizer_state")
-    if isinstance(optimizer_state, dict) and optimizer_state:
-        child_payload["optimizer_state"] = optimizer_state
-
-    replay_buffer_state = parent_state.get("replay_buffer_state")
-    if isinstance(replay_buffer_state, dict) and replay_buffer_state:
-        child_payload["replay_buffer_state"] = replay_buffer_state
-
+    # Payload construction and load are non-fatal (see P2): failures return a
+    # skip reason rather than raising into the reproduction transaction.
     load_model_state = getattr(child_algorithm, "load_model_state", None)
     try:
+        policy_state = parent_state["policy_state_dict"]
+
+        child_payload: Dict[str, Any] = {"policy_state_dict": policy_state}
+
+        step_count = parent_state.get("step_count")
+        if step_count is not None:
+            child_payload["step_count"] = step_count
+
+        optimizer_state = parent_state.get("optimizer_state")
+        if isinstance(optimizer_state, dict) and optimizer_state:
+            child_payload["optimizer_state"] = optimizer_state
+
+        replay_buffer_state = parent_state.get("replay_buffer_state")
+        if isinstance(replay_buffer_state, dict) and replay_buffer_state:
+            child_payload["replay_buffer_state"] = replay_buffer_state
+
         load_model_state(child_payload)
     except Exception:
         logger.exception(
@@ -388,11 +414,17 @@ def apply_p4_policy_warmstart(
     This soft warm-start bounds local-niche lock-in by not fully committing to
     the parent's learned representation.
 
+    Scope note: the current implementation blends *policy weights only* (the
+    P1-level payload). The design ladder allows P4 to layer the gate/blend over
+    P2/P3 payloads as well; that is intentionally left as a follow-up so the
+    gate and blend can be evaluated in isolation first.
+
     Returns ``None`` on success; returns a ``WARMSTART_REASON_*`` string on any
     skip, including ``WARMSTART_REASON_GATE_NOT_CLEARED`` when the parent does
     not meet the fitness threshold.
     """
-    # Fitness gate: check parent resource level.
+    # Fitness gate: check parent resource level. Agents without a
+    # ``resource_level`` attribute skip the gate (it cannot be evaluated).
     parent_resource_level = getattr(parent, "resource_level", None)
     if parent_resource_level is not None:
         if float(parent_resource_level) < fitness_gate_min_resources:
@@ -410,45 +442,46 @@ def apply_p4_policy_warmstart(
     if skip_reason is not None:
         return skip_reason
 
-    parent_policy_state = parent_state["policy_state_dict"]
-
-    # Capture the child's current (init) weights before blending.
-    child_policy = getattr(child_algorithm, "policy", None)
-    try:
-        child_init_state = child_policy.state_dict() if child_policy is not None else {}
-    except Exception:
-        child_init_state = {}
-
-    # Blend: θ_child = α*θ_parent + (1-α)*θ_init
-    try:
-        import torch  # noqa: PLC0415
-    except ImportError:
-        torch = None  # type: ignore[assignment]
-
-    blended_state: Dict[str, Any] = {}
-    for key, parent_value in parent_policy_state.items():
-        child_value = child_init_state.get(key)
-        if child_value is None:
-            blended_state[key] = parent_value
-            continue
-        if (
-            torch is not None
-            and isinstance(parent_value, torch.Tensor)
-            and isinstance(child_value, torch.Tensor)
-        ):
-            blended_state[key] = (
-                blend_alpha * parent_value + (1.0 - blend_alpha) * child_value
-            ).detach()
-        else:
-            blended_state[key] = parent_value
-
-    step_count = parent_state.get("step_count")
-    child_payload: Dict[str, Any] = {"policy_state_dict": blended_state}
-    if step_count is not None:
-        child_payload["step_count"] = step_count
-
+    # Blend + load are non-fatal (see P2): tensor dtype/device mismatches or a
+    # failed load return a skip reason instead of aborting reproduction.
     load_model_state = getattr(child_algorithm, "load_model_state", None)
     try:
+        parent_policy_state = parent_state["policy_state_dict"]
+
+        # Capture the child's current (init) weights before blending.
+        child_policy = getattr(child_algorithm, "policy", None)
+        try:
+            child_init_state = child_policy.state_dict() if child_policy is not None else {}
+        except Exception:
+            child_init_state = {}
+
+        # Blend: θ_child = α*θ_parent + (1-α)*θ_init. Only float tensors are
+        # blended; non-tensor entries and integer buffers (e.g. BatchNorm
+        # ``num_batches_tracked``) are copied from the parent verbatim.
+        blended_state: Dict[str, Any] = {}
+        for key, parent_value in parent_policy_state.items():
+            child_value = child_init_state.get(key)
+            if child_value is None:
+                blended_state[key] = parent_value
+                continue
+            if (
+                torch is not None
+                and isinstance(parent_value, torch.Tensor)
+                and isinstance(child_value, torch.Tensor)
+                and parent_value.is_floating_point()
+                and child_value.is_floating_point()
+            ):
+                blended_state[key] = (
+                    blend_alpha * parent_value + (1.0 - blend_alpha) * child_value
+                ).detach()
+            else:
+                blended_state[key] = parent_value
+
+        step_count = parent_state.get("step_count")
+        child_payload: Dict[str, Any] = {"policy_state_dict": blended_state}
+        if step_count is not None:
+            child_payload["step_count"] = step_count
+
         load_model_state(child_payload)
     except Exception:
         logger.exception(

--- a/farm/core/policy_inheritance.py
+++ b/farm/core/policy_inheritance.py
@@ -17,6 +17,13 @@ These methods are automatically used by
 :class:`farm.core.decision.algorithms.tianshou.TianshouWrapper` when
 ``get_model_state(include_replay_buffer=True, replay_buffer_limit=N)`` is called,
 and are integrated with the existing ``load_model_state`` machinery.
+
+P2–P4 variant hooks are also provided here (see the variant ladder in
+``docs/design/inherited_payload_design.md``):
+
+* :func:`apply_p2_policy_warmstart` — weights + plasticity damping.
+* :func:`apply_p3_policy_warmstart` — weights + optimizer state + bounded replay slice.
+* :func:`apply_p4_policy_warmstart` — gated/blended transfer.
 """
 
 from __future__ import annotations
@@ -28,7 +35,7 @@ from farm.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-# Skip-reason constants emitted by :func:`apply_lamarckian_policy_warmstart`.
+# Skip-reason constants emitted by warm-start helpers.
 # Keeping them as module-level strings (instead of an Enum) lets downstream
 # JSON metadata round-trip them without a custom encoder; the comparator
 # script and tests rely on the literal values.
@@ -39,6 +46,26 @@ WARMSTART_REASON_PARENT_STATE_FAILED = "parent_state_failed"
 WARMSTART_REASON_NO_POLICY_STATE = "no_policy_state"
 WARMSTART_REASON_INCOMPATIBLE_STATE = "incompatible_state"
 WARMSTART_REASON_LOAD_FAILED = "load_failed"
+
+# P4-specific: parent did not clear the fitness gate.
+WARMSTART_REASON_GATE_NOT_CLEARED = "gate_not_cleared"
+
+# Default plasticity damping factor applied by the P2 variant.
+# The child's inherited LR and ε are scaled by this factor so the
+# copied weights are not immediately overwritten by noisy early updates.
+P2_PLASTICITY_DAMPING = 0.5
+
+# Replay-buffer slice size cap used by the P3 variant.
+P3_REPLAY_BUFFER_LIMIT = 256
+
+# Blend coefficient used by the P4 variant:
+#   θ_child = P4_BLEND_ALPHA * θ_parent + (1 - P4_BLEND_ALPHA) * θ_init
+P4_BLEND_ALPHA = 0.5
+
+# P4 gate: minimum resource level (as a fraction of initial resources, or
+# absolute level depending on the environment) the parent must hold to pass
+# the fitness gate. Uses resource_level attribute when available.
+P4_FITNESS_GATE_MIN_RESOURCES = 1.0
 
 
 def _policy_state_is_compatible(
@@ -127,4 +154,310 @@ def apply_lamarckian_policy_warmstart(parent: Any, offspring: Any) -> Optional[s
             offspring_id=getattr(offspring, "agent_id", None),
         )
         return WARMSTART_REASON_LOAD_FAILED
+    return None
+
+
+def _get_parent_algorithm_state(
+    parent: Any,
+    offspring: Any,
+    *,
+    include_optimizer_state: bool = False,
+    include_replay_buffer: bool = False,
+    replay_buffer_limit: Optional[int] = None,
+    include_plasticity_state: bool = False,
+) -> tuple:
+    """Extract the parent's algorithm objects and model state.
+
+    Returns a 4-tuple ``(parent_algorithm, child_algorithm, policy_state, skip_reason)``.
+    If ``skip_reason`` is not ``None`` the caller should propagate it immediately;
+    the other three elements will be ``None``.
+    """
+    parent_behavior = getattr(parent, "behavior", None)
+    child_behavior = getattr(offspring, "behavior", None)
+    parent_module = getattr(parent_behavior, "decision_module", None)
+    child_module = getattr(child_behavior, "decision_module", None)
+    if parent_module is None or child_module is None:
+        return None, None, None, WARMSTART_REASON_NO_DECISION_MODULE
+
+    parent_algorithm = getattr(parent_module, "algorithm", None)
+    child_algorithm = getattr(child_module, "algorithm", None)
+    if parent_algorithm is None or child_algorithm is None:
+        return None, None, None, WARMSTART_REASON_NO_ALGORITHM
+
+    get_model_state = getattr(parent_algorithm, "get_model_state", None)
+    load_model_state = getattr(child_algorithm, "load_model_state", None)
+    if not callable(get_model_state) or not callable(load_model_state):
+        return None, None, None, WARMSTART_REASON_NO_WARMSTART_API
+
+    try:
+        parent_state = get_model_state(
+            include_optimizer_state=include_optimizer_state,
+            include_replay_buffer=include_replay_buffer,
+            replay_buffer_limit=replay_buffer_limit,
+            include_plasticity_state=include_plasticity_state,
+        )
+    except TypeError:
+        # Fallback: the implementation does not accept extended kwargs (e.g. in
+        # tests or older algorithm versions).  Call without arguments and accept
+        # the core policy state without the optional payloads.
+        try:
+            parent_state = get_model_state()
+        except Exception:
+            logger.exception(
+                "warmstart_parent_state_failed",
+                parent_id=getattr(parent, "agent_id", None),
+                offspring_id=getattr(offspring, "agent_id", None),
+            )
+            return None, None, None, WARMSTART_REASON_PARENT_STATE_FAILED
+    except Exception:
+        logger.exception(
+            "warmstart_parent_state_failed",
+            parent_id=getattr(parent, "agent_id", None),
+            offspring_id=getattr(offspring, "agent_id", None),
+        )
+        return None, None, None, WARMSTART_REASON_PARENT_STATE_FAILED
+
+    if not isinstance(parent_state, dict):
+        return None, None, None, WARMSTART_REASON_NO_POLICY_STATE
+
+    policy_state = parent_state.get("policy_state_dict")
+    if not isinstance(policy_state, dict) or not policy_state:
+        return None, None, None, WARMSTART_REASON_NO_POLICY_STATE
+
+    child_policy = getattr(child_algorithm, "policy", None)
+    if not _policy_state_is_compatible(policy_state, child_policy):
+        return None, None, None, WARMSTART_REASON_INCOMPATIBLE_STATE
+
+    return parent_algorithm, child_algorithm, parent_state, None
+
+
+def apply_p2_policy_warmstart(
+    parent: Any,
+    offspring: Any,
+    *,
+    plasticity_damping: float = P2_PLASTICITY_DAMPING,
+) -> Optional[str]:
+    """P2: Warm-start offspring with parent weights plus plasticity damping.
+
+    Copies the parent policy weights (same as Lamarckian / P1), and
+    additionally reduces the child's initial learning rate and exploration
+    rate (ε) by ``plasticity_damping`` so the inherited weights are not
+    immediately overwritten by noisy early updates.  The parent's
+    ``step_count`` is also carried over so the child's exploration schedule
+    continues from the parent's position rather than resetting to zero.
+
+    Returns ``None`` on success; returns a ``WARMSTART_REASON_*`` string on
+    any skip so callers can attribute the outcome through telemetry.
+    """
+    parent_algorithm, child_algorithm, parent_state, skip_reason = (
+        _get_parent_algorithm_state(parent, offspring, include_plasticity_state=True)
+    )
+    if skip_reason is not None:
+        return skip_reason
+
+    policy_state = parent_state["policy_state_dict"]
+    plasticity_state = parent_state.get("plasticity_state", {})
+    step_count = parent_state.get("step_count")
+
+    # Build the child payload: weights + damped plasticity parameters.
+    child_payload: Dict[str, Any] = {"policy_state_dict": policy_state}
+
+    if step_count is not None:
+        child_payload["step_count"] = step_count
+
+    if plasticity_state:
+        damped: Dict[str, Any] = {}
+        if "learning_rate" in plasticity_state:
+            damped["learning_rate"] = float(plasticity_state["learning_rate"]) * plasticity_damping
+        if "learning_rates" in plasticity_state:
+            damped["learning_rates"] = {
+                k: float(v) * plasticity_damping
+                for k, v in plasticity_state["learning_rates"].items()
+            }
+        if "epsilon" in plasticity_state:
+            damped["epsilon"] = float(plasticity_state["epsilon"]) * plasticity_damping
+        if "eps_test" in plasticity_state:
+            damped["eps_test"] = float(plasticity_state["eps_test"]) * plasticity_damping
+        if "train_mode" in plasticity_state:
+            damped["train_mode"] = plasticity_state["train_mode"]
+        if damped:
+            child_payload["plasticity_state"] = damped
+
+    load_model_state = getattr(child_algorithm, "load_model_state", None)
+    try:
+        load_model_state(child_payload)
+    except Exception:
+        logger.exception(
+            "p2_warmstart_load_failed",
+            parent_id=getattr(parent, "agent_id", None),
+            offspring_id=getattr(offspring, "agent_id", None),
+        )
+        return WARMSTART_REASON_LOAD_FAILED
+
+    logger.debug(
+        "p2_warmstart_applied",
+        parent_id=getattr(parent, "agent_id", None),
+        offspring_id=getattr(offspring, "agent_id", None),
+        plasticity_damping=plasticity_damping,
+    )
+    return None
+
+
+def apply_p3_policy_warmstart(
+    parent: Any,
+    offspring: Any,
+    *,
+    replay_buffer_limit: int = P3_REPLAY_BUFFER_LIMIT,
+) -> Optional[str]:
+    """P3: Warm-start offspring with weights + optimizer state + replay slice.
+
+    Copies the parent's policy weights, optimizer state (Adam moments), and
+    a bounded slice of the parent's replay buffer so the offspring continues
+    the parent's learning trajectory instead of restarting from scratch.
+
+    Returns ``None`` on success; returns a ``WARMSTART_REASON_*`` string on
+    any skip.
+    """
+    parent_algorithm, child_algorithm, parent_state, skip_reason = (
+        _get_parent_algorithm_state(
+            parent,
+            offspring,
+            include_optimizer_state=True,
+            include_replay_buffer=True,
+            replay_buffer_limit=replay_buffer_limit,
+            include_plasticity_state=False,
+        )
+    )
+    if skip_reason is not None:
+        return skip_reason
+
+    policy_state = parent_state["policy_state_dict"]
+
+    # Build the child payload: weights + optional continuation machinery.
+    child_payload: Dict[str, Any] = {"policy_state_dict": policy_state}
+
+    step_count = parent_state.get("step_count")
+    if step_count is not None:
+        child_payload["step_count"] = step_count
+
+    optimizer_state = parent_state.get("optimizer_state")
+    if isinstance(optimizer_state, dict) and optimizer_state:
+        child_payload["optimizer_state"] = optimizer_state
+
+    replay_buffer_state = parent_state.get("replay_buffer_state")
+    if isinstance(replay_buffer_state, dict) and replay_buffer_state:
+        child_payload["replay_buffer_state"] = replay_buffer_state
+
+    load_model_state = getattr(child_algorithm, "load_model_state", None)
+    try:
+        load_model_state(child_payload)
+    except Exception:
+        logger.exception(
+            "p3_warmstart_load_failed",
+            parent_id=getattr(parent, "agent_id", None),
+            offspring_id=getattr(offspring, "agent_id", None),
+        )
+        return WARMSTART_REASON_LOAD_FAILED
+
+    logger.debug(
+        "p3_warmstart_applied",
+        parent_id=getattr(parent, "agent_id", None),
+        offspring_id=getattr(offspring, "agent_id", None),
+        replay_buffer_limit=replay_buffer_limit,
+        has_optimizer_state=bool(optimizer_state),
+        has_replay_buffer=bool(replay_buffer_state),
+    )
+    return None
+
+
+def apply_p4_policy_warmstart(
+    parent: Any,
+    offspring: Any,
+    *,
+    blend_alpha: float = P4_BLEND_ALPHA,
+    fitness_gate_min_resources: float = P4_FITNESS_GATE_MIN_RESOURCES,
+) -> Optional[str]:
+    """P4: Gated and blended policy transfer.
+
+    Applies transfer only when the parent clears a resource-based fitness gate.
+    When the gate is cleared, weights are blended as::
+
+        θ_child = blend_alpha * θ_parent + (1 - blend_alpha) * θ_init
+
+    where ``θ_init`` is the offspring's current (freshly initialised) weights.
+    This soft warm-start bounds local-niche lock-in by not fully committing to
+    the parent's learned representation.
+
+    Returns ``None`` on success; returns a ``WARMSTART_REASON_*`` string on any
+    skip, including ``WARMSTART_REASON_GATE_NOT_CLEARED`` when the parent does
+    not meet the fitness threshold.
+    """
+    # Fitness gate: check parent resource level.
+    parent_resource_level = getattr(parent, "resource_level", None)
+    if parent_resource_level is not None:
+        if float(parent_resource_level) < fitness_gate_min_resources:
+            logger.debug(
+                "p4_warmstart_gate_not_cleared",
+                parent_id=getattr(parent, "agent_id", None),
+                resource_level=parent_resource_level,
+                threshold=fitness_gate_min_resources,
+            )
+            return WARMSTART_REASON_GATE_NOT_CLEARED
+
+    parent_algorithm, child_algorithm, parent_state, skip_reason = (
+        _get_parent_algorithm_state(parent, offspring)
+    )
+    if skip_reason is not None:
+        return skip_reason
+
+    parent_policy_state = parent_state["policy_state_dict"]
+
+    # Capture the child's current (init) weights before blending.
+    child_policy = getattr(child_algorithm, "policy", None)
+    try:
+        child_init_state = child_policy.state_dict() if child_policy is not None else {}
+    except Exception:
+        child_init_state = {}
+
+    # Blend: θ_child = α*θ_parent + (1-α)*θ_init
+    blended_state: Dict[str, Any] = {}
+    for key, parent_value in parent_policy_state.items():
+        child_value = child_init_state.get(key)
+        if child_value is None:
+            blended_state[key] = parent_value
+            continue
+        try:
+            import torch  # noqa: PLC0415
+
+            if isinstance(parent_value, torch.Tensor) and isinstance(child_value, torch.Tensor):
+                blended_state[key] = (
+                    blend_alpha * parent_value + (1.0 - blend_alpha) * child_value
+                ).detach()
+            else:
+                blended_state[key] = parent_value
+        except Exception:
+            blended_state[key] = parent_value
+
+    step_count = parent_state.get("step_count")
+    child_payload: Dict[str, Any] = {"policy_state_dict": blended_state}
+    if step_count is not None:
+        child_payload["step_count"] = step_count
+
+    load_model_state = getattr(child_algorithm, "load_model_state", None)
+    try:
+        load_model_state(child_payload)
+    except Exception:
+        logger.exception(
+            "p4_warmstart_load_failed",
+            parent_id=getattr(parent, "agent_id", None),
+            offspring_id=getattr(offspring, "agent_id", None),
+        )
+        return WARMSTART_REASON_LOAD_FAILED
+
+    logger.debug(
+        "p4_warmstart_applied",
+        parent_id=getattr(parent, "agent_id", None),
+        offspring_id=getattr(offspring, "agent_id", None),
+        blend_alpha=blend_alpha,
+    )
     return None

--- a/farm/core/policy_inheritance.py
+++ b/farm/core/policy_inheritance.py
@@ -168,7 +168,7 @@ def _get_parent_algorithm_state(
 ) -> tuple:
     """Extract the parent's algorithm objects and model state.
 
-    Returns a 4-tuple ``(parent_algorithm, child_algorithm, policy_state, skip_reason)``.
+    Returns a 4-tuple ``(parent_algorithm, child_algorithm, parent_state, skip_reason)``.
     If ``skip_reason`` is not ``None`` the caller should propagate it immediately;
     the other three elements will be ``None``.
     """
@@ -249,7 +249,7 @@ def apply_p2_policy_warmstart(
     Returns ``None`` on success; returns a ``WARMSTART_REASON_*`` string on
     any skip so callers can attribute the outcome through telemetry.
     """
-    parent_algorithm, child_algorithm, parent_state, skip_reason = (
+    _, child_algorithm, parent_state, skip_reason = (
         _get_parent_algorithm_state(parent, offspring, include_plasticity_state=True)
     )
     if skip_reason is not None:
@@ -318,7 +318,7 @@ def apply_p3_policy_warmstart(
     Returns ``None`` on success; returns a ``WARMSTART_REASON_*`` string on
     any skip.
     """
-    parent_algorithm, child_algorithm, parent_state, skip_reason = (
+    _, child_algorithm, parent_state, skip_reason = (
         _get_parent_algorithm_state(
             parent,
             offspring,
@@ -404,7 +404,7 @@ def apply_p4_policy_warmstart(
             )
             return WARMSTART_REASON_GATE_NOT_CLEARED
 
-    parent_algorithm, child_algorithm, parent_state, skip_reason = (
+    _, child_algorithm, parent_state, skip_reason = (
         _get_parent_algorithm_state(parent, offspring)
     )
     if skip_reason is not None:
@@ -420,22 +420,26 @@ def apply_p4_policy_warmstart(
         child_init_state = {}
 
     # Blend: θ_child = α*θ_parent + (1-α)*θ_init
+    try:
+        import torch  # noqa: PLC0415
+    except ImportError:
+        torch = None  # type: ignore[assignment]
+
     blended_state: Dict[str, Any] = {}
     for key, parent_value in parent_policy_state.items():
         child_value = child_init_state.get(key)
         if child_value is None:
             blended_state[key] = parent_value
             continue
-        try:
-            import torch  # noqa: PLC0415
-
-            if isinstance(parent_value, torch.Tensor) and isinstance(child_value, torch.Tensor):
-                blended_state[key] = (
-                    blend_alpha * parent_value + (1.0 - blend_alpha) * child_value
-                ).detach()
-            else:
-                blended_state[key] = parent_value
-        except Exception:
+        if (
+            torch is not None
+            and isinstance(parent_value, torch.Tensor)
+            and isinstance(child_value, torch.Tensor)
+        ):
+            blended_state[key] = (
+                blend_alpha * parent_value + (1.0 - blend_alpha) * child_value
+            ).detach()
+        else:
             blended_state[key] = parent_value
 
     step_count = parent_state.get("step_count")

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -44,7 +44,7 @@ logger = get_logger(__name__)
 CoparentStrategy = Literal["nearest_alive_same_type", "random_alive_same_type"]
 SelectionPressurePreset = Literal["none", "low", "medium", "high"]
 InitialConditionsProfileName = Literal["stable", "stress", "exploratory", "legacy"]
-InheritanceMode = Literal["baldwinian", "lamarckian"]
+InheritanceMode = Literal["baldwinian", "lamarckian", "p2", "p3", "p4"]
 
 # ── Selection-pressure preset definitions ─────────────────────────────────────
 # Each preset maps to a ReproductionPressureConfig with sensible defaults that
@@ -472,8 +472,18 @@ class IntrinsicEvolutionPolicy:
         reproduction_pressure: Fine-grained density-dependent cost config.
             Ignored when ``selection_pressure`` is not ``None``.
         inheritance_mode: Offspring policy-state inheritance mode.
-            ``"baldwinian"`` keeps cold-start offspring policies.
-            ``"lamarckian"`` attempts compatible policy warm-starts.
+            ``"baldwinian"`` keeps cold-start offspring policies (default).
+            ``"lamarckian"`` (P1) attempts compatible policy warm-starts.
+            ``"p2"`` adds plasticity damping: weights are inherited with a
+            lowered initial learning rate and exploration rate (ε) so the
+            inherited weights are not immediately overwritten.
+            ``"p3"`` adds continuation machinery: weights plus optimizer state
+            and a bounded replay-buffer slice are transferred so the offspring
+            continues the parent's learning trajectory.
+            ``"p4"`` applies a gated/blended transfer: a fitness gate screens
+            the parent, and weights are blended as
+            ``θ_child = α·θ_parent + (1−α)·θ_init`` to bound local-niche
+            lock-in.
     """
 
     enabled: bool = True
@@ -517,8 +527,10 @@ class IntrinsicEvolutionPolicy:
             raise ValueError(
                 "coparent_strategy must be 'nearest_alive_same_type' or 'random_alive_same_type'."
             )
-        if self.inheritance_mode not in ("baldwinian", "lamarckian"):
-            raise ValueError("inheritance_mode must be 'baldwinian' or 'lamarckian'.")
+        if self.inheritance_mode not in ("baldwinian", "lamarckian", "p2", "p3", "p4"):
+            raise ValueError(
+                "inheritance_mode must be one of 'baldwinian', 'lamarckian', 'p2', 'p3', 'p4'."
+            )
         # Derive reproduction_pressure from the selection_pressure preset/scale when set.
         if self.selection_pressure is not None:
             derived = _preset_or_scale_to_pressure_config(self.selection_pressure)

--- a/scripts/run_inheritance_mode_ab.py
+++ b/scripts/run_inheritance_mode_ab.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
-"""Inheritance-mode A/B orchestrator for intrinsic evolution (Issue #849).
+"""Inheritance-mode A/B orchestrator for intrinsic evolution (Issue #849/#903).
 
-Runs matched seed sweeps for two arms:
+Runs matched seed sweeps across inheritance arms:
 
-- ``baldwinian``: offspring start with a fresh policy.
-- ``lamarckian``: offspring attempt policy warm-start from parent.
+- ``baldwinian``: offspring start with a fresh policy (default/baseline).
+- ``lamarckian``: offspring attempt policy warm-start from parent (P1).
+- ``p2``: weights inherited with plasticity damping (lower child LR/ε).
+- ``p3``: weights + optimizer state + bounded replay slice transferred.
+- ``p4``: gated/blended transfer (fitness gate + θ blend).
 """
 
 from __future__ import annotations
@@ -30,6 +33,9 @@ from scripts.run_stable_profile_seed_sweep import (  # noqa: E402
 ARM_PRESETS: Dict[str, Dict[str, Any]] = {
     "baldwinian": {"inheritance_mode": "baldwinian"},
     "lamarckian": {"inheritance_mode": "lamarckian"},
+    "p2": {"inheritance_mode": "p2"},
+    "p3": {"inheritance_mode": "p3"},
+    "p4": {"inheritance_mode": "p4"},
 }
 DEFAULT_ARMS: List[str] = ["baldwinian", "lamarckian"]
 
@@ -37,8 +43,9 @@ DEFAULT_ARMS: List[str] = ["baldwinian", "lamarckian"]
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Orchestrate Baldwinian vs Lamarckian matched A/B sweeps "
-            "using the stable-profile intrinsic evolution runner."
+            "Orchestrate inheritance-mode matched A/B sweeps "
+            "using the stable-profile intrinsic evolution runner. "
+            "Supports baldwinian (baseline), lamarckian (P1), p2, p3, and p4 arms."
         ),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
@@ -48,7 +55,11 @@ def _build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_ARMS,
         choices=list(ARM_PRESETS),
         metavar="ARM",
-        help="Inheritance arms to run.",
+        help=(
+            "Inheritance arms to run. "
+            "Choices: baldwinian (baseline), lamarckian (P1), p2, p3, p4. "
+            "Default: baldwinian lamarckian."
+        ),
     )
     parser.add_argument(
         "--output-dir",

--- a/scripts/run_stable_profile_seed_sweep.py
+++ b/scripts/run_stable_profile_seed_sweep.py
@@ -80,7 +80,7 @@ COPARENT_STRATEGIES: List[str] = [
     "nearest_alive_same_type",
     "random_alive_same_type",
 ]
-INHERITANCE_MODES: List[str] = ["baldwinian", "lamarckian"]
+INHERITANCE_MODES: List[str] = ["baldwinian", "lamarckian", "p2", "p3", "p4"]
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -126,7 +126,14 @@ def _build_parser() -> argparse.ArgumentParser:
         type=str,
         default="baldwinian",
         choices=INHERITANCE_MODES,
-        help="Policy inheritance mode for offspring (Baldwinian or Lamarckian warm-start).",
+        help=(
+            "Policy inheritance mode for offspring. "
+            "'baldwinian' (default): cold-start. "
+            "'lamarckian' (P1): weights only. "
+            "'p2': weights + plasticity damping. "
+            "'p3': weights + optimizer state + replay slice. "
+            "'p4': gated/blended transfer."
+        ),
     )
     parser.add_argument("--initial-diversity-mutation-rate", type=float, default=1.0)
     parser.add_argument("--initial-diversity-mutation-scale", type=float, default=0.25)

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -119,6 +119,27 @@ class TestIntrinsicEvolutionPolicy(unittest.TestCase):
         with self.assertRaises(ValueError):
             IntrinsicEvolutionPolicy(mutation_mode="not_a_mode")  # type: ignore[arg-type]
 
+    def test_p2_mode_accepted(self):
+        policy = IntrinsicEvolutionPolicy(inheritance_mode="p2")
+        self.assertEqual(policy.inheritance_mode, "p2")
+
+    def test_p3_mode_accepted(self):
+        policy = IntrinsicEvolutionPolicy(inheritance_mode="p3")
+        self.assertEqual(policy.inheritance_mode, "p3")
+
+    def test_p4_mode_accepted(self):
+        policy = IntrinsicEvolutionPolicy(inheritance_mode="p4")
+        self.assertEqual(policy.inheritance_mode, "p4")
+
+    def test_invalid_inheritance_mode_raises(self):
+        with self.assertRaises(ValueError):
+            IntrinsicEvolutionPolicy(inheritance_mode="epigenetic")  # type: ignore[arg-type]
+
+    def test_all_valid_inheritance_modes_accepted(self):
+        for mode in ("baldwinian", "lamarckian", "p2", "p3", "p4"):
+            policy = IntrinsicEvolutionPolicy(inheritance_mode=mode)
+            self.assertEqual(policy.inheritance_mode, mode)
+
 
 class TestIntrinsicEvolutionExperimentConfig(unittest.TestCase):
     def test_rejects_zero_steps(self):

--- a/tests/scripts/test_run_inheritance_mode_ab_args.py
+++ b/tests/scripts/test_run_inheritance_mode_ab_args.py
@@ -1,0 +1,81 @@
+"""Tests for the ``scripts/run_inheritance_mode_ab.py`` CLI / preset table.
+
+Covers the subset that can be exercised without a full simulation: parser
+defaults, choice validation, and the ARM_PRESETS / DEFAULT_ARMS constants.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+_repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+import pytest  # noqa: E402
+
+from scripts.run_inheritance_mode_ab import (  # noqa: E402
+    ARM_PRESETS,
+    DEFAULT_ARMS,
+    _build_parser,
+)
+
+
+class TestArmPresetsConstant(unittest.TestCase):
+    def test_all_p_modes_present(self):
+        for mode in ("p2", "p3", "p4"):
+            self.assertIn(mode, ARM_PRESETS, f"ARM_PRESETS missing '{mode}'")
+
+    def test_baseline_arms_present(self):
+        self.assertIn("baldwinian", ARM_PRESETS)
+        self.assertIn("lamarckian", ARM_PRESETS)
+
+    def test_each_preset_maps_to_correct_mode(self):
+        for arm, preset in ARM_PRESETS.items():
+            self.assertEqual(
+                preset["inheritance_mode"],
+                arm,
+                f"ARM_PRESETS[{arm!r}]['inheritance_mode'] != {arm!r}",
+            )
+
+    def test_default_arms_are_subset_of_presets(self):
+        for arm in DEFAULT_ARMS:
+            self.assertIn(arm, ARM_PRESETS)
+
+
+class TestABParserArmChoices(unittest.TestCase):
+    def test_default_arms_are_baseline_pair(self):
+        args = _build_parser().parse_args([])
+        self.assertEqual(args.arms, ["baldwinian", "lamarckian"])
+
+    def test_p2_arm_accepted(self):
+        args = _build_parser().parse_args(["--arms", "p2"])
+        self.assertEqual(args.arms, ["p2"])
+
+    def test_p3_arm_accepted(self):
+        args = _build_parser().parse_args(["--arms", "p3"])
+        self.assertEqual(args.arms, ["p3"])
+
+    def test_p4_arm_accepted(self):
+        args = _build_parser().parse_args(["--arms", "p4"])
+        self.assertEqual(args.arms, ["p4"])
+
+    def test_multiple_arms_including_new_modes(self):
+        args = _build_parser().parse_args(["--arms", "baldwinian", "p2", "p3", "p4"])
+        self.assertEqual(args.arms, ["baldwinian", "p2", "p3", "p4"])
+
+    def test_invalid_arm_rejected(self):
+        with pytest.raises(SystemExit):
+            _build_parser().parse_args(["--arms", "epigenetic"])
+
+    def test_all_arms_accepted_together(self):
+        args = _build_parser().parse_args(
+            ["--arms", "baldwinian", "lamarckian", "p2", "p3", "p4"]
+        )
+        self.assertEqual(set(args.arms), set(ARM_PRESETS))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_run_stable_profile_seed_sweep_args.py
+++ b/tests/scripts/test_run_stable_profile_seed_sweep_args.py
@@ -45,7 +45,31 @@ class TestInheritanceModeFlag(unittest.TestCase):
             _build_parser().parse_args(["--inheritance-mode", "epigenetic"])
 
     def test_choices_match_module_constant(self):
-        self.assertEqual(set(INHERITANCE_MODES), {"baldwinian", "lamarckian"})
+        self.assertEqual(set(INHERITANCE_MODES), {"baldwinian", "lamarckian", "p2", "p3", "p4"})
+
+    def test_p2_accepted(self):
+        args = _build_parser().parse_args(["--inheritance-mode", "p2"])
+        self.assertEqual(args.inheritance_mode, "p2")
+        self.assertEqual(
+            _inheritance_settings_dict(args),
+            {"inheritance_mode": "p2"},
+        )
+
+    def test_p3_accepted(self):
+        args = _build_parser().parse_args(["--inheritance-mode", "p3"])
+        self.assertEqual(args.inheritance_mode, "p3")
+        self.assertEqual(
+            _inheritance_settings_dict(args),
+            {"inheritance_mode": "p3"},
+        )
+
+    def test_p4_accepted(self):
+        args = _build_parser().parse_args(["--inheritance-mode", "p4"])
+        self.assertEqual(args.inheritance_mode, "p4")
+        self.assertEqual(
+            _inheritance_settings_dict(args),
+            {"inheritance_mode": "p4"},
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -714,3 +714,68 @@ def test_reproduce_baldwinian_mode_never_calls_warmstart():
     assert telemetry.lamarckian_warmstart_applied == 0
     assert telemetry.lamarckian_warmstart_skipped == 0
     offspring.behavior.decision_module.algorithm.load_model_state.assert_not_called()
+
+
+def test_reproduce_warmstart_failure_is_non_fatal():
+    """A raising warm-start must not fail reproduction; it records a skip.
+
+    This guards the contract that policy warm-start is best-effort: a failure
+    in the (P2) payload load leaves a cold-start child rather than aborting the
+    birth event and refunding the parent's resources.
+    """
+    from farm.core.policy_inheritance import WARMSTART_REASON_LOAD_FAILED
+
+    parent = _build_p_mode_parent("p2")
+    offspring = _build_offspring_mock()
+    offspring.behavior.decision_module.algorithm.load_model_state.side_effect = (
+        RuntimeError("boom")
+    )
+
+    with patch("farm.core.agent.factory.AgentFactory") as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is True
+    telemetry = parent.environment.inheritance_telemetry
+    assert telemetry.lamarckian_warmstart_applied == 0
+    assert telemetry.lamarckian_warmstart_skipped == 1
+    assert telemetry.lamarckian_warmstart_skipped_reasons[WARMSTART_REASON_LOAD_FAILED] == 1
+
+
+def test_reproduce_extended_state_unsupported_is_observable():
+    """A P3 run on a kwargless algorithm records EXTENDED_STATE_UNSUPPORTED.
+
+    Rather than silently downgrading to a weights-only (P1) transfer, the
+    outcome is attributed so a misconfigured arm shows up as all-skipped.
+    """
+    from farm.core.policy_inheritance import (
+        WARMSTART_REASON_EXTENDED_STATE_UNSUPPORTED,
+    )
+
+    parent = _build_p_mode_parent("p3")
+
+    def _kwargless_get_model_state():
+        return {"policy_state_dict": {"w": Mock(shape=(2, 2))}}
+
+    parent.behavior.decision_module.algorithm.get_model_state = (
+        _kwargless_get_model_state
+    )
+    offspring = _build_offspring_mock()
+
+    with patch("farm.core.agent.factory.AgentFactory") as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is True
+    telemetry = parent.environment.inheritance_telemetry
+    assert telemetry.lamarckian_warmstart_applied == 0
+    assert telemetry.lamarckian_warmstart_skipped == 1
+    assert (
+        telemetry.lamarckian_warmstart_skipped_reasons[
+            WARMSTART_REASON_EXTENDED_STATE_UNSUPPORTED
+        ]
+        == 1
+    )
+    offspring.behavior.decision_module.algorithm.load_model_state.assert_not_called()

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -577,3 +577,140 @@ def test_reproduce_uses_environment_partial_add_rollback_hook_when_available():
     assert parent.environment.rollback_calls == ["child_1"]
     parent.get_component("resource").add.assert_called_once_with(5.0)
 
+
+
+def _build_p_mode_parent(inheritance_mode: str) -> AgentCore:
+    """Build a parent with the given inheritance_mode and warm-start API mocks."""
+    parent = _build_parent_agent_for_reproduction()
+    parent.environment.intrinsic_evolution_policy = IntrinsicEvolutionPolicy(
+        mutation_rate=0.0,
+        mutation_scale=0.0,
+        inheritance_mode=inheritance_mode,
+    )
+    parent.behavior = Mock()
+    parent.behavior.decision_module = Mock()
+    parent.behavior.decision_module.algorithm = Mock()
+
+    def _get_model_state(
+        include_optimizer_state=False,
+        include_replay_buffer=False,
+        replay_buffer_limit=None,
+        include_plasticity_state=False,
+    ):
+        state = {"policy_state_dict": {"w": Mock(shape=(2, 2))}}
+        if include_plasticity_state:
+            state["plasticity_state"] = {"learning_rate": 0.01, "epsilon": 0.3}
+        if include_optimizer_state:
+            state["optimizer_state"] = {"optim": {}}
+        if include_replay_buffer:
+            state["replay_buffer_state"] = {"transitions": [], "size": 0}
+        return state
+
+    parent.behavior.decision_module.algorithm.get_model_state = _get_model_state
+    return parent
+
+
+def _build_offspring_mock() -> Mock:
+    offspring = Mock()
+    offspring.state = Mock()
+    offspring.state._state = Mock()
+    offspring.state._state.model_copy.return_value = Mock()
+    offspring.behavior = Mock()
+    offspring.behavior.decision_module = Mock()
+    offspring.behavior.decision_module.algorithm = Mock()
+    offspring.behavior.decision_module.algorithm.policy = Mock()
+    offspring.behavior.decision_module.algorithm.policy.state_dict.return_value = {
+        "w": Mock(shape=(2, 2))
+    }
+    return offspring
+
+
+def test_reproduce_p2_mode_applies_warmstart_and_tracks_counter():
+    """P2 mode should invoke warm-start and record an applied outcome."""
+    parent = _build_p_mode_parent("p2")
+    offspring = _build_offspring_mock()
+
+    with patch("farm.core.agent.factory.AgentFactory") as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is True
+    telemetry = parent.environment.inheritance_telemetry
+    assert telemetry.lamarckian_warmstart_applied == 1
+    assert telemetry.lamarckian_warmstart_skipped == 0
+    offspring.behavior.decision_module.algorithm.load_model_state.assert_called_once()
+
+
+def test_reproduce_p3_mode_applies_warmstart_and_tracks_counter():
+    """P3 mode should invoke warm-start and record an applied outcome."""
+    parent = _build_p_mode_parent("p3")
+    offspring = _build_offspring_mock()
+
+    with patch("farm.core.agent.factory.AgentFactory") as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is True
+    telemetry = parent.environment.inheritance_telemetry
+    assert telemetry.lamarckian_warmstart_applied == 1
+    assert telemetry.lamarckian_warmstart_skipped == 0
+    offspring.behavior.decision_module.algorithm.load_model_state.assert_called_once()
+
+
+def test_reproduce_p4_mode_applies_warmstart_when_gate_cleared():
+    """P4 mode with sufficient resources should apply warm-start."""
+    parent = _build_p_mode_parent("p4")
+    # Give the parent enough resources to clear the gate.
+    parent.resource_level = 100.0
+    offspring = _build_offspring_mock()
+
+    with patch("farm.core.agent.factory.AgentFactory") as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is True
+    telemetry = parent.environment.inheritance_telemetry
+    assert telemetry.lamarckian_warmstart_applied == 1
+    assert telemetry.lamarckian_warmstart_skipped == 0
+    offspring.behavior.decision_module.algorithm.load_model_state.assert_called_once()
+
+
+def test_reproduce_p4_mode_skips_when_gate_not_cleared():
+    """P4 mode should skip warm-start when the parent fails the fitness gate."""
+    from farm.core.policy_inheritance import WARMSTART_REASON_GATE_NOT_CLEARED
+
+    parent = _build_p_mode_parent("p4")
+    parent.resource_level = 0.0  # below P4_FITNESS_GATE_MIN_RESOURCES
+    offspring = _build_offspring_mock()
+
+    with patch("farm.core.agent.factory.AgentFactory") as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is True
+    telemetry = parent.environment.inheritance_telemetry
+    assert telemetry.lamarckian_warmstart_applied == 0
+    assert telemetry.lamarckian_warmstart_skipped == 1
+    assert telemetry.lamarckian_warmstart_skipped_reasons[WARMSTART_REASON_GATE_NOT_CLEARED] == 1
+    offspring.behavior.decision_module.algorithm.load_model_state.assert_not_called()
+
+
+def test_reproduce_baldwinian_mode_never_calls_warmstart():
+    """Baldwinian mode must not touch policy inheritance at all."""
+    parent = _build_p_mode_parent("baldwinian")
+    offspring = _build_offspring_mock()
+
+    with patch("farm.core.agent.factory.AgentFactory") as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is True
+    telemetry = parent.environment.inheritance_telemetry
+    assert telemetry.lamarckian_warmstart_applied == 0
+    assert telemetry.lamarckian_warmstart_skipped == 0
+    offspring.behavior.decision_module.algorithm.load_model_state.assert_not_called()

--- a/tests/test_policy_inheritance.py
+++ b/tests/test_policy_inheritance.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 
 from farm.core.inheritance_telemetry import InheritanceTelemetry
 from farm.core.policy_inheritance import (
+    WARMSTART_REASON_GATE_NOT_CLEARED,
     WARMSTART_REASON_INCOMPATIBLE_STATE,
     WARMSTART_REASON_LOAD_FAILED,
     WARMSTART_REASON_NO_ALGORITHM,
@@ -16,6 +17,9 @@ from farm.core.policy_inheritance import (
     WARMSTART_REASON_PARENT_STATE_FAILED,
     _policy_state_is_compatible,
     apply_lamarckian_policy_warmstart,
+    apply_p2_policy_warmstart,
+    apply_p3_policy_warmstart,
+    apply_p4_policy_warmstart,
 )
 
 
@@ -268,3 +272,317 @@ def test_apply_skips_when_offspring_behavior_is_none():
         apply_lamarckian_policy_warmstart(parent, offspring)
         == WARMSTART_REASON_NO_DECISION_MODULE
     )
+
+
+# ---------------------------------------------------------------------------
+# Helpers for P2/P3/P4 tests
+# ---------------------------------------------------------------------------
+
+
+def _make_extended_pair(
+    parent_state,
+    child_state,
+    *,
+    child_load=None,
+    parent_resource_level=None,
+):
+    """Build parent/offspring objects whose ``get_model_state`` accepts kwargs.
+
+    Unlike :func:`_make_pair`, the ``get_model_state`` callable here accepts
+    ``include_optimizer_state``, ``include_replay_buffer``, etc., mirroring the
+    real :class:`TianshouWrapper` API used by P2/P3/P4.
+    """
+
+    def _get_model_state(
+        include_optimizer_state=False,
+        include_replay_buffer=False,
+        replay_buffer_limit=None,
+        include_plasticity_state=False,
+    ):
+        return parent_state
+
+    parent_kwargs = dict(
+        agent_id="parent",
+        behavior=SimpleNamespace(
+            decision_module=SimpleNamespace(
+                algorithm=SimpleNamespace(
+                    get_model_state=_get_model_state,
+                ),
+            ),
+        ),
+    )
+    if parent_resource_level is not None:
+        parent_kwargs["resource_level"] = parent_resource_level
+    parent = SimpleNamespace(**parent_kwargs)
+
+    child_policy = SimpleNamespace(
+        state_dict=lambda: child_state,
+    )
+    offspring = SimpleNamespace(
+        agent_id="child",
+        behavior=SimpleNamespace(
+            decision_module=SimpleNamespace(
+                algorithm=SimpleNamespace(
+                    policy=child_policy,
+                    load_model_state=child_load if child_load is not None else Mock(),
+                ),
+            ),
+        ),
+    )
+    return parent, offspring
+
+
+# ---------------------------------------------------------------------------
+# P2 tests
+# ---------------------------------------------------------------------------
+
+
+def test_p2_applies_weights_and_damped_plasticity():
+    """P2 must load policy weights with dampened LR and ε."""
+    parent_state = {
+        "policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))},
+        "step_count": 100,
+        "plasticity_state": {
+            "learning_rate": 0.01,
+            "epsilon": 0.4,
+            "train_mode": True,
+        },
+    }
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    load = Mock()
+    parent, offspring = _make_extended_pair(parent_state, child_state, child_load=load)
+
+    reason = apply_p2_policy_warmstart(parent, offspring, plasticity_damping=0.5)
+
+    assert reason is None
+    load.assert_called_once()
+    payload = load.call_args.args[0]
+    assert payload["policy_state_dict"] is parent_state["policy_state_dict"]
+    assert payload["step_count"] == 100
+    assert "plasticity_state" in payload
+    damped = payload["plasticity_state"]
+    assert abs(damped["learning_rate"] - 0.005) < 1e-9
+    assert abs(damped["epsilon"] - 0.2) < 1e-9
+    assert damped["train_mode"] is True
+
+
+def test_p2_works_without_plasticity_state():
+    """P2 must succeed even when the parent has no plasticity_state key."""
+    parent_state = {
+        "policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))},
+    }
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    load = Mock()
+    parent, offspring = _make_extended_pair(parent_state, child_state, child_load=load)
+
+    reason = apply_p2_policy_warmstart(parent, offspring)
+
+    assert reason is None
+    load.assert_called_once()
+    payload = load.call_args.args[0]
+    assert payload["policy_state_dict"] is parent_state["policy_state_dict"]
+    assert "plasticity_state" not in payload
+
+
+def test_p2_skips_on_incompatible_state():
+    """P2 must propagate INCOMPATIBLE_STATE when shapes mismatch."""
+    parent_state = {"policy_state_dict": {"w": SimpleNamespace(shape=(4, 4))}}
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    parent, offspring = _make_extended_pair(parent_state, child_state)
+
+    assert apply_p2_policy_warmstart(parent, offspring) == WARMSTART_REASON_INCOMPATIBLE_STATE
+
+
+def test_p2_returns_load_failed_when_load_raises():
+    parent_state = {"policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))}}
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+
+    def _load(_payload):
+        raise RuntimeError("load failed")
+
+    parent, offspring = _make_extended_pair(parent_state, child_state, child_load=_load)
+    assert apply_p2_policy_warmstart(parent, offspring) == WARMSTART_REASON_LOAD_FAILED
+
+
+# ---------------------------------------------------------------------------
+# P3 tests
+# ---------------------------------------------------------------------------
+
+
+def test_p3_applies_weights_optimizer_and_replay():
+    """P3 must pass all three continuation-machinery payloads to load_model_state."""
+    parent_state = {
+        "policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))},
+        "step_count": 50,
+        "optimizer_state": {"optim": {"state": {}, "param_groups": []}},
+        "replay_buffer_state": {"transitions": [], "size": 0},
+    }
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    load = Mock()
+    parent, offspring = _make_extended_pair(parent_state, child_state, child_load=load)
+
+    reason = apply_p3_policy_warmstart(parent, offspring)
+
+    assert reason is None
+    load.assert_called_once()
+    payload = load.call_args.args[0]
+    assert payload["policy_state_dict"] is parent_state["policy_state_dict"]
+    assert payload["step_count"] == 50
+    assert payload["optimizer_state"] is parent_state["optimizer_state"]
+    assert payload["replay_buffer_state"] is parent_state["replay_buffer_state"]
+
+
+def test_p3_works_without_optional_payloads():
+    """P3 must succeed even when optimizer/replay state is absent."""
+    parent_state = {"policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))}}
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    load = Mock()
+    parent, offspring = _make_extended_pair(parent_state, child_state, child_load=load)
+
+    reason = apply_p3_policy_warmstart(parent, offspring)
+
+    assert reason is None
+    load.assert_called_once()
+    payload = load.call_args.args[0]
+    assert "optimizer_state" not in payload
+    assert "replay_buffer_state" not in payload
+
+
+def test_p3_skips_on_incompatible_state():
+    parent_state = {"policy_state_dict": {"w": SimpleNamespace(shape=(4, 4))}}
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    parent, offspring = _make_extended_pair(parent_state, child_state)
+
+    assert apply_p3_policy_warmstart(parent, offspring) == WARMSTART_REASON_INCOMPATIBLE_STATE
+
+
+def test_p3_returns_load_failed_when_load_raises():
+    parent_state = {"policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))}}
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+
+    def _load(_payload):
+        raise RuntimeError("load failed")
+
+    parent, offspring = _make_extended_pair(parent_state, child_state, child_load=_load)
+    assert apply_p3_policy_warmstart(parent, offspring) == WARMSTART_REASON_LOAD_FAILED
+
+
+# ---------------------------------------------------------------------------
+# P4 tests
+# ---------------------------------------------------------------------------
+
+
+def test_p4_gate_not_cleared_when_resources_too_low():
+    """P4 must skip when the parent's resource level is below the fitness gate."""
+    parent_state = {"policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))}}
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    load = Mock()
+    parent, offspring = _make_extended_pair(
+        parent_state, child_state, child_load=load, parent_resource_level=0.0
+    )
+
+    reason = apply_p4_policy_warmstart(
+        parent, offspring, fitness_gate_min_resources=1.0
+    )
+
+    assert reason == WARMSTART_REASON_GATE_NOT_CLEARED
+    load.assert_not_called()
+
+
+def test_p4_gate_cleared_when_resources_sufficient():
+    """P4 must proceed when the parent clears the fitness gate."""
+    parent_state = {"policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))}}
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    load = Mock()
+    parent, offspring = _make_extended_pair(
+        parent_state, child_state, child_load=load, parent_resource_level=5.0
+    )
+
+    reason = apply_p4_policy_warmstart(
+        parent, offspring, fitness_gate_min_resources=1.0
+    )
+
+    assert reason is None
+    load.assert_called_once()
+
+
+def test_p4_gate_skipped_when_no_resource_level():
+    """P4 must proceed (not gate-fail) when the parent has no resource_level attr."""
+    parent_state = {"policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))}}
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    load = Mock()
+    parent, offspring = _make_extended_pair(parent_state, child_state, child_load=load)
+    # parent has no resource_level attribute — gate check is skipped
+
+    reason = apply_p4_policy_warmstart(parent, offspring, fitness_gate_min_resources=1.0)
+
+    assert reason is None
+    load.assert_called_once()
+
+
+def test_p4_blends_tensor_weights(tmp_path):
+    """P4 blending produces the expected linear combination when torch is available."""
+    try:
+        import torch  # noqa: PLC0415
+    except ImportError:
+        return  # skip on environments without torch
+
+    parent_weights = torch.tensor([4.0, 4.0])
+    child_weights = torch.tensor([0.0, 0.0])
+
+    parent_state = {"policy_state_dict": {"w": parent_weights}}
+    child_state = {"w": child_weights}
+    load = Mock()
+    parent, offspring = _make_extended_pair(
+        parent_state, child_state, child_load=load, parent_resource_level=10.0
+    )
+
+    reason = apply_p4_policy_warmstart(
+        parent, offspring, blend_alpha=0.5, fitness_gate_min_resources=1.0
+    )
+
+    assert reason is None
+    load.assert_called_once()
+    payload = load.call_args.args[0]
+    blended = payload["policy_state_dict"]["w"]
+    expected = torch.tensor([2.0, 2.0])
+    assert torch.allclose(blended, expected), f"expected {expected}, got {blended}"
+
+
+def test_p4_falls_back_to_parent_weights_for_non_tensor():
+    """P4 must pass parent weights through unchanged for non-Tensor values."""
+    parent_state = {"policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))}}
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    load = Mock()
+    parent, offspring = _make_extended_pair(
+        parent_state, child_state, child_load=load, parent_resource_level=10.0
+    )
+
+    reason = apply_p4_policy_warmstart(parent, offspring)
+
+    assert reason is None
+    payload = load.call_args.args[0]
+    assert payload["policy_state_dict"]["w"] is parent_state["policy_state_dict"]["w"]
+
+
+def test_p4_skips_on_incompatible_state():
+    parent_state = {"policy_state_dict": {"w": SimpleNamespace(shape=(4, 4))}}
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    parent, offspring = _make_extended_pair(
+        parent_state, child_state, parent_resource_level=10.0
+    )
+
+    assert apply_p4_policy_warmstart(parent, offspring) == WARMSTART_REASON_INCOMPATIBLE_STATE
+
+
+def test_p4_returns_load_failed_when_load_raises():
+    parent_state = {"policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))}}
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+
+    def _load(_payload):
+        raise RuntimeError("load failed")
+
+    parent, offspring = _make_extended_pair(
+        parent_state, child_state, child_load=_load, parent_resource_level=10.0
+    )
+    assert apply_p4_policy_warmstart(parent, offspring) == WARMSTART_REASON_LOAD_FAILED

--- a/tests/test_policy_inheritance.py
+++ b/tests/test_policy_inheritance.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 
 from farm.core.inheritance_telemetry import InheritanceTelemetry
 from farm.core.policy_inheritance import (
+    WARMSTART_REASON_EXTENDED_STATE_UNSUPPORTED,
     WARMSTART_REASON_GATE_NOT_CLEARED,
     WARMSTART_REASON_INCOMPATIBLE_STATE,
     WARMSTART_REASON_LOAD_FAILED,
@@ -586,3 +587,141 @@ def test_p4_returns_load_failed_when_load_raises():
         parent_state, child_state, child_load=_load, parent_resource_level=10.0
     )
     assert apply_p4_policy_warmstart(parent, offspring) == WARMSTART_REASON_LOAD_FAILED
+
+
+# ---------------------------------------------------------------------------
+# Extended-state capability detection (observable downgrade)
+# ---------------------------------------------------------------------------
+
+
+def test_p2_skips_when_extended_state_unsupported():
+    """P2 must report EXTENDED_STATE_UNSUPPORTED rather than silently downgrade.
+
+    ``_make_pair`` builds a ``get_model_state`` that takes no kwargs (like an
+    older algorithm), so P2 cannot obtain plasticity state.
+    """
+    parent_state = {"policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))}}
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    load = Mock()
+    parent, offspring = _make_pair(parent_state, child_state, child_load=load)
+
+    reason = apply_p2_policy_warmstart(parent, offspring)
+
+    assert reason == WARMSTART_REASON_EXTENDED_STATE_UNSUPPORTED
+    load.assert_not_called()
+
+
+def test_p3_skips_when_extended_state_unsupported():
+    """P3 must report EXTENDED_STATE_UNSUPPORTED when kwargs aren't accepted."""
+    parent_state = {"policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))}}
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    load = Mock()
+    parent, offspring = _make_pair(parent_state, child_state, child_load=load)
+
+    reason = apply_p3_policy_warmstart(parent, offspring)
+
+    assert reason == WARMSTART_REASON_EXTENDED_STATE_UNSUPPORTED
+    load.assert_not_called()
+
+
+def test_p1_works_with_kwargless_get_model_state():
+    """Lamarckian (P1) needs no extended state, so a kwargless API still works."""
+    parent_state = {"policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))}}
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    load = Mock()
+    parent, offspring = _make_pair(parent_state, child_state, child_load=load)
+
+    assert apply_lamarckian_policy_warmstart(parent, offspring) is None
+    load.assert_called_once()
+
+
+def test_p4_works_with_kwargless_get_model_state():
+    """P4 blends weights only, so it does not require extended-state support."""
+    parent_state = {"policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))}}
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    load = Mock()
+    parent, offspring = _make_pair(parent_state, child_state, child_load=load)
+
+    assert apply_p4_policy_warmstart(parent, offspring) is None
+    load.assert_called_once()
+
+
+def test_extended_state_supported_via_var_keyword():
+    """A ``**kwargs`` signature is treated as supporting extended state."""
+    parent_state = {
+        "policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))},
+        "plasticity_state": {"learning_rate": 0.01},
+    }
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    load = Mock()
+
+    def _get_model_state(**_kwargs):
+        return parent_state
+
+    parent = SimpleNamespace(
+        agent_id="parent",
+        behavior=SimpleNamespace(
+            decision_module=SimpleNamespace(
+                algorithm=SimpleNamespace(get_model_state=_get_model_state),
+            ),
+        ),
+    )
+    offspring = SimpleNamespace(
+        agent_id="child",
+        behavior=SimpleNamespace(
+            decision_module=SimpleNamespace(
+                algorithm=SimpleNamespace(
+                    policy=SimpleNamespace(state_dict=lambda: child_state),
+                    load_model_state=load,
+                ),
+            ),
+        ),
+    )
+
+    assert apply_p2_policy_warmstart(parent, offspring) is None
+    load.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Non-fatal payload construction
+# ---------------------------------------------------------------------------
+
+
+def test_p2_malformed_plasticity_is_non_fatal():
+    """A non-numeric learning_rate must yield LOAD_FAILED, never raise."""
+    parent_state = {
+        "policy_state_dict": {"w": SimpleNamespace(shape=(2, 2))},
+        "plasticity_state": {"learning_rate": "not-a-number"},
+    }
+    child_state = {"w": SimpleNamespace(shape=(2, 2))}
+    load = Mock()
+    parent, offspring = _make_extended_pair(parent_state, child_state, child_load=load)
+
+    reason = apply_p2_policy_warmstart(parent, offspring)
+
+    assert reason == WARMSTART_REASON_LOAD_FAILED
+    load.assert_not_called()
+
+
+def test_p4_does_not_blend_integer_tensors():
+    """Integer (non-float) tensors must pass through verbatim, not blend."""
+    try:
+        import torch  # noqa: PLC0415
+    except ImportError:
+        return  # skip on environments without torch
+
+    parent_buffer = torch.tensor([4, 4], dtype=torch.long)
+    child_buffer = torch.tensor([0, 0], dtype=torch.long)
+
+    parent_state = {"policy_state_dict": {"n": parent_buffer}}
+    child_state = {"n": child_buffer}
+    load = Mock()
+    parent, offspring = _make_extended_pair(
+        parent_state, child_state, child_load=load, parent_resource_level=10.0
+    )
+
+    reason = apply_p4_policy_warmstart(parent, offspring, blend_alpha=0.5)
+
+    assert reason is None
+    payload = load.call_args.args[0]
+    assert payload["policy_state_dict"]["n"] is parent_buffer

--- a/tests/test_policy_inheritance.py
+++ b/tests/test_policy_inheritance.py
@@ -520,7 +520,7 @@ def test_p4_gate_skipped_when_no_resource_level():
     load.assert_called_once()
 
 
-def test_p4_blends_tensor_weights(tmp_path):
+def test_p4_blends_tensor_weights():
     """P4 blending produces the expected linear combination when torch is available."""
     try:
         import torch  # noqa: PLC0415


### PR DESCRIPTION
This pull request adds support for multiple new policy inheritance modes (P2, P3, P4) in intrinsic evolution experiments, extending beyond the previous "baldwinian" and "lamarckian" options. It introduces new warm-start mechanisms for agent offspring, updates configuration and validation logic, and enhances experiment orchestration scripts to support these new modes.

**Inheritance mode support and configuration:**
- Added new inheritance modes "p2", "p3", and "p4" to the allowed `inheritance_mode` options, with corresponding validation and documentation updates in `IntrinsicEvolutionPolicy` and related scripts. [[1]](diffhunk://#diff-7df2829374038ce4ba23f7d77ce0f8c289eb1ff9b3959afc3c853239c703ec5eL47-R47) [[2]](diffhunk://#diff-7df2829374038ce4ba23f7d77ce0f8c289eb1ff9b3959afc3c853239c703ec5eL475-R486) [[3]](diffhunk://#diff-7df2829374038ce4ba23f7d77ce0f8c289eb1ff9b3959afc3c853239c703ec5eL520-R533) [[4]](diffhunk://#diff-0c1a489d433979494f32421f58b59f1ea8b7da23264a71a83cebf915b9c95187L83-R83) [[5]](diffhunk://#diff-bd75231b5097e49f9fac95448ec4dc90e10f879eef315b52d79ca45e1176d732R36-R48) [[6]](diffhunk://#diff-bd75231b5097e49f9fac95448ec4dc90e10f879eef315b52d79ca45e1176d732L51-R62) [[7]](diffhunk://#diff-bd75231b5097e49f9fac95448ec4dc90e10f879eef315b52d79ca45e1176d732L2-R10)

**Warm-start mechanism implementations:**
- Implemented `apply_p2_policy_warmstart`, `apply_p3_policy_warmstart`, and `apply_p4_policy_warmstart` in `policy_inheritance.py`, each with distinct transfer logic:
  - P2: Inherits weights and applies plasticity damping to learning/exploration rates.
  - P3: Inherits weights, optimizer state, and a bounded replay buffer slice.
  - P4: Performs gated/blended transfer, blending parent and child weights if a fitness threshold is met. [[1]](diffhunk://#diff-e7b1139b26913335b3cfc007bf25b568d7e77169a69aea2c132964c8a4a9a46aR20-R26) [[2]](diffhunk://#diff-e7b1139b26913335b3cfc007bf25b568d7e77169a69aea2c132964c8a4a9a46aR50-R69) [[3]](diffhunk://#diff-e7b1139b26913335b3cfc007bf25b568d7e77169a69aea2c132964c8a4a9a46aR158-R463)

**Agent logic and dispatch:**
- Updated `AgentCore._apply_lamarckian_inheritance_if_enabled` to dispatch to the appropriate inheritance variant based on configuration, and clarified docstrings to reflect the new modes. [[1]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393L35-R40) [[2]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393L1202-R1215) [[3]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393L1215-R1243)

**Documentation:**
- Expanded docstrings and comments throughout the codebase to describe the new inheritance modes and their behavior, including references to design documents and parameter explanations. [[1]](diffhunk://#diff-e7b1139b26913335b3cfc007bf25b568d7e77169a69aea2c132964c8a4a9a46aR20-R26) [[2]](diffhunk://#diff-7df2829374038ce4ba23f7d77ce0f8c289eb1ff9b3959afc3c853239c703ec5eL475-R486) [[3]](diffhunk://#diff-bd75231b5097e49f9fac95448ec4dc90e10f879eef315b52d79ca45e1176d732L2-R10)

These changes enable more flexible and nuanced experiments on policy inheritance in evolutionary reinforcement learning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offspring RL initialization at reproduction (weights, optimizer, replay, exploration schedule), which can alter learning dynamics; behavior is gated by `inheritance_mode` and skip telemetry, with broad test coverage.
> 
> **Overview**
> Adds **`p2`**, **`p3`**, and **`p4`** as selectable `inheritance_mode` values alongside `baldwinian` and `lamarckian`, so intrinsic-evolution runs can compare richer parent→offspring policy transfer without changing the Baldwinian default.
> 
> **Reproduction dispatch:** `AgentCore._apply_lamarckian_inheritance_if_enabled` now routes non-Baldwinian modes to dedicated warm-start helpers instead of only handling `lamarckian`.
> 
> **New warm-start variants in `policy_inheritance`:** shared `_get_parent_algorithm_state` (extended `get_model_state` kwargs with fallback), then **P2** (weights + damped LR/ε and optional `step_count`), **P3** (weights + optimizer + capped replay slice), and **P4** (resource fitness gate with `gate_not_cleared`, optional tensor blend of parent vs child init weights). P4 adds `WARMSTART_REASON_GATE_NOT_CLEARED` and tunable defaults (damping, replay limit, blend α, gate threshold).
> 
> **Config & tooling:** `IntrinsicEvolutionPolicy` validates and documents the new modes; seed-sweep and inheritance A/B scripts accept them as CLI arms/`--inheritance-mode` choices.
> 
> **Tests:** unit coverage for P2–P4 helpers, reproduction integration (including P4 gate skip), policy config validation, and A/B parser presets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05b9120068844a5b791f51c852d9f525137f0faf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->