### PR TITLE
Enforce population cap and improve reproduction config readability

### DIFF
--- a/default_config.json
+++ b/default_config.json
@@ -11,6 +11,7 @@
   "starvation_threshold": 10,
   "offspring_cost": 3,
   "min_reproduction_resources": 8,
+  "reproduction_chance": 0.5,
   "offspring_initial_resources": 5,
   "perception_radius": 2,
   "base_attack_strength": 2,

--- a/farm/config/config.py
+++ b/farm/config/config.py
@@ -400,6 +400,7 @@ class AgentBehaviorConfig:
     starvation_threshold: float = 10
     offspring_cost: int = 3
     min_reproduction_resources: int = 8
+    reproduction_chance: float = 0.5
     offspring_initial_resources: int = 5
     social_range: int = 30  # Range for social interactions (share/attack)
     move_mult_no_resources: float = 1.5  # Multiplier when no resources nearby
@@ -1354,6 +1355,7 @@ class SimulationConfig:
                     "starvation_threshold",
                     "offspring_cost",
                     "min_reproduction_resources",
+                    "reproduction_chance",
                     "offspring_initial_resources",
                     "social_range",
                     "move_mult_no_resources",

--- a/farm/config/default.yaml
+++ b/farm/config/default.yaml
@@ -18,6 +18,7 @@ max_population: 300
 starvation_threshold: 10
 offspring_cost: 3
 min_reproduction_resources: 8
+reproduction_chance: 0.5
 offspring_initial_resources: 5
 perception_radius: 2
 base_attack_strength: 2

--- a/farm/config/schema.json
+++ b/farm/config/schema.json
@@ -66,6 +66,10 @@
           "type": "integer",
           "default": 8
         },
