### PR TITLE
change app to farm.api.server.app in uvicron.run() in __main__ block …

### DIFF
--- a/farm/api/server.py
+++ b/farm/api/server.py
@@ -922,4 +922,4 @@ if __name__ == "__main__":
     os.makedirs("logs", exist_ok=True)
 
     # Start FastAPI server with uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=5000, reload=True)
+    uvicorn.run("farm.api.server:app", host="0.0.0.0", port=5000, reload=True)


### PR DESCRIPTION
<!--
Base branch: please target `dev`, not `main`.
`main` is the stable release branch and is updated only by maintainers.
See CONTRIBUTING.md > Branching Model.
-->

## Description

<!-- A clear description of what this PR changes and why. -->
Changed the uvicorn.run(app -> "farm.api.server:app" in the __main__ block in farm/api/server.py

## Related Issues

<!-- Link any related issues, e.g. "Closes #123". -->
Closes #925

## Checklist

- [x] This PR targets the `dev` branch (not `main`)
- [x] My branch is up to date with the latest `dev`
- [ ] I ran the test suite (`pytest`) and it passes
- [x] I linted my changes (`ruff check .`)
- [ ] I added or updated tests for behavior changes
- [ ] I updated documentation as necessary


NOTE:

When I ran the pytest suite as part of the PR checklist on my branch, I was surprised to see so many tests fail.
However, when I switched back to the dev branch, and ran the pytest command again, it seemed that they both have the same tests failing.

`dev` branch:
<img width="1533" height="864" alt="image" src="https://github.com/user-attachments/assets/3cd3cd74-5e95-4dcf-a636-52776ab45ed5" />

`fix/925-api-server-command` branch` (my branch)
<img width="1534" height="845" alt="image" src="https://github.com/user-attachments/assets/03c43389-bd3e-4d42-895f-b2da2a99a6c9" />

So I don't think this is an issue on my end.

