### PR TITLE
Refactor warmstart logic and telemetry for improved clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,82 @@ Suggested grouping:
 
 ## Entries
 
+### 2026-06-16
+
+#### Docs
+
+- **Inherited payload design** — added `docs/design/inherited_payload_design.md` (Issue #848) re-deriving what offspring should inherit from a parent's learned decision module after the Baldwinian vs Lamarckian A/B and early-life fitness follow-ups showed full policy-weight copy is a null and action priors already cross via Chromosome A; updated the hyperparameter-genome devlog open questions and clarified non-default Lamarckian wording. ([#905](https://github.com/Dooders/AgentFarm/pull/905))
+
+---
+
+### 2026-06-09
+
+#### Added
+
+- **Per-agent evolvable RL goals (Chromosome C)** — added nine `reward_*` loci to `HyperparameterChromosome`, rewired `AgentCore._calculate_reward` to read heritable goal weights (with caching), and introduced `IntrinsicGoalsExperiment` plus `scripts/run_intrinsic_goals_experiment.py` to run uniform-vs-unique goal-diversity arms with per-step action-mix and goal-gene telemetry; documented in `docs/experiments/intrinsic_evolution/intrinsic_goals.md`. Default chromosomes reproduce the historical reward formula unchanged. ([#891](https://github.com/Dooders/AgentFarm/pull/891), [#899](https://github.com/Dooders/AgentFarm/pull/899))
+- **Determinism regression expansion** — hardened the determinism harness (`tests/test_deterministic.py`) to compare intermediate snapshots and DB contents without masking production seeding, added `tests/test_cross_process_determinism.py` for cross-process reproducibility, and wired both into the deterministic-simulation CI workflow. ([#898](https://github.com/Dooders/AgentFarm/pull/898), [#900](https://github.com/Dooders/AgentFarm/pull/900))
+- **Test-suite coverage pass** — added property-based and utility tests, expanded coverage for `farm/research/analysis` and database model/utilities, fixed false-positive tests, and updated `.coveragerc` / `pytest.ini` / CI coverage settings. ([#896](https://github.com/Dooders/AgentFarm/pull/896), [#897](https://github.com/Dooders/AgentFarm/pull/897))
+
+#### Fixed
+
+- Snapshot determinism checks now require every requested step to be present (not just a subset), and early-terminated simulations compare only the overlapping step range instead of failing on missing later snapshots. ([#898](https://github.com/Dooders/AgentFarm/pull/898), [#900](https://github.com/Dooders/AgentFarm/pull/900))
+- Action-mix telemetry no longer counts inactive agents or stale `last_action_name` values, fixing skewed aggregate plots in the intrinsic-goals experiment. ([#899](https://github.com/Dooders/AgentFarm/pull/899))
+- Component tests no longer infinite-loop when probing genome IDs against a bare `Mock` database object. ([#898](https://github.com/Dooders/AgentFarm/pull/898))
+
+#### Docs
+
+- Devlog `2026-06-09-every-agent-a-different-goal.md` introduces the goal-diversity experiment and its first readouts. ([#891](https://github.com/Dooders/AgentFarm/pull/891))
+- `docs/deterministic_simulations.md` now points at `tests/test_deterministic.py` and documents the cross-process determinism pytest entry point. ([#898](https://github.com/Dooders/AgentFarm/pull/898))
+
+---
+
+### 2026-06-05
+
+#### Added
+
+- **Early-life offspring fitness analysis** — added `scripts/analyze_early_life_fitness.py` and `scripts/plot_early_life_fitness.py` to quantify newborn-level fitness under Baldwinian vs Lamarckian inheritance (paired-seed deltas, startup transients, reward/action breakdowns) with unit tests and a devlog entry on measuring at the wrong level. ([#890](https://github.com/Dooders/AgentFarm/pull/890))
+
+---
+
+### 2026-06-01
+
+#### Docs
+
+- Refreshed the Baldwinian vs Lamarckian A/B devlog (`2026-05-21-baldwinian-vs-lamarckian-ab-harness.md`) with post-fix aggregate results, warm-start coverage context, and updated index links. ([#889](https://github.com/Dooders/AgentFarm/pull/889))
+
+---
+
+### 2026-05-31
+
+#### Changed
+
+- `compare_inheritance_arms.py` now reports warm-start coverage metrics (applied vs skipped counts and skip-reason breakdowns) so Lamarckian A/B readouts distinguish "inheritance disabled" from "inheritance attempted but incompatible." ([#888](https://github.com/Dooders/AgentFarm/pull/888))
+
+---
+
+### 2026-05-22
+
+#### Added
+
+- **Baldwinian vs Lamarckian inheritance A/B** — added `farm/core/policy_inheritance.py`, `InheritanceTelemetry`, `scripts/run_inheritance_mode_ab.py`, and `scripts/compare_inheritance_arms.py` to run matched intrinsic-evolution sweeps under Baldwinian (fresh policy) vs Lamarckian (parent policy warm-start) arms with paired-seed delta summaries, heatmaps, and lineage metrics; documented in `docs/experiments/intrinsic_evolution/inheritance_mode_ab.md`. ([#886](https://github.com/Dooders/AgentFarm/pull/886))
+- **`farm/analysis/lineage_metrics.py`** — shared helper for churn/cluster-count extraction used by inheritance and crossover comparison scripts. ([#887](https://github.com/Dooders/AgentFarm/pull/887))
+
+#### Changed
+
+- **Decision-path refactor** — rewired `TianshouWrapper` action selection through explicit `_policy_q_values` + masked-softmax composition with optional action weights, fixing a defect where learned policy weights did not influence executed actions (invalidating pre-fix inheritance A/B aggregates); `DecisionModule.decide_action` now multiplicatively combines policy probabilities with per-action weights. ([#886](https://github.com/Dooders/AgentFarm/pull/886))
+- Structured logging only attaches the JSON traceback processor when JSON output is enabled, keeping console rendering clean in non-JSON environments. ([#887](https://github.com/Dooders/AgentFarm/pull/887))
+
+#### Fixed
+
+- `compare_inheritance_arms` paired-delta heatmap handles null `mean_delta` entries in JSON summaries without crashing. ([#887](https://github.com/Dooders/AgentFarm/pull/887))
+- `compare_inheritance_arms` robust paired deltas now require `n >= 2` seeds. ([#886](https://github.com/Dooders/AgentFarm/pull/886))
+
+#### Docs
+
+- Devlog `2026-05-21-baldwinian-vs-lamarckian-ab-harness.md` and backfilled CHANGELOG entries through 2026-05-20. ([#886](https://github.com/Dooders/AgentFarm/pull/886))
+
+---
+
 ### 2026-05-20
 
 #### Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,29 @@ Suggested grouping:
 
 ## Entries
 
+### 2026-06-17
+
+#### Added
+
+- **Bounded, deterministic replay-buffer transfer** — added `get_transfer_slice()` / `load_transfer_slice()` to `PrioritizedReplayBuffer` and wired them into the Tianshou wrapper (`_get_replay_buffer_state` / `_load_replay_buffer_state` with a `_deserialize_replay_value` helper) so offspring can inherit a deterministic, size-bounded slice of a parent's experience while preserving PER metadata (beta, beta step count, replay strategy). Covered by `tests/decision/test_replay_buffer_transfer.py` and a `tests/helpers/replay_slice_hash.py` helper; closes the #902 item in the inherited-payload design. ([#909](https://github.com/Dooders/AgentFarm/pull/909))
+- **Extended-state policy inheritance and warmstart** — extended `policy_inheritance.py` with `_supports_extended_state` detection and a streamlined `_get_parent_algorithm_state`, switched `AgentCore` to a dispatch table for warmstart hooks, and added P2–P4 `inheritance_mode` values for richer payload variants, with explicit skip reasons when an algorithm cannot consume the extended payload. ([#911](https://github.com/Dooders/AgentFarm/pull/911))
+
+#### Fixed
+
+- Empty or zero-limit replay buffers (`replay_buffer_limit=0`) no longer drop PER metadata on serialize, and the unused `seed` parameter was removed from `get_transfer_slice` to simplify the API. ([#909](https://github.com/Dooders/AgentFarm/pull/909))
+- Warmstart failures from unsupported extended state are now non-fatal and report a specific skip reason instead of aborting inheritance. ([#911](https://github.com/Dooders/AgentFarm/pull/911))
+
+---
+
 ### 2026-06-16
+
+#### Added
+
+- **Richer Tianshou model-state payload** — `farm/core/decision/algorithms/tianshou.py` now exposes an extended model state (alpha/epsilon and related optimizer fields) with a `_coerce_float` static helper and try/except/else error handling so core policy weights are always preserved even when optional payload serialization fails. ([#907](https://github.com/Dooders/AgentFarm/pull/907))
+
+#### Fixed
+
+- Replay-buffer checkpoint restore now reinstates `replay_strategy` so PER/uniform sampling matches the saved run, and `replay_buffer_limit=0` is treated as an empty slice instead of serializing the full buffer via Python's negative-zero slice quirk. ([#907](https://github.com/Dooders/AgentFarm/pull/907))
 
 #### Docs
 

--- a/docs/devlog/2026-05-21-baldwinian-vs-lamarckian-ab-harness.md
+++ b/docs/devlog/2026-05-21-baldwinian-vs-lamarckian-ab-harness.md
@@ -160,6 +160,8 @@ The experiment path that produced these numbers:
   `apply_lamarckian_policy_warmstart`
 - Telemetry in run metadata:
   `policy_inheritance_metrics.lamarckian_warmstart_applied/skipped`
+  (renamed to mode-neutral `warmstart_applied/skipped` on 2026-06-17 when the
+  P2–P4 variants landed)
 - `scripts/run_inheritance_mode_ab.py` — orchestrates both arms
 - `scripts/compare_inheritance_arms.py` — paired-seed deltas and verdicts
 - `scripts/run_stable_profile_seed_sweep.py` accepts `--inheritance-mode`

--- a/docs/experiments/intrinsic_evolution/inheritance_mode_ab.md
+++ b/docs/experiments/intrinsic_evolution/inheritance_mode_ab.md
@@ -79,7 +79,7 @@ Primary readouts:
 - Stability: `startup_transient.peak_death_rate`,
   `startup_transient.oscillation_amplitude`, `lineage.churn_rate`
 - Diversity impact: `speciation_final`, `speciation_slope`
-- Mechanism coverage: `lamarckian_warmstart_rate`
+- Mechanism coverage: `warmstart_rate`, `gate_hit_rate` (P4), `blend_alpha` (P4)
 
 Per-profile recommendation categories (label-aware):
 

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -1285,8 +1285,11 @@ class AgentCore:
         telemetry = getattr(self.environment, "inheritance_telemetry", None)
         if not isinstance(telemetry, InheritanceTelemetry):
             return
-        # The P4 blend coefficient is a run-level constant; record it so the
-        # serialized metadata surfaces the effective alpha alongside coverage.
+        # The P4 blend coefficient is a run-level constant; record it
+        # regardless of this birth's per-attempt skip outcome so the serialized
+        # metadata surfaces the effective alpha alongside coverage. Recording it
+        # also marks the run as P4 for ``InheritanceTelemetry._gate_hit_rate``,
+        # which is gated on ``blend_alpha`` being set.
         if inheritance_mode == "p4":
             telemetry.record_blend_alpha(warmstart_kwargs.get("blend_alpha"))
         if skip_reason is None:

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -33,6 +33,10 @@ from farm.core.hyperparameter_chromosome import (
 from farm.core.environment import _AgentList
 from farm.core.inheritance_telemetry import InheritanceTelemetry
 from farm.core.policy_inheritance import (
+    P2_PLASTICITY_DAMPING,
+    P3_REPLAY_BUFFER_LIMIT,
+    P4_BLEND_ALPHA,
+    P4_FITNESS_GATE_MIN_RESOURCES,
     apply_lamarckian_policy_warmstart,
     apply_p2_policy_warmstart,
     apply_p3_policy_warmstart,
@@ -56,6 +60,39 @@ _WARMSTART_DISPATCH = {
     "p3": apply_p3_policy_warmstart,
     "p4": apply_p4_policy_warmstart,
 }
+
+
+def _warmstart_kwargs_for_mode(mode: str, policy: Any) -> Dict[str, Any]:
+    """Build the per-mode tuning kwargs for a warm-start hook from ``policy``.
+
+    The richer variants (P2/P3/P4) expose tunable knobs on the runner's
+    :class:`IntrinsicEvolutionPolicy`. We read them via ``getattr`` with the
+    module-default fallback so test doubles and legacy policy objects that do
+    not carry the ``warmstart_*`` fields still warm-start with the documented
+    defaults instead of raising.
+    """
+    if mode == "p2":
+        return {
+            "plasticity_damping": getattr(
+                policy, "warmstart_plasticity_damping", P2_PLASTICITY_DAMPING
+            )
+        }
+    if mode == "p3":
+        return {
+            "replay_buffer_limit": getattr(
+                policy, "warmstart_replay_buffer_limit", P3_REPLAY_BUFFER_LIMIT
+            )
+        }
+    if mode == "p4":
+        return {
+            "blend_alpha": getattr(policy, "warmstart_blend_alpha", P4_BLEND_ALPHA),
+            "fitness_gate_min_resources": getattr(
+                policy,
+                "warmstart_fitness_gate_min_resources",
+                P4_FITNESS_GATE_MIN_RESOURCES,
+            ),
+        }
+    return {}
 
 
 def compute_effective_reproduction_cost(agent: Any, base_cost: float) -> float:
@@ -1242,11 +1279,16 @@ class AgentCore:
             # ``baldwinian`` (cold start) and any unrecognized mode are no-ops.
             return
 
-        skip_reason = warmstart_hook(self, offspring)
+        warmstart_kwargs = _warmstart_kwargs_for_mode(inheritance_mode, policy)
+        skip_reason = warmstart_hook(self, offspring, **warmstart_kwargs)
 
         telemetry = getattr(self.environment, "inheritance_telemetry", None)
         if not isinstance(telemetry, InheritanceTelemetry):
             return
+        # The P4 blend coefficient is a run-level constant; record it so the
+        # serialized metadata surfaces the effective alpha alongside coverage.
+        if inheritance_mode == "p4":
+            telemetry.record_blend_alpha(warmstart_kwargs.get("blend_alpha"))
         if skip_reason is None:
             telemetry.record_applied()
         else:

--- a/farm/core/inheritance_telemetry.py
+++ b/farm/core/inheritance_telemetry.py
@@ -80,9 +80,14 @@ class InheritanceTelemetry:
         """Fraction of warm-start attempts that cleared the P4 fitness gate.
 
         Computed over all attempts as ``(total - gate_not_cleared) / total``.
-        ``None`` when there were no attempts. For non-gated modes this is 1.0
-        because nothing is attributed to ``gate_not_cleared``.
+        Returns ``None`` for non-gated modes and for runs with no attempts:
+        only P4 records a ``blend_alpha`` (see :meth:`record_blend_alpha`), so
+        a ``None`` ``blend_alpha`` means no gate ran and a numeric hit-rate
+        would be a misleading ``1.0``. This keeps the gate metric P4-specific
+        and symmetric with ``blend_alpha`` for downstream reporting.
         """
+        if self.blend_alpha is None:
+            return None
         total = self.warmstart_applied + self.warmstart_skipped
         if total <= 0:
             return None

--- a/farm/core/inheritance_telemetry.py
+++ b/farm/core/inheritance_telemetry.py
@@ -13,17 +13,28 @@ from __future__ import annotations
 
 from collections import Counter
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+from farm.core.policy_inheritance import WARMSTART_REASON_GATE_NOT_CLEARED
 
 
 @dataclass
 class InheritanceTelemetry:
-    """In-memory counters for Lamarckian warm-start outcomes during a run.
+    """In-memory counters for policy warm-start outcomes during a run.
 
-    ``lamarckian_warmstart_skipped_reasons`` is a multiset keyed by the stable
+    The counters are mode-neutral: a single run uses one ``inheritance_mode``
+    (see the inheritance-mode A/B harness), so ``warmstart_applied`` /
+    ``warmstart_skipped`` already describe that run's active mode.
+
+    ``warmstart_skipped_reasons`` is a multiset keyed by the stable
     ``WARMSTART_REASON_*`` strings from
     :mod:`farm.core.policy_inheritance`, so downstream analysis can split
-    "skipped because architecture mutated" from genuine missing-API cases.
+    "skipped because architecture mutated" from genuine missing-API cases and
+    from the P4 fitness gate.
+
+    ``blend_alpha`` records the P4 blend coefficient actually used for the run
+    (``None`` when the active mode does not blend). It is constant per run, so
+    :meth:`record_blend_alpha` simply stores the most recently observed value.
 
     ``decide_action_failures`` counts agent-step decision failures so
     experiment harnesses can detect a silent degradation regime (the
@@ -34,32 +45,66 @@ class InheritanceTelemetry:
     the persisted metadata.
     """
 
-    lamarckian_warmstart_applied: int = 0
-    lamarckian_warmstart_skipped: int = 0
-    lamarckian_warmstart_skipped_reasons: Counter = field(default_factory=Counter)
+    warmstart_applied: int = 0
+    warmstart_skipped: int = 0
+    warmstart_skipped_reasons: Counter = field(default_factory=Counter)
+    blend_alpha: Optional[float] = None
     decide_action_failures: int = 0
     decide_action_failure_reasons: Counter = field(default_factory=Counter)
 
     def record_applied(self) -> None:
-        self.lamarckian_warmstart_applied += 1
+        self.warmstart_applied += 1
 
     def record_skipped(self, reason: str) -> None:
-        self.lamarckian_warmstart_skipped += 1
-        self.lamarckian_warmstart_skipped_reasons[reason] += 1
+        self.warmstart_skipped += 1
+        self.warmstart_skipped_reasons[reason] += 1
+
+    def record_blend_alpha(self, alpha: Optional[float]) -> None:
+        """Record the P4 blend coefficient in effect for this run."""
+        if alpha is not None:
+            self.blend_alpha = float(alpha)
 
     def record_decide_action_failure(self, error_type: str = "Exception") -> None:
         """Record one agent-step decision failure attributed to ``error_type``."""
         self.decide_action_failures += 1
         self.decide_action_failure_reasons[error_type] += 1
 
+    def _coverage(self) -> Optional[float]:
+        """Fraction of warm-start attempts that applied a payload."""
+        total = self.warmstart_applied + self.warmstart_skipped
+        if total <= 0:
+            return None
+        return self.warmstart_applied / total
+
+    def _gate_hit_rate(self) -> Optional[float]:
+        """Fraction of warm-start attempts that cleared the P4 fitness gate.
+
+        Computed over all attempts as ``(total - gate_not_cleared) / total``.
+        ``None`` when there were no attempts. For non-gated modes this is 1.0
+        because nothing is attributed to ``gate_not_cleared``.
+        """
+        total = self.warmstart_applied + self.warmstart_skipped
+        if total <= 0:
+            return None
+        gate_not_cleared = self.warmstart_skipped_reasons.get(
+            WARMSTART_REASON_GATE_NOT_CLEARED, 0
+        )
+        return (total - gate_not_cleared) / total
+
     def to_dict(self) -> Dict[str, Any]:
         """Render as a JSON-friendly dict for run metadata."""
         return {
-            "lamarckian_warmstart_applied": int(self.lamarckian_warmstart_applied),
-            "lamarckian_warmstart_skipped": int(self.lamarckian_warmstart_skipped),
-            "lamarckian_warmstart_skipped_reasons": dict(
-                self.lamarckian_warmstart_skipped_reasons
+            "warmstart_applied": int(self.warmstart_applied),
+            "warmstart_skipped": int(self.warmstart_skipped),
+            "warmstart_skipped_reasons": dict(self.warmstart_skipped_reasons),
+            "warmstart_coverage": self._coverage(),
+            "gate_not_cleared": int(
+                self.warmstart_skipped_reasons.get(
+                    WARMSTART_REASON_GATE_NOT_CLEARED, 0
+                )
             ),
+            "gate_hit_rate": self._gate_hit_rate(),
+            "blend_alpha": self.blend_alpha,
             "decide_action_failures": int(self.decide_action_failures),
             "decide_action_failure_reasons": dict(
                 self.decide_action_failure_reasons

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -34,6 +34,12 @@ from farm.core.initial_diversity import (
     InitialDiversityConfig,
     SeedingMode,
 )
+from farm.core.policy_inheritance import (
+    P2_PLASTICITY_DAMPING,
+    P3_REPLAY_BUFFER_LIMIT,
+    P4_BLEND_ALPHA,
+    P4_FITNESS_GATE_MIN_RESOURCES,
+)
 from farm.core.simulation import run_simulation
 from farm.runners.gene_trajectory_logger import GeneTrajectoryLogger, VALID_SCALERS
 from farm.utils.logging import get_logger
@@ -484,6 +490,14 @@ class IntrinsicEvolutionPolicy:
             the parent, and weights are blended as
             ``θ_child = α·θ_parent + (1−α)·θ_init`` to bound local-niche
             lock-in.
+        warmstart_plasticity_damping: P2 damping factor in ``(0, 1]`` applied
+            to the child's inherited learning rate and exploration rate.
+        warmstart_replay_buffer_limit: P3 cap (>= 1) on the number of replay
+            transitions transferred from parent to child.
+        warmstart_blend_alpha: P4 blend coefficient in ``[0, 1]`` weighting the
+            parent's policy in ``θ_child = α·θ_parent + (1−α)·θ_init``.
+        warmstart_fitness_gate_min_resources: P4 minimum parent resource level
+            (>= 0) required to clear the fitness gate.
     """
 
     enabled: bool = True
@@ -502,6 +516,10 @@ class IntrinsicEvolutionPolicy:
     seed: Optional[int] = None
     selection_pressure: Union[SelectionPressurePreset, float, None] = None
     inheritance_mode: InheritanceMode = "baldwinian"
+    warmstart_plasticity_damping: float = P2_PLASTICITY_DAMPING
+    warmstart_replay_buffer_limit: int = P3_REPLAY_BUFFER_LIMIT
+    warmstart_blend_alpha: float = P4_BLEND_ALPHA
+    warmstart_fitness_gate_min_resources: float = P4_FITNESS_GATE_MIN_RESOURCES
     reproduction_pressure: ReproductionPressureConfig = field(
         default_factory=ReproductionPressureConfig
     )
@@ -530,6 +548,18 @@ class IntrinsicEvolutionPolicy:
         if self.inheritance_mode not in ("baldwinian", "lamarckian", "p2", "p3", "p4"):
             raise ValueError(
                 "inheritance_mode must be one of 'baldwinian', 'lamarckian', 'p2', 'p3', 'p4'."
+            )
+        if not 0.0 < self.warmstart_plasticity_damping <= 1.0:
+            raise ValueError(
+                "warmstart_plasticity_damping must be in the interval (0, 1]."
+            )
+        if self.warmstart_replay_buffer_limit < 1:
+            raise ValueError("warmstart_replay_buffer_limit must be at least 1.")
+        if not 0.0 <= self.warmstart_blend_alpha <= 1.0:
+            raise ValueError("warmstart_blend_alpha must be between 0 and 1.")
+        if self.warmstart_fitness_gate_min_resources < 0.0:
+            raise ValueError(
+                "warmstart_fitness_gate_min_resources must be non-negative."
             )
         # Derive reproduction_pressure from the selection_pressure preset/scale when set.
         if self.selection_pressure is not None:

--- a/scripts/_warmstart_cli.py
+++ b/scripts/_warmstart_cli.py
@@ -1,0 +1,78 @@
+"""Shared CLI plumbing for the P2–P4 warm-start tuning knobs.
+
+The intrinsic-evolution runner scripts (`run_intrinsic_evolution_experiment`,
+`run_stable_profile_seed_sweep`, and the `run_inheritance_mode_ab` orchestrator)
+all expose the same four warm-start tuning flags and forward them identically to
+:class:`farm.runners.intrinsic_evolution_experiment.IntrinsicEvolutionPolicy`.
+Centralising the argparse definitions and the args→kwargs extraction here keeps
+the flag names, defaults, and help text in one place so a new knob is added once.
+
+Range validation intentionally lives on ``IntrinsicEvolutionPolicy`` (a single
+source of truth) rather than being duplicated into each parser.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, Dict
+
+from farm.core.policy_inheritance import (
+    P2_PLASTICITY_DAMPING,
+    P3_REPLAY_BUFFER_LIMIT,
+    P4_BLEND_ALPHA,
+    P4_FITNESS_GATE_MIN_RESOURCES,
+)
+
+
+def add_warmstart_tuning_arguments(parser: argparse.ArgumentParser) -> None:
+    """Register the four P2–P4 warm-start tuning flags on ``parser``."""
+    parser.add_argument(
+        "--warmstart-plasticity-damping",
+        type=float,
+        default=P2_PLASTICITY_DAMPING,
+        help="P2 damping factor in (0, 1] for child LR/epsilon.",
+    )
+    parser.add_argument(
+        "--warmstart-replay-buffer-limit",
+        type=int,
+        default=P3_REPLAY_BUFFER_LIMIT,
+        help="P3 cap (>= 1) on replay transitions transferred to the child.",
+    )
+    parser.add_argument(
+        "--warmstart-blend-alpha",
+        type=float,
+        default=P4_BLEND_ALPHA,
+        help="P4 blend coefficient in [0, 1] weighting the parent's policy.",
+    )
+    parser.add_argument(
+        "--warmstart-fitness-gate-min-resources",
+        type=float,
+        default=P4_FITNESS_GATE_MIN_RESOURCES,
+        help="P4 minimum parent resource level (>= 0) to clear the fitness gate.",
+    )
+
+
+def warmstart_tuning_kwargs(args: argparse.Namespace) -> Dict[str, Any]:
+    """Extract the warm-start tuning values from ``args`` as policy kwargs.
+
+    Uses ``getattr`` with the module defaults so callers that build a partial
+    ``Namespace`` (or omit the flags entirely) still get the documented values.
+    """
+    return {
+        "warmstart_plasticity_damping": float(
+            getattr(args, "warmstart_plasticity_damping", P2_PLASTICITY_DAMPING)
+        ),
+        "warmstart_replay_buffer_limit": int(
+            getattr(args, "warmstart_replay_buffer_limit", P3_REPLAY_BUFFER_LIMIT)
+        ),
+        "warmstart_blend_alpha": float(
+            getattr(args, "warmstart_blend_alpha", P4_BLEND_ALPHA)
+        ),
+        "warmstart_fitness_gate_min_resources": float(
+            getattr(
+                args,
+                "warmstart_fitness_gate_min_resources",
+                P4_FITNESS_GATE_MIN_RESOURCES,
+            )
+        ),
+    }

--- a/scripts/analyze_early_life_fitness.py
+++ b/scripts/analyze_early_life_fitness.py
@@ -149,8 +149,8 @@ def _read_warmstart_rate(run_dir: Path) -> Optional[float]:
     pim = meta.get("policy_inheritance_metrics")
     if not isinstance(pim, dict):
         return None
-    applied = pim.get("lamarckian_warmstart_applied")
-    skipped = pim.get("lamarckian_warmstart_skipped")
+    applied = pim.get("warmstart_applied")
+    skipped = pim.get("warmstart_skipped")
     if applied is None or skipped is None:
         return None
     total = float(applied) + float(skipped)

--- a/scripts/compare_inheritance_arms.py
+++ b/scripts/compare_inheritance_arms.py
@@ -56,7 +56,7 @@ STABILITY_KEYS: List[str] = [
     "startup_transient.peak_death_rate",
     "startup_transient.oscillation_amplitude",
 ]
-INFO_KEYS: List[str] = ["lamarckian_warmstart_rate", "decide_action_failures"]
+INFO_KEYS: List[str] = ["warmstart_rate", "decide_action_failures"]
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -157,13 +157,15 @@ def _extract_metadata_metrics(run_dir: Path) -> Dict[str, Any]:
 
     startup = meta.get("startup_transient_metrics", {})
     inheritance = meta.get("policy_inheritance_metrics", {})
-    applied = int(inheritance.get("lamarckian_warmstart_applied", 0))
-    skipped = int(inheritance.get("lamarckian_warmstart_skipped", 0))
+    applied = int(inheritance.get("warmstart_applied", 0))
+    skipped = int(inheritance.get("warmstart_skipped", 0))
     skipped_reasons = dict(
-        inheritance.get("lamarckian_warmstart_skipped_reasons", {}) or {}
+        inheritance.get("warmstart_skipped_reasons", {}) or {}
     )
     denom = applied + skipped
     warmstart_rate = float(applied / denom) if denom > 0 else float("nan")
+    gate_hit_rate = inheritance.get("gate_hit_rate")
+    blend_alpha = inheritance.get("blend_alpha")
     # ``decide_action_failures`` was added so paired A/B comparisons can flag
     # arms where the new fail-loud decision path is degrading silently
     # (see ``InheritanceTelemetry`` and the 2026-05-22 dev-log entry).
@@ -177,10 +179,12 @@ def _extract_metadata_metrics(run_dir: Path) -> Dict[str, Any]:
             "peak_death_rate": float(startup.get("peak_death_rate", float("nan"))),
             "oscillation_amplitude": float(startup.get("oscillation_amplitude", float("nan"))),
         },
-        "lamarckian_warmstart_applied": applied,
-        "lamarckian_warmstart_skipped": skipped,
-        "lamarckian_warmstart_rate": warmstart_rate,
-        "lamarckian_warmstart_skipped_reasons": skipped_reasons,
+        "warmstart_applied": applied,
+        "warmstart_skipped": skipped,
+        "warmstart_rate": warmstart_rate,
+        "warmstart_skipped_reasons": skipped_reasons,
+        "gate_hit_rate": (float(gate_hit_rate) if gate_hit_rate is not None else None),
+        "blend_alpha": (float(blend_alpha) if blend_alpha is not None else None),
         "decide_action_failures": decide_failures,
         "decide_action_failure_reasons": decide_failure_reasons,
     }
@@ -492,8 +496,8 @@ def _plot_startup_transient(
 
 
 def _warmstart_rate_from_run(run: Dict[str, Any]) -> Optional[float]:
-    applied = int(run.get("lamarckian_warmstart_applied", 0))
-    skipped = int(run.get("lamarckian_warmstart_skipped", 0))
+    applied = int(run.get("warmstart_applied", 0))
+    skipped = int(run.get("warmstart_skipped", 0))
     denom = applied + skipped
     if denom <= 0:
         return None
@@ -503,36 +507,48 @@ def _warmstart_rate_from_run(run: Dict[str, Any]) -> Optional[float]:
 def _summarize_warmstart_coverage(
     treatment_runs: Dict[int, Dict[str, Any]],
 ) -> Dict[str, Any]:
-    """Aggregate Lamarckian warm-start coverage for one (profile, arm) pair."""
+    """Aggregate warm-start coverage for one (profile, arm) pair."""
     per_seed: Dict[str, Dict[str, Any]] = {}
     rates: List[float] = []
+    gate_hit_rates: List[float] = []
+    blend_alphas: List[float] = []
     total_applied = 0
     total_skipped = 0
     skip_reasons: Counter = Counter()
 
     for seed in sorted(treatment_runs):
         run = treatment_runs[seed]
-        applied = int(run.get("lamarckian_warmstart_applied", 0))
-        skipped = int(run.get("lamarckian_warmstart_skipped", 0))
+        applied = int(run.get("warmstart_applied", 0))
+        skipped = int(run.get("warmstart_skipped", 0))
         rate = _warmstart_rate_from_run(run)
+        gate_hit_rate = run.get("gate_hit_rate")
+        blend_alpha = run.get("blend_alpha")
         per_seed[str(seed)] = {
             "applied": applied,
             "skipped": skipped,
             "rate": rate,
-            "skip_reasons": dict(run.get("lamarckian_warmstart_skipped_reasons", {}) or {}),
+            "gate_hit_rate": gate_hit_rate,
+            "blend_alpha": blend_alpha,
+            "skip_reasons": dict(run.get("warmstart_skipped_reasons", {}) or {}),
         }
         total_applied += applied
         total_skipped += skipped
-        for reason, count in (run.get("lamarckian_warmstart_skipped_reasons", {}) or {}).items():
+        for reason, count in (run.get("warmstart_skipped_reasons", {}) or {}).items():
             skip_reasons[str(reason)] += int(count)
         if rate is not None:
             rates.append(rate)
+        if gate_hit_rate is not None:
+            gate_hit_rates.append(float(gate_hit_rate))
+        if blend_alpha is not None:
+            blend_alphas.append(float(blend_alpha))
 
     lo, hi = _t_ci(rates) if rates else (None, None)
     return {
         "n": len(rates),
         "mean_rate": _mean(rates) if rates else None,
         "rate_ci95": [lo, hi],
+        "mean_gate_hit_rate": _mean(gate_hit_rates) if gate_hit_rates else None,
+        "blend_alpha": blend_alphas[0] if blend_alphas else None,
         "total_applied": total_applied,
         "total_skipped": total_skipped,
         "skip_reasons": dict(skip_reasons),
@@ -552,7 +568,7 @@ def _compute_mechanism_coverage(
         for arm in arm_labels:
             treatment_runs = treatments.get(arm, {}).get(profile, {})
             out[profile][arm] = {
-                "lamarckian_warmstart": _summarize_warmstart_coverage(treatment_runs),
+                "warmstart": _summarize_warmstart_coverage(treatment_runs),
             }
     return out
 
@@ -615,26 +631,32 @@ def _build_markdown(
             "## Mechanism coverage (treatment only)",
             "",
             (
-                "Lamarckian warm-start rate is an absolute treatment-arm statistic. "
+                "Warm-start rate is an absolute treatment-arm statistic. "
                 f"The `{baseline_label}` baseline performs no warm-start attempts, "
-                "so paired deltas are undefined."
+                "so paired deltas are undefined. Gate hit-rate and blend alpha are "
+                "P4-specific (n/a for other modes)."
             ),
             "",
-            "| Profile | Arm | Mean rate | 95% CI | Applied | Skipped | Skip reasons | n |",
-            "| --- | --- | --- | --- | --- | --- | --- | --- |",
+            (
+                "| Profile | Arm | Mean rate | 95% CI | Gate hit-rate | Blend alpha "
+                "| Applied | Skipped | Skip reasons | n |"
+            ),
+            "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
         ]
         for profile in PROFILE_ORDER:
             if profile not in mechanism_coverage:
                 continue
             for arm in arm_labels:
                 warmstart = mechanism_coverage.get(profile, {}).get(arm, {}).get(
-                    "lamarckian_warmstart", {}
+                    "warmstart", {}
                 )
                 if not warmstart:
                     continue
                 lines.append(
                     f"| {profile} | {arm} | {_fmt(warmstart.get('mean_rate'))} "
                     f"| {_fmt(warmstart.get('rate_ci95'))} "
+                    f"| {_fmt(warmstart.get('mean_gate_hit_rate'))} "
+                    f"| {_fmt(warmstart.get('blend_alpha'))} "
                     f"| {warmstart.get('total_applied', 0)} "
                     f"| {warmstart.get('total_skipped', 0)} "
                     f"| {_fmt_skip_reasons(warmstart.get('skip_reasons', {}))} "

--- a/scripts/compare_inheritance_arms.py
+++ b/scripts/compare_inheritance_arms.py
@@ -157,11 +157,26 @@ def _extract_metadata_metrics(run_dir: Path) -> Dict[str, Any]:
 
     startup = meta.get("startup_transient_metrics", {})
     inheritance = meta.get("policy_inheritance_metrics", {})
-    applied = int(inheritance.get("warmstart_applied", 0))
-    skipped = int(inheritance.get("warmstart_skipped", 0))
-    skipped_reasons = dict(
-        inheritance.get("warmstart_skipped_reasons", {}) or {}
+    applied = int(
+        inheritance.get(
+            "warmstart_applied",
+            inheritance.get("lamarckian_warmstart_applied", 0),
+        )
     )
+    skipped = int(
+        inheritance.get(
+            "warmstart_skipped",
+            inheritance.get("lamarckian_warmstart_skipped", 0),
+        )
+    )
+    if "warmstart_skipped_reasons" in inheritance:
+        skipped_reasons = dict(inheritance.get("warmstart_skipped_reasons") or {})
+    elif "lamarckian_warmstart_skipped_reasons" in inheritance:
+        skipped_reasons = dict(
+            inheritance.get("lamarckian_warmstart_skipped_reasons") or {}
+        )
+    else:
+        skipped_reasons = {}
     denom = applied + skipped
     warmstart_rate = float(applied / denom) if denom > 0 else float("nan")
     gate_hit_rate = inheritance.get("gate_hit_rate")

--- a/scripts/run_inheritance_mode_ab.py
+++ b/scripts/run_inheritance_mode_ab.py
@@ -23,11 +23,9 @@ _repo_root = Path(__file__).resolve().parent.parent
 if str(_repo_root) not in sys.path:
     sys.path.insert(0, str(_repo_root))
 
-from farm.core.policy_inheritance import (  # noqa: E402
-    P2_PLASTICITY_DAMPING,
-    P3_REPLAY_BUFFER_LIMIT,
-    P4_BLEND_ALPHA,
-    P4_FITNESS_GATE_MIN_RESOURCES,
+from scripts._warmstart_cli import (  # noqa: E402
+    add_warmstart_tuning_arguments,
+    warmstart_tuning_kwargs,
 )
 from scripts import analyze_stable_profile_seed_sweep as analyzer_mod  # noqa: E402
 from scripts import run_stable_profile_seed_sweep as runner_mod  # noqa: E402
@@ -95,30 +93,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--mutation-rate", type=float, default=0.15)
     parser.add_argument("--mutation-scale", type=float, default=0.10)
     parser.add_argument("--selection-pressure", type=str, default="low")
-    parser.add_argument(
-        "--warmstart-plasticity-damping",
-        type=float,
-        default=P2_PLASTICITY_DAMPING,
-        help="P2 damping factor in (0, 1] for child LR/epsilon.",
-    )
-    parser.add_argument(
-        "--warmstart-replay-buffer-limit",
-        type=int,
-        default=P3_REPLAY_BUFFER_LIMIT,
-        help="P3 cap (>= 1) on replay transitions transferred to the child.",
-    )
-    parser.add_argument(
-        "--warmstart-blend-alpha",
-        type=float,
-        default=P4_BLEND_ALPHA,
-        help="P4 blend coefficient in [0, 1] weighting the parent's policy.",
-    )
-    parser.add_argument(
-        "--warmstart-fitness-gate-min-resources",
-        type=float,
-        default=P4_FITNESS_GATE_MIN_RESOURCES,
-        help="P4 minimum parent resource level (>= 0) to clear the fitness gate.",
-    )
+    add_warmstart_tuning_arguments(parser)
     parser.add_argument("--initial-diversity-mutation-rate", type=float, default=1.0)
     parser.add_argument("--initial-diversity-mutation-scale", type=float, default=0.25)
     parser.add_argument(
@@ -171,20 +146,7 @@ def _build_runner_args(
         mutation_scale=args.mutation_scale,
         selection_pressure=args.selection_pressure,
         inheritance_mode=preset["inheritance_mode"],
-        warmstart_plasticity_damping=getattr(
-            args, "warmstart_plasticity_damping", P2_PLASTICITY_DAMPING
-        ),
-        warmstart_replay_buffer_limit=getattr(
-            args, "warmstart_replay_buffer_limit", P3_REPLAY_BUFFER_LIMIT
-        ),
-        warmstart_blend_alpha=getattr(
-            args, "warmstart_blend_alpha", P4_BLEND_ALPHA
-        ),
-        warmstart_fitness_gate_min_resources=getattr(
-            args,
-            "warmstart_fitness_gate_min_resources",
-            P4_FITNESS_GATE_MIN_RESOURCES,
-        ),
+        **warmstart_tuning_kwargs(args),
         initial_diversity_mutation_rate=args.initial_diversity_mutation_rate,
         initial_diversity_mutation_scale=args.initial_diversity_mutation_scale,
         log_level=args.log_level,

--- a/scripts/run_inheritance_mode_ab.py
+++ b/scripts/run_inheritance_mode_ab.py
@@ -23,6 +23,12 @@ _repo_root = Path(__file__).resolve().parent.parent
 if str(_repo_root) not in sys.path:
     sys.path.insert(0, str(_repo_root))
 
+from farm.core.policy_inheritance import (  # noqa: E402
+    P2_PLASTICITY_DAMPING,
+    P3_REPLAY_BUFFER_LIMIT,
+    P4_BLEND_ALPHA,
+    P4_FITNESS_GATE_MIN_RESOURCES,
+)
 from scripts import analyze_stable_profile_seed_sweep as analyzer_mod  # noqa: E402
 from scripts import run_stable_profile_seed_sweep as runner_mod  # noqa: E402
 from scripts.run_stable_profile_seed_sweep import (  # noqa: E402
@@ -89,6 +95,30 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--mutation-rate", type=float, default=0.15)
     parser.add_argument("--mutation-scale", type=float, default=0.10)
     parser.add_argument("--selection-pressure", type=str, default="low")
+    parser.add_argument(
+        "--warmstart-plasticity-damping",
+        type=float,
+        default=P2_PLASTICITY_DAMPING,
+        help="P2 damping factor in (0, 1] for child LR/epsilon.",
+    )
+    parser.add_argument(
+        "--warmstart-replay-buffer-limit",
+        type=int,
+        default=P3_REPLAY_BUFFER_LIMIT,
+        help="P3 cap (>= 1) on replay transitions transferred to the child.",
+    )
+    parser.add_argument(
+        "--warmstart-blend-alpha",
+        type=float,
+        default=P4_BLEND_ALPHA,
+        help="P4 blend coefficient in [0, 1] weighting the parent's policy.",
+    )
+    parser.add_argument(
+        "--warmstart-fitness-gate-min-resources",
+        type=float,
+        default=P4_FITNESS_GATE_MIN_RESOURCES,
+        help="P4 minimum parent resource level (>= 0) to clear the fitness gate.",
+    )
     parser.add_argument("--initial-diversity-mutation-rate", type=float, default=1.0)
     parser.add_argument("--initial-diversity-mutation-scale", type=float, default=0.25)
     parser.add_argument(
@@ -141,6 +171,20 @@ def _build_runner_args(
         mutation_scale=args.mutation_scale,
         selection_pressure=args.selection_pressure,
         inheritance_mode=preset["inheritance_mode"],
+        warmstart_plasticity_damping=getattr(
+            args, "warmstart_plasticity_damping", P2_PLASTICITY_DAMPING
+        ),
+        warmstart_replay_buffer_limit=getattr(
+            args, "warmstart_replay_buffer_limit", P3_REPLAY_BUFFER_LIMIT
+        ),
+        warmstart_blend_alpha=getattr(
+            args, "warmstart_blend_alpha", P4_BLEND_ALPHA
+        ),
+        warmstart_fitness_gate_min_resources=getattr(
+            args,
+            "warmstart_fitness_gate_min_resources",
+            P4_FITNESS_GATE_MIN_RESOURCES,
+        ),
         initial_diversity_mutation_rate=args.initial_diversity_mutation_rate,
         initial_diversity_mutation_scale=args.initial_diversity_mutation_scale,
         log_level=args.log_level,

--- a/scripts/run_intrinsic_evolution_experiment.py
+++ b/scripts/run_intrinsic_evolution_experiment.py
@@ -45,11 +45,9 @@ from farm.core.initial_diversity import (  # noqa: E402
     InitialDiversityConfig,
     SeedingMode,
 )
-from farm.core.policy_inheritance import (  # noqa: E402
-    P2_PLASTICITY_DAMPING,
-    P3_REPLAY_BUFFER_LIMIT,
-    P4_BLEND_ALPHA,
-    P4_FITNESS_GATE_MIN_RESOURCES,
+from scripts._warmstart_cli import (  # noqa: E402
+    add_warmstart_tuning_arguments,
+    warmstart_tuning_kwargs,
 )
 from farm.runners.intrinsic_evolution_experiment import (  # noqa: E402
     InitialConditionsConfig,
@@ -230,30 +228,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "slice. 'p4': gated/blended transfer."
         ),
     )
-    parser.add_argument(
-        "--warmstart-plasticity-damping",
-        type=float,
-        default=P2_PLASTICITY_DAMPING,
-        help="P2 damping factor in (0, 1] for child LR/epsilon.",
-    )
-    parser.add_argument(
-        "--warmstart-replay-buffer-limit",
-        type=int,
-        default=P3_REPLAY_BUFFER_LIMIT,
-        help="P3 cap (>= 1) on replay transitions transferred to the child.",
-    )
-    parser.add_argument(
-        "--warmstart-blend-alpha",
-        type=float,
-        default=P4_BLEND_ALPHA,
-        help="P4 blend coefficient in [0, 1] weighting the parent's policy.",
-    )
-    parser.add_argument(
-        "--warmstart-fitness-gate-min-resources",
-        type=float,
-        default=P4_FITNESS_GATE_MIN_RESOURCES,
-        help="P4 minimum parent resource level (>= 0) to clear the fitness gate.",
-    )
+    add_warmstart_tuning_arguments(parser)
     parser.add_argument(
         "--log-level",
         type=str,
@@ -310,10 +285,7 @@ def _build_run(args: argparse.Namespace) -> IntrinsicEvolutionExperiment:
         coparent_max_radius=args.coparent_max_radius,
         selection_pressure=_parse_selection_pressure(args.selection_pressure),
         inheritance_mode=args.inheritance_mode,
-        warmstart_plasticity_damping=args.warmstart_plasticity_damping,
-        warmstart_replay_buffer_limit=args.warmstart_replay_buffer_limit,
-        warmstart_blend_alpha=args.warmstart_blend_alpha,
-        warmstart_fitness_gate_min_resources=args.warmstart_fitness_gate_min_resources,
+        **warmstart_tuning_kwargs(args),
         seed=args.seed,
     )
 

--- a/scripts/run_intrinsic_evolution_experiment.py
+++ b/scripts/run_intrinsic_evolution_experiment.py
@@ -45,6 +45,12 @@ from farm.core.initial_diversity import (  # noqa: E402
     InitialDiversityConfig,
     SeedingMode,
 )
+from farm.core.policy_inheritance import (  # noqa: E402
+    P2_PLASTICITY_DAMPING,
+    P3_REPLAY_BUFFER_LIMIT,
+    P4_BLEND_ALPHA,
+    P4_FITNESS_GATE_MIN_RESOURCES,
+)
 from farm.runners.intrinsic_evolution_experiment import (  # noqa: E402
     InitialConditionsConfig,
     IntrinsicEvolutionExperiment,
@@ -213,6 +219,42 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
+        "--inheritance-mode",
+        type=str,
+        default="baldwinian",
+        choices=["baldwinian", "lamarckian", "p2", "p3", "p4"],
+        help=(
+            "Policy inheritance mode for offspring. 'baldwinian' (default): "
+            "cold-start. 'lamarckian' (P1): weights only. 'p2': weights + "
+            "plasticity damping. 'p3': weights + optimizer state + replay "
+            "slice. 'p4': gated/blended transfer."
+        ),
+    )
+    parser.add_argument(
+        "--warmstart-plasticity-damping",
+        type=float,
+        default=P2_PLASTICITY_DAMPING,
+        help="P2 damping factor in (0, 1] for child LR/epsilon.",
+    )
+    parser.add_argument(
+        "--warmstart-replay-buffer-limit",
+        type=int,
+        default=P3_REPLAY_BUFFER_LIMIT,
+        help="P3 cap (>= 1) on replay transitions transferred to the child.",
+    )
+    parser.add_argument(
+        "--warmstart-blend-alpha",
+        type=float,
+        default=P4_BLEND_ALPHA,
+        help="P4 blend coefficient in [0, 1] weighting the parent's policy.",
+    )
+    parser.add_argument(
+        "--warmstart-fitness-gate-min-resources",
+        type=float,
+        default=P4_FITNESS_GATE_MIN_RESOURCES,
+        help="P4 minimum parent resource level (>= 0) to clear the fitness gate.",
+    )
+    parser.add_argument(
         "--log-level",
         type=str,
         default="INFO",
@@ -267,6 +309,11 @@ def _build_run(args: argparse.Namespace) -> IntrinsicEvolutionExperiment:
         coparent_strategy=args.coparent_strategy,
         coparent_max_radius=args.coparent_max_radius,
         selection_pressure=_parse_selection_pressure(args.selection_pressure),
+        inheritance_mode=args.inheritance_mode,
+        warmstart_plasticity_damping=args.warmstart_plasticity_damping,
+        warmstart_replay_buffer_limit=args.warmstart_replay_buffer_limit,
+        warmstart_blend_alpha=args.warmstart_blend_alpha,
+        warmstart_fitness_gate_min_resources=args.warmstart_fitness_gate_min_resources,
         seed=args.seed,
     )
 

--- a/scripts/run_stable_profile_seed_sweep.py
+++ b/scripts/run_stable_profile_seed_sweep.py
@@ -62,6 +62,12 @@ from farm.core.hyperparameter_chromosome import (  # noqa: E402
     MutationMode,
 )
 from farm.core.initial_diversity import InitialDiversityConfig, SeedingMode  # noqa: E402
+from farm.core.policy_inheritance import (  # noqa: E402
+    P2_PLASTICITY_DAMPING,
+    P3_REPLAY_BUFFER_LIMIT,
+    P4_BLEND_ALPHA,
+    P4_FITNESS_GATE_MIN_RESOURCES,
+)
 from farm.runners.intrinsic_evolution_experiment import (  # noqa: E402
     STABLE_SUB_PROFILES,
     InitialConditionsConfig,
@@ -134,6 +140,30 @@ def _build_parser() -> argparse.ArgumentParser:
             "'p3': weights + optimizer state + replay slice. "
             "'p4': gated/blended transfer."
         ),
+    )
+    parser.add_argument(
+        "--warmstart-plasticity-damping",
+        type=float,
+        default=P2_PLASTICITY_DAMPING,
+        help="P2 damping factor in (0, 1] for child LR/epsilon.",
+    )
+    parser.add_argument(
+        "--warmstart-replay-buffer-limit",
+        type=int,
+        default=P3_REPLAY_BUFFER_LIMIT,
+        help="P3 cap (>= 1) on replay transitions transferred to the child.",
+    )
+    parser.add_argument(
+        "--warmstart-blend-alpha",
+        type=float,
+        default=P4_BLEND_ALPHA,
+        help="P4 blend coefficient in [0, 1] weighting the parent's policy.",
+    )
+    parser.add_argument(
+        "--warmstart-fitness-gate-min-resources",
+        type=float,
+        default=P4_FITNESS_GATE_MIN_RESOURCES,
+        help="P4 minimum parent resource level (>= 0) to clear the fitness gate.",
     )
     parser.add_argument("--initial-diversity-mutation-rate", type=float, default=1.0)
     parser.add_argument("--initial-diversity-mutation-scale", type=float, default=0.25)
@@ -260,6 +290,22 @@ def _build_run(profile: str, seed: int, args: argparse.Namespace, run_dir: Path)
         ),
         selection_pressure=args.selection_pressure,
         inheritance_mode=str(getattr(args, "inheritance_mode", "baldwinian")),
+        warmstart_plasticity_damping=float(
+            getattr(args, "warmstart_plasticity_damping", P2_PLASTICITY_DAMPING)
+        ),
+        warmstart_replay_buffer_limit=int(
+            getattr(args, "warmstart_replay_buffer_limit", P3_REPLAY_BUFFER_LIMIT)
+        ),
+        warmstart_blend_alpha=float(
+            getattr(args, "warmstart_blend_alpha", P4_BLEND_ALPHA)
+        ),
+        warmstart_fitness_gate_min_resources=float(
+            getattr(
+                args,
+                "warmstart_fitness_gate_min_resources",
+                P4_FITNESS_GATE_MIN_RESOURCES,
+            )
+        ),
         seed=seed,
     )
 
@@ -408,6 +454,22 @@ def _inheritance_settings_dict(args: argparse.Namespace) -> Dict[str, Any]:
     """Snapshot of inheritance mode related args for the manifest."""
     return {
         "inheritance_mode": str(getattr(args, "inheritance_mode", "baldwinian")),
+        "warmstart_plasticity_damping": float(
+            getattr(args, "warmstart_plasticity_damping", P2_PLASTICITY_DAMPING)
+        ),
+        "warmstart_replay_buffer_limit": int(
+            getattr(args, "warmstart_replay_buffer_limit", P3_REPLAY_BUFFER_LIMIT)
+        ),
+        "warmstart_blend_alpha": float(
+            getattr(args, "warmstart_blend_alpha", P4_BLEND_ALPHA)
+        ),
+        "warmstart_fitness_gate_min_resources": float(
+            getattr(
+                args,
+                "warmstart_fitness_gate_min_resources",
+                P4_FITNESS_GATE_MIN_RESOURCES,
+            )
+        ),
     }
 
 

--- a/scripts/run_stable_profile_seed_sweep.py
+++ b/scripts/run_stable_profile_seed_sweep.py
@@ -62,11 +62,9 @@ from farm.core.hyperparameter_chromosome import (  # noqa: E402
     MutationMode,
 )
 from farm.core.initial_diversity import InitialDiversityConfig, SeedingMode  # noqa: E402
-from farm.core.policy_inheritance import (  # noqa: E402
-    P2_PLASTICITY_DAMPING,
-    P3_REPLAY_BUFFER_LIMIT,
-    P4_BLEND_ALPHA,
-    P4_FITNESS_GATE_MIN_RESOURCES,
+from scripts._warmstart_cli import (  # noqa: E402
+    add_warmstart_tuning_arguments,
+    warmstart_tuning_kwargs,
 )
 from farm.runners.intrinsic_evolution_experiment import (  # noqa: E402
     STABLE_SUB_PROFILES,
@@ -141,30 +139,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "'p4': gated/blended transfer."
         ),
     )
-    parser.add_argument(
-        "--warmstart-plasticity-damping",
-        type=float,
-        default=P2_PLASTICITY_DAMPING,
-        help="P2 damping factor in (0, 1] for child LR/epsilon.",
-    )
-    parser.add_argument(
-        "--warmstart-replay-buffer-limit",
-        type=int,
-        default=P3_REPLAY_BUFFER_LIMIT,
-        help="P3 cap (>= 1) on replay transitions transferred to the child.",
-    )
-    parser.add_argument(
-        "--warmstart-blend-alpha",
-        type=float,
-        default=P4_BLEND_ALPHA,
-        help="P4 blend coefficient in [0, 1] weighting the parent's policy.",
-    )
-    parser.add_argument(
-        "--warmstart-fitness-gate-min-resources",
-        type=float,
-        default=P4_FITNESS_GATE_MIN_RESOURCES,
-        help="P4 minimum parent resource level (>= 0) to clear the fitness gate.",
-    )
+    add_warmstart_tuning_arguments(parser)
     parser.add_argument("--initial-diversity-mutation-rate", type=float, default=1.0)
     parser.add_argument("--initial-diversity-mutation-scale", type=float, default=0.25)
     parser.add_argument(
@@ -290,22 +265,7 @@ def _build_run(profile: str, seed: int, args: argparse.Namespace, run_dir: Path)
         ),
         selection_pressure=args.selection_pressure,
         inheritance_mode=str(getattr(args, "inheritance_mode", "baldwinian")),
-        warmstart_plasticity_damping=float(
-            getattr(args, "warmstart_plasticity_damping", P2_PLASTICITY_DAMPING)
-        ),
-        warmstart_replay_buffer_limit=int(
-            getattr(args, "warmstart_replay_buffer_limit", P3_REPLAY_BUFFER_LIMIT)
-        ),
-        warmstart_blend_alpha=float(
-            getattr(args, "warmstart_blend_alpha", P4_BLEND_ALPHA)
-        ),
-        warmstart_fitness_gate_min_resources=float(
-            getattr(
-                args,
-                "warmstart_fitness_gate_min_resources",
-                P4_FITNESS_GATE_MIN_RESOURCES,
-            )
-        ),
+        **warmstart_tuning_kwargs(args),
         seed=seed,
     )
 
@@ -454,22 +414,7 @@ def _inheritance_settings_dict(args: argparse.Namespace) -> Dict[str, Any]:
     """Snapshot of inheritance mode related args for the manifest."""
     return {
         "inheritance_mode": str(getattr(args, "inheritance_mode", "baldwinian")),
-        "warmstart_plasticity_damping": float(
-            getattr(args, "warmstart_plasticity_damping", P2_PLASTICITY_DAMPING)
-        ),
-        "warmstart_replay_buffer_limit": int(
-            getattr(args, "warmstart_replay_buffer_limit", P3_REPLAY_BUFFER_LIMIT)
-        ),
-        "warmstart_blend_alpha": float(
-            getattr(args, "warmstart_blend_alpha", P4_BLEND_ALPHA)
-        ),
-        "warmstart_fitness_gate_min_resources": float(
-            getattr(
-                args,
-                "warmstart_fitness_gate_min_resources",
-                P4_FITNESS_GATE_MIN_RESOURCES,
-            )
-        ),
+        **warmstart_tuning_kwargs(args),
     }
 
 

--- a/tests/runners/test_intrinsic_evolution_experiment.py
+++ b/tests/runners/test_intrinsic_evolution_experiment.py
@@ -28,6 +28,12 @@ from farm.core.initial_diversity import (
     InitialDiversityMetrics,
     SeedingMode,
 )
+from farm.core.policy_inheritance import (
+    P2_PLASTICITY_DAMPING,
+    P3_REPLAY_BUFFER_LIMIT,
+    P4_BLEND_ALPHA,
+    P4_FITNESS_GATE_MIN_RESOURCES,
+)
 from farm.runners.intrinsic_evolution_experiment import (
     IntrinsicEvolutionExperiment,
     IntrinsicEvolutionExperimentConfig,
@@ -139,6 +145,46 @@ class TestIntrinsicEvolutionPolicy(unittest.TestCase):
         for mode in ("baldwinian", "lamarckian", "p2", "p3", "p4"):
             policy = IntrinsicEvolutionPolicy(inheritance_mode=mode)
             self.assertEqual(policy.inheritance_mode, mode)
+
+    def test_warmstart_tuning_defaults(self):
+        policy = IntrinsicEvolutionPolicy()
+        self.assertEqual(policy.warmstart_plasticity_damping, P2_PLASTICITY_DAMPING)
+        self.assertEqual(policy.warmstart_replay_buffer_limit, P3_REPLAY_BUFFER_LIMIT)
+        self.assertEqual(policy.warmstart_blend_alpha, P4_BLEND_ALPHA)
+        self.assertEqual(
+            policy.warmstart_fitness_gate_min_resources,
+            P4_FITNESS_GATE_MIN_RESOURCES,
+        )
+
+    def test_warmstart_tuning_overrides_accepted(self):
+        policy = IntrinsicEvolutionPolicy(
+            warmstart_plasticity_damping=0.25,
+            warmstart_replay_buffer_limit=64,
+            warmstart_blend_alpha=0.75,
+            warmstart_fitness_gate_min_resources=5.0,
+        )
+        self.assertEqual(policy.warmstart_plasticity_damping, 0.25)
+        self.assertEqual(policy.warmstart_replay_buffer_limit, 64)
+        self.assertEqual(policy.warmstart_blend_alpha, 0.75)
+        self.assertEqual(policy.warmstart_fitness_gate_min_resources, 5.0)
+
+    def test_invalid_plasticity_damping_raises(self):
+        for bad in (0.0, -0.1, 1.5):
+            with self.assertRaises(ValueError):
+                IntrinsicEvolutionPolicy(warmstart_plasticity_damping=bad)
+
+    def test_invalid_replay_buffer_limit_raises(self):
+        with self.assertRaises(ValueError):
+            IntrinsicEvolutionPolicy(warmstart_replay_buffer_limit=0)
+
+    def test_invalid_blend_alpha_raises(self):
+        for bad in (-0.1, 1.1):
+            with self.assertRaises(ValueError):
+                IntrinsicEvolutionPolicy(warmstart_blend_alpha=bad)
+
+    def test_invalid_fitness_gate_min_resources_raises(self):
+        with self.assertRaises(ValueError):
+            IntrinsicEvolutionPolicy(warmstart_fitness_gate_min_resources=-1.0)
 
 
 class TestIntrinsicEvolutionExperimentConfig(unittest.TestCase):
@@ -313,11 +359,15 @@ class TestRunnerOrchestration(unittest.TestCase):
             self.assertEqual(metadata["policy"]["mutation_mode"], "gaussian")
             self.assertEqual(metadata["policy"]["inheritance_mode"], "baldwinian")
             inheritance_metrics = metadata["policy_inheritance_metrics"]
-            self.assertEqual(inheritance_metrics["lamarckian_warmstart_applied"], 0)
-            self.assertEqual(inheritance_metrics["lamarckian_warmstart_skipped"], 0)
+            self.assertEqual(inheritance_metrics["warmstart_applied"], 0)
+            self.assertEqual(inheritance_metrics["warmstart_skipped"], 0)
             self.assertEqual(
-                inheritance_metrics["lamarckian_warmstart_skipped_reasons"], {}
+                inheritance_metrics["warmstart_skipped_reasons"], {}
             )
+            self.assertIsNone(inheritance_metrics["warmstart_coverage"])
+            self.assertIsNone(inheritance_metrics["gate_hit_rate"])
+            self.assertIsNone(inheritance_metrics["blend_alpha"])
+            self.assertEqual(inheritance_metrics["gate_not_cleared"], 0)
             self.assertEqual(inheritance_metrics["decide_action_failures"], 0)
             self.assertEqual(
                 inheritance_metrics["decide_action_failure_reasons"], {}

--- a/tests/scripts/test_compare_inheritance_arms.py
+++ b/tests/scripts/test_compare_inheritance_arms.py
@@ -215,7 +215,7 @@ class TestPairedMetricDeltas(unittest.TestCase):
                 "peak_death_rate": 0.4,
                 "oscillation_amplitude": 12.0,
             },
-            "lamarckian_warmstart_rate": 0.75,
+            "warmstart_rate": 0.75,
         }
 
     def test_seed_pairing_returns_tuple(self):
@@ -259,11 +259,13 @@ class TestExtractMetadataMetrics(unittest.TestCase):
                             "oscillation_amplitude": 12,
                         },
                         "policy_inheritance_metrics": {
-                            "lamarckian_warmstart_applied": 8,
-                            "lamarckian_warmstart_skipped": 2,
-                            "lamarckian_warmstart_skipped_reasons": {
+                            "warmstart_applied": 8,
+                            "warmstart_skipped": 2,
+                            "warmstart_skipped_reasons": {
                                 "incompatible_state": 2,
                             },
+                            "gate_hit_rate": 1.0,
+                            "blend_alpha": 0.5,
                             "decide_action_failures": 4,
                             "decide_action_failure_reasons": {
                                 "RuntimeError": 3,
@@ -275,12 +277,14 @@ class TestExtractMetadataMetrics(unittest.TestCase):
                 encoding="utf-8",
             )
             metrics = _extract_metadata_metrics(run_dir)
-        self.assertAlmostEqual(metrics["lamarckian_warmstart_rate"], 0.8)
-        self.assertEqual(metrics["lamarckian_warmstart_applied"], 8)
-        self.assertEqual(metrics["lamarckian_warmstart_skipped"], 2)
+        self.assertAlmostEqual(metrics["warmstart_rate"], 0.8)
+        self.assertEqual(metrics["warmstart_applied"], 8)
+        self.assertEqual(metrics["warmstart_skipped"], 2)
         self.assertEqual(
-            metrics["lamarckian_warmstart_skipped_reasons"], {"incompatible_state": 2}
+            metrics["warmstart_skipped_reasons"], {"incompatible_state": 2}
         )
+        self.assertAlmostEqual(metrics["gate_hit_rate"], 1.0)
+        self.assertAlmostEqual(metrics["blend_alpha"], 0.5)
         self.assertEqual(metrics["decide_action_failures"], 4.0)
         self.assertEqual(
             metrics["decide_action_failure_reasons"],
@@ -295,9 +299,9 @@ class TestExtractMetadataMetrics(unittest.TestCase):
 class TestWarmstartCoverage(unittest.TestCase):
     def _run(self, applied: int, skipped: int, reasons: Optional[dict] = None):
         return {
-            "lamarckian_warmstart_applied": applied,
-            "lamarckian_warmstart_skipped": skipped,
-            "lamarckian_warmstart_skipped_reasons": reasons or {},
+            "warmstart_applied": applied,
+            "warmstart_skipped": skipped,
+            "warmstart_skipped_reasons": reasons or {},
         }
 
     def test_rate_from_run(self):
@@ -326,7 +330,7 @@ class TestWarmstartCoverage(unittest.TestCase):
             }
         }
         coverage = _compute_mechanism_coverage(treatments, ["conservative"], ["lamarckian"])
-        warmstart = coverage["conservative"]["lamarckian"]["lamarckian_warmstart"]
+        warmstart = coverage["conservative"]["lamarckian"]["warmstart"]
         self.assertAlmostEqual(warmstart["mean_rate"], 0.8)
         self.assertEqual(warmstart["total_applied"], 8)
 
@@ -334,10 +338,12 @@ class TestWarmstartCoverage(unittest.TestCase):
         coverage = {
             "conservative": {
                 "lamarckian": {
-                    "lamarckian_warmstart": {
+                    "warmstart": {
                         "n": 1,
                         "mean_rate": 0.8,
                         "rate_ci95": [0.8, 0.8],
+                        "mean_gate_hit_rate": 1.0,
+                        "blend_alpha": 0.5,
                         "total_applied": 8,
                         "total_skipped": 2,
                         "skip_reasons": {"incompatible_state": 2},
@@ -348,7 +354,7 @@ class TestWarmstartCoverage(unittest.TestCase):
         }
         md = _build_markdown({}, {}, ["lamarckian"], "baldwinian", mechanism_coverage=coverage)
         self.assertIn("## Mechanism coverage (treatment only)", md)
-        self.assertIn("Lamarckian warm-start rate is an absolute treatment-arm statistic", md)
+        self.assertIn("Warm-start rate is an absolute treatment-arm statistic", md)
         self.assertNotIn("| lamarckian | warmstart rate delta |", md)
 
 

--- a/tests/scripts/test_run_inheritance_mode_ab_args.py
+++ b/tests/scripts/test_run_inheritance_mode_ab_args.py
@@ -14,12 +14,21 @@ _repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__f
 if _repo_root not in sys.path:
     sys.path.insert(0, _repo_root)
 
+from pathlib import Path  # noqa: E402
+
 import pytest  # noqa: E402
 
+from farm.core.policy_inheritance import (  # noqa: E402
+    P2_PLASTICITY_DAMPING,
+    P3_REPLAY_BUFFER_LIMIT,
+    P4_BLEND_ALPHA,
+    P4_FITNESS_GATE_MIN_RESOURCES,
+)
 from scripts.run_inheritance_mode_ab import (  # noqa: E402
     ARM_PRESETS,
     DEFAULT_ARMS,
     _build_parser,
+    _build_runner_args,
 )
 
 
@@ -75,6 +84,39 @@ class TestABParserArmChoices(unittest.TestCase):
             ["--arms", "baldwinian", "lamarckian", "p2", "p3", "p4"]
         )
         self.assertEqual(set(args.arms), set(ARM_PRESETS))
+
+
+class TestWarmstartTuningForwarding(unittest.TestCase):
+    def test_defaults_forwarded_to_runner_args(self):
+        args = _build_parser().parse_args(["--arms", "p4"])
+        runner_args = _build_runner_args(args, "p4", Path("/tmp/out"))
+        self.assertEqual(
+            runner_args.warmstart_plasticity_damping, P2_PLASTICITY_DAMPING
+        )
+        self.assertEqual(
+            runner_args.warmstart_replay_buffer_limit, P3_REPLAY_BUFFER_LIMIT
+        )
+        self.assertEqual(runner_args.warmstart_blend_alpha, P4_BLEND_ALPHA)
+        self.assertEqual(
+            runner_args.warmstart_fitness_gate_min_resources,
+            P4_FITNESS_GATE_MIN_RESOURCES,
+        )
+
+    def test_overrides_forwarded_to_runner_args(self):
+        args = _build_parser().parse_args(
+            [
+                "--arms", "p4",
+                "--warmstart-plasticity-damping", "0.25",
+                "--warmstart-replay-buffer-limit", "64",
+                "--warmstart-blend-alpha", "0.75",
+                "--warmstart-fitness-gate-min-resources", "5.0",
+            ]
+        )
+        runner_args = _build_runner_args(args, "p4", Path("/tmp/out"))
+        self.assertEqual(runner_args.warmstart_plasticity_damping, 0.25)
+        self.assertEqual(runner_args.warmstart_replay_buffer_limit, 64)
+        self.assertEqual(runner_args.warmstart_blend_alpha, 0.75)
+        self.assertEqual(runner_args.warmstart_fitness_gate_min_resources, 5.0)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_run_stable_profile_seed_sweep_args.py
+++ b/tests/scripts/test_run_stable_profile_seed_sweep_args.py
@@ -16,6 +16,12 @@ if _repo_root not in sys.path:
 
 import pytest  # noqa: E402
 
+from farm.core.policy_inheritance import (  # noqa: E402
+    P2_PLASTICITY_DAMPING,
+    P3_REPLAY_BUFFER_LIMIT,
+    P4_BLEND_ALPHA,
+    P4_FITNESS_GATE_MIN_RESOURCES,
+)
 from scripts.run_stable_profile_seed_sweep import (  # noqa: E402
     INHERITANCE_MODES,
     _build_parser,
@@ -23,22 +29,28 @@ from scripts.run_stable_profile_seed_sweep import (  # noqa: E402
 )
 
 
+def _expected(mode: str, **overrides) -> dict:
+    base = {
+        "inheritance_mode": mode,
+        "warmstart_plasticity_damping": P2_PLASTICITY_DAMPING,
+        "warmstart_replay_buffer_limit": P3_REPLAY_BUFFER_LIMIT,
+        "warmstart_blend_alpha": P4_BLEND_ALPHA,
+        "warmstart_fitness_gate_min_resources": P4_FITNESS_GATE_MIN_RESOURCES,
+    }
+    base.update(overrides)
+    return base
+
+
 class TestInheritanceModeFlag(unittest.TestCase):
     def test_default_is_baldwinian(self):
         args = _build_parser().parse_args([])
         self.assertEqual(args.inheritance_mode, "baldwinian")
-        self.assertEqual(
-            _inheritance_settings_dict(args),
-            {"inheritance_mode": "baldwinian"},
-        )
+        self.assertEqual(_inheritance_settings_dict(args), _expected("baldwinian"))
 
     def test_lamarckian_accepted(self):
         args = _build_parser().parse_args(["--inheritance-mode", "lamarckian"])
         self.assertEqual(args.inheritance_mode, "lamarckian")
-        self.assertEqual(
-            _inheritance_settings_dict(args),
-            {"inheritance_mode": "lamarckian"},
-        )
+        self.assertEqual(_inheritance_settings_dict(args), _expected("lamarckian"))
 
     def test_invalid_value_rejected(self):
         with pytest.raises(SystemExit):
@@ -50,25 +62,49 @@ class TestInheritanceModeFlag(unittest.TestCase):
     def test_p2_accepted(self):
         args = _build_parser().parse_args(["--inheritance-mode", "p2"])
         self.assertEqual(args.inheritance_mode, "p2")
-        self.assertEqual(
-            _inheritance_settings_dict(args),
-            {"inheritance_mode": "p2"},
-        )
+        self.assertEqual(_inheritance_settings_dict(args), _expected("p2"))
 
     def test_p3_accepted(self):
         args = _build_parser().parse_args(["--inheritance-mode", "p3"])
         self.assertEqual(args.inheritance_mode, "p3")
-        self.assertEqual(
-            _inheritance_settings_dict(args),
-            {"inheritance_mode": "p3"},
-        )
+        self.assertEqual(_inheritance_settings_dict(args), _expected("p3"))
 
     def test_p4_accepted(self):
         args = _build_parser().parse_args(["--inheritance-mode", "p4"])
         self.assertEqual(args.inheritance_mode, "p4")
+        self.assertEqual(_inheritance_settings_dict(args), _expected("p4"))
+
+
+class TestWarmstartTuningFlags(unittest.TestCase):
+    def test_defaults_match_module_constants(self):
+        args = _build_parser().parse_args([])
+        self.assertEqual(args.warmstart_plasticity_damping, P2_PLASTICITY_DAMPING)
+        self.assertEqual(args.warmstart_replay_buffer_limit, P3_REPLAY_BUFFER_LIMIT)
+        self.assertEqual(args.warmstart_blend_alpha, P4_BLEND_ALPHA)
+        self.assertEqual(
+            args.warmstart_fitness_gate_min_resources,
+            P4_FITNESS_GATE_MIN_RESOURCES,
+        )
+
+    def test_overrides_are_parsed_and_surfaced(self):
+        args = _build_parser().parse_args(
+            [
+                "--inheritance-mode", "p4",
+                "--warmstart-plasticity-damping", "0.25",
+                "--warmstart-replay-buffer-limit", "64",
+                "--warmstart-blend-alpha", "0.75",
+                "--warmstart-fitness-gate-min-resources", "5.0",
+            ]
+        )
         self.assertEqual(
             _inheritance_settings_dict(args),
-            {"inheritance_mode": "p4"},
+            _expected(
+                "p4",
+                warmstart_plasticity_damping=0.25,
+                warmstart_replay_buffer_limit=64,
+                warmstart_blend_alpha=0.75,
+                warmstart_fitness_gate_min_resources=5.0,
+            ),
         )
 
 

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -156,9 +156,9 @@ def test_reproduce_lamarckian_policy_applies_warmstart_and_tracks_counter():
 
     assert success is True
     telemetry = parent.environment.inheritance_telemetry
-    assert telemetry.lamarckian_warmstart_applied == 1
-    assert telemetry.lamarckian_warmstart_skipped == 0
-    assert dict(telemetry.lamarckian_warmstart_skipped_reasons) == {}
+    assert telemetry.warmstart_applied == 1
+    assert telemetry.warmstart_skipped == 0
+    assert dict(telemetry.warmstart_skipped_reasons) == {}
     offspring.behavior.decision_module.algorithm.load_model_state.assert_called_once()
 
 
@@ -223,9 +223,9 @@ def test_reproduce_lamarckian_incompatible_policy_counts_as_skipped():
 
     assert success is True
     telemetry = parent.environment.inheritance_telemetry
-    assert telemetry.lamarckian_warmstart_applied == 0
-    assert telemetry.lamarckian_warmstart_skipped == 1
-    assert telemetry.lamarckian_warmstart_skipped_reasons[
+    assert telemetry.warmstart_applied == 0
+    assert telemetry.warmstart_skipped == 1
+    assert telemetry.warmstart_skipped_reasons[
         WARMSTART_REASON_INCOMPATIBLE_STATE
     ] == 1
     offspring.behavior.decision_module.algorithm.load_model_state.assert_not_called()
@@ -579,13 +579,19 @@ def test_reproduce_uses_environment_partial_add_rollback_hook_when_available():
 
 
 
-def _build_p_mode_parent(inheritance_mode: str) -> AgentCore:
-    """Build a parent with the given inheritance_mode and warm-start API mocks."""
+def _build_p_mode_parent(inheritance_mode: str, **policy_kwargs) -> AgentCore:
+    """Build a parent with the given inheritance_mode and warm-start API mocks.
+
+    Extra ``policy_kwargs`` (e.g. ``warmstart_blend_alpha``) are forwarded to
+    the :class:`IntrinsicEvolutionPolicy` so tests can verify tuning params are
+    threaded through the reproduction dispatch.
+    """
     parent = _build_parent_agent_for_reproduction()
     parent.environment.intrinsic_evolution_policy = IntrinsicEvolutionPolicy(
         mutation_rate=0.0,
         mutation_scale=0.0,
         inheritance_mode=inheritance_mode,
+        **policy_kwargs,
     )
     parent.behavior = Mock()
     parent.behavior.decision_module = Mock()
@@ -637,8 +643,8 @@ def test_reproduce_p2_mode_applies_warmstart_and_tracks_counter():
 
     assert success is True
     telemetry = parent.environment.inheritance_telemetry
-    assert telemetry.lamarckian_warmstart_applied == 1
-    assert telemetry.lamarckian_warmstart_skipped == 0
+    assert telemetry.warmstart_applied == 1
+    assert telemetry.warmstart_skipped == 0
     offspring.behavior.decision_module.algorithm.load_model_state.assert_called_once()
 
 
@@ -654,8 +660,8 @@ def test_reproduce_p3_mode_applies_warmstart_and_tracks_counter():
 
     assert success is True
     telemetry = parent.environment.inheritance_telemetry
-    assert telemetry.lamarckian_warmstart_applied == 1
-    assert telemetry.lamarckian_warmstart_skipped == 0
+    assert telemetry.warmstart_applied == 1
+    assert telemetry.warmstart_skipped == 0
     offspring.behavior.decision_module.algorithm.load_model_state.assert_called_once()
 
 
@@ -673,8 +679,8 @@ def test_reproduce_p4_mode_applies_warmstart_when_gate_cleared():
 
     assert success is True
     telemetry = parent.environment.inheritance_telemetry
-    assert telemetry.lamarckian_warmstart_applied == 1
-    assert telemetry.lamarckian_warmstart_skipped == 0
+    assert telemetry.warmstart_applied == 1
+    assert telemetry.warmstart_skipped == 0
     offspring.behavior.decision_module.algorithm.load_model_state.assert_called_once()
 
 
@@ -693,10 +699,68 @@ def test_reproduce_p4_mode_skips_when_gate_not_cleared():
 
     assert success is True
     telemetry = parent.environment.inheritance_telemetry
-    assert telemetry.lamarckian_warmstart_applied == 0
-    assert telemetry.lamarckian_warmstart_skipped == 1
-    assert telemetry.lamarckian_warmstart_skipped_reasons[WARMSTART_REASON_GATE_NOT_CLEARED] == 1
+    assert telemetry.warmstart_applied == 0
+    assert telemetry.warmstart_skipped == 1
+    assert telemetry.warmstart_skipped_reasons[WARMSTART_REASON_GATE_NOT_CLEARED] == 1
     offspring.behavior.decision_module.algorithm.load_model_state.assert_not_called()
+
+
+def test_reproduce_p4_records_configured_blend_alpha():
+    """A non-default warmstart_blend_alpha must reach telemetry via the dispatch."""
+    parent = _build_p_mode_parent("p4", warmstart_blend_alpha=0.25)
+    parent.resource_level = 100.0
+    offspring = _build_offspring_mock()
+
+    with patch("farm.core.agent.factory.AgentFactory") as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is True
+    telemetry = parent.environment.inheritance_telemetry
+    assert telemetry.warmstart_applied == 1
+    assert telemetry.blend_alpha == 0.25
+
+
+def test_reproduce_p4_honors_configured_fitness_gate():
+    """A custom fitness-gate threshold must gate the parent through the dispatch."""
+    from farm.core.policy_inheritance import WARMSTART_REASON_GATE_NOT_CLEARED
+
+    # Threshold 50 with a resource level of 10 (above the default 1.0) must skip.
+    parent = _build_p_mode_parent(
+        "p4", warmstart_fitness_gate_min_resources=50.0
+    )
+    parent.resource_level = 10.0
+    offspring = _build_offspring_mock()
+
+    with patch("farm.core.agent.factory.AgentFactory") as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is True
+    telemetry = parent.environment.inheritance_telemetry
+    assert telemetry.warmstart_applied == 0
+    assert telemetry.warmstart_skipped_reasons[WARMSTART_REASON_GATE_NOT_CLEARED] == 1
+
+
+def test_reproduce_p2_honors_configured_plasticity_damping():
+    """A custom plasticity damping must scale the inherited LR/epsilon payload."""
+    parent = _build_p_mode_parent("p2", warmstart_plasticity_damping=0.1)
+    offspring = _build_offspring_mock()
+
+    with patch("farm.core.agent.factory.AgentFactory") as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is True
+    load_model_state = offspring.behavior.decision_module.algorithm.load_model_state
+    payload = load_model_state.call_args.args[0]
+    damped = payload["plasticity_state"]
+    # Source LR 0.01 and epsilon 0.3 (see _build_p_mode_parent) scaled by 0.1.
+    assert damped["learning_rate"] == pytest.approx(0.001)
+    assert damped["epsilon"] == pytest.approx(0.03)
 
 
 def test_reproduce_baldwinian_mode_never_calls_warmstart():
@@ -711,8 +775,8 @@ def test_reproduce_baldwinian_mode_never_calls_warmstart():
 
     assert success is True
     telemetry = parent.environment.inheritance_telemetry
-    assert telemetry.lamarckian_warmstart_applied == 0
-    assert telemetry.lamarckian_warmstart_skipped == 0
+    assert telemetry.warmstart_applied == 0
+    assert telemetry.warmstart_skipped == 0
     offspring.behavior.decision_module.algorithm.load_model_state.assert_not_called()
 
 
@@ -738,9 +802,9 @@ def test_reproduce_warmstart_failure_is_non_fatal():
 
     assert success is True
     telemetry = parent.environment.inheritance_telemetry
-    assert telemetry.lamarckian_warmstart_applied == 0
-    assert telemetry.lamarckian_warmstart_skipped == 1
-    assert telemetry.lamarckian_warmstart_skipped_reasons[WARMSTART_REASON_LOAD_FAILED] == 1
+    assert telemetry.warmstart_applied == 0
+    assert telemetry.warmstart_skipped == 1
+    assert telemetry.warmstart_skipped_reasons[WARMSTART_REASON_LOAD_FAILED] == 1
 
 
 def test_reproduce_extended_state_unsupported_is_observable():
@@ -770,10 +834,10 @@ def test_reproduce_extended_state_unsupported_is_observable():
 
     assert success is True
     telemetry = parent.environment.inheritance_telemetry
-    assert telemetry.lamarckian_warmstart_applied == 0
-    assert telemetry.lamarckian_warmstart_skipped == 1
+    assert telemetry.warmstart_applied == 0
+    assert telemetry.warmstart_skipped == 1
     assert (
-        telemetry.lamarckian_warmstart_skipped_reasons[
+        telemetry.warmstart_skipped_reasons[
             WARMSTART_REASON_EXTENDED_STATE_UNSUPPORTED
         ]
         == 1

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -665,6 +665,37 @@ def test_reproduce_p3_mode_applies_warmstart_and_tracks_counter():
     offspring.behavior.decision_module.algorithm.load_model_state.assert_called_once()
 
 
+def test_reproduce_p3_threads_configured_replay_buffer_limit():
+    """A custom warmstart_replay_buffer_limit must reach get_model_state."""
+    parent = _build_p_mode_parent("p3", warmstart_replay_buffer_limit=64)
+    offspring = _build_offspring_mock()
+
+    captured: dict = {}
+
+    def _capturing_get_model_state(**kwargs):
+        captured.update(kwargs)
+        return {
+            "policy_state_dict": {"w": Mock(shape=(2, 2))},
+            "optimizer_state": {"optim": {}},
+            "replay_buffer_state": {"transitions": [], "size": 0},
+        }
+
+    parent.behavior.decision_module.algorithm.get_model_state = (
+        _capturing_get_model_state
+    )
+
+    with patch("farm.core.agent.factory.AgentFactory") as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is True
+    assert captured["replay_buffer_limit"] == 64
+    telemetry = parent.environment.inheritance_telemetry
+    assert telemetry.warmstart_applied == 1
+    assert telemetry.warmstart_skipped == 0
+
+
 def test_reproduce_p4_mode_applies_warmstart_when_gate_cleared():
     """P4 mode with sufficient resources should apply warm-start."""
     parent = _build_p_mode_parent("p4")

--- a/tests/test_policy_inheritance.py
+++ b/tests/test_policy_inheritance.py
@@ -225,12 +225,40 @@ def test_inheritance_telemetry_records_applied_and_skipped():
     telemetry.record_skipped(WARMSTART_REASON_NO_POLICY_STATE)
 
     payload = telemetry.to_dict()
-    assert payload["lamarckian_warmstart_applied"] == 2
-    assert payload["lamarckian_warmstart_skipped"] == 3
-    assert payload["lamarckian_warmstart_skipped_reasons"] == {
+    assert payload["warmstart_applied"] == 2
+    assert payload["warmstart_skipped"] == 3
+    assert payload["warmstart_skipped_reasons"] == {
         WARMSTART_REASON_INCOMPATIBLE_STATE: 2,
         WARMSTART_REASON_NO_POLICY_STATE: 1,
     }
+    # Coverage = applied / (applied + skipped); no gate skips => gate hit-rate 1.0.
+    assert payload["warmstart_coverage"] == 2 / 5
+    assert payload["gate_not_cleared"] == 0
+    assert payload["gate_hit_rate"] == 1.0
+    assert payload["blend_alpha"] is None
+
+
+def test_inheritance_telemetry_empty_metrics_are_none():
+    payload = InheritanceTelemetry().to_dict()
+    assert payload["warmstart_coverage"] is None
+    assert payload["gate_hit_rate"] is None
+    assert payload["blend_alpha"] is None
+
+
+def test_inheritance_telemetry_gate_hit_rate_and_blend_alpha():
+    telemetry = InheritanceTelemetry()
+    telemetry.record_blend_alpha(0.25)
+    telemetry.record_applied()
+    telemetry.record_applied()
+    telemetry.record_applied()
+    telemetry.record_skipped(WARMSTART_REASON_GATE_NOT_CLEARED)
+
+    payload = telemetry.to_dict()
+    # 4 attempts, 1 gated => coverage 3/4, gate hit-rate (4-1)/4.
+    assert payload["warmstart_coverage"] == 3 / 4
+    assert payload["gate_not_cleared"] == 1
+    assert payload["gate_hit_rate"] == 3 / 4
+    assert payload["blend_alpha"] == 0.25
 
 
 def test_inheritance_telemetry_records_decide_action_failures():

--- a/tests/test_policy_inheritance.py
+++ b/tests/test_policy_inheritance.py
@@ -231,10 +231,12 @@ def test_inheritance_telemetry_records_applied_and_skipped():
         WARMSTART_REASON_INCOMPATIBLE_STATE: 2,
         WARMSTART_REASON_NO_POLICY_STATE: 1,
     }
-    # Coverage = applied / (applied + skipped); no gate skips => gate hit-rate 1.0.
+    # Coverage = applied / (applied + skipped). No blend_alpha was recorded, so
+    # this is a non-P4 run: gate_hit_rate is None (the gate never ran) rather
+    # than a misleading 1.0, staying symmetric with the None blend_alpha.
     assert payload["warmstart_coverage"] == 2 / 5
     assert payload["gate_not_cleared"] == 0
-    assert payload["gate_hit_rate"] == 1.0
+    assert payload["gate_hit_rate"] is None
     assert payload["blend_alpha"] is None
 
 


### PR DESCRIPTION
This pull request introduces extended support for richer policy inheritance mechanisms (P2–P4) in the agent evolution framework, generalizes and expands warm-start telemetry to be mode-neutral, and adds new experiment-level tuning parameters for advanced inheritance modes. It also updates downstream documentation and experiment scripts to reflect these changes, ensuring that new metrics and invariants are surfaced for analysis.

**Policy inheritance and warmstart enhancements:**

* Added support for P2 (plasticity damping), P3 (bounded replay-buffer transfer), and P4 (blended policy weights with fitness gating) inheritance modes, with corresponding tuning parameters exposed in `IntrinsicEvolutionPolicy` and passed via `_warmstart_kwargs_for_mode`. [[1]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393R36-R39) [[2]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393R65-R97) [[3]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393L1245-R1294) [[4]](diffhunk://#diff-7df2829374038ce4ba23f7d77ce0f8c289eb1ff9b3959afc3c853239c703ec5eR493-R500) [[5]](diffhunk://#diff-7df2829374038ce4ba23f7d77ce0f8c289eb1ff9b3959afc3c853239c703ec5eR519-R522) [[6]](diffhunk://#diff-7df2829374038ce4ba23f7d77ce0f8c289eb1ff9b3959afc3c853239c703ec5eR552-R563)
* Replay-buffer transfer for inheritance is now deterministic and size-bounded, with helper methods and tests to ensure reproducibility and correct metadata transfer.

**Telemetry and metrics:**

* `InheritanceTelemetry` is refactored to use mode-neutral counters (`warmstart_applied`, `warmstart_skipped`, etc.) and now records the P4 blend coefficient (`blend_alpha`) and fitness gate hit rate (`gate_hit_rate`). These metrics are surfaced in the experiment metadata for downstream analysis. [[1]](diffhunk://#diff-7ccdb2e9a57c15b8f41c574db23174f605c2ef58fe42e7025fd4850db9746759L16-R37) [[2]](diffhunk://#diff-7ccdb2e9a57c15b8f41c574db23174f605c2ef58fe42e7025fd4850db9746759L37-R112)
* Documentation and experiment readouts are updated to use the new telemetry fields and to report P4-specific metrics. [[1]](diffhunk://#diff-46c29a2495937a3ebe508decdc1bba95ee4e20a7566a0365c8af2fa80b196f97L82-R82) [[2]](diffhunk://#diff-b93ce3bb466b341c6a13aa564567c67e4d27dc57e92269acf911340f12d1cfb8R163-R164)

**Documentation and changelog:**

* The changelog is updated with detailed entries for all major changes, including new inheritance modes, replay-buffer transfer, and telemetry metrics.
* Experiment and devlog documentation is refreshed to match the new inheritance mechanisms and telemetry fields. [[1]](diffhunk://#diff-46c29a2495937a3ebe508decdc1bba95ee4e20a7566a0365c8af2fa80b196f97L82-R82) [[2]](diffhunk://#diff-b93ce3bb466b341c6a13aa564567c67e4d27dc57e92269acf911340f12d1cfb8R163-R164)

These changes provide a foundation for more nuanced analysis of inheritance mechanisms, enable richer experiment configurations, and ensure that all relevant metrics are tracked and reported for advanced evolutionary RL experiments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reproduction warm-start now depends on policy tuning kwargs and serialized metadata keys changed (breaking for scripts expecting `lamarckian_warmstart_*`), though behavior for default Lamarckian mode is largely unchanged and coverage is extensive.
> 
> **Overview**
> **Warm-start telemetry** is renamed from Lamarckian-specific fields (`lamarckian_warmstart_*`) to mode-neutral counters (`warmstart_applied` / `warmstart_skipped`, `warmstart_coverage`). P4 runs also persist **`blend_alpha`**, **`gate_hit_rate`**, and **`gate_not_cleared`** in `policy_inheritance_metrics`.
> 
> **Reproduction dispatch** now passes per-mode tuning from `IntrinsicEvolutionPolicy` into the P2–P4 hooks via `_warmstart_kwargs_for_mode` (plasticity damping, replay buffer limit, blend alpha, fitness gate threshold). P4 records `blend_alpha` on every warm-start attempt, not only successes.
> 
> **Experiment surface**: `IntrinsicEvolutionPolicy` gains validated `warmstart_*` fields; `scripts/_warmstart_cli.py` centralizes four CLI flags wired through intrinsic evolution, stable-profile sweep, and inheritance A/B runners. `run_intrinsic_evolution_experiment.py` adds `--inheritance-mode`. Analysis (`compare_inheritance_arms`, `analyze_early_life_fitness`) and docs read the new metadata keys and report gate/blend coverage for P4.
> 
> Tests and CHANGELOG/devlog entries are updated to match the new field names and forwarding behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 036a83b67939cdb31ee3ec1774339b31b15f28f6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->