### PR TITLE
docs: refresh README and supporting docs for accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,14 +145,16 @@ Run the REST/WebSocket API for managing simulations and analysis:
 
 ```bash
 # From repository root
-python -m farm.api.server
-# or
-python farm/api/server.py
+uvicorn farm.api.server:app --host 0.0.0.0 --port 5000
 ```
+
+> **Note:** Use the `uvicorn` command directly. Running `python -m farm.api.server`
+> (or `python farm/api/server.py`) enables `reload=True`, which requires an import
+> string and exits with `WARNING: You must pass the application as an import string …`.
 
 Defaults:
 - Binds to port 5000
-- Writes logs to `logs/api.log`
+- Writes structured logs to `logs/application.json.log` (and `logs/application.log`)
 
 Key endpoints:
 - `POST /api/simulation/new` — create and run a simulation
@@ -240,7 +242,7 @@ For detailed documentation and advanced usage:
 - [Core Architecture](docs/core_architecture.md)
 - [Hyperparameter Chromosome Design](docs/design/hyperparameter_chromosome.md)
 - [Devlog](docs/devlog/index.md)
-- [Latest Devlog: Evolving Hyperparameter Genomes in Foraging and Learning Agents](docs/devlog/2026-04-23-evolving-hyperparameter-genomes-foraging-learning-agents.md)
+- [Latest Devlog: The transferable-signal gate — do learned policies beat their own init?](docs/devlog/2026-06-20-transferable-signal-budget.md)
 - [Full Documentation Index](docs/README.md)
 
 ### GitHub Pages
@@ -266,6 +268,10 @@ Please see [Contributing Guidelines](CONTRIBUTING.md) for more information on ho
 - **Don't Repeat Yourself (DRY)**: Avoid duplicating code or logic; centralize shared functionality to improve maintainability and reduce errors.
 - **Keep It Simple, Stupid (KISS)**: Favor simple, straightforward solutions over complex ones to enhance readability and reduce bugs.
 - **Composition Over Inheritance**: Prefer composing objects (e.g., via dependencies) to achieve behavior rather than relying on inheritance hierarchies, for greater flexibility.
+
+## License
+
+AgentFarm is licensed under the [Apache License 2.0](LICENSE).
 
 ## Support
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -207,6 +207,8 @@ We welcome contributions to both the platform and its documentation:
 
 ## 📄 License & Attribution
 
+AgentFarm is licensed under the [Apache License 2.0](../LICENSE).
+
 This project is part of the [Dooders](https://github.com/Dooders) research initiative exploring complex adaptive systems through computational modeling.
 
 ---

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,7 +6,7 @@ Deploy the Python package and API according to your environment (venv, container
 
 - Install with `pip install -r requirements.txt` and `pip install -e .` (or install a built wheel in production).
 - Run simulations via `run_simulation.py`, `farm.core.cli`, or your own entrypoints.
-- Run the HTTP API with `python -m farm.api.server` (see [README](../README.md) for defaults and endpoints).
+- Run the HTTP API with `uvicorn farm.api.server:app --host 0.0.0.0 --port 5000` (see [README](../README.md) for defaults and endpoints). Do not use `python -m farm.api.server`; the `reload=True` flag in `__main__` requires an import string and exits with a warning.
 
 There is no single Dockerfile or cloud manifest maintained in this repository; treat deployment as environment-specific.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited the README and supporting docs against the current codebase and fixed inaccurate/stale content.

### Fixes
- **Broken API server command**: README and `docs/deployment.md` recommended `python -m farm.api.server` / `python farm/api/server.py`, which enable `reload=True` (requires an import string) and exit with `WARNING: You must pass the application as an import string …` (exit code 1, verified). Replaced with the working `uvicorn farm.api.server:app --host 0.0.0.0 --port 5000`.
- **Wrong API log path**: README claimed logs go to `logs/api.log`. The server uses `configure_logging(log_dir="logs", json_logs=True)`, which writes `logs/application.json.log` and `logs/application.log` (verified). Corrected.
- **Stale "Latest Devlog" link**: pointed to the 2026-04-23 post; updated to the newest devlog, `2026-06-20-transferable-signal-budget.md`.
- **Missing license info**: the repo now ships an Apache-2.0 `LICENSE` (and `pyproject.toml` declares it), but neither README mentioned it. Added a License section to `README.md` and `docs/README.md`.

### Verification (all checked against the running code)
- `uvicorn farm.api.server:app` starts cleanly; `GET /api/simulations` returns `HTTP 200`.
- `python -m farm.api.server` exits 1 with the import-string warning (confirms the old instructions were broken).
- Log files written are `logs/application.json.log` / `logs/application.log`.
- All doc links referenced in `README.md` and `docs/README.md` resolve to existing files.
- Documented benchmark (`python -m benchmarks.run_benchmarks --list`) and CLI args (`--mode`, `--experiment-name`, `--iterations`, `--db-path`) verified accurate and left unchanged.

Docs-only change; no code paths modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9b4e022-f709-445d-b3a3-178b873f9c53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9b4e022-f709-445d-b3a3-178b873f9c53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

