### PR TITLE
Add non blocking ruff lint check to CI

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pip show *)",
+      "Bash(python -c \"import ruff; print\\(ruff.__version__\\)\")",
+      "Bash(pip index *)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(pip show *)",
-      "Bash(python -c \"import ruff; print\\(ruff.__version__\\)\")",
-      "Bash(pip index *)"
-    ]
-  }
-}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,4 +59,16 @@ jobs:
         run: npm ci || npm install --no-audit --no-fund
       - name: Run Jest
         run: npm test -- --runInBand
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install Ruff
+        run: pip install ruff==0.15.18
+      - name: Run Ruff
+        run: ruff check .
+        continue-on-error: true
 


### PR DESCRIPTION
## Summary
Adds a `ruff check` step to the CI workflow as a new `lint` job, run non-blocking (`continue-on-error: true`) per the acceptance criteria in #935, so it surfaces lint findings on PRs without failing builds against the existing backlog.

## Changes
- Added a `lint` job to `.github/workflows/tests.yml`, matching the existing `python`/`js-ui` job structure (same `actions/checkout@v4`, `actions/setup-python@v5`, Python 3.10)
- Pinned `ruff==0.15.18` rather than installing latest, to keep CI output stable/reproducible and avoid this job silently changing behavior on future ruff releases — this overlaps with what #928 is asking for (pinning ruff in dev-requirements), so happy to adjust if that issue's pin should be the single source of truth instead and this job should just reference it

## Why CI over pre-commit
Issue #935 allows either approach. Went with a CI job since it guarantees visibility on every PR regardless of whether a contributor has pre-commit set up locally; a `.pre-commit-config.yaml` hook could still be added later as a complementary local-dev convenience if maintainers want both.

## Testing
Ran `ruff check .` locally and confirmed it executes cleanly against the current codebase, surfacing 168 pre-existing findings (42 auto-fixable) without crashing — consistent with the backlog mentioned in the issue. Confirmed `continue-on-error: true` is necessary given this volume.

Closes #935