### PR TITLE
fix: add missing FineTuningConfig and EnvFactory imports (F821)

### DIFF
--- a/scripts/finetune_child.py
+++ b/scripts/finetune_child.py
@@ -70,6 +70,7 @@ from farm.core.decision.training.finetune import (  # noqa: E402
     FINETUNE_OPTIMIZERS,
     QUANTIZATION_APPLIED_MODES,
     FineTuner,
+    FineTuningConfig,
     load_finetuning_config_from_yaml,
 )
 

--- a/scripts/validate_distillation.py
+++ b/scripts/validate_distillation.py
@@ -66,6 +66,7 @@ from farm.core.decision.training.distillation_rollout import (  # noqa: E402
     compare_parent_student_rollouts,
 )
 from farm.core.decision.training.sim_rollout_adapter import (  # noqa: E402
+    EnvFactory,
     PolicyRolloutAdapter,
     SimRolloutConfig,
     SimRolloutResult,
@@ -627,8 +628,6 @@ def _load_env_factory(
         Seed for initializing the shim :class:`SeededLinearMDP` dynamics (must match
         :class:`SimRolloutConfig.base_seed` used by :class:`PolicyRolloutAdapter`).
     """
-    from farm.core.decision.training.sim_rollout_adapter import EnvFactory  # noqa: F401
-
     if not sim_env_factory:
         # Default: SeededLinearMDP shim wrapped to satisfy EpisodeEnvProtocol.
         # SeededLinearMDP.reset(episode_seed) returns a bare numpy array and


### PR DESCRIPTION
## Summary

Fixes #930.

Two scripts referenced names that were never imported at module scope. They
only avoided a `NameError` because both files declare `from __future__ import
annotations` (PEP 563), which turns annotations into strings that are never
evaluated. The names are therefore *latent* bugs and are reported by ruff as
`F821 Undefined name`.

`ruff check scripts/finetune_child.py scripts/validate_distillation.py --select F821`
reported **3 errors** before this change.

## Root cause

| File | Symbol | Used at | Defined in |
|---|---|---|---|
| `scripts/finetune_child.py` | `FineTuningConfig` | return annotation of `_merged_finetune_config` (line 135) | `farm/core/decision/training/finetune.py` (`class FineTuningConfig`) |
| `scripts/validate_distillation.py` | `EnvFactory` | annotations at lines 609 and 685 | `farm/core/decision/training/sim_rollout_adapter.py` (`EnvFactory = Callable[[], EpisodeEnvProtocol]`) |

In `finetune_child.py` the import block already pulled several names from
`farm.core.decision.training.finetune` but omitted `FineTuningConfig`.

In `validate_distillation.py` the module-level import from
`sim_rollout_adapter` omitted `EnvFactory`; a function-local
`from ... import EnvFactory  # noqa: F401` existed inside `_load_env_factory`,
but it was unused (hence the `F401` suppression) and lived in a local scope, so
it did not make the name available to the module-scope annotations.

## Fix

- Add `FineTuningConfig` to the existing import in `scripts/finetune_child.py`.
- Add `EnvFactory` to the existing module-level import in
  `scripts/validate_distillation.py`, and remove the now-redundant
  function-local import.

The change is import-only; no runtime behaviour changes.

## Verification

```
$ ruff check scripts/finetune_child.py scripts/validate_distillation.py --select F821
All checks passed!
```

Both files also pass `python -m py_compile`. The two pre-existing `F541`
findings in `validate_distillation.py` (unrelated `f""` without placeholders)
are out of scope and left untouched.
