### PR TITLE
Enhance CPU thread policy and improve device validation and logging

### DIFF
--- a/default_config.json
+++ b/default_config.json
@@ -211,6 +211,7 @@
   "device_fallback": true,
   "device_memory_fraction": null,
   "device_validate_compatibility": true,
+  "cpu_threads": 1,
   "agent_processing_batch_size": 32,
   "resource_processing_batch_size": 100,
   "enable_parallel_processing": false,

--- a/docs/config/configuration_guide.md
+++ b/docs/config/configuration_guide.md
@@ -231,6 +231,7 @@ device_preference: "auto"            # "auto", "cpu", "cuda", "cuda:X"
 device_fallback: true                # Fallback to CPU if preferred device unavailable
 device_memory_fraction: null         # GPU memory fraction (0.0-1.0)
 device_validate_compatibility: true  # Validate tensor compatibility
+cpu_threads: 1                       # CPU thread cap for torch/OpenMP/MKL on CPU runs
 
 # Simulation control
 simulation_steps: 100                # Number of steps to simulate
@@ -241,6 +242,10 @@ max_wait_steps: 10                   # Maximum wait steps between actions
 debug: false                         # Enable debug output
 verbose_logging: false               # Enable verbose logging
 ```
+
+When running many small per-agent models on CPU, `cpu_threads: 1` usually avoids
+thread oversubscription and improves step time. For a single large model on CPU,
+increasing `cpu_threads` may improve throughput.
 
 ## Visualization Configuration
 

--- a/farm/config/config.py
+++ b/farm/config/config.py
@@ -452,7 +452,9 @@ class DeviceConfig:
     device_fallback: bool = True  # Whether to fallback to CPU if preferred device unavailable
     device_memory_fraction: Optional[float] = None  # GPU memory fraction to use (0.0-1.0)
     device_validate_compatibility: bool = True  # Whether to validate tensor compatibility when moving devices
-    cpu_threads: Optional[int] = 1  # CPU thread cap for CPU-backed torch workloads (None keeps defaults)
+    cpu_threads: Optional[int] = field(
+        default=1, metadata={"minimum": 1}
+    )  # CPU thread cap for CPU-backed torch workloads (None keeps defaults)
 
 
 @dataclass

--- a/farm/config/config.py
+++ b/farm/config/config.py
@@ -456,6 +456,24 @@ class DeviceConfig:
         default=1, metadata={"minimum": 1}
     )  # CPU thread cap for CPU-backed torch workloads (None keeps defaults)
 
+    def __post_init__(self) -> None:
+        """Validate device settings so misconfiguration fails fast at config load.
+
+        Without this, an invalid ``cpu_threads`` would only surface later, when a
+        device is first resolved during agent construction.
+        """
+        if self.cpu_threads is None:
+            return
+        # bool is a subclass of int in Python; reject bool explicitly.
+        if type(self.cpu_threads) is bool or not isinstance(self.cpu_threads, int):
+            raise ValueError(
+                f"device.cpu_threads must be an int >= 1 or None, got {self.cpu_threads!r}"
+            )
+        if self.cpu_threads < 1:
+            raise ValueError(
+                f"device.cpu_threads must be >= 1 or None, got {self.cpu_threads}"
+            )
+
 
 @dataclass
 class CurriculumConfig:

--- a/farm/config/config.py
+++ b/farm/config/config.py
@@ -452,6 +452,7 @@ class DeviceConfig:
     device_fallback: bool = True  # Whether to fallback to CPU if preferred device unavailable
     device_memory_fraction: Optional[float] = None  # GPU memory fraction to use (0.0-1.0)
     device_validate_compatibility: bool = True  # Whether to validate tensor compatibility when moving devices
+    cpu_threads: Optional[int] = 1  # CPU thread cap for CPU-backed torch workloads (None keeps defaults)
 
 
 @dataclass
@@ -1375,6 +1376,7 @@ class SimulationConfig:
                     "device_fallback",
                     "device_memory_fraction",
                     "device_validate_compatibility",
+                    "cpu_threads",
                 ],
             ),
             "curriculum": (CurriculumConfig, ["curriculum_phases"]),

--- a/farm/config/default.yaml
+++ b/farm/config/default.yaml
@@ -240,6 +240,7 @@ device_preference: "auto"
 device_fallback: true
 device_memory_fraction: null
 device_validate_compatibility: true
+cpu_threads: 1
 
 # Performance optimization settings
 agent_processing_batch_size: 32

--- a/farm/config/schema.json
+++ b/farm/config/schema.json
@@ -644,6 +644,11 @@
               ]
             }
           ]
+        },
+        "cpu_threads": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 1
         }
       }
     },

--- a/farm/config/schema.json
+++ b/farm/config/schema.json
@@ -607,7 +607,10 @@
           "default": true
         },
         "device_memory_fraction": {
-          "type": "number",
+          "type": [
+            "number",
+            "null"
+          ],
           "default": null
         },
         "device_validate_compatibility": {

--- a/farm/config/schema.json
+++ b/farm/config/schema.json
@@ -646,7 +646,10 @@
           ]
         },
         "cpu_threads": {
-          "type": "integer",
+          "type": [
+            "integer",
+            "null"
+          ],
           "default": 1,
           "minimum": 1
         }

--- a/farm/config/schema.py
+++ b/farm/config/schema.py
@@ -231,6 +231,8 @@ def generate_combined_config_schema() -> Dict[str, Any]:
     sim_props = _dataclass_to_properties(
         SimulationConfig, known_enums=simulation_known_enums
     )
+    if "cpu_threads" in sim_props:
+        sim_props["cpu_threads"]["minimum"] = 1
     performance_props = _dataclass_to_properties(PerformanceConfig)
     if "max_learning_updates_per_step" in performance_props:
         performance_props["max_learning_updates_per_step"]["minimum"] = 0

--- a/farm/config/schema.py
+++ b/farm/config/schema.py
@@ -92,7 +92,7 @@ def _get_default_from_instance(instance: Any, name: str) -> Any:
         return None
 
 
-def _schema_type_for_dataclass_field(field_type: Any) -> Any:
+def _get_schema_type_with_nullability(field_type: Any) -> Any:
     """Return schema type for dataclass field, preserving Optional nullability."""
     schema_type: Any = _python_type_to_schema_type(field_type)
     if get_origin(field_type) is Union and type(None) in get_args(field_type):
@@ -132,7 +132,7 @@ def _dataclass_to_properties(
                 default_value = None
 
         schema_entry: Dict[str, Any] = {
-            "type": _schema_type_for_dataclass_field(f.type),
+            "type": _get_schema_type_with_nullability(f.type),
             "default": default_value,
         }
 

--- a/farm/config/schema.py
+++ b/farm/config/schema.py
@@ -231,8 +231,7 @@ def generate_combined_config_schema() -> Dict[str, Any]:
     sim_props = _dataclass_to_properties(
         SimulationConfig, known_enums=simulation_known_enums
     )
-    if "cpu_threads" in sim_props:
-        sim_props["cpu_threads"]["minimum"] = 1
+    sim_props["cpu_threads"]["minimum"] = 1
     performance_props = _dataclass_to_properties(PerformanceConfig)
     if "max_learning_updates_per_step" in performance_props:
         performance_props["max_learning_updates_per_step"]["minimum"] = 0

--- a/farm/config/schema.py
+++ b/farm/config/schema.py
@@ -145,7 +145,8 @@ def _dataclass_to_properties(
         if enum_vals:
             schema_entry["enum"] = enum_vals
 
-        # Add numeric/string constraints from dataclass field metadata
+        # Copy declarative validation constraints (e.g., minimum, pattern) from
+        # dataclass field metadata into the emitted JSON schema properties.
         for key in (
             "minimum",
             "maximum",

--- a/farm/config/schema.py
+++ b/farm/config/schema.py
@@ -92,6 +92,14 @@ def _get_default_from_instance(instance: Any, name: str) -> Any:
         return None
 
 
+def _schema_type_for_dataclass_field(field_type: Any) -> Any:
+    """Return schema type for dataclass field, preserving Optional nullability."""
+    schema_type: Any = _python_type_to_schema_type(field_type)
+    if get_origin(field_type) is Union and type(None) in get_args(field_type):
+        return [schema_type, "null"]
+    return schema_type
+
+
 def _dataclass_to_properties(
     dc_cls: type, known_enums: Optional[Dict[str, List[Any]]] = None
 ) -> Dict[str, Dict[str, Any]]:
@@ -124,14 +132,9 @@ def _dataclass_to_properties(
                 default_value = None
 
         schema_entry: Dict[str, Any] = {
-            "type": _python_type_to_schema_type(f.type),
+            "type": _schema_type_for_dataclass_field(f.type),
             "default": default_value,
         }
-
-        origin = get_origin(f.type)
-        args = get_args(f.type)
-        if origin is Union and type(None) in args:
-            schema_entry["type"] = [schema_entry["type"], "null"]
 
         # Add enums if known by name
         if known_enums and f.name in known_enums:

--- a/farm/config/schema.py
+++ b/farm/config/schema.py
@@ -11,11 +11,23 @@ from dataclasses import fields, is_dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union, get_args, get_origin
 
+try:
+    # PEP 604 unions (``int | None``) report this origin on Python 3.10+.
+    from types import UnionType
+except ImportError:  # pragma: no cover - Python < 3.10
+    UnionType = None  # type: ignore[assignment,misc]
+
 from pydantic import BaseModel, ValidationError
 
 from farm.core.observations import ObservationConfig, StorageMode
 
-from .config import PerformanceConfig, RedisMemoryConfig, SimulationConfig, VisualizationConfig
+from .config import (
+    DeviceConfig,
+    PerformanceConfig,
+    RedisMemoryConfig,
+    SimulationConfig,
+    VisualizationConfig,
+)
 
 
 def _python_type_to_schema_type(annotation: Any) -> str:
@@ -92,10 +104,20 @@ def _get_default_from_instance(instance: Any, name: str) -> Any:
         return None
 
 
+def _is_optional_type(field_type: Any) -> bool:
+    """Return True if the annotation is an Optional/union that includes ``None``.
+
+    Handles both ``typing.Union``/``Optional`` and PEP 604 ``X | None`` unions.
+    """
+    origin = get_origin(field_type)
+    is_union = origin is Union or (UnionType is not None and origin is UnionType)
+    return is_union and type(None) in get_args(field_type)
+
+
 def _get_schema_type_with_nullability(field_type: Any) -> Any:
     """Return schema type for dataclass field, preserving Optional nullability."""
     schema_type: Any = _python_type_to_schema_type(field_type)
-    if get_origin(field_type) is Union and type(None) in get_args(field_type):
+    if _is_optional_type(field_type):
         return [schema_type, "null"]
     return schema_type
 
@@ -270,6 +292,15 @@ def generate_combined_config_schema() -> Dict[str, Any]:
     ):
         if key in performance_props:
             sim_props[key] = performance_props[key]
+
+    # Flatten device settings into the simulation section so device fields
+    # (including ``cpu_threads``) are emitted by the generator rather than
+    # maintained by hand. ``device_preference`` is treated as an enum.
+    device_props = _dataclass_to_properties(
+        DeviceConfig, known_enums={"device_preference": ["auto", "cpu", "cuda"]}
+    )
+    sim_props.update(device_props)
+
     # Remove nested sections from simulation section to avoid duplication
     # These are handled as separate top-level sections in the schema
     for nested in ("visualization", "redis", "observation"):

--- a/farm/config/schema.py
+++ b/farm/config/schema.py
@@ -137,6 +137,19 @@ def _dataclass_to_properties(
         if enum_vals:
             schema_entry["enum"] = enum_vals
 
+        # Add numeric/string constraints from dataclass field metadata
+        for key in (
+            "minimum",
+            "maximum",
+            "exclusiveMinimum",
+            "exclusiveMaximum",
+            "minLength",
+            "maxLength",
+            "pattern",
+        ):
+            if key in f.metadata:
+                schema_entry[key] = f.metadata[key]
+
         props[f.name] = schema_entry
 
     return props
@@ -231,7 +244,6 @@ def generate_combined_config_schema() -> Dict[str, Any]:
     sim_props = _dataclass_to_properties(
         SimulationConfig, known_enums=simulation_known_enums
     )
-    sim_props["cpu_threads"]["minimum"] = 1
     performance_props = _dataclass_to_properties(PerformanceConfig)
     if "max_learning_updates_per_step" in performance_props:
         performance_props["max_learning_updates_per_step"]["minimum"] = 0

--- a/farm/config/schema.py
+++ b/farm/config/schema.py
@@ -9,7 +9,7 @@ import dataclasses
 import datetime
 from dataclasses import fields, is_dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple, get_args, get_origin
+from typing import Any, Dict, List, Optional, Tuple, Union, get_args, get_origin
 
 from pydantic import BaseModel, ValidationError
 
@@ -127,6 +127,11 @@ def _dataclass_to_properties(
             "type": _python_type_to_schema_type(f.type),
             "default": default_value,
         }
+
+        origin = get_origin(f.type)
+        args = get_args(f.type)
+        if origin is Union and type(None) in args:
+            schema_entry["type"] = [schema_entry["type"], "null"]
 
         # Add enums if known by name
         if known_enums and f.name in known_enums:

--- a/farm/core/device_utils.py
+++ b/farm/core/device_utils.py
@@ -7,7 +7,6 @@ compatibility validation, and CPU thread policy controls.
 """
 
 import os
-import warnings
 from typing import Optional, Union
 
 import torch
@@ -75,8 +74,12 @@ class DeviceManager:
         """
         if not self._initialized:
             self._device = self._resolve_device()
+            try:
+                self._configure_device()
+            except Exception:
+                self.reset()
+                raise
             self._initialized = True
-            self._configure_device()
 
         assert self._device is not None, "Device should be initialized"
         return self._device
@@ -226,6 +229,17 @@ class DeviceManager:
         """Configure CPU math thread limits for CPU-backed runs."""
         if self.cpu_threads is None:
             return
+
+        if isinstance(self.cpu_threads, bool) or not isinstance(self.cpu_threads, int):
+            logger.warning(
+                "invalid_cpu_threads_type",
+                cpu_threads=self.cpu_threads,
+                cpu_threads_type=type(self.cpu_threads).__name__,
+                expected_type="int",
+            )
+            raise ValueError(
+                f"cpu_threads must be an int >= 1 or None, got {self.cpu_threads!r}"
+            )
 
         if self.cpu_threads < 1:
             logger.warning(

--- a/farm/core/device_utils.py
+++ b/farm/core/device_utils.py
@@ -230,6 +230,7 @@ class DeviceManager:
         if self.cpu_threads is None:
             return
 
+        # bool is a subclass of int in Python; reject bool explicitly.
         if isinstance(self.cpu_threads, bool) or not isinstance(self.cpu_threads, int):
             logger.warning(
                 "invalid_cpu_threads_type",

--- a/farm/core/device_utils.py
+++ b/farm/core/device_utils.py
@@ -188,9 +188,12 @@ class DeviceManager:
 
     def _configure_device(self) -> None:
         """Configure device-specific settings."""
-        if self._device and self._device.type == "cpu":
+        if self._device is None:
+            return
+
+        if self._device.type == "cpu":
             self._configure_cpu_threads()
-        elif self._device and self._device.type == "cuda":
+        elif self._device.type == "cuda":
             if self.memory_fraction is not None:
                 if 0.0 <= self.memory_fraction <= 1.0:
                     try:

--- a/farm/core/device_utils.py
+++ b/farm/core/device_utils.py
@@ -231,7 +231,9 @@ class DeviceManager:
             logger.warning(
                 "invalid_cpu_threads", cpu_threads=self.cpu_threads, minimum=1
             )
-            return
+            raise ValueError(
+                f"cpu_threads must be >= 1 or None, got {self.cpu_threads}"
+            )
 
         os.environ["OMP_NUM_THREADS"] = str(self.cpu_threads)
         os.environ["MKL_NUM_THREADS"] = str(self.cpu_threads)

--- a/farm/core/device_utils.py
+++ b/farm/core/device_utils.py
@@ -231,16 +231,14 @@ class DeviceManager:
             return
 
         # bool is a subclass of int in Python; reject bool explicitly.
-        if isinstance(self.cpu_threads, bool) or not isinstance(self.cpu_threads, int):
+        if type(self.cpu_threads) is bool or not isinstance(self.cpu_threads, int):
             logger.warning(
                 "invalid_cpu_threads_type",
                 cpu_threads=self.cpu_threads,
                 cpu_threads_type=type(self.cpu_threads).__name__,
                 expected_type="int",
             )
-            raise ValueError(
-                f"cpu_threads must be an int >= 1 or None, got {self.cpu_threads!r}"
-            )
+            raise ValueError(f"cpu_threads must be an int >= 1, got {self.cpu_threads!r}")
 
         if self.cpu_threads < 1:
             logger.warning(
@@ -393,21 +391,18 @@ def get_device_manager(
     """
     global _global_device_manager
 
-    resolved_cpu_threads = (
-        1 if cpu_threads is _CPU_THREADS_UNSET else cpu_threads
-    )
-
     if _global_device_manager is None:
+        initial_cpu_threads = 1 if cpu_threads is _CPU_THREADS_UNSET else cpu_threads
         _global_device_manager = DeviceManager(
             preference=preference,
             fallback=fallback,
             memory_fraction=memory_fraction,
             validate_compatibility=validate_compatibility,
-            cpu_threads=resolved_cpu_threads,
+            cpu_threads=initial_cpu_threads,
         )
     else:
         effective_cpu_threads = (
-            resolved_cpu_threads
+            cpu_threads
             if cpu_threads is not _CPU_THREADS_UNSET
             else _global_device_manager.cpu_threads
         )
@@ -425,7 +420,7 @@ def get_device_manager(
             _global_device_manager.memory_fraction = memory_fraction
             _global_device_manager.validate_compatibility = validate_compatibility
             if cpu_threads is not _CPU_THREADS_UNSET:
-                _global_device_manager.cpu_threads = resolved_cpu_threads
+                _global_device_manager.cpu_threads = cpu_threads
 
     return _global_device_manager
 

--- a/farm/core/device_utils.py
+++ b/farm/core/device_utils.py
@@ -353,6 +353,7 @@ class DeviceManager:
 
 # Global device manager instance
 _global_device_manager: Optional[DeviceManager] = None
+_CPU_THREADS_UNSET = object()
 
 
 def get_device_manager(
@@ -360,7 +361,7 @@ def get_device_manager(
     fallback: bool = True,
     memory_fraction: Optional[float] = None,
     validate_compatibility: bool = True,
-    cpu_threads: Optional[int] = 1,
+    cpu_threads: Union[int, None, object] = _CPU_THREADS_UNSET,
 ) -> DeviceManager:
     """
     Get or create a global device manager instance.
@@ -377,29 +378,39 @@ def get_device_manager(
     """
     global _global_device_manager
 
+    resolved_cpu_threads = (
+        1 if cpu_threads is _CPU_THREADS_UNSET else cpu_threads
+    )
+
     if _global_device_manager is None:
         _global_device_manager = DeviceManager(
             preference=preference,
             fallback=fallback,
             memory_fraction=memory_fraction,
             validate_compatibility=validate_compatibility,
-            cpu_threads=cpu_threads,
+            cpu_threads=resolved_cpu_threads,
         )
     else:
+        effective_cpu_threads = (
+            resolved_cpu_threads
+            if cpu_threads is not _CPU_THREADS_UNSET
+            else _global_device_manager.cpu_threads
+        )
         # Update configuration if different
         if (
             _global_device_manager.preference != preference
             or _global_device_manager.fallback != fallback
             or _global_device_manager.memory_fraction != memory_fraction
             or _global_device_manager.validate_compatibility != validate_compatibility
-            or _global_device_manager.cpu_threads != cpu_threads
+            or _global_device_manager.cpu_threads != effective_cpu_threads
         ):
             _global_device_manager.reset()
             _global_device_manager.preference = preference
             _global_device_manager.fallback = fallback
             _global_device_manager.memory_fraction = memory_fraction
             _global_device_manager.validate_compatibility = validate_compatibility
-            _global_device_manager.cpu_threads = cpu_threads
+            if cpu_threads is not _CPU_THREADS_UNSET:
+                _global_device_manager.cpu_threads = resolved_cpu_threads
 
     return _global_device_manager
 
@@ -409,7 +420,7 @@ def get_device(
     fallback: bool = True,
     memory_fraction: Optional[float] = None,
     validate_compatibility: bool = True,
-    cpu_threads: Optional[int] = 1,
+    cpu_threads: Union[int, None, object] = _CPU_THREADS_UNSET,
 ) -> torch.device:
     """
     Convenience function to get device directly.

--- a/farm/core/device_utils.py
+++ b/farm/core/device_utils.py
@@ -230,7 +230,7 @@ class DeviceManager:
         if self.cpu_threads is None:
             return
 
-        if not isinstance(self.cpu_threads, int) or isinstance(self.cpu_threads, bool):
+        if isinstance(self.cpu_threads, bool) or not isinstance(self.cpu_threads, int):
             logger.warning(
                 "invalid_cpu_threads_type",
                 cpu_threads=self.cpu_threads,

--- a/farm/core/device_utils.py
+++ b/farm/core/device_utils.py
@@ -244,9 +244,7 @@ class DeviceManager:
             logger.warning(
                 "invalid_cpu_threads", cpu_threads=self.cpu_threads, minimum=1
             )
-            raise ValueError(
-                f"cpu_threads must be >= 1 or None, got {self.cpu_threads}"
-            )
+            raise ValueError(f"cpu_threads must be >= 1, got {self.cpu_threads}")
 
         os.environ["OMP_NUM_THREADS"] = str(self.cpu_threads)
         os.environ["MKL_NUM_THREADS"] = str(self.cpu_threads)

--- a/farm/core/device_utils.py
+++ b/farm/core/device_utils.py
@@ -229,7 +229,7 @@ class DeviceManager:
 
         if self.cpu_threads < 1:
             logger.warning(
-                "cpu_threads_must_be_positive", cpu_threads=self.cpu_threads, minimum=1
+                "invalid_cpu_threads", cpu_threads=self.cpu_threads, minimum=1
             )
             return
 
@@ -245,7 +245,7 @@ class DeviceManager:
             )
         except RuntimeError as e:
             logger.warning(
-                "cpu_threads_configuration_failed",
+                "cpu_threads_config_failed",
                 cpu_threads=self.cpu_threads,
                 error_type=type(e).__name__,
                 error_message=str(e),

--- a/farm/core/device_utils.py
+++ b/farm/core/device_utils.py
@@ -2,10 +2,11 @@
 Device utilities for managing PyTorch device selection, validation, and fallbacks.
 
 This module provides centralized device management for neural network computations,
-with support for configurable device preferences, automatic fallbacks, and tensor
-compatibility validation.
+with support for configurable device preferences, automatic fallbacks, tensor
+compatibility validation, and CPU thread policy controls.
 """
 
+import os
 import warnings
 from typing import Optional, Union
 
@@ -29,6 +30,7 @@ class DeviceManager:
         fallback: bool = True,
         memory_fraction: Optional[float] = None,
         validate_compatibility: bool = True,
+        cpu_threads: Optional[int] = 1,
     ):
         """
         Initialize the device manager.
@@ -38,13 +40,31 @@ class DeviceManager:
             fallback: Whether to fallback to CPU if preferred device unavailable
             memory_fraction: GPU memory fraction to reserve (0.0-1.0)
             validate_compatibility: Whether to validate tensor compatibility
+            cpu_threads: CPU thread cap for PyTorch/OpenMP/MKL. ``None`` keeps defaults.
         """
         self.preference = preference
         self.fallback = fallback
         self.memory_fraction = memory_fraction
         self.validate_compatibility = validate_compatibility
+        self.cpu_threads = cpu_threads
         self._device: Optional[torch.device] = None
         self._initialized = False
+        self._cached_cuda_available: Optional[bool] = None
+        self._cached_cuda_device_count: Optional[int] = None
+
+    def _is_cuda_available(self) -> bool:
+        """Return cached CUDA availability result."""
+        if self._cached_cuda_available is None:
+            self._cached_cuda_available = torch.cuda.is_available()
+        return self._cached_cuda_available
+
+    def _get_cuda_device_count(self) -> int:
+        """Return cached CUDA device count."""
+        if self._cached_cuda_device_count is None:
+            self._cached_cuda_device_count = (
+                torch.cuda.device_count() if self._is_cuda_available() else 0
+            )
+        return self._cached_cuda_device_count
 
     def get_device(self) -> torch.device:
         """
@@ -82,7 +102,7 @@ class DeviceManager:
 
     def _auto_select_device(self) -> torch.device:
         """Automatically select the best available device."""
-        if torch.cuda.is_available():
+        if self._is_cuda_available():
             # Check if CUDA is actually working
             try:
                 # Test CUDA device
@@ -110,7 +130,7 @@ class DeviceManager:
 
     def _resolve_cuda_device(self) -> torch.device:
         """Resolve CUDA device specification."""
-        if not torch.cuda.is_available():
+        if not self._is_cuda_available():
             if self.fallback:
                 logger.warning("CUDA requested but not available, falling back to CPU")
                 return torch.device("cpu")
@@ -124,7 +144,7 @@ class DeviceManager:
         elif self.preference.startswith("cuda:"):
             try:
                 device_idx = int(self.preference.split(":")[1])
-                if device_idx >= torch.cuda.device_count():
+                if device_idx >= self._get_cuda_device_count():
                     if self.fallback:
                         logger.warning(
                             f"CUDA device {device_idx} not available, falling back to cuda:0"
@@ -168,7 +188,9 @@ class DeviceManager:
 
     def _configure_device(self) -> None:
         """Configure device-specific settings."""
-        if self._device and self._device.type == "cuda":
+        if self._device and self._device.type == "cpu":
+            self._configure_cpu_threads()
+        elif self._device and self._device.type == "cuda":
             if self.memory_fraction is not None:
                 if 0.0 <= self.memory_fraction <= 1.0:
                     try:
@@ -195,6 +217,33 @@ class DeviceManager:
                 "cuda_device_configured",
                 device_name=device_props.name,
                 memory_gb=device_props.total_memory // (1024**3),
+            )
+
+    def _configure_cpu_threads(self) -> None:
+        """Configure CPU math thread limits for CPU-backed runs."""
+        if self.cpu_threads is None:
+            return
+
+        if self.cpu_threads < 1:
+            logger.warning("invalid_cpu_threads", cpu_threads=self.cpu_threads)
+            return
+
+        os.environ["OMP_NUM_THREADS"] = str(self.cpu_threads)
+        os.environ["MKL_NUM_THREADS"] = str(self.cpu_threads)
+        try:
+            torch.set_num_threads(self.cpu_threads)
+            logger.info(
+                "cpu_threads_configured",
+                cpu_threads=self.cpu_threads,
+                omp_num_threads=os.environ["OMP_NUM_THREADS"],
+                mkl_num_threads=os.environ["MKL_NUM_THREADS"],
+            )
+        except RuntimeError as e:
+            logger.warning(
+                "cpu_threads_configuration_failed",
+                cpu_threads=self.cpu_threads,
+                error_type=type(e).__name__,
+                error_message=str(e),
             )
 
     def validate_tensor_compatibility(
@@ -304,6 +353,7 @@ def get_device_manager(
     fallback: bool = True,
     memory_fraction: Optional[float] = None,
     validate_compatibility: bool = True,
+    cpu_threads: Optional[int] = 1,
 ) -> DeviceManager:
     """
     Get or create a global device manager instance.
@@ -313,6 +363,7 @@ def get_device_manager(
         fallback: Whether to fallback to CPU
         memory_fraction: GPU memory fraction
         validate_compatibility: Whether to validate compatibility
+        cpu_threads: CPU thread cap for CPU-backed runs
 
     Returns:
         DeviceManager: Global device manager instance
@@ -325,6 +376,7 @@ def get_device_manager(
             fallback=fallback,
             memory_fraction=memory_fraction,
             validate_compatibility=validate_compatibility,
+            cpu_threads=cpu_threads,
         )
     else:
         # Update configuration if different
@@ -333,12 +385,14 @@ def get_device_manager(
             or _global_device_manager.fallback != fallback
             or _global_device_manager.memory_fraction != memory_fraction
             or _global_device_manager.validate_compatibility != validate_compatibility
+            or _global_device_manager.cpu_threads != cpu_threads
         ):
             _global_device_manager.reset()
             _global_device_manager.preference = preference
             _global_device_manager.fallback = fallback
             _global_device_manager.memory_fraction = memory_fraction
             _global_device_manager.validate_compatibility = validate_compatibility
+            _global_device_manager.cpu_threads = cpu_threads
 
     return _global_device_manager
 
@@ -348,6 +402,7 @@ def get_device(
     fallback: bool = True,
     memory_fraction: Optional[float] = None,
     validate_compatibility: bool = True,
+    cpu_threads: Optional[int] = 1,
 ) -> torch.device:
     """
     Convenience function to get device directly.
@@ -357,6 +412,7 @@ def get_device(
         fallback: Whether to fallback to CPU
         memory_fraction: GPU memory fraction
         validate_compatibility: Whether to validate compatibility
+        cpu_threads: CPU thread cap for CPU-backed runs
 
     Returns:
         torch.device: The selected device
@@ -366,6 +422,7 @@ def get_device(
         fallback=fallback,
         memory_fraction=memory_fraction,
         validate_compatibility=validate_compatibility,
+        cpu_threads=cpu_threads,
     )
     return manager.get_device()
 
@@ -434,9 +491,19 @@ def create_device_from_config(config) -> torch.device:
         expected_types=(bool,),
     )
 
+    cpu_threads = get_nested_then_flat(
+        config=config,
+        nested_parent_attr="device",
+        nested_attr_name="cpu_threads",
+        flat_attr_name="cpu_threads",
+        default_value=1,
+        expected_types=(int, type(None)),
+    )
+
     return get_device(
         preference=preference,
         fallback=fallback,
         memory_fraction=memory_fraction,
         validate_compatibility=validate_compatibility,
+        cpu_threads=cpu_threads,
     )

--- a/farm/core/device_utils.py
+++ b/farm/core/device_utils.py
@@ -15,6 +15,18 @@ from farm.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+# Environment variables consulted by CPU math backends (OpenMP, MKL, OpenBLAS,
+# NumExpr, Accelerate/vecLib). These are read once when each backend
+# initializes, so setting them only affects subprocesses spawned afterward; the
+# current process is pinned via ``torch.set_num_threads``.
+_CPU_THREAD_ENV_VARS = (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+)
+
 
 class DeviceManager:
     """
@@ -226,7 +238,15 @@ class DeviceManager:
             )
 
     def _configure_cpu_threads(self) -> None:
-        """Configure CPU math thread limits for CPU-backed runs."""
+        """Configure CPU math thread limits for CPU-backed runs.
+
+        ``torch.set_num_threads`` is the authoritative in-process control and is
+        the only setting that re-pins the already-initialized PyTorch CPU thread
+        pool. The environment variables (OpenMP/MKL/BLAS) are read by those math
+        backends *once at initialization*, so writing them here does not resize
+        the current process's thread pools; they only take effect for CPU math
+        backends in subprocesses spawned afterward (e.g. parallel workers).
+        """
         if self.cpu_threads is None:
             return
 
@@ -246,16 +266,12 @@ class DeviceManager:
             )
             raise ValueError(f"cpu_threads must be >= 1, got {self.cpu_threads}")
 
-        os.environ["OMP_NUM_THREADS"] = str(self.cpu_threads)
-        os.environ["MKL_NUM_THREADS"] = str(self.cpu_threads)
+        thread_str = str(self.cpu_threads)
+        for env_var in _CPU_THREAD_ENV_VARS:
+            os.environ[env_var] = thread_str
+
         try:
             torch.set_num_threads(self.cpu_threads)
-            logger.info(
-                "cpu_threads_configured",
-                cpu_threads=self.cpu_threads,
-                omp_num_threads=os.environ["OMP_NUM_THREADS"],
-                mkl_num_threads=os.environ["MKL_NUM_THREADS"],
-            )
         except RuntimeError as e:
             logger.warning(
                 "cpu_threads_config_failed",
@@ -263,6 +279,14 @@ class DeviceManager:
                 error_type=type(e).__name__,
                 error_message=str(e),
             )
+            return
+
+        logger.info(
+            "cpu_threads_configured",
+            requested_cpu_threads=self.cpu_threads,
+            torch_num_threads=torch.get_num_threads(),
+            subprocess_env_vars=list(_CPU_THREAD_ENV_VARS),
+        )
 
     def validate_tensor_compatibility(
         self, tensor: torch.Tensor, target_device: torch.device

--- a/farm/core/device_utils.py
+++ b/farm/core/device_utils.py
@@ -230,7 +230,7 @@ class DeviceManager:
         if self.cpu_threads is None:
             return
 
-        if isinstance(self.cpu_threads, bool) or not isinstance(self.cpu_threads, int):
+        if not isinstance(self.cpu_threads, int) or isinstance(self.cpu_threads, bool):
             logger.warning(
                 "invalid_cpu_threads_type",
                 cpu_threads=self.cpu_threads,

--- a/farm/core/device_utils.py
+++ b/farm/core/device_utils.py
@@ -225,7 +225,9 @@ class DeviceManager:
             return
 
         if self.cpu_threads < 1:
-            logger.warning("invalid_cpu_threads", cpu_threads=self.cpu_threads)
+            logger.warning(
+                "cpu_threads_must_be_positive", cpu_threads=self.cpu_threads, minimum=1
+            )
             return
 
         os.environ["OMP_NUM_THREADS"] = str(self.cpu_threads)

--- a/tests/config/test_config_classes.py
+++ b/tests/config/test_config_classes.py
@@ -10,7 +10,7 @@ This module tests the core configuration dataclasses including:
 import unittest
 from types import SimpleNamespace
 from farm.config import RedisMemoryConfig, VisualizationConfig
-from farm.config.config import PerformanceConfig
+from farm.config.config import DeviceConfig, PerformanceConfig
 from farm.core.agent.config.component_configs import AgentComponentConfig
 
 
@@ -281,6 +281,30 @@ class TestPerformanceConfig(unittest.TestCase):
     def test_max_learning_updates_per_step_rejects_negative_values(self):
         with self.assertRaises(ValueError):
             PerformanceConfig(max_learning_updates_per_step=-1)
+
+
+class TestDeviceConfig(unittest.TestCase):
+    """Test cases for DeviceConfig fail-fast validation."""
+
+    def test_defaults_to_single_cpu_thread(self):
+        config = DeviceConfig()
+        self.assertEqual(config.cpu_threads, 1)
+
+    def test_none_cpu_threads_allowed(self):
+        config = DeviceConfig(cpu_threads=None)
+        self.assertIsNone(config.cpu_threads)
+
+    def test_rejects_zero_cpu_threads_at_load(self):
+        with self.assertRaises(ValueError):
+            DeviceConfig(cpu_threads=0)
+
+    def test_rejects_negative_cpu_threads_at_load(self):
+        with self.assertRaises(ValueError):
+            DeviceConfig(cpu_threads=-2)
+
+    def test_rejects_bool_cpu_threads_at_load(self):
+        with self.assertRaises(ValueError):
+            DeviceConfig(cpu_threads=True)
 
 
 if __name__ == '__main__':

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -1,6 +1,7 @@
 """Tests for config schema generation module."""
 
 import unittest
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional
 
@@ -123,6 +124,19 @@ class TestDataclassToProperties(unittest.TestCase):
 
         props = _dataclass_to_properties(DeviceConfig)
         self.assertEqual(props["cpu_threads"]["type"], ["integer", "null"])
+
+    def test_copies_metadata_constraints_to_schema(self):
+        @dataclass
+        class ConstrainedConfig:
+            value: int = field(
+                default=3,
+                metadata={"minimum": 1, "maximum": 5, "pattern": r"^[0-9]+$"},
+            )
+
+        props = _dataclass_to_properties(ConstrainedConfig)
+        self.assertEqual(props["value"]["minimum"], 1)
+        self.assertEqual(props["value"]["maximum"], 5)
+        self.assertEqual(props["value"]["pattern"], r"^[0-9]+$")
 
 
 class TestPydanticModelToProperties(unittest.TestCase):

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -1,16 +1,30 @@
 """Tests for config schema generation module."""
 
+import json
+import sys
 import unittest
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
 from typing import Dict, List, Optional
 
+import farm.config as _farm_config_pkg
 from farm.config.schema import (
     _dataclass_to_properties,
     _enum_values,
+    _is_optional_type,
     _pydantic_model_to_properties,
     _python_type_to_schema_type,
     generate_combined_config_schema,
+)
+
+_SCHEMA_JSON_PATH = Path(_farm_config_pkg.__file__).parent / "schema.json"
+_DEVICE_FIELDS = (
+    "device_preference",
+    "device_fallback",
+    "device_memory_fraction",
+    "device_validate_compatibility",
+    "cpu_threads",
 )
 
 
@@ -265,6 +279,53 @@ class TestGenerateCombinedConfigSchema(unittest.TestCase):
         self.assertEqual(obs["title"], "Observation")
         self.assertIn("enums", obs)
         self.assertIn("storage_mode", obs["enums"])
+
+    def test_simulation_includes_device_fields(self):
+        sim_props = self.schema["sections"]["simulation"]["properties"]
+        for name in _DEVICE_FIELDS:
+            self.assertIn(name, sim_props)
+        # cpu_threads is Optional[int] with a minimum constraint from metadata.
+        self.assertEqual(sim_props["cpu_threads"]["type"], ["integer", "null"])
+        self.assertEqual(sim_props["cpu_threads"]["minimum"], 1)
+        # Optional float field is nullable too.
+        self.assertEqual(
+            sim_props["device_memory_fraction"]["type"], ["number", "null"]
+        )
+
+    def test_committed_schema_json_device_block_matches_generator(self):
+        """Guard against drift between the generator and the committed artifact.
+
+        The device block in ``schema.json`` is produced by the generator; if the
+        dataclass changes, regenerate the device fields rather than hand-editing.
+        """
+        with open(_SCHEMA_JSON_PATH, "r", encoding="utf-8") as f:
+            committed = json.load(f)
+
+        committed_sim = committed["sections"]["simulation"]["properties"]
+        generated_sim = self.schema["sections"]["simulation"]["properties"]
+        for name in _DEVICE_FIELDS:
+            self.assertIn(name, committed_sim, f"{name} missing from schema.json")
+            self.assertEqual(
+                committed_sim[name],
+                generated_sim[name],
+                f"schema.json device field '{name}' drifted from the generator",
+            )
+
+
+class TestIsOptionalType(unittest.TestCase):
+    """Tests for _is_optional_type covering typing and PEP 604 unions."""
+
+    def test_optional_typing_union(self):
+        self.assertTrue(_is_optional_type(Optional[int]))
+
+    def test_non_optional(self):
+        self.assertFalse(_is_optional_type(int))
+
+    @unittest.skipIf(
+        sys.version_info < (3, 10), "PEP 604 unions require Python 3.10+"
+    )
+    def test_pep604_union(self):
+        self.assertTrue(_is_optional_type(int | None))
 
 
 if __name__ == "__main__":

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -118,6 +118,12 @@ class TestDataclassToProperties(unittest.TestCase):
         self.assertIn("height", props)
         self.assertEqual(props["width"]["type"], "integer")
 
+    def test_optional_dataclass_field_allows_null(self):
+        from farm.config.config import DeviceConfig
+
+        props = _dataclass_to_properties(DeviceConfig)
+        self.assertEqual(props["cpu_threads"]["type"], ["integer", "null"])
+
 
 class TestPydanticModelToProperties(unittest.TestCase):
     """Tests for _pydantic_model_to_properties."""

--- a/tests/core/test_device_utils.py
+++ b/tests/core/test_device_utils.py
@@ -15,7 +15,7 @@ from farm.core.device_utils import (
 import farm.core.device_utils as _dutils
 
 
-def _raise_value_error(*_args, **_kwargs):
+def _raise_cpu_threads_error(*_args, **_kwargs):
     raise ValueError("bad cpu_threads")
 
 
@@ -76,7 +76,9 @@ class TestDeviceManagerGetDevice:
             dm.get_device()
 
     def test_failed_configuration_does_not_leave_manager_initialized(self, monkeypatch):
-        monkeypatch.setattr(DeviceManager, "_configure_cpu_threads", _raise_value_error)
+        monkeypatch.setattr(
+            DeviceManager, "_configure_cpu_threads", _raise_cpu_threads_error
+        )
         dm = DeviceManager(preference="cpu", cpu_threads=2)
         with pytest.raises(ValueError, match="bad cpu_threads"):
             dm.get_device()

--- a/tests/core/test_device_utils.py
+++ b/tests/core/test_device_utils.py
@@ -15,6 +15,10 @@ from farm.core.device_utils import (
 import farm.core.device_utils as _dutils
 
 
+def _raise_value_error(*_args, **_kwargs):
+    raise ValueError("bad cpu_threads")
+
+
 @pytest.fixture(autouse=True)
 def reset_global_device_manager():
     """Ensure each test starts with a fresh global device manager."""
@@ -72,11 +76,7 @@ class TestDeviceManagerGetDevice:
             dm.get_device()
 
     def test_failed_configuration_does_not_leave_manager_initialized(self, monkeypatch):
-        monkeypatch.setattr(
-            DeviceManager,
-            "_configure_cpu_threads",
-            lambda self: (_ for _ in ()).throw(ValueError("bad cpu_threads")),
-        )
+        monkeypatch.setattr(DeviceManager, "_configure_cpu_threads", _raise_value_error)
         dm = DeviceManager(preference="cpu", cpu_threads=2)
         with pytest.raises(ValueError, match="bad cpu_threads"):
             dm.get_device()

--- a/tests/core/test_device_utils.py
+++ b/tests/core/test_device_utils.py
@@ -191,7 +191,10 @@ class TestDeviceManagerCaching:
 
 
 class TestCreateDeviceFromConfig:
-    def test_uses_nested_cpu_threads(self):
+    def test_uses_nested_cpu_threads(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(torch, "set_num_threads", lambda n: calls.append(n))
+
         class DeviceSettings:
             device_preference = "cpu"
             device_fallback = True
@@ -206,3 +209,4 @@ class TestCreateDeviceFromConfig:
         assert device.type == "cpu"
         manager = get_device_manager(preference="cpu", cpu_threads=3)
         assert manager.cpu_threads == 3
+        assert calls == [3]

--- a/tests/core/test_device_utils.py
+++ b/tests/core/test_device_utils.py
@@ -15,7 +15,7 @@ from farm.core.device_utils import (
 import farm.core.device_utils as _dutils
 
 
-def _raise_cpu_threads_error(*_args, **_kwargs):
+def _mock_cpu_threads_config_error(*_args, **_kwargs):
     raise ValueError("bad cpu_threads")
 
 
@@ -77,7 +77,7 @@ class TestDeviceManagerGetDevice:
 
     def test_failed_configuration_does_not_leave_manager_initialized(self, monkeypatch):
         monkeypatch.setattr(
-            DeviceManager, "_configure_cpu_threads", _raise_cpu_threads_error
+            DeviceManager, "_configure_cpu_threads", _mock_cpu_threads_config_error
         )
         dm = DeviceManager(preference="cpu", cpu_threads=2)
         with pytest.raises(ValueError, match="bad cpu_threads"):

--- a/tests/core/test_device_utils.py
+++ b/tests/core/test_device_utils.py
@@ -204,5 +204,5 @@ class TestCreateDeviceFromConfig:
 
         device = create_device_from_config(Config())
         assert device.type == "cpu"
-        assert _dutils._global_device_manager is not None
-        assert _dutils._global_device_manager.cpu_threads == 3
+        manager = get_device_manager(preference="cpu", cpu_threads=3)
+        assert manager.cpu_threads == 3

--- a/tests/core/test_device_utils.py
+++ b/tests/core/test_device_utils.py
@@ -65,12 +65,12 @@ class TestDeviceManagerGetDevice:
         assert os.environ["OMP_NUM_THREADS"] == "2"
         assert os.environ["MKL_NUM_THREADS"] == "2"
 
-    def test_invalid_cpu_threads_raise_value_error(self):
+    def test_invalid_cpu_threads_raises_value_error(self):
         dm = DeviceManager(preference="cpu", cpu_threads=0)
         with pytest.raises(ValueError, match="cpu_threads must be >= 1"):
             dm.get_device()
 
-    def test_bool_cpu_threads_raise_value_error(self):
+    def test_bool_cpu_threads_raises_value_error(self):
         dm = DeviceManager(preference="cpu", cpu_threads=True)
         with pytest.raises(ValueError, match="cpu_threads must be an int >= 1"):
             dm.get_device()

--- a/tests/core/test_device_utils.py
+++ b/tests/core/test_device_utils.py
@@ -1,10 +1,13 @@
 """Tests for farm/core/device_utils.py – DeviceManager and convenience helpers."""
 
+import os
+
 import pytest
 import torch
 
 from farm.core.device_utils import (
     DeviceManager,
+    create_device_from_config,
     get_device,
     get_device_manager,
     safe_tensor_to_device,
@@ -27,17 +30,35 @@ class TestDeviceManagerInit:
         assert dm.fallback is True
         assert dm.memory_fraction is None
         assert dm.validate_compatibility is True
+        assert dm.cpu_threads == 1
         assert not dm._initialized
 
     def test_custom_params(self):
-        dm = DeviceManager(preference="cpu", fallback=False, memory_fraction=0.5, validate_compatibility=False)
+        dm = DeviceManager(
+            preference="cpu",
+            fallback=False,
+            memory_fraction=0.5,
+            validate_compatibility=False,
+            cpu_threads=2,
+        )
         assert dm.preference == "cpu"
         assert dm.fallback is False
         assert dm.memory_fraction == 0.5
         assert dm.validate_compatibility is False
+        assert dm.cpu_threads == 2
 
 
 class TestDeviceManagerGetDevice:
+    def test_cpu_thread_policy_applied_for_cpu_device(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(torch, "set_num_threads", lambda n: calls.append(n))
+        dm = DeviceManager(preference="cpu", cpu_threads=2)
+        device = dm.get_device()
+        assert device.type == "cpu"
+        assert calls == [2]
+        assert os.environ["OMP_NUM_THREADS"] == "2"
+        assert os.environ["MKL_NUM_THREADS"] == "2"
+
     def test_cpu_preference_returns_cpu(self):
         dm = DeviceManager(preference="cpu")
         device = dm.get_device()
@@ -126,6 +147,13 @@ class TestConvenienceFunctions:
         # After reconfiguration the manager should be reset
         assert not m2._initialized or m2.preference == "auto"
 
+    def test_get_device_manager_reconfigures_on_different_cpu_threads(self):
+        m1 = get_device_manager(preference="cpu", cpu_threads=1)
+        m2 = get_device_manager(preference="cpu", cpu_threads=2)
+        assert m1 is m2
+        assert m2.cpu_threads == 2
+        assert not m2._initialized
+
     def test_safe_tensor_to_device_function(self):
         t = torch.tensor([3.0])
         result = safe_tensor_to_device(t, torch.device("cpu"))
@@ -142,3 +170,37 @@ class TestGetOptimalDevice:
         dm = DeviceManager(preference="cpu")
         d = dm.get_optimal_device_for_model(model_size_mb=10.0)
         assert isinstance(d, torch.device)
+
+
+class TestDeviceManagerCaching:
+    def test_cuda_availability_cached(self, monkeypatch):
+        calls = {"is_available": 0}
+
+        def fake_is_available():
+            calls["is_available"] += 1
+            return False
+
+        dm = DeviceManager()
+        monkeypatch.setattr(torch.cuda, "is_available", fake_is_available)
+
+        assert dm._is_cuda_available() is False
+        assert dm._is_cuda_available() is False
+        assert calls["is_available"] == 1
+
+
+class TestCreateDeviceFromConfig:
+    def test_uses_nested_cpu_threads(self):
+        class DeviceSettings:
+            device_preference = "cpu"
+            device_fallback = True
+            device_memory_fraction = None
+            device_validate_compatibility = True
+            cpu_threads = 3
+
+        class Config:
+            device = DeviceSettings()
+
+        device = create_device_from_config(Config())
+        assert device.type == "cpu"
+        assert _dutils._global_device_manager is not None
+        assert _dutils._global_device_manager.cpu_threads == 3

--- a/tests/core/test_device_utils.py
+++ b/tests/core/test_device_utils.py
@@ -61,6 +61,11 @@ class TestDeviceManagerGetDevice:
         assert os.environ["OMP_NUM_THREADS"] == "2"
         assert os.environ["MKL_NUM_THREADS"] == "2"
 
+    def test_invalid_cpu_threads_raise_value_error(self):
+        dm = DeviceManager(preference="cpu", cpu_threads=0)
+        with pytest.raises(ValueError, match="cpu_threads must be >= 1"):
+            dm.get_device()
+
     def test_cpu_preference_returns_cpu(self):
         dm = DeviceManager(preference="cpu")
         device = dm.get_device()
@@ -191,7 +196,7 @@ class TestDeviceManagerCaching:
 
 
 class TestCreateDeviceFromConfig:
-    def test_uses_nested_cpu_threads(self, monkeypatch):
+    def test_create_device_from_config_applies_cpu_threads(self, monkeypatch):
         calls = []
         monkeypatch.setattr(torch, "set_num_threads", lambda n: calls.append(n))
 

--- a/tests/core/test_device_utils.py
+++ b/tests/core/test_device_utils.py
@@ -65,6 +65,32 @@ class TestDeviceManagerGetDevice:
         assert os.environ["OMP_NUM_THREADS"] == "2"
         assert os.environ["MKL_NUM_THREADS"] == "2"
 
+    def test_cpu_threads_none_skips_thread_configuration(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(torch, "set_num_threads", lambda n: calls.append(n))
+        dm = DeviceManager(preference="cpu", cpu_threads=None)
+        device = dm.get_device()
+        assert device.type == "cpu"
+        assert calls == []
+
+    def test_cpu_threads_sets_blas_env_vars(self, monkeypatch):
+        monkeypatch.setattr(torch, "set_num_threads", lambda n: None)
+        for env_var in (
+            "OMP_NUM_THREADS",
+            "MKL_NUM_THREADS",
+            "OPENBLAS_NUM_THREADS",
+            "NUMEXPR_NUM_THREADS",
+            "VECLIB_MAXIMUM_THREADS",
+        ):
+            monkeypatch.delenv(env_var, raising=False)
+        dm = DeviceManager(preference="cpu", cpu_threads=2)
+        dm.get_device()
+        assert os.environ["OMP_NUM_THREADS"] == "2"
+        assert os.environ["MKL_NUM_THREADS"] == "2"
+        assert os.environ["OPENBLAS_NUM_THREADS"] == "2"
+        assert os.environ["NUMEXPR_NUM_THREADS"] == "2"
+        assert os.environ["VECLIB_MAXIMUM_THREADS"] == "2"
+
     def test_invalid_cpu_threads_raises_value_error(self):
         dm = DeviceManager(preference="cpu", cpu_threads=0)
         with pytest.raises(ValueError, match="cpu_threads must be >= 1"):

--- a/tests/core/test_device_utils.py
+++ b/tests/core/test_device_utils.py
@@ -52,6 +52,8 @@ class TestDeviceManagerGetDevice:
     def test_cpu_thread_policy_applied_for_cpu_device(self, monkeypatch):
         calls = []
         monkeypatch.setattr(torch, "set_num_threads", lambda n: calls.append(n))
+        monkeypatch.setenv("OMP_NUM_THREADS", "999")
+        monkeypatch.setenv("MKL_NUM_THREADS", "999")
         dm = DeviceManager(preference="cpu", cpu_threads=2)
         device = dm.get_device()
         assert device.type == "cpu"

--- a/tests/core/test_device_utils.py
+++ b/tests/core/test_device_utils.py
@@ -66,6 +66,23 @@ class TestDeviceManagerGetDevice:
         with pytest.raises(ValueError, match="cpu_threads must be >= 1"):
             dm.get_device()
 
+    def test_bool_cpu_threads_raise_value_error(self):
+        dm = DeviceManager(preference="cpu", cpu_threads=True)
+        with pytest.raises(ValueError, match="cpu_threads must be an int >= 1"):
+            dm.get_device()
+
+    def test_failed_configuration_does_not_leave_manager_initialized(self, monkeypatch):
+        monkeypatch.setattr(
+            DeviceManager,
+            "_configure_cpu_threads",
+            lambda self: (_ for _ in ()).throw(ValueError("bad cpu_threads")),
+        )
+        dm = DeviceManager(preference="cpu", cpu_threads=2)
+        with pytest.raises(ValueError, match="bad cpu_threads"):
+            dm.get_device()
+        assert dm._initialized is False
+        assert dm._device is None
+
     def test_cpu_preference_returns_cpu(self):
         dm = DeviceManager(preference="cpu")
         device = dm.get_device()


### PR DESCRIPTION
This pull request adds support for configuring the number of CPU threads used by PyTorch and underlying math libraries (OpenMP/MKL) via a new `cpu_threads` setting. This allows users to control CPU parallelism for improved performance and resource management, especially when running on CPU. The change introduces the new setting throughout the configuration files, device management logic, and documentation, and includes thorough tests for the new functionality.

**Device configuration enhancements:**

* Added a new `cpu_threads` setting (default: 1) to all configuration files (`default_config.json`, `default.yaml`, `schema.json`, and `DeviceConfig` dataclass) to control the number of CPU threads used for CPU-backed PyTorch workloads. [[1]](diffhunk://#diff-0bf2778c863f907e9b6e06a42828f931fd26720b2e9c664db060b69e6d0ebf37R214) [[2]](diffhunk://#diff-94a4310d8944e9dbc193e0152339310b66f9a0533e7d896de4c05f32abcf2b99R243) [[3]](diffhunk://#diff-4b2fc3c00fa9df153de28d46f1d13e4a6d9eede8ef44d3b56f6aea46238defc4R455-R457) [[4]](diffhunk://#diff-a87fea74d7c70125e08e9abce390569925b90fd37d88023e297b38fa0194c8d2R647-R651)
* Updated the device manager (`DeviceManager` in `device_utils.py`) to accept and apply the `cpu_threads` parameter, setting `OMP_NUM_THREADS`, `MKL_NUM_THREADS`, and calling `torch.set_num_threads` when running on CPU. [[1]](diffhunk://#diff-afeb6146899e54e8e905bf2f11c215640e20b4c6c7eea94c573351d349ca9676R33) [[2]](diffhunk://#diff-afeb6146899e54e8e905bf2f11c215640e20b4c6c7eea94c573351d349ca9676R43-R67) [[3]](diffhunk://#diff-afeb6146899e54e8e905bf2f11c215640e20b4c6c7eea94c573351d349ca9676L171-R196) [[4]](diffhunk://#diff-afeb6146899e54e8e905bf2f11c215640e20b4c6c7eea94c573351d349ca9676R225-R255)
* Updated all device manager entry points and helpers (`get_device_manager`, `get_device`, `create_device_from_config`) to support and propagate the new `cpu_threads` parameter. [[1]](diffhunk://#diff-afeb6146899e54e8e905bf2f11c215640e20b4c6c7eea94c573351d349ca9676R363) [[2]](diffhunk://#diff-afeb6146899e54e8e905bf2f11c215640e20b4c6c7eea94c573351d349ca9676R386) [[3]](diffhunk://#diff-afeb6146899e54e8e905bf2f11c215640e20b4c6c7eea94c573351d349ca9676R395-R402) [[4]](diffhunk://#diff-afeb6146899e54e8e905bf2f11c215640e20b4c6c7eea94c573351d349ca9676R412) [[5]](diffhunk://#diff-afeb6146899e54e8e905bf2f11c215640e20b4c6c7eea94c573351d349ca9676R422) [[6]](diffhunk://#diff-afeb6146899e54e8e905bf2f11c215640e20b4c6c7eea94c573351d349ca9676R501-R515)

**Documentation improvements:**

* Documented the new `cpu_threads` setting and provided usage guidance in `configuration_guide.md`, including recommendations for multi-agent and single-model CPU runs. [[1]](diffhunk://#diff-c44d50d96a8e2c5f85b66b86d0a14906c1dc5a7766d140caae9f46383c2cb591R234) [[2]](diffhunk://#diff-c44d50d96a8e2c5f85b66b86d0a14906c1dc5a7766d140caae9f46383c2cb591R246-R249)

**Validation, schema, and testing:**

* Enforced minimum value constraints for `cpu_threads` in the schema and at runtime, raising a clear error if an invalid value is provided. [[1]](diffhunk://#diff-4b2fc3c00fa9df153de28d46f1d13e4a6d9eede8ef44d3b56f6aea46238defc4R455-R457) [[2]](diffhunk://#diff-afeb6146899e54e8e905bf2f11c215640e20b4c6c7eea94c573351d349ca9676R225-R255) [[3]](diffhunk://#diff-e2c7195a3115ea7bf1f0dc6a876915778bb59fb0f9b74918aeac4381b6bbe8f1R140-R152)
* Extended tests to cover the new functionality, including correct application of thread limits, error handling for invalid values, and configuration propagation. [[1]](diffhunk://#diff-82c8c0eb6bfbcd7ea7608842b2f2a72d103e35a77f5c8336d9e6595428195d77R33-R68) [[2]](diffhunk://#diff-82c8c0eb6bfbcd7ea7608842b2f2a72d103e35a77f5c8336d9e6595428195d77R157-R163) [[3]](diffhunk://#diff-82c8c0eb6bfbcd7ea7608842b2f2a72d103e35a77f5c8336d9e6595428195d77R180-R217)

**Internal improvements:**

* Refactored device manager to cache CUDA availability and device count checks for efficiency. [[1]](diffhunk://#diff-afeb6146899e54e8e905bf2f11c215640e20b4c6c7eea94c573351d349ca9676R43-R67) [[2]](diffhunk://#diff-afeb6146899e54e8e905bf2f11c215640e20b4c6c7eea94c573351d349ca9676L85-R105) [[3]](diffhunk://#diff-afeb6146899e54e8e905bf2f11c215640e20b4c6c7eea94c573351d349ca9676L113-R133) [[4]](diffhunk://#diff-afeb6146899e54e8e905bf2f11c215640e20b4c6c7eea94c573351d349ca9676L127-R147) [[5]](diffhunk://#diff-82c8c0eb6bfbcd7ea7608842b2f2a72d103e35a77f5c8336d9e6595428195d77R180-R217)
* Updated module docstrings to reflect support for CPU thread policy controls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-tuning and config surface changes on the device path; default `cpu_threads: 1` may change CPU throughput versus prior library defaults but does not affect CUDA logic or security-sensitive code.
> 
> **Overview**
> Adds a **`cpu_threads`** device setting (default **1**) across defaults, `DeviceConfig`, JSON schema, and the configuration guide, so CPU runs can cap PyTorch/OpenMP/MKL parallelism and reduce oversubscription with many small per-agent models.
> 
> **`DeviceManager`** now accepts `cpu_threads`, applies it when the resolved device is CPU (`OMP_NUM_THREADS`, `MKL_NUM_THREADS`, `torch.set_num_threads`), rejects values below 1, and propagates the option through `get_device_manager`, `get_device`, and `create_device_from_config` (including global manager reset when the value changes). CUDA availability/device-count probes are cached on the manager instance.
> 
> Schema generation from dataclasses now copies **`minimum`/`maximum`** (and related) constraints from field metadata into generated JSON schema properties. Tests cover thread application, invalid values, reconfiguration, config wiring, and CUDA cache behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30d70ffaa88e28df2a24a666b916783df0651dbd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->