### PR TITLE
Fix: Pin torch threads for multi-agent parallel runs to prevent CPU oversubscription

### DIFF
--- a/farm/runners/batch_runner.py
+++ b/farm/runners/batch_runner.py
@@ -191,6 +191,16 @@ class BatchRunner:
 def run_simulation_wrapper(args):
     params, config_file_path, num_steps, path = args
     try:
+        # Pin torch threads for worker processes to prevent CPU oversubscription
+        import os
+        os.environ["OMP_NUM_THREADS"] = "1"
+        os.environ["MKL_NUM_THREADS"] = "1"
+        try:
+            import torch
+            torch.set_num_threads(1)
+        except ImportError:
+            pass
+
         if config_file_path:
             # Check if it's a centralized config request
             if config_file_path.startswith("centralized:"):

--- a/farm/runners/parallel_experiment_runner.py
+++ b/farm/runners/parallel_experiment_runner.py
@@ -173,6 +173,16 @@ class ParallelExperimentRunner:
             Results or error information
         """
         try:
+            # Pin torch threads for worker processes to prevent CPU oversubscription
+            import os
+            os.environ["OMP_NUM_THREADS"] = "1"
+            os.environ["MKL_NUM_THREADS"] = "1"
+            try:
+                import torch
+                torch.set_num_threads(1)
+            except ImportError:
+                pass
+
             # Ensure output directory exists
             os.makedirs(output_path, exist_ok=True)
 


### PR DESCRIPTION
Fixes #915 by explicitly pinning torch threads inside parallel workers to prevent massive CPU oversubscription and performance degradation during batch/parallel agent runs.