### PR TITLE
Fix #924: comparison summary file writes literal \n instead of real newlines

### DIFF
--- a/farm/analysis/comparative/compare.py
+++ b/farm/analysis/comparative/compare.py
@@ -60,9 +60,9 @@ def compare_simulations(search_path: str, analysis_path: str) -> None:
     # For now, create a placeholder result file
     result_file = analysis_path / "comparison_summary.txt"
     with open(result_file, 'w') as f:
-        f.write(f"Comparative analysis of {len(simulation_dirs)} simulations\\n")
-        f.write(f"Simulation directories: {[str(d) for d in simulation_dirs]}\\n")
-        f.write("\\nNote: Full comparative analysis implementation pending\\n")
+        f.write(f"Comparative analysis of {len(simulation_dirs)} simulations\n")
+        f.write(f"Simulation directories: {[str(d) for d in simulation_dirs]}\n")
+        f.write("\nNote: Full comparative analysis implementation pending\n")
 
     print(f"Comparative analysis placeholder created at: {result_file}")
 

--- a/tests/analysis/test_comparative.py
+++ b/tests/analysis/test_comparative.py
@@ -490,6 +490,10 @@ class TestSimulationComparison:
         result_file = output_path / "comparison_summary.txt"
         assert result_file.exists()
 
+        content = result_file.read_text()
+        assert "Comparative analysis" in content
+        assert "\\n" not in content
+
 
 class TestComparativeModule:
     """Test comparative module integration."""


### PR DESCRIPTION
## Description

This PR fixes an issue where `compare_simulations()` wrote literal `\n` sequences to `comparison_summary.txt` instead of actual newline characters.

### Changes

* Replaced escaped newline strings (`\\n`) with actual newline characters (`\n`) in `farm/analysis/comparative/compare.py`
* Added a test assertion in `test_compare_simulations_success` to verify that the generated summary file does not contain literal `\n` substrings

## Related Issues

Closes #924

## Checklist

* [x] This PR targets the `dev` branch (not `main`)
* [x] My branch is up to date with the latest `dev`
* [ ] I ran the test suite (`pytest`) and it passes
* [x] I linted my changes (`ruff check .`)
* [x] I added or updated tests for behavior changes
* [ ] I updated documentation as necessary