+        "reproduction_chance": {
+          "type": "number",
+          "default": 0.5
+        },
         "offspring_initial_resources": {
           "type": "integer",
           "default": 5

--- a/farm/core/action.py
+++ b/farm/core/action.py
@@ -20,11 +20,14 @@ Technical Details:
 """
 
 import math
+import random
 from collections import Counter
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any, Callable, List, Optional
 
 import numpy as np
+
+from farm.core.population import get_population_cap_status
 
 if TYPE_CHECKING:
     from farm.core.agent import AgentCore
@@ -905,8 +908,6 @@ def move_action(agent: "AgentCore") -> dict:
     Returns:
         dict: Action result containing success status and details
     """
-    import random
-
     # Validate agent configuration
     if not validate_agent_config(agent, "move"):
         return {
@@ -1005,6 +1006,7 @@ def reproduce_action(agent: "AgentCore") -> dict:
     probability-based decision making, and offspring creation into a complete lifecycle.
 
     Behavior details:
+    - Enforces the environment's population cap (population.max_population) when set
     - Checks minimum resource requirements (min_reproduction_resources, default: 8)
     - Verifies total cost including offspring_cost (default: 5) can be met
     - Applies reproduction chance probability (reproduction_chance, default: 0.5)
@@ -1016,8 +1018,6 @@ def reproduce_action(agent: "AgentCore") -> dict:
     Returns:
         dict: Action result containing success status and details
     """
-    import random
-
     # Validate agent configuration
     if not validate_agent_config(agent, "reproduce"):
         return {
@@ -1042,25 +1042,17 @@ def reproduce_action(agent: "AgentCore") -> dict:
     try:
         env = getattr(agent, "environment", None)
         if env is not None:
-            env_config = getattr(env, "config", None)
-            population_config = getattr(env_config, "population", None)
-            max_population = getattr(population_config, "max_population", None)
-            if isinstance(max_population, int) and not isinstance(max_population, bool) and max_population > 0:
-                # Prefer the PettingZoo-style agent-id list when available (O(1) len);
-                # fall back to alive agent objects for environments without `agents`.
-                if hasattr(env, "agents"):
-                    current_population = len(getattr(env, "agents", []))
-                else:
-                    current_population = len(getattr(env, "alive_agent_objects", []))
-                if current_population >= max_population:
-                    return {
-                        "success": False,
-                        "error": f"Maximum population reached ({current_population}/{max_population})",
-                        "details": {
-                            "current_population": current_population,
-                            "max_population": max_population,
-                        },
-                    }
+            cap_status = get_population_cap_status(env)
+            if cap_status is not None and cap_status[0]:
+                _, current_population, max_population = cap_status
+                return {
+                    "success": False,
+                    "error": f"Maximum population reached ({current_population}/{max_population})",
+                    "details": {
+                        "current_population": current_population,
+                        "max_population": max_population,
+                    },
+                }
 
         if not check_resource_requirement(agent, total_required, "reproduce"):
             return {

--- a/farm/core/action.py
+++ b/farm/core/action.py
@@ -1026,23 +1026,14 @@ def reproduce_action(agent: "AgentCore") -> dict:
             "details": {},
         }
 
+    def _get_reproduction_param(name: str, default: Any) -> Any:
+        return getattr(reproduction_config, name, getattr(agent.config, name, default))
+
     # Get reproduction parameters from config
     reproduction_config = getattr(agent.config, "reproduction", None)
-    min_resources = getattr(
-        reproduction_config,
-        "min_reproduction_resources",
-        getattr(agent.config, "min_reproduction_resources", 8),
-    )
-    offspring_cost = getattr(
-        reproduction_config,
-        "offspring_cost",
-        getattr(agent.config, "offspring_cost", 5),
-    )
-    reproduction_chance = getattr(
-        reproduction_config,
-        "reproduction_chance",
-        getattr(agent.config, "reproduction_chance", 0.5),
-    )
+    min_resources = _get_reproduction_param("min_reproduction_resources", 8)
+    offspring_cost = _get_reproduction_param("offspring_cost", 5)
+    reproduction_chance = _get_reproduction_param("reproduction_chance", 0.5)
 
     # Check total resource requirements (minimum + offspring cost)
     total_required = min_resources + offspring_cost
@@ -1050,11 +1041,9 @@ def reproduce_action(agent: "AgentCore") -> dict:
     try:
         env = getattr(agent, "environment", None)
         if env is not None:
-            max_population = getattr(
-                getattr(getattr(env, "config", None), "population", None),
-                "max_population",
-                None,
-            )
+            env_config = getattr(env, "config", None)
+            population_config = getattr(env_config, "population", None)
+            max_population = getattr(population_config, "max_population", None)
             if isinstance(max_population, (int, float)) and max_population > 0:
                 alive_agents = getattr(env, "alive_agent_objects", None)
                 current_population = (

--- a/farm/core/action.py
+++ b/farm/core/action.py
@@ -1029,11 +1029,12 @@ def reproduce_action(agent: "AgentCore") -> dict:
     # Get reproduction parameters from config
     reproduction_config = getattr(agent.config, "reproduction", None)
 
-    def _get_reproduction_param(name: str, default: Any) -> Any:
+    def _get_reproduction_config_value(name: str, default: Any) -> Any:
         return getattr(reproduction_config, name, getattr(agent.config, name, default))
-    min_resources = _get_reproduction_param("min_reproduction_resources", 8)
-    offspring_cost = _get_reproduction_param("offspring_cost", 5)
-    reproduction_chance = _get_reproduction_param("reproduction_chance", 0.5)
+
+    min_resources = _get_reproduction_config_value("min_reproduction_resources", 8)
+    offspring_cost = _get_reproduction_config_value("offspring_cost", 5)
+    reproduction_chance = _get_reproduction_config_value("reproduction_chance", 0.5)
 
     # Check total resource requirements (minimum + offspring cost)
     total_required = min_resources + offspring_cost
@@ -1047,12 +1048,12 @@ def reproduce_action(agent: "AgentCore") -> dict:
             if isinstance(max_population, (int, float)) and max_population > 0:
                 alive_agents = getattr(env, "alive_agent_objects", None)
                 # Prefer alive agent objects when available; fall back to the
-                # legacy agent-id list for lightweight test doubles/environments.
-                current_population = (
-                    len(alive_agents)
-                    if alive_agents is not None
-                    else len(getattr(env, "agents", []))
-                )
+                # legacy agent-id list for environments without this property.
+                # An empty alive-agent list is still authoritative (population 0).
+                if alive_agents is not None:
+                    current_population = len(alive_agents)
+                else:
+                    current_population = len(getattr(env, "agents", []))
                 if current_population >= max_population:
                     return {
                         "success": False,

--- a/farm/core/action.py
+++ b/farm/core/action.py
@@ -1026,11 +1026,11 @@ def reproduce_action(agent: "AgentCore") -> dict:
             "details": {},
         }
 
-    def _get_reproduction_param(name: str, default: Any) -> Any:
-        return getattr(reproduction_config, name, getattr(agent.config, name, default))
-
     # Get reproduction parameters from config
     reproduction_config = getattr(agent.config, "reproduction", None)
+
+    def _get_reproduction_param(name: str, default: Any) -> Any:
+        return getattr(reproduction_config, name, getattr(agent.config, name, default))
     min_resources = _get_reproduction_param("min_reproduction_resources", 8)
     offspring_cost = _get_reproduction_param("offspring_cost", 5)
     reproduction_chance = _get_reproduction_param("reproduction_chance", 0.5)
@@ -1046,6 +1046,8 @@ def reproduce_action(agent: "AgentCore") -> dict:
             max_population = getattr(population_config, "max_population", None)
             if isinstance(max_population, (int, float)) and max_population > 0:
                 alive_agents = getattr(env, "alive_agent_objects", None)
+                # Prefer alive agent objects when available; fall back to the
+                # legacy agent-id list for lightweight test doubles/environments.
                 current_population = (
                     len(alive_agents)
                     if alive_agents is not None

--- a/farm/core/action.py
+++ b/farm/core/action.py
@@ -1027,14 +1027,51 @@ def reproduce_action(agent: "AgentCore") -> dict:
         }
 
     # Get reproduction parameters from config
-    min_resources = getattr(agent.config, "min_reproduction_resources", 8)
-    offspring_cost = getattr(agent.config, "offspring_cost", 5)
-    reproduction_chance = getattr(agent.config, "reproduction_chance", 0.5)
+    reproduction_config = getattr(agent.config, "reproduction", None)
+    min_resources = getattr(
+        reproduction_config,
+        "min_reproduction_resources",
+        getattr(agent.config, "min_reproduction_resources", 8),
+    )
+    offspring_cost = getattr(
+        reproduction_config,
+        "offspring_cost",
+        getattr(agent.config, "offspring_cost", 5),
+    )
+    reproduction_chance = getattr(
+        reproduction_config,
+        "reproduction_chance",
+        getattr(agent.config, "reproduction_chance", 0.5),
+    )
 
     # Check total resource requirements (minimum + offspring cost)
     total_required = min_resources + offspring_cost
 
     try:
+        env = getattr(agent, "environment", None)
+        if env is not None:
+            max_population = getattr(
+                getattr(getattr(env, "config", None), "population", None),
+                "max_population",
+                None,
+            )
+            if isinstance(max_population, (int, float)) and max_population > 0:
+                alive_agents = getattr(env, "alive_agent_objects", None)
+                current_population = (
+                    len(alive_agents)
+                    if alive_agents is not None
+                    else len(getattr(env, "agents", []))
+                )
+                if current_population >= max_population:
+                    return {
+                        "success": False,
+                        "error": f"Maximum population reached ({current_population}/{max_population})",
+                        "details": {
+                            "current_population": current_population,
+                            "max_population": max_population,
+                        },
+                    }
+
         if not check_resource_requirement(agent, total_required, "reproduce"):
             return {
                 "success": False,

--- a/farm/core/action.py
+++ b/farm/core/action.py
@@ -1045,15 +1045,13 @@ def reproduce_action(agent: "AgentCore") -> dict:
             env_config = getattr(env, "config", None)
             population_config = getattr(env_config, "population", None)
             max_population = getattr(population_config, "max_population", None)
-            if isinstance(max_population, (int, float)) and max_population > 0:
-                alive_agents = getattr(env, "alive_agent_objects", None)
-                # Prefer alive agent objects when available; fall back to the
-                # legacy agent-id list for environments without this property.
-                # An empty alive-agent list is still authoritative (population 0).
-                if alive_agents is not None:
-                    current_population = len(alive_agents)
-                else:
+            if isinstance(max_population, int) and not isinstance(max_population, bool) and max_population > 0:
+                # Prefer the PettingZoo-style agent-id list when available (O(1) len);
+                # fall back to alive agent objects for environments without `agents`.
+                if hasattr(env, "agents"):
                     current_population = len(getattr(env, "agents", []))
+                else:
+                    current_population = len(getattr(env, "alive_agent_objects", []))
                 if current_population >= max_population:
                     return {
                         "success": False,

--- a/farm/core/agent/config/component_configs.py
+++ b/farm/core/agent/config/component_configs.py
@@ -101,6 +101,12 @@ class ReproductionConfig:
     offspring_cost: float = 5.0
     """Resources consumed by parent when reproducing."""
 
+    min_reproduction_resources: float = 8.0
+    """Minimum resources required before reproduction can be attempted."""
+
+    reproduction_chance: float = 0.5
+    """Probability gate for each reproduction attempt."""
+
 
 @dataclass(frozen=True)
 class ReproductionPressureConfig:
@@ -296,6 +302,7 @@ class AgentComponentConfig:
             starvation_threshold = getattr(agent_behavior, 'starvation_threshold', 10)
             offspring_cost = getattr(agent_behavior, 'offspring_cost', 5.0)
             offspring_initial_resources = getattr(agent_behavior, 'offspring_initial_resources', 10.0)
+            min_reproduction_resources = getattr(agent_behavior, "min_reproduction_resources", 8.0)
             
             # Combat config
             starting_health = getattr(agent_behavior, 'starting_health', 100.0)
@@ -307,6 +314,7 @@ class AgentComponentConfig:
             starvation_threshold = 10
             offspring_cost = 5.0
             offspring_initial_resources = 10.0
+            min_reproduction_resources = 8.0
             starting_health = 100.0
             base_attack_strength = 10.0
             base_defense_strength = 5.0
@@ -353,6 +361,7 @@ class AgentComponentConfig:
             reproduction=ReproductionConfig(
                 offspring_cost=offspring_cost,
                 offspring_initial_resources=offspring_initial_resources,
+                min_reproduction_resources=min_reproduction_resources,
             ),
             decision=DecisionConfig(**decision_kwargs),
         )

--- a/farm/core/agent/config/component_configs.py
+++ b/farm/core/agent/config/component_configs.py
@@ -303,6 +303,7 @@ class AgentComponentConfig:
             offspring_cost = getattr(agent_behavior, 'offspring_cost', 5.0)
             offspring_initial_resources = getattr(agent_behavior, 'offspring_initial_resources', 10.0)
             min_reproduction_resources = getattr(agent_behavior, "min_reproduction_resources", 8.0)
+            reproduction_chance = getattr(agent_behavior, "reproduction_chance", 0.5)
             
             # Combat config
             starting_health = getattr(agent_behavior, 'starting_health', 100.0)
@@ -315,6 +316,7 @@ class AgentComponentConfig:
             offspring_cost = 5.0
             offspring_initial_resources = 10.0
             min_reproduction_resources = 8.0
+            reproduction_chance = 0.5
             starting_health = 100.0
             base_attack_strength = 10.0
             base_defense_strength = 5.0
@@ -362,6 +364,7 @@ class AgentComponentConfig:
                 offspring_cost=offspring_cost,
                 offspring_initial_resources=offspring_initial_resources,
                 min_reproduction_resources=min_reproduction_resources,
+                reproduction_chance=reproduction_chance,
             ),
             decision=DecisionConfig(**decision_kwargs),
         )

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 import torch
 
 from farm.core.action import Action, action_registry
+from farm.core.population import is_population_at_cap
 from farm.core.agent.behaviors.base import IAgentBehavior
 from farm.core.agent.components.base import AgentComponent
 from farm.core.agent.config.component_configs import AgentComponentConfig
@@ -1110,6 +1111,9 @@ class AgentCore:
 
         # Check if we have environment to add offspring to
         if not self.environment:
+            return False
+
+        if is_population_at_cap(self.environment):
             return False
 
         resource_comp = self.get_component("resource")

--- a/farm/core/population.py
+++ b/farm/core/population.py
@@ -1,0 +1,36 @@
+"""Population cap helpers shared by reproduction gates."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Tuple
+
+
+def get_current_population(environment: Any) -> int:
+    """Return the current alive-agent count for cap checks."""
+    # Prefer the PettingZoo-style agent-id list when available (O(1) len);
+    # fall back to alive agent objects for environments without `agents`.
+    if hasattr(environment, "agents"):
+        return len(getattr(environment, "agents", []))
+    return len(getattr(environment, "alive_agent_objects", []))
+
+
+def get_population_cap_status(environment: Any) -> Optional[Tuple[bool, int, float]]:
+    """Return ``(at_cap, current, max)`` when a positive cap is configured."""
+    env_config = getattr(environment, "config", None)
+    population_config = getattr(env_config, "population", None)
+    max_population = getattr(population_config, "max_population", None)
+    if not (
+        isinstance(max_population, (int, float))
+        and not isinstance(max_population, bool)
+        and max_population > 0
+    ):
+        return None
+
+    current_population = get_current_population(environment)
+    return current_population >= max_population, current_population, float(max_population)
+
+
+def is_population_at_cap(environment: Any) -> bool:
+    """True when the environment has a positive cap and alive count is at/above it."""
+    status = get_population_cap_status(environment)
+    return status is not None and status[0]

--- a/tests/config/test_config_classes.py
+++ b/tests/config/test_config_classes.py
@@ -238,6 +238,7 @@ class TestAgentComponentConfig(unittest.TestCase):
                         "starvation_threshold": 8,
                         "offspring_cost": 4.0,
                         "min_reproduction_resources": 12.0,
+                        "reproduction_chance": 0.75,
                         "offspring_initial_resources": 6.0,
                         "starting_health": 90.0,
                         "base_attack_strength": 3.0,
@@ -271,6 +272,7 @@ class TestAgentComponentConfig(unittest.TestCase):
         self.assertEqual(component_config.decision.dqn_hidden_size, 32)
         self.assertEqual(component_config.decision.tau, 0.02)
         self.assertEqual(component_config.reproduction.min_reproduction_resources, 12.0)
+        self.assertEqual(component_config.reproduction.reproduction_chance, 0.75)
 
 
 class TestPerformanceConfig(unittest.TestCase):

--- a/tests/config/test_config_classes.py
+++ b/tests/config/test_config_classes.py
@@ -237,6 +237,7 @@ class TestAgentComponentConfig(unittest.TestCase):
                         "base_consumption_rate": 0.2,
                         "starvation_threshold": 8,
                         "offspring_cost": 4.0,
+                        "min_reproduction_resources": 12.0,
                         "offspring_initial_resources": 6.0,
                         "starting_health": 90.0,
                         "base_attack_strength": 3.0,
@@ -269,6 +270,7 @@ class TestAgentComponentConfig(unittest.TestCase):
         self.assertEqual(component_config.decision.rl_train_freq, 3)
         self.assertEqual(component_config.decision.dqn_hidden_size, 32)
         self.assertEqual(component_config.decision.tau, 0.02)
+        self.assertEqual(component_config.reproduction.min_reproduction_resources, 12.0)
 
 
 class TestPerformanceConfig(unittest.TestCase):

--- a/tests/core/test_action_extended.py
+++ b/tests/core/test_action_extended.py
@@ -114,6 +114,34 @@ class TestActionExtended(unittest.TestCase):
         self.assertIn("Maximum population reached", result["error"])
         agent.reproduce.assert_not_called()
 
+    def test_reproduce_action_blocks_when_population_cap_is_float(self):
+        """A float max_population (e.g. from YAML) must still enforce the cap."""
+        agent = Mock()
+        agent.agent_id = "test_agent"
+        agent.resource_level = 100.0
+        agent.generation = 0
+        agent.reproduce.return_value = True
+        agent.config = SimpleNamespace(
+            reproduction=SimpleNamespace(
+                min_reproduction_resources=1.0,
+                offspring_cost=1.0,
+                reproduction_chance=1.0,
+            )
+        )
+        agent.environment = SimpleNamespace(
+            alive_agent_objects=[Mock(), Mock()],
+            agents=["a", "b"],
+            config=SimpleNamespace(
+                population=SimpleNamespace(max_population=2.0),
+            ),
+        )
+
+        result = reproduce_action(agent)
+
+        self.assertFalse(result["success"])
+        self.assertIn("Maximum population reached", result["error"])
+        agent.reproduce.assert_not_called()
+
     def test_reproduce_action_uses_component_config_thresholds(self):
         """Reproduction resource checks should use component reproduction config."""
         agent = Mock()

--- a/tests/core/test_action_extended.py
+++ b/tests/core/test_action_extended.py
@@ -114,7 +114,7 @@ class TestActionExtended(unittest.TestCase):
         self.assertIn("Maximum population reached", result["error"])
         agent.reproduce.assert_not_called()
 
-    def test_reproduce_action_uses_reproduction_component_thresholds(self):
+    def test_reproduce_action_uses_component_config_thresholds(self):
         """Reproduction resource checks should use component reproduction config."""
         agent = Mock()
         agent.agent_id = "test_agent"

--- a/tests/core/test_action_extended.py
+++ b/tests/core/test_action_extended.py
@@ -1,6 +1,7 @@
 """Extended tests for action system covering execution and validation."""
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 from farm.core.action import (
@@ -8,6 +9,7 @@ from farm.core.action import (
     calculate_euclidean_distance,
     check_resource_requirement,
     gather_action,
+    reproduce_action,
     validate_action_result,
 )
 
@@ -84,7 +86,64 @@ class TestActionExtended(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertEqual(agent.resource_level, 5.0)
 
+    def test_reproduce_action_blocks_when_population_cap_reached(self):
+        """Reproduction should be blocked once max_population is reached."""
+        agent = Mock()
+        agent.agent_id = "test_agent"
+        agent.resource_level = 100.0
+        agent.generation = 0
+        agent.reproduce.return_value = True
+        agent.config = SimpleNamespace(
+            reproduction=SimpleNamespace(
+                min_reproduction_resources=1.0,
+                offspring_cost=1.0,
+                reproduction_chance=1.0,
+            )
+        )
+        agent.environment = SimpleNamespace(
+            alive_agent_objects=[Mock(), Mock()],
+            agents=["a", "b"],
+            config=SimpleNamespace(
+                population=SimpleNamespace(max_population=2),
+            ),
+        )
+
+        result = reproduce_action(agent)
+
+        self.assertFalse(result["success"])
+        self.assertIn("Maximum population reached", result["error"])
+        agent.reproduce.assert_not_called()
+
+    def test_reproduce_action_uses_reproduction_component_thresholds(self):
+        """Reproduction resource checks should use component reproduction config."""
+        agent = Mock()
+        agent.agent_id = "test_agent"
+        agent.resource_level = 11.0
+        agent.reproduce.return_value = True
+        agent.config = SimpleNamespace(
+            reproduction=SimpleNamespace(
+                min_reproduction_resources=10.0,
+                offspring_cost=2.0,
+                reproduction_chance=1.0,
+            )
+        )
+        agent.environment = SimpleNamespace(
+            alive_agent_objects=[],
+            agents=[],
+            config=SimpleNamespace(
+                population=SimpleNamespace(max_population=99),
+            ),
+        )
+
+        result = reproduce_action(agent)
+
+        self.assertFalse(result["success"])
+        self.assertIn("Insufficient resources", result["error"])
+        self.assertEqual(result["details"]["min_resources"], 10.0)
+        self.assertEqual(result["details"]["offspring_cost"], 2.0)
+        self.assertEqual(result["details"]["total_required"], 12.0)
+        agent.reproduce.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/core/test_max_population_cap.py
+++ b/tests/core/test_max_population_cap.py
@@ -1,0 +1,151 @@
+"""Population cap enforcement for reproduction (issue #916)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from farm.config import SimulationConfig
+from farm.core.agent.config.component_configs import AgentComponentConfig
+from farm.core.agent.core import AgentCore
+from farm.core.decision.config import DecisionConfig
+from farm.core.hyperparameter_chromosome import chromosome_from_learning_config
+from farm.core.inheritance_telemetry import InheritanceTelemetry
+from farm.core.population import get_population_cap_status, is_population_at_cap
+from farm.core.simulation import run_simulation
+
+
+def _reproduction_friendly_config(max_population: int = 8) -> SimulationConfig:
+    """Minimal config that encourages reproduction without blowing up runtime."""
+    cfg = SimulationConfig.from_centralized_config(environment="testing")
+    cfg.simulation_steps = 80
+    cfg.max_steps = 80
+    cfg.population.system_agents = 2
+    cfg.population.independent_agents = 2
+    cfg.population.control_agents = 0
+    cfg.population.order_agents = 0
+    cfg.population.chaos_agents = 0
+    cfg.population.max_population = max_population
+    cfg.resources.initial_resources = 400
+    cfg.agent_behavior.initial_resource_level = 40.0
+    cfg.agent_behavior.offspring_cost = 1
+    cfg.agent_behavior.min_reproduction_resources = 1
+    cfg.agent_behavior.reproduction_chance = 1.0
+    cfg.agent_behavior.offspring_initial_resources = 5
+    cfg.environment.width = 20
+    cfg.environment.height = 20
+    cfg.database.use_in_memory_db = True
+    cfg.database.persist_db_on_completion = False
+    return cfg
+
+
+def _build_parent_agent_for_cap_test() -> AgentCore:
+    agent = object.__new__(AgentCore)
+    agent.agent_id = "parent_1"
+    agent.agent_type = "system"
+    agent.generation = 0
+    agent.services = Mock()
+    agent.environment = SimpleNamespace(
+        agents=["existing"],
+        config=SimpleNamespace(population=SimpleNamespace(max_population=1)),
+        get_next_agent_id=lambda: "child_1",
+        intrinsic_evolution_policy=None,
+        intrinsic_evolution_rng=None,
+        inheritance_telemetry=InheritanceTelemetry(),
+    )
+    agent.state = Mock()
+    agent.state.position = (1.0, 2.0)
+    agent.state._state = Mock()
+    agent.state._state.model_copy.return_value = Mock()
+
+    config = AgentComponentConfig.default()
+    config.decision = DecisionConfig(learning_rate=0.01)
+    agent.config = config
+
+    resource_component = Mock()
+    reproduction_component = Mock()
+    reproduction_component.can_reproduce.return_value = True
+    reproduction_component.config.offspring_cost = 1.0
+    reproduction_component.config.offspring_initial_resources = 5.0
+
+    agent._components = {
+        "resource": resource_component,
+        "reproduction": reproduction_component,
+    }
+    agent.hyperparameter_chromosome = chromosome_from_learning_config(agent.config.decision)
+    agent.environment.add_agent = Mock()
+    return agent
+
+
+def test_get_population_cap_status_accepts_float_limits():
+    env = SimpleNamespace(
+        agents=["a", "b"],
+        config=SimpleNamespace(population=SimpleNamespace(max_population=2.0)),
+    )
+    assert get_population_cap_status(env) == (True, 2, 2.0)
+    assert is_population_at_cap(env) is True
+
+
+def test_agent_core_reproduce_blocks_at_population_cap_without_adding_offspring():
+    """Direct AgentCore.reproduce calls must respect max_population."""
+    parent = _build_parent_agent_for_cap_test()
+
+    success = AgentCore.reproduce(parent)
+
+    assert success is False
+    parent.environment.add_agent.assert_not_called()
+    parent.get_component("resource").remove.assert_not_called()
+
+
+def test_agent_core_reproduce_bypasses_cap_when_below_limit():
+    parent = _build_parent_agent_for_cap_test()
+    parent.environment.agents = []
+    parent.environment.config.population.max_population = 2
+
+    offspring = Mock()
+    offspring.state = Mock()
+    offspring.state._state = Mock()
+    offspring.state._state.model_copy.return_value = Mock()
+
+    with patch("farm.core.agent.factory.AgentFactory") as factory_cls:
+        factory = factory_cls.return_value
+        factory.create_learning_agent.return_value = offspring
+        success = AgentCore.reproduce(parent)
+
+    assert success is True
+    parent.environment.add_agent.assert_called_once_with(offspring, flush_immediately=True)
+
+
+@pytest.mark.integration
+def test_run_simulation_never_exceeds_max_population(tmp_path):
+    """Acceptance criterion for #916: alive agents never exceed max_population."""
+    max_pop = 8
+    cfg = _reproduction_friendly_config(max_population=max_pop)
+    initial_population = (
+        cfg.population.system_agents
+        + cfg.population.independent_agents
+        + cfg.population.control_agents
+        + cfg.population.order_agents
+        + cfg.population.chaos_agents
+    )
+    peak_alive = {"count": initial_population}
+
+    def on_step_end(environment, step):
+        alive = len(environment.agents)
+        peak_alive["count"] = max(peak_alive["count"], alive)
+        assert alive <= max_pop, f"step {step}: alive={alive} exceeds max_population={max_pop}"
+
+    env = run_simulation(
+        num_steps=cfg.max_steps,
+        config=cfg,
+        path=str(tmp_path),
+        save_config=False,
+        seed=42,
+        on_step_end=on_step_end,
+    )
+
+    assert len(env.agents) <= max_pop
+    assert peak_alive["count"] <= max_pop
+    assert peak_alive["count"] > initial_population, "expected reproduction to grow toward the cap"

--- a/tests/scripts/test_measure_transferable_signal.py
+++ b/tests/scripts/test_measure_transferable_signal.py
@@ -350,13 +350,13 @@ def test_eval_config_is_single_agent():
 
 
 def test_reproduction_is_blocked_in_train_and_eval_modes():
-    """The reproduce no-op patch is the only reliable population cap.
+    """The reproduce no-op patch fully suppresses reproduction in train/eval.
 
-    ``reproduce_action`` enforces no ``max_population`` cap and the action stays
-    in every agent's set, so the gate blocks reproduction by patching
-    ``AgentCore.reproduce`` while the recorder is active. Without this the
-    population explodes (100+ agents on high-resource ecologies) and exhausts
-    RAM / slows each step to seconds.
+    While ``reproduce_action`` now honors ``population.max_population``, train
+    and eval probes need reproduction disabled entirely (not merely capped), so
+    the gate patches ``AgentCore.reproduce`` to a no-op while the recorder is
+    active. Without this the population grows up to the cap and slows each step,
+    so this asserts the patch returns ``False`` in both modes.
     """
     from scripts.measure_transferable_signal import _REC, install_instrumentation
     from farm.core.agent.core import AgentCore


### PR DESCRIPTION
This pull request enhances the agent reproduction logic by allowing more flexible configuration and enforcing population caps. It introduces new configuration options for reproduction thresholds and adds comprehensive tests to ensure correct behavior when population limits or resource constraints are in effect.

**Reproduction logic improvements:**

* The `reproduce_action` function now checks for a `reproduction` config section on the agent, falling back to legacy config attributes if missing, and supports new parameters: `min_reproduction_resources`, `offspring_cost`, and `reproduction_chance`. It also enforces a maximum population cap by checking the environment’s population settings and blocks reproduction if the cap is reached.

**Configuration enhancements:**

* Added `min_reproduction_resources` and `reproduction_chance` fields to the `ReproductionConfig` dataclass, with appropriate docstrings.
* Updated the `from_simulation_config` method to extract `min_reproduction_resources` from simulation configs and include it in the constructed `ReproductionConfig`. [[1]](diffhunk://#diff-e6b88b518e7ae957bc0757795c99fa2143b200d0065d5c2ac42290449f63c8e4R305) [[2]](diffhunk://#diff-e6b88b518e7ae957bc0757795c99fa2143b200d0065d5c2ac42290449f63c8e4R317) [[3]](diffhunk://#diff-e6b88b518e7ae957bc0757795c99fa2143b200d0065d5c2ac42290449f63c8e4R364)

**Testing improvements:**

* Added and updated tests to verify that `min_reproduction_resources` is correctly loaded from simulation configs and that the reproduction logic respects both resource thresholds and population caps. [[1]](diffhunk://#diff-1c0146c99ca98d5158f670e02607b576b6896c48b9d5abe908eacd45af5bf6c7R240) [[2]](diffhunk://#diff-1c0146c99ca98d5158f670e02607b576b6896c48b9d5abe908eacd45af5bf6c7R273) [[3]](diffhunk://#diff-f4ca585334f17f33c32fd9c1751cde3a5f561c6f558c7c3d04a654ea62463a9eR4-R12) [[4]](diffhunk://#diff-f4ca585334f17f33c32fd9c1751cde3a5f561c6f558c7c3d04a654ea62463a9eR89-L90)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enforcing `max_population` during reproduce changes live simulation dynamics; the change is scoped to one action path and covered by new unit tests.
> 
> **Overview**
> **Reproduction** now reads `min_reproduction_resources`, `offspring_cost`, and `reproduction_chance` from `agent.config.reproduction` when present, with the same values still accepted from legacy top-level config attributes as a fallback.
> 
> Before resource checks, `reproduce_action` blocks when the environment’s `population.max_population` is set and the current count (preferring `alive_agent_objects`, else `agents`) is already at the cap.
> 
> `ReproductionConfig` gains `min_reproduction_resources` and `reproduction_chance`, and `AgentComponentConfig.from_simulation_config` maps `min_reproduction_resources` from `agent_behavior` into that struct. Tests cover the cap, nested config thresholds, and simulation config projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f6e17a5b3e411c73f26d550d07d75a72e520bcf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->