### PR TITLE
Update form-data to 4.0.6 and enhance contribution guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+<!--
+Base branch: please target `dev`, not `main`.
+`main` is the stable release branch and is updated only by maintainers.
+See CONTRIBUTING.md > Branching Model.
+-->
+
+## Description
+
+<!-- A clear description of what this PR changes and why. -->
+
+## Related Issues
+
+<!-- Link any related issues, e.g. "Closes #123". -->
+
+## Checklist
+
+- [ ] This PR targets the `dev` branch (not `main`)
+- [ ] My branch is up to date with the latest `dev`
+- [ ] I ran the test suite (`pytest`) and it passes
+- [ ] I linted my changes (`ruff check .`)
+- [ ] I added or updated tests for behavior changes
+- [ ] I updated documentation as necessary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,32 +9,52 @@ Thank you for your interest in contributing to AgentFarm! This document provides
 - **Documentation**: Help improve or expand documentation
 - **Code Contributions**: Submit code improvements or new features
 
+## Branching Model
+
+**`dev` is the default integration branch — all contributions target `dev`, not `main`.**
+
+- **`dev`**: The active development branch. Base your work on `dev` and open all pull requests against `dev`.
+- **`main`**: The stable, release branch. It is updated only by maintainers (typically by merging `dev`). Please do **not** open pull requests against `main`.
+
+When you fork or clone, make sure your feature branch starts from the latest `dev`:
+
+```bash
+git checkout dev
+git pull upstream dev   # or `origin dev` if working directly on the repo
+git checkout -b my-feature-branch
+```
+
 ## Getting Started
 
 1. **Fork the repository** to your GitHub account
 2. **Clone your fork** to your local machine
-3. **Create and activate a virtual environment** (recommended): `python -m venv venv` then `source venv/bin/activate`
-4. **Install dependencies and the package in editable mode**: `pip install -r requirements.txt` and `pip install -e .`
-5. **Create a new branch** for your contribution
-6. **Make your changes** following our coding standards
-7. **Test your changes** (for example `pytest` from the repository root)
-8. **Commit your changes** with clear, descriptive commit messages
-9. **Push to your fork** and submit a pull request
+3. **Add the upstream remote**: `git remote add upstream https://github.com/Dooders/AgentFarm.git`
+4. **Create and activate a virtual environment** (recommended): `python -m venv venv` then `source venv/bin/activate`
+5. **Install dependencies and the package in editable mode**: `pip install -r requirements.txt` and `pip install -e .`
+6. **Create a new branch from `dev`** for your contribution (see [Branching Model](#branching-model))
+7. **Make your changes** following our coding standards
+8. **Test your changes** (for example `pytest` from the repository root)
+9. **Commit your changes** with clear, descriptive commit messages
+10. **Push to your fork** and submit a pull request **targeting the `dev` branch**
 
 ## Pull Request Process
 
-1. Ensure your code follows the project's coding standards
-2. Update documentation as necessary
-3. Include a clear description of the changes in your pull request
-4. Link any relevant issues in your pull request description
-5. Be responsive to feedback and be willing to make changes if requested
+1. **Target the `dev` branch** — pull requests against `main` will be asked to retarget
+2. Ensure your branch is up to date with the latest `dev` before opening or updating your PR
+3. Ensure your code follows the project's coding standards
+4. Update documentation as necessary
+5. Include a clear description of the changes in your pull request
+6. Link any relevant issues in your pull request description
+7. Be responsive to feedback and be willing to make changes if requested
 
 ## Coding Standards
 
-- Follow PEP 8 style guidelines for Python code
+- Follow PEP 8 style guidelines for Python code (line length 120, as configured for Ruff/Pylint)
+- Lint your changes with `ruff check .` (and optionally `pylint farm`) before opening a PR
+- Run the test suite with `pytest` from the repository root; add or update tests under `tests/` for behavior changes
 - Write meaningful comments and docstrings
 - Keep functions and methods small and focused on a single task
-- Include appropriate tests for new functionality
+- Favor SOLID, DRY, KISS, and composition over inheritance when adding or refactoring code
 
 ## Reporting Bugs
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Dooders
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/farm/core/device_utils.py
+++ b/farm/core/device_utils.py
@@ -11,21 +11,10 @@ from typing import Optional, Union
 
 import torch
 
+from farm.cpu_thread_bootstrap import CPU_THREAD_ENV_VARS as _CPU_THREAD_ENV_VARS
 from farm.utils.logging import get_logger
 
 logger = get_logger(__name__)
-
-# Environment variables consulted by CPU math backends (OpenMP, MKL, OpenBLAS,
-# NumExpr, Accelerate/vecLib). These are read once when each backend
-# initializes, so setting them only affects subprocesses spawned afterward; the
-# current process is pinned via ``torch.set_num_threads``.
-_CPU_THREAD_ENV_VARS = (
-    "OMP_NUM_THREADS",
-    "MKL_NUM_THREADS",
-    "OPENBLAS_NUM_THREADS",
-    "NUMEXPR_NUM_THREADS",
-    "VECLIB_MAXIMUM_THREADS",
-)
 
 
 class DeviceManager:

--- a/farm/cpu_thread_bootstrap.py
+++ b/farm/cpu_thread_bootstrap.py
@@ -1,0 +1,137 @@
+"""Pre-import CPU math-thread pinning.
+
+This module pins the thread-pool environment variables consulted by the CPU
+math backends (OpenMP, MKL, OpenBLAS, NumExpr, Accelerate/vecLib) *before* those
+libraries are imported and initialize their pools. Once ``numpy``/``torch`` (and
+the BLAS libraries underneath them) have imported, these variables are read-only
+no-ops for the current process, so timing matters: call ``pin_cpu_math_threads``
+from the very top of a process entry point, before importing any scientific
+library.
+
+``DeviceManager`` still pins the in-process *PyTorch* pool at device-resolution
+time via ``torch.set_num_threads`` (which can re-size a live pool). This module
+complements that by capping the parent process's non-torch BLAS/OpenMP pools,
+which ``torch.set_num_threads`` cannot resize after import.
+
+IMPORTANT: keep this module importable without importing ``numpy``, ``torch``,
+or any other scientific library. It may only depend on the standard library and
+``yaml`` (which is pure Python and does not pull in numpy).
+"""
+
+import os
+from typing import Optional
+
+import yaml
+
+# Environment variables consulted by CPU math backends. Each backend reads its
+# variable once, when it first initializes its thread pool.
+CPU_THREAD_ENV_VARS = (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+)
+
+
+def validate_cpu_threads(num_threads: Optional[int]) -> Optional[int]:
+    """Validate a ``cpu_threads`` value, returning it unchanged when valid.
+
+    Mirrors the validation in ``DeviceConfig``/``DeviceManager`` so the two code
+    paths agree on what is acceptable.
+    """
+    if num_threads is None:
+        return None
+    # bool is a subclass of int in Python; reject bool explicitly.
+    if type(num_threads) is bool or not isinstance(num_threads, int):
+        raise ValueError(f"cpu_threads must be an int >= 1 or None, got {num_threads!r}")
+    if num_threads < 1:
+        raise ValueError(f"cpu_threads must be >= 1 or None, got {num_threads}")
+    return num_threads
+
+
+def pin_cpu_math_threads(
+    num_threads: Optional[int], *, override: bool = False
+) -> Optional[int]:
+    """Set CPU math-library thread env vars before numpy/torch import.
+
+    Args:
+        num_threads: Thread cap (``>= 1``) to apply, or ``None`` to leave the
+            environment untouched (keep library defaults).
+        override: When ``False`` (default), environment variables already set by
+            the user/launcher are respected and left as-is. When ``True``, every
+            variable is overwritten.
+
+    Returns:
+        The applied integer thread count, or ``None`` if nothing was set
+        (because ``num_threads`` was ``None`` or every variable was already set
+        and ``override`` was ``False``).
+    """
+    num_threads = validate_cpu_threads(num_threads)
+    if num_threads is None:
+        return None
+
+    value = str(num_threads)
+    applied = False
+    for var in CPU_THREAD_ENV_VARS:
+        if override or var not in os.environ:
+            os.environ[var] = value
+            applied = True
+    return num_threads if applied else None
+
+
+def _extract_cpu_threads(config: object) -> Optional[int]:
+    """Pull ``cpu_threads`` out of a parsed config mapping, flat or nested."""
+    if not isinstance(config, dict):
+        return None
+    if "cpu_threads" in config:
+        return config["cpu_threads"]
+    device = config.get("device")
+    if isinstance(device, dict) and "cpu_threads" in device:
+        return device["cpu_threads"]
+    return None
+
+
+def resolve_cpu_threads_from_config(
+    environment: str = "development",
+    profile: Optional[str] = None,
+    config_dir: str = "farm/config",
+    default: Optional[int] = 1,
+) -> Optional[int]:
+    """Resolve the configured ``cpu_threads`` from the centralized YAML files.
+
+    This intentionally re-reads the YAML files with the standard library + PyYAML
+    instead of going through the full config loader, because the full loader
+    imports ``numpy``/``torch`` transitively and would defeat pre-import pinning.
+
+    Files are consulted in *descending* precedence (profile > environment >
+    base), matching the deep-merge order used by the real config loader, and the
+    first file that specifies ``cpu_threads`` wins. ``cpu_threads: null`` is a
+    valid, explicit "keep defaults" value and is returned as ``None``.
+
+    Falls back to ``default`` if no file specifies the key or the files cannot be
+    read, so a misconfigured/missing config never blocks startup.
+    """
+    candidate_paths = []
+    if profile:
+        candidate_paths.append(os.path.join(config_dir, "profiles", f"{profile}.yaml"))
+    candidate_paths.append(
+        os.path.join(config_dir, "environments", f"{environment}.yaml")
+    )
+    candidate_paths.append(os.path.join(config_dir, "default.yaml"))
+
+    for path in candidate_paths:
+        if not os.path.exists(path):
+            continue
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                parsed = yaml.safe_load(f)
+        except (OSError, yaml.YAMLError):
+            continue
+        if isinstance(parsed, dict) and (
+            "cpu_threads" in parsed
+            or (isinstance(parsed.get("device"), dict) and "cpu_threads" in parsed["device"])
+        ):
+            return _extract_cpu_threads(parsed)
+
+    return default

--- a/farm/editor/package-lock.json
+++ b/farm/editor/package-lock.json
@@ -3840,17 +3840,17 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -4052,9 +4052,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ name = "agentfarm"
 version = "0.1.0"
 description = "Agent Farm Simulation Framework"
 readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -5,24 +5,8 @@ Simple script to run a single simulation using the farm simulation framework.
 
 # Standard library imports
 import argparse
-import cProfile
 import os
-import pstats
 import sys
-import time
-import warnings
-from io import StringIO
-
-# Local imports
-from farm.config import SimulationConfig
-from farm.core.hyperparameter_chromosome import BoundaryMode, MutationMode
-from farm.core.initial_diversity import InitialDiversityConfig, SeedingMode
-from farm.core.simulation import run_simulation
-from farm.utils.logging import configure_logging, get_logger
-
-# Suppress warnings that might interfere with CI output parsing
-warnings.filterwarnings("ignore", category=RuntimeWarning)
-warnings.filterwarnings("ignore", category=UserWarning, module="tianshou")
 
 # CRITICAL: Ensure PYTHONHASHSEED is set for deterministic simulations
 # This must be set before Python starts, so we restart if needed
@@ -34,6 +18,50 @@ if "PYTHONHASHSEED" not in os.environ or os.environ["PYTHONHASHSEED"] != "0":
 
 # If we reach here, PYTHONHASHSEED is set correctly
 # Note: We don't print this during normal operation to avoid cluttering output
+
+# CRITICAL: Pin CPU math threads BEFORE importing numpy/torch (or anything that
+# imports them). OpenMP/MKL/BLAS read their thread-pool env vars once at import,
+# so this must run before the heavy imports below to cap the parent process's
+# non-torch math pools. ``farm.cpu_thread_bootstrap`` is intentionally
+# lightweight (stdlib + yaml only) so importing it here does not pull in numpy.
+from farm.cpu_thread_bootstrap import (  # noqa: E402
+    pin_cpu_math_threads,
+    resolve_cpu_threads_from_config,
+)
+
+
+def _preparse_device_context(argv) -> "tuple[str, str | None]":
+    """Read just ``--environment``/``--profile`` so CPU threads can be resolved
+    from config before the heavy imports below run."""
+    pre = argparse.ArgumentParser(add_help=False)
+    pre.add_argument("--environment", type=str, default="development")
+    pre.add_argument("--profile", type=str, default=None)
+    known, _ = pre.parse_known_args(argv)
+    return known.environment, known.profile
+
+
+_pre_environment, _pre_profile = _preparse_device_context(sys.argv[1:])
+pin_cpu_math_threads(
+    resolve_cpu_threads_from_config(environment=_pre_environment, profile=_pre_profile)
+)
+
+# Remaining standard library imports (safe to import after thread pinning)
+import cProfile  # noqa: E402
+import pstats  # noqa: E402
+import time  # noqa: E402
+import warnings  # noqa: E402
+from io import StringIO  # noqa: E402
+
+# Local imports
+from farm.config import SimulationConfig  # noqa: E402
+from farm.core.hyperparameter_chromosome import BoundaryMode, MutationMode  # noqa: E402
+from farm.core.initial_diversity import InitialDiversityConfig, SeedingMode  # noqa: E402
+from farm.core.simulation import run_simulation  # noqa: E402
+from farm.utils.logging import configure_logging, get_logger  # noqa: E402
+
+# Suppress warnings that might interfere with CI output parsing
+warnings.filterwarnings("ignore", category=RuntimeWarning)
+warnings.filterwarnings("ignore", category=UserWarning, module="tianshou")
 
 
 def run_profiled_simulation(num_steps, config, output_dir, enable_console_logging=False):

--- a/tests/test_cpu_thread_bootstrap.py
+++ b/tests/test_cpu_thread_bootstrap.py
@@ -1,0 +1,156 @@
+"""Tests for farm/cpu_thread_bootstrap.py – pre-import CPU thread pinning."""
+
+import os
+
+import pytest
+
+from farm.cpu_thread_bootstrap import (
+    CPU_THREAD_ENV_VARS,
+    pin_cpu_math_threads,
+    resolve_cpu_threads_from_config,
+    validate_cpu_threads,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_thread_env(monkeypatch):
+    """Run each test with the CPU thread env vars cleared."""
+    for var in CPU_THREAD_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+class TestValidateCpuThreads:
+    def test_none_passes_through(self):
+        assert validate_cpu_threads(None) is None
+
+    def test_valid_int(self):
+        assert validate_cpu_threads(4) == 4
+
+    def test_zero_rejected(self):
+        with pytest.raises(ValueError):
+            validate_cpu_threads(0)
+
+    def test_negative_rejected(self):
+        with pytest.raises(ValueError):
+            validate_cpu_threads(-1)
+
+    def test_bool_rejected(self):
+        with pytest.raises(ValueError):
+            validate_cpu_threads(True)
+
+    def test_non_int_rejected(self):
+        with pytest.raises(ValueError):
+            validate_cpu_threads(2.0)
+
+
+class TestPinCpuMathThreads:
+    def test_sets_all_env_vars(self):
+        applied = pin_cpu_math_threads(3)
+        assert applied == 3
+        for var in CPU_THREAD_ENV_VARS:
+            assert os.environ[var] == "3"
+
+    def test_none_leaves_env_untouched(self):
+        assert pin_cpu_math_threads(None) is None
+        for var in CPU_THREAD_ENV_VARS:
+            assert var not in os.environ
+
+    def test_respects_preexisting_env_by_default(self, monkeypatch):
+        monkeypatch.setenv("OMP_NUM_THREADS", "8")
+        applied = pin_cpu_math_threads(1)
+        # Pre-existing var is respected; the others are newly set.
+        assert os.environ["OMP_NUM_THREADS"] == "8"
+        assert os.environ["MKL_NUM_THREADS"] == "1"
+        assert applied == 1
+
+    def test_override_replaces_preexisting(self, monkeypatch):
+        monkeypatch.setenv("OMP_NUM_THREADS", "8")
+        pin_cpu_math_threads(2, override=True)
+        assert os.environ["OMP_NUM_THREADS"] == "2"
+
+    def test_returns_none_when_all_present_and_no_override(self, monkeypatch):
+        for var in CPU_THREAD_ENV_VARS:
+            monkeypatch.setenv(var, "8")
+        assert pin_cpu_math_threads(1) is None
+
+    def test_invalid_value_raises(self):
+        with pytest.raises(ValueError):
+            pin_cpu_math_threads(0)
+
+
+class TestResolveCpuThreadsFromConfig:
+    def _write(self, path, content):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+
+    def test_reads_base_default(self, tmp_path):
+        cfg = tmp_path / "cfg"
+        self._write(str(cfg / "default.yaml"), "cpu_threads: 1\n")
+        self._write(str(cfg / "environments" / "development.yaml"), "foo: bar\n")
+        assert (
+            resolve_cpu_threads_from_config(
+                environment="development", config_dir=str(cfg)
+            )
+            == 1
+        )
+
+    def test_environment_overrides_base(self, tmp_path):
+        cfg = tmp_path / "cfg"
+        self._write(str(cfg / "default.yaml"), "cpu_threads: 1\n")
+        self._write(
+            str(cfg / "environments" / "production.yaml"), "cpu_threads: 8\n"
+        )
+        assert (
+            resolve_cpu_threads_from_config(
+                environment="production", config_dir=str(cfg)
+            )
+            == 8
+        )
+
+    def test_profile_has_highest_precedence(self, tmp_path):
+        cfg = tmp_path / "cfg"
+        self._write(str(cfg / "default.yaml"), "cpu_threads: 1\n")
+        self._write(
+            str(cfg / "environments" / "development.yaml"), "cpu_threads: 4\n"
+        )
+        self._write(str(cfg / "profiles" / "benchmark.yaml"), "cpu_threads: 16\n")
+        assert (
+            resolve_cpu_threads_from_config(
+                environment="development",
+                profile="benchmark",
+                config_dir=str(cfg),
+            )
+            == 16
+        )
+
+    def test_explicit_null_returns_none(self, tmp_path):
+        cfg = tmp_path / "cfg"
+        self._write(str(cfg / "default.yaml"), "cpu_threads: null\n")
+        assert (
+            resolve_cpu_threads_from_config(
+                environment="development", config_dir=str(cfg), default=1
+            )
+            is None
+        )
+
+    def test_nested_device_key(self, tmp_path):
+        cfg = tmp_path / "cfg"
+        self._write(str(cfg / "default.yaml"), "device:\n  cpu_threads: 5\n")
+        assert (
+            resolve_cpu_threads_from_config(
+                environment="development", config_dir=str(cfg)
+            )
+            == 5
+        )
+
+    def test_missing_files_falls_back_to_default(self, tmp_path):
+        cfg = tmp_path / "does_not_exist"
+        assert (
+            resolve_cpu_threads_from_config(config_dir=str(cfg), default=2) == 2
+        )
+
+    def test_real_repo_default_is_one(self):
+        # The shipped default config pins a single CPU thread.
+        assert resolve_cpu_threads_from_config(environment="development") == 1


### PR DESCRIPTION
This pull request introduces several improvements to project infrastructure, documentation, and CPU threading control. It adds a new module for pre-import CPU math thread pinning, clarifies and enforces the project's branching and pull request model, updates licensing to Apache 2.0, and upgrades some frontend dependencies. These changes help ensure reproducibility, clarify contribution workflow, and improve project maintainability.

**Infrastructure and CPU Threading**

* Added a new `farm/cpu_thread_bootstrap.py` module for pre-import pinning of CPU math-library thread environment variables, ensuring deterministic and efficient thread usage for scientific libraries. This module can resolve thread settings from YAML config files before importing `numpy`/`torch`, and exposes a function for use in process entry points.
* Updated `farm/core/device_utils.py` to import `CPU_THREAD_ENV_VARS` from the new module, removing the local definition to centralize thread environment variable management.

**Documentation and Contribution Workflow**

* Added a new pull request template `.github/pull_request_template.md` to guide contributors in targeting the correct branch, describing changes, and following checklist items.
* Updated `CONTRIBUTING.md` to clarify the branching model: all contributions should target the `dev` branch, not `main`, and to provide step-by-step instructions for forking, branching, and submitting pull requests. Coding standards and PR process sections were also improved.

**Licensing**

* Added an `Apache-2.0` license file and updated `pyproject.toml` to declare the license and include the license file in distributions. [[1]](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7R1-R201) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R10-R11)

**Frontend Dependency Updates**

* Upgraded `form-data` and `hasown` packages in `farm/editor/package-lock.json` to address dependency security and compatibility. [[1]](diffhunk://#diff-253ba410d54b773366e6eb920eea26dd5a510859b6eee6b9f58a89463c749f1eL3843-R3853) [[2]](diffhunk://#diff-253ba410d54b773366e6eb920eea26dd5a510859b6eee6b9f58a89463c749f1eL4055-R4057)

**Code Cleanup**

* Removed unused imports and warning suppressions from `run_simulation.py` to simplify the entrypoint script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to simulation entrypoint thread env setup before scientific imports; it is covered by new unit tests and does not touch auth or data paths.
> 
> **Overview**
> Adds **`farm/cpu_thread_bootstrap`** so OpenMP/MKL/BLAS thread env vars can be set **before** `numpy`/`torch` import, with lightweight YAML resolution of `cpu_threads` (profile → environment → default) that avoids the full config loader. **`run_simulation.py`** now pre-parses `--environment` / `--profile`, calls `pin_cpu_math_threads`, then defers heavy imports; **`device_utils`** reuses the shared `CPU_THREAD_ENV_VARS` constant instead of defining it locally.
> 
> Contributor-facing updates: new **PR template** targeting `dev`, expanded **`CONTRIBUTING.md`** (branching model, upstream remote, `ruff`/`pytest` checklist), plus **Apache-2.0** `LICENSE` and **`pyproject.toml`** license metadata.
> 
> **`farm/editor/package-lock.json`** bumps `form-data` (4.0.6) and `hasown` (2.0.4). New **`tests/test_cpu_thread_bootstrap.py`** covers validation, pinning behavior, and config precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 213e8a417ca923c4cfff67304b0e45c0c9a1fa23. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->