### PR TITLE
docs: Phase 1 documentation reorganization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,277 +2,39 @@
 
 ![Project Status](https://img.shields.io/badge/status-in%20development-orange)
 
-**AgentFarm** is an advanced simulation and computational modeling platform for exploring complex systems. Designed as a comprehensive workbench, it enables users to run, analyze, and compare simulations with ease.
+Simulation and analysis platform for agent-based modeling, reinforcement learning experiments, and complex adaptive systems research in the [Dooders](https://github.com/Dooders) project.
 
-This repository is being developed to support research in the [Dooders](https://github.com/Dooders) project, focusing on complex adaptive systems and agent-based modeling approaches.
+> **Note:** Active development — APIs may change between releases. See [CHANGELOG](CHANGELOG.md).
 
-> **Note**: This project is currently in active development. APIs and features may change between releases. See the [Contributing Guidelines](CONTRIBUTING.md) for information on getting involved.
+## Features
 
-**Choosing a framework:** AgentFarm targets research workflows and is still evolving. If you need a mature, battle-tested agent-based modeling stack, consider [Mesa](https://github.com/projectmesa/mesa) or other widely used ABM frameworks. For reinforcement learning, established ecosystems such as [Stable-Baselines3](https://github.com/DLR-RM/stable-baselines3), [RLlib](https://docs.ray.io/en/latest/rllib/index.html), and [CleanRL](https://github.com/vwxyzjn/cleanrl) are often better fits when reliability and community scale matter most.
+- Multi-agent simulations with configurable genomes, actions, and spatial indexing
+- Experiment runner, SQLite-backed metrics, and analysis pipeline
+- RL/decision stack (DQN, distillation, evolution experiments)
+- REST/WebSocket API and structured logging with `structlog`
 
-## Key Features
-
-### [Agent-Based Modeling & Analysis](docs/features/agent_based_modeling_analysis.md)
-- Run complex simulations with interacting, adaptive agents
-- Study emergent behaviors and system dynamics
-- Track agent interactions and environmental influences
-- Analyze trends and patterns over time
-
-### [Customization & Flexibility](docs/features/customization_flexibility.md)
-- Define custom parameters, rules, and environments
-- Create specialized agent behaviors and properties
-- Configure simulation parameters and conditions
-- Design custom experiments and scenarios
-- Opt-in [initial genotype diversity](docs/initial_diversity.md) for any simulation - seed the starting population with `independent_mutation`, `unique`, or `min_distance` modes via `SimulationConfig.initial_diversity`
-
-### [AI & Machine Learning](docs/features/ai_machine_learning.md)
-- Reinforcement learning for agent adaptation
-- Automated data analysis and insight generation
-- Pattern recognition and behavior prediction
-- Evolutionary algorithms and genetic modeling
-
-### [Data & Visualization](docs/features/data_visualization.md)
-- Comprehensive data collection and metrics
-- Simulation visualization tools
-- Charting and plotting utilities
-- Automated report generation
-
-### [Research Tools](docs/features/research_tools.md)
-- Parameter sweep experiments
-- Comparative analysis framework
-- Experiment replication tools
-- Professional-grade logging with structlog for rich, contextual, machine-readable logs
-
-### [Data System](docs/features/data_system.md)
-- Layered system with database, repositories, analyzers, and services
-- Action statistics, behavioral clustering, causal analysis, and pattern recognition
-- Repository pattern for efficient data retrieval and querying
-- Coordinated analysis operations with built-in error handling
-- Experiment database for comparing multiple simulation runs
-
-### [Spatial Indexing & Performance](docs/features/spatial_indexing_performance.md)
-- KD-tree, Quadtree, and Spatial Hash Grid implementations for efficient proximity queries
-- Dirty region tracking system that only updates changed regions, reducing computational overhead by up to 70%
-- Choose optimal spatial index type for different query patterns (radial, range, neighbor queries)
-- Comprehensive metrics and statistics for spatial query optimization
-- Efficiently handles thousands of agents with minimal performance degradation
-
-
-## Logging & Observability ✨
-
-AgentFarm now includes **professional-grade structured logging** with `structlog`:
-
-**Key Features:**
-- 🔍 Rich contextual logs (simulation_id, step, agent_id, etc.)
-- 📊 Machine-readable JSON output for analysis
-- 🎨 Multiple formats: Console (colored), JSON, plain text
-- ⚡ Performance-optimized with log sampling
-- 🛡️ Automatic sensitive data censoring
-
-**Quick Example:**
-```python
-from farm.utils import configure_logging, get_logger
-
-configure_logging(environment="development", log_level="INFO")
-logger = get_logger(__name__)
-
-logger.info("simulation_started", num_agents=100, num_steps=1000)
-```
-
-**Learn More:**
-- [Quick Reference](docs/LOGGING_QUICK_REFERENCE.md)
-- [Complete Documentation](docs/logging_guide.md)
-- [Logging module overview](farm/utils/logging/README.md) (inline examples)
-
-## Quick Start
-
-### Prerequisites
-- Python 3.8 or higher (3.9+ recommended for best performance)
-- pip (Python package installer)
-- Git
-- Redis (optional, for enhanced memory management)
-
-### Installation
+## Quick start
 
 ```bash
-# Clone the repository
-git clone https://github.com/Dooders/AgentFarm.git
-cd AgentFarm
-
-# Set up virtual environment
-python -m venv venv
-source venv/bin/activate  # On Windows use `venv\Scripts\activate`
-
-# Install dependencies and the package in editable mode (required for `farm` imports)
-pip install -r requirements.txt
-pip install -e .
-
-# Optional: Install Redis for enhanced memory management
-# Note: Redis is used for agent memory storage and can improve performance
-# On Ubuntu/Debian: sudo apt-get install redis-server
-# On macOS: brew install redis
-# On Windows: Download from https://redis.io/download
-# Then start Redis: redis-server
-```
-
-### Running Your First Simulation
-
-AgentFarm provides multiple ways to run simulations:
-
-**Command Line (Simple)**
-```bash
+git clone https://github.com/Dooders/AgentFarm.git && cd AgentFarm
+python -m venv venv && source venv/bin/activate  # Windows: venv\Scripts\activate
+pip install -r requirements.txt && pip install -e .
 python run_simulation.py --environment development --steps 1000
 ```
 
-**Experiments and Tools**
-```bash
-# Run experiments with parameter variations
-python farm/core/cli.py --mode experiment --environment development --experiment-name test --iterations 3
-
-# Visualize existing simulation results
-python farm/core/cli.py --mode visualize --db-path simulations/simulation.db
-
-# Generate analysis reports
-python farm/core/cli.py --mode analyze --db-path simulations/simulation.db
-```
-
-**Results**
-All simulation results are saved in the `simulations` directory with database files, logs, and analysis reports.
-
-### API Server
-
-Run the REST/WebSocket API for managing simulations and analysis:
-
-```bash
-# From repository root
-uvicorn farm.api.server:app --host 0.0.0.0 --port 5000
-```
-
-> **Note:** Use the `uvicorn` command directly. Running `python -m farm.api.server`
-> (or `python farm/api/server.py`) enables `reload=True`, which requires an import
-> string and exits with `WARNING: You must pass the application as an import string …`.
-
-Defaults:
-- Binds to port 5000
-- Writes structured logs to `logs/application.json.log` (and `logs/application.log`)
-
-Key endpoints:
-- `POST /api/simulation/new` — create and run a simulation
-- `GET /api/simulation/<sim_id>/step/<step>` — fetch a specific step
-- `GET /api/simulation/<sim_id>/analysis` — run analysis
-- `GET /api/simulation/<sim_id>/export` — export data
-- `WS /ws/<client_id>` — WebSocket for streaming-style client messages
-
-### Benchmarks
-
-```bash
-# List spec-driven experiments
-python -m benchmarks.run_benchmarks --list
-
-# Run from a YAML spec (example: in-memory DB benchmark)
-python -m benchmarks.run_benchmarks --spec benchmarks/specs/memory_db_baseline.yaml
-```
-See `benchmarks/README.md` for details and recommended configurations.
-
-### Distillation, PTQ, and optional QAT
-
-After distilling student Q-networks you can apply **8-bit post-training quantization (PTQ)** and, if accuracy is not good enough, **quantization-aware training (QAT)**. Full behavior, PyTorch version notes, and CPU/CUDA limits are in [`farm/core/decision/training/quantize_ptq.py`](farm/core/decision/training/quantize_ptq.py) and [`farm/core/decision/training/quantize_qat.py`](farm/core/decision/training/quantize_qat.py).
-
-**Typical flow**
-
-1. **Distill** float students (`student_A.pt` / `student_B.pt`):
-
-   ```bash
-   python scripts/run_distillation.py --help
-   ```
-
-2. **PTQ** (default: dynamic weight-only `qint8`; static mode needs calibration states):
-
-   ```bash
-   python scripts/quantize_distilled.py \
-       --checkpoint-dir checkpoints/distillation \
-       --output-dir checkpoints/quantized
-   ```
-
-   For static PTQ, use `--states-file` or synthetic `--n-states` / `--seed`; calibration volume uses `--calibration-batches` and `--calibration-batch-size` (defaults 10 / 64). Match distillation architecture with `--input-dim`, `--output-dim`, `--parent-hidden` (defaults **8**, **4**, **64**).
-
-3. **Validate** float students (optional): `python scripts/validate_distillation.py --help`
-
-4. **Validate quantized vs float** (CPU): `python scripts/validate_quantized.py --help`. The validator loads quantized checkpoints as full-model pickles, so pass `--allow-unsafe-unpickle` only for trusted artifacts. The JSON report includes median/mean/p95 single-sample latency, optional **throughput** (`--throughput-batch-size`), **memory** RSS snapshots, float–quant **MSE/KL/top-k** agreement, and optional **teacher** metrics if `parent_*.pt` is found under `--float-dir` / `--teacher-dir` or via `--teacher-*-ckpt`.
-
-5. **Evaluate a crossover child vs both parents** (offline Q metrics, versioned JSON): `python scripts/validate_recombination.py --help`. Baselines: **child vs parent A**, **child vs parent B**, optional **parent A vs parent B** (`--include-parent-baseline`), plus **oracle** agreement in the report summary. Use the same `--states-file` / `--seed` / `--n-states` pattern as other validation scripts. For **quantized** full-model checkpoints (PTQ or post-QAT `torch.save` exports), add `--parent-a-quantized`, `--parent-b-quantized`, and/or `--child-quantized` together with `--allow-unsafe-unpickle`; those roles are loaded with `load_quantized_checkpoint` and run on **CPU**.
-
-6. **Search many crossover + fine-tune combinations** (leaderboard + manifest): `python scripts/run_crossover_search.py --help`. Presets include `minimal` / `default`, plus **`minimal-qat`** / **`default-qat`** (adds a `short_qat` / `ptq_dynamic` regime). Use **`--workers N`** for process-parallel children (float `BaseQNetwork` parents only). Quick check: `make crossover-search-smoke`. Design notes: `docs/design/crossover_search_space.md`, strategy semantics: `docs/design/crossover_strategies.md`.
-
-**Crossover from PTQ parent paths (Python):** [`initialize_child_from_crossover`](farm/core/decision/training/crossover.py) can auto-detect a **dynamic** PTQ sidecar next to a `.pt` file (same JSON shape as `PostTrainingQuantizer.save_checkpoint`) and load via `load_quantized_checkpoint`. That path uses full-model unpickling (`weights_only=False`); pass **`allow_unsafe_unpickle=True` only for trusted checkpoints**. Static PTQ sidecars are not auto-loaded here—use float state dicts or in-memory modules. Details: [`docs/design/crossover_strategies.md`](docs/design/crossover_strategies.md).
-
-**Optional QAT** (after PTQ if action agreement or Q-error is unacceptable): weight-only fake quant on linear layers, same int8 export format as PTQ after convert.
-
-```bash
-python scripts/qat_distilled.py \
-    --checkpoint-dir checkpoints/distillation \
-    --output-dir checkpoints/qat
-```
-
-Use `--teacher-a-ckpt` / `--student-a-ckpt` (and `*-b-*` for pair B) when paths are not under a single `--checkpoint-dir`; see `python scripts/qat_distilled.py --help` for epochs, learning rate, and `--no-convert` (float QAT checkpoint only). Quantized QAT checkpoints work with `scripts/validate_quantized.py` like PTQ outputs.
-
-**Tests:** `pytest tests/decision/test_ptq.py tests/decision/test_validate_quantized.py tests/decision/test_qat.py tests/decision/test_crossover_search.py`
-
-### Testing
-
-```bash
-# Using pytest
-pytest -q
-
-# Or using the bundled test runner
-python run_tests.py
-```
+Results appear under `simulations/`. See [Installation](docs/getting-started/installation.md) and [First simulation](docs/getting-started/first-simulation.md) for prerequisites, Redis, API server, and benchmarks.
 
 ## Documentation
 
-For detailed documentation and advanced usage:
-- [Changelog](CHANGELOG.md)
-- [Agent Loop Design](docs/design/agent_loop.md)
-- [Agent Design](docs/design/Agent.md)
-- [User Guide](docs/user-guide.md)
-- [Developer Guide](docs/developer-guide.md)
-- [Deployment](docs/deployment.md)
-- [Monitoring & Performance](docs/monitoring.md)
-- [Benchmarking & Profiling Report](benchmarks/reports/0.1.0/benchmark_profiling_summary_report.md)
-- [Core Architecture](docs/core_architecture.md)
-- [Hyperparameter Chromosome Design](docs/design/hyperparameter_chromosome.md)
-- [Devlog](docs/devlog/index.md)
-- [Latest Devlog: The transferable-signal gate — do learned policies beat their own init?](docs/devlog/2026-06-20-transferable-signal-budget.md)
-- [Full Documentation Index](docs/README.md)
-
-### GitHub Pages
-
-This repository includes a GitHub Pages workflow that publishes content from `docs/`.
-
-- Docs home: `https://dooders.github.io/AgentFarm/`
-- Devlog index: `https://dooders.github.io/AgentFarm/devlog/`
-
-## Contributing
-
-Whether you're interested in fixing bugs, adding new features, or improving documentation, your help is appreciated.
-
-Please see [Contributing Guidelines](CONTRIBUTING.md) for more information on how to get involved.
-
-## Design Principles
-
-- **Single Responsibility Principle (SRP)**: A class or module should have only one reason to change, focusing on a single responsibility to reduce complexity.
-- **Open-Closed Principle (OCP)**: Entities should be open for extension (e.g., via new subclasses) but closed for modification, allowing behavior addition without altering existing code.
-- **Liskov Substitution Principle (LSP)**: Subclasses must be substitutable for their base classes without breaking program behavior, honoring the base class's contract.
-- **Interface Segregation Principle (ISP)**: Clients should not depend on interfaces they don't use; prefer small, specific interfaces over large, general ones.
-- **Dependency Inversion Principle (DIP)**: High-level modules should depend on abstractions (e.g., interfaces), not concrete implementations, to decouple components.
-- **Don't Repeat Yourself (DRY)**: Avoid duplicating code or logic; centralize shared functionality to improve maintainability and reduce errors.
-- **Keep It Simple, Stupid (KISS)**: Favor simple, straightforward solutions over complex ones to enhance readability and reduce bugs.
-- **Composition Over Inheritance**: Prefer composing objects (e.g., via dependencies) to achieve behavior rather than relying on inheritance hierarchies, for greater flexibility.
+- **Docs site:** [dooders.github.io/AgentFarm](https://dooders.github.io/AgentFarm/)
+- **Hub:** [docs/README.md](docs/README.md)
+- **Research:** [Devlog](docs/devlog/index.md) · [Experiments](docs/experiments.md)
+- **Contributing:** [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## License
 
-AgentFarm is licensed under the [Apache License 2.0](LICENSE).
+Apache 2.0 — see [LICENSE](LICENSE).
 
 ## Support
 
-If you encounter any issues, please check [issues page](https://github.com/Dooders/AgentFarm/issues) or open a new issue.
+[Open an issue](https://github.com/Dooders/AgentFarm/issues) on GitHub.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,223 +1,35 @@
 # AgentFarm documentation
 
-Start here for navigation; detailed guides live in this directory.
+Navigation hub for the published docs site and repository guides.
 
-- [User Guide](user-guide.md)
-- [Developer Guide](developer-guide.md)
-- [IPC API Reference](ipc-api.md)
-- [Deployment](deployment.md)
-- [Monitoring & Performance](monitoring.md)
-- [Electron Config Explorer architecture](electron/config_explorer_architecture.md) (renderer/main, IPC)
+## New here?
 
-If you are new, read the User Guide, then the Developer Guide for setup and contribution patterns.
+1. [Installation](getting-started/installation.md)
+2. [First simulation](getting-started/first-simulation.md)
+3. [Module overview](module_overview.md) — architecture and components
 
-## 📚 Documentation overview
+## By role
 
-AgentFarm is a simulation and analysis platform for agent-based modeling and reinforcement learning experiments. The sections below link deeper guides and references.
+| Role | Start here |
+|------|------------|
+| **User / researcher** | [Experiment QuickStart](ExperimentQuickStart.md) · [Experiments](experiments.md) · [Devlog](devlog/index.md) |
+| **Developer** | [CONTRIBUTING](../CONTRIBUTING.md) · [Developer guide](developer-guide.md) · [Core architecture](core_architecture.md) |
+| **Operator** | [Deployment](deployment.md) · [Logging guide](logging_guide.md) · [Monitoring](monitoring.md) |
 
-### 🗂️ Structure
+## Guides
 
-- **[Module Overview](module_overview.md)** - High-level introduction to AgentFarm's architecture and capabilities
-- **[Core Architecture](core_architecture.md)** - Deep dive into fundamental components and design patterns
-- **[Electron Config Explorer Architecture](electron/config_explorer_architecture.md)** - Electron renderer/main boundaries, IPC, and migration plan
-- **[Usage Examples](usage_examples.md)** - Practical tutorials and code examples
-- **[Configuration Guide](config/configuration_guide.md)** - Comprehensive configuration system documentation (includes Electron Config Explorer compare/diff/presets/status bar)
-- **[API Reference](api_reference.md)** - Complete API documentation for all modules
+- [Configuration](config/configuration_guide.md)
+- [Neural recombination](guides/neural-recombination.md) — distillation, PTQ, QAT, crossover
+- [Neural recombination runbook](howto/neural_recombination_runbook.md) — full pipeline walkthrough
+- [Usage examples](usage_examples.md)
+- [API reference](api_reference.md)
 
-## 🚀 Quick Start Guides
+## Design & research
 
-- [Experiment QuickStart Guide](ExperimentQuickStart.md) - Running parameter studies
+- [Design RFCs](design/agent_loop.md) — agent loop, chromosomes, crossover
+- [Devlog](devlog/index.md) — build notes and experiment outcomes
+- [Experiments catalog](experiments.md)
 
-## 🏗️ Core System Components
+## Package docs
 
-### Agent System
-- [Agents](agents.md) - Agent architecture, types, and behaviors
-- [Perception](perception_system.md) - Sensory systems and observation processing
-- [State System](state_system.md) - Agent state management and transitions
-
-### Action System
-- [Action System](action_system.md) - Core action execution framework
-- [Action Data](action_data.md) - Action data structures and management
-
-### Observation & Channels
-- [Dynamic Channel System](dynamic_channel_system.md) - Flexible observation channel framework
-- Custom channel implementation examples (see [Usage Examples](usage_examples.md))
-
-#### Sparse Observation Storage (HYBRID mode)
-The observation system supports tensor-backed sparse point storage via `SparsePoints` for channels that are naturally sparse (e.g., allies/enemies/trajectories). This reduces Python dict overhead and improves GPU transfers.
-
-- Configuration (in `ObservationConfig`):
-  - `storage_mode`: `HYBRID` (default) uses `SparsePoints` for point-sparse channels; `DENSE` writes directly to a dense tensor.
-  - `sparse_backend`: `"scatter"` (default) or `"coo"`. Use `coo` when `sum` reduction with many duplicates is common.
-  - `default_point_reduction`: `"max"` (default), `"sum"`, or `"overwrite"`.
-  - `channel_reduction_overrides`: per-channel overrides by channel name.
-
-- Reductions:
-  - `max`: keep maximum per index (deterministic, good for presence maps)
-  - `sum`: accumulate contributions (good for intensities)
-  - `overwrite`: last write wins (order-dependent; not deterministic with duplicates)
-
-- Metrics via `AgentObservation.get_metrics()`:
-  - `dense_bytes`, `sparse_points`, `sparse_logical_bytes`, `memory_reduction_percent`
-  - `cache_hits`, `cache_misses`, `dense_rebuilds`, `dense_rebuild_time_s_total`
-  - `sparse_apply_calls`, `sparse_apply_time_s_total`
-
-Example:
-```python
-config = ObservationConfig(
-  R=6,
-  sparse_backend="scatter",
-  default_point_reduction="max",
-  channel_reduction_overrides={"TRAILS": "sum"},
-)
-obs = AgentObservation(config)
-tensor = obs.tensor()
-metrics = obs.get_metrics()
-```
-
-### Data & Analysis
-- [Data API](data/data_api.md) - Interfaces for data access and manipulation
-- [Data Services](data/data_services.md) - Data processing and management services
-- [Data Retrieval](data/data_retrieval.md) - Methods for accessing simulation data
-- [Database Schema](data/database_schema.md) - Data structure and organization
-- [Metrics](metrics.md) - Performance and behavior measurement systems
-- [Repositories](data/repositories.md) - Data storage and retrieval patterns
-- [Health Resource Analysis](health_resource_analysis.md) - Agent health and resource utilization analysis
-- [Experiment Analysis](experiment_analysis.md) - Tools for analyzing experiment results
-- [Genetics Analysis Module](genetics_analysis.md) - Genetics-specific analysis groups, plots, and reports
-
-### AI & Learning
-- [Deep Q Learning](deep_q_learning.md) - Reinforcement learning implementation
-- [Redis Agent Memory](redis_agent_memory.md) - Distributed agent memory system
-- [Hyperparameter Chromosome Design](design/hyperparameter_chromosome.md) - Typed, bounded hyperparameter genes and reproduction-time evolution wiring
-
-## 🔬 Research & Experiments
-
-- [Experiments](experiments.md) - Catalog of currently defined experiments (intrinsic evolution, hyperparameter convergence, cohort runner, memory agent, one of a kind, rabbit's foot)
-- [ExperimentRunner](experiment_runner.md) - Generic multi-iteration simulation runner
-- Experiment case studies (see [Usage Examples](usage_examples.md))
-
-## 📖 Specialized Guides & Tutorials
-
-### Tutorials
-Step-by-step guides for specific use cases:
-- Basic simulation setup
-- Custom agent implementation
-- Extending observation channels
-- Experiment management
-- Analysis and visualization
-
-### Analysis Techniques
-- [Analysis modules](analysis/modules/README.md) - Analysis module index (population, spatial, learning, etc.)
-- [Experiment Analysis](experiment_analysis.md) - Tools for analyzing experiment results
-- [Genetics Analysis Module](genetics_analysis.md) - Genetics-specific usage and API map
-- Comparative and behavioral analysis APIs live under `farm/analysis/`; see [Usage Examples](usage_examples.md) for patterns
-
-### Experiments
-- [Experiments](experiments/) - Detailed experiment configurations
-- Parameter sweep examples
-- Comparative studies
-- Replication techniques
-
-## 🔧 Technical Reference
-
-### API Documentation
-- **[Complete API Reference](api_reference.md)** - All classes, methods, and functions
-- Module-specific API documentation
-- Type hints and signatures
-- Usage examples for each API
-
-### Configuration System
-- **[Configuration Guide](config/configuration_guide.md)** - Comprehensive configuration reference
-- YAML configuration format
-- Parameter validation
-- Configuration management tools
-
-### Database & Persistence
-- [Database schema](data/database_schema.md) and [data retrieval](data/data_retrieval.md)
-- Database utilities and maintenance
-- Data export and import procedures
-
-## 🎯 Use Cases & Examples
-
-### Basic Usage Patterns
-1. **Simple Simulation**: Load config → Create environment → Add agents → Run simulation
-2. **Custom Agents**: Extend BaseAgent → Implement custom decision logic → Register behaviors
-3. **Extended Observations**: Create ChannelHandler → Register channel → Process observations
-4. **Parameter Studies**: Define parameter ranges → Run experiment → Analyze results
-
-### Advanced Scenarios
-- Multi-agent cooperation studies
-- Resource competition dynamics
-- Learning algorithm comparison
-- Emergent behavior analysis
-- Scalability testing
-
-## 🤝 Contributing
-
-We welcome contributions to both the platform and its documentation:
-
-### Ways to Contribute
-- **Bug Reports**: Use [GitHub Issues](https://github.com/Dooders/AgentFarm/issues) for bugs
-- **Feature Requests**: Propose new features via GitHub Issues
-- **Documentation**: Improve existing docs or add new guides
-- **Code Contributions**: Submit pull requests for enhancements
-
-### Development Setup
-1. Fork the repository
-2. Clone your fork: `git clone https://github.com/your-username/AgentFarm.git`
-3. Create a virtual environment and install: `pip install -r requirements.txt` and `pip install -e .`
-4. Run tests: `pytest` (from the repository root)
-5. Submit pull request
-
-### Documentation Guidelines
-- Use clear, concise language
-- Include code examples where helpful
-- Follow existing documentation structure
-- Test examples to ensure they work
-- Update this README when adding new documentation
-
-## 📞 Support & Community
-
-### Getting Help
-- **Documentation**: Start with this README and the guides listed above
-- **Issues**: Check existing [GitHub Issues](https://github.com/Dooders/AgentFarm/issues)
-- **Discussions**: Use GitHub Discussions for questions and general discussion
-- **Examples**: [Usage Examples](usage_examples.md), benchmark samples under `benchmarks/examples/`, and tests under `tests/`
-
-### Community Resources
-- **Research code**: `farm/research/` (analysis helpers and experiment tooling)
-- **Tutorials**: Community-contributed tutorials and guides
-- **Case Studies**: Real-world applications and results
-
-## 📋 Roadmap & Future Development
-
-### Planned Features
-- Enhanced visualization tools
-- Distributed simulation support
-- Additional agent types and behaviors
-- Advanced analysis frameworks
-- Integration with popular RL libraries
-
-### Research Directions
-- Complex social dynamics modeling
-- Evolutionary algorithm integration
-- Multi-objective optimization
-- Real-time adaptive systems
-
-## 📄 License & Attribution
-
-AgentFarm is licensed under the [Apache License 2.0](../LICENSE).
-
-This project is part of the [Dooders](https://github.com/Dooders) research initiative exploring complex adaptive systems through computational modeling.
-
----
-
-**🎓 Learning Path Recommendation:**
-1. Start with [Module Overview](module_overview.md) for high-level understanding
-2. Follow [Usage Examples](usage_examples.md) for hands-on experience
-3. Dive into [Configuration Guide](config/configuration_guide.md) for customization
-4. Reference [API Documentation](api_reference.md) for development
-5. Explore specialized guides for advanced topics
-
-**Happy simulating! 🚀** 
+Module-local READMEs live next to code under `farm/` (for example [logging](../farm/utils/logging/README.md) and [decision](../farm/core/decision/README.md)).

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -56,14 +56,14 @@ collections:
 # Top navigation links shown in the site header. URLs use the trailing-slash
 # permalinks Jekyll generates from optional-front-matter pages.
 nav_links:
-  - title: Docs
-    url: /README/
+  - title: Getting Started
+    url: /getting-started/installation/
+  - title: Guides
+    url: /guides/neural-recombination/
+  - title: Reference
+    url: /api_reference/
   - title: Devlog
     url: /devlog/
-  - title: Experiments
-    url: /experiments/
-  - title: API
-    url: /api_reference/
   - title: GitHub
     url: https://github.com/Dooders/AgentFarm
     external: true

--- a/docs/features/FEATURES.md
+++ b/docs/features/FEATURES.md
@@ -1,5 +1,7 @@
 # AgentFarm Features
 
+> **Deprecated:** Legacy feature documentation scheduled for consolidation in a future docs reorganization. Prefer [Installation](../getting-started/installation.md) and the [documentation hub](../README.md) for current navigation.
+
 **A Comprehensive Platform for Agent-Based Modeling & Simulation**
 
 ![Status](https://img.shields.io/badge/status-in%20development-orange)

--- a/docs/features/agent_based_modeling_analysis.md
+++ b/docs/features/agent_based_modeling_analysis.md
@@ -1,5 +1,7 @@
 # Agent-Based Modeling & Analysis
 
+> **Deprecated:** Legacy feature documentation scheduled for consolidation in a future docs reorganization. Prefer [Installation](../getting-started/installation.md) and the [documentation hub](../README.md) for current navigation.
+
 ![Project Status](https://img.shields.io/badge/feature-agent%20modeling-blue)
 
 > **Documentation note:** Many narrative examples below use **illustrative pseudocode** (for example `BaseAgent`, `run_simulation_batch`, and `SimulationConfig(width=...)` flat constructors). The real API uses **nested** `SimulationConfig` fields (`environment`, `population`, `resources`, …), **`run_simulation(...)`** which returns an **`Environment`**, and **`farm.core.analysis.SimulationAnalyzer`** as implemented in `farm/core/analysis.py` (see [System Dynamics Analysis](#system-dynamics-analysis)). For sweeps and multi-run studies use **`farm.runners.experiment_runner.ExperimentRunner`**. See [Usage examples](../usage_examples.md).
@@ -827,4 +829,4 @@ For questions and support:
 
 ---
 
-**Ready to explore complex systems?** Start with the [Basic Simulation Example](#example-1-basic-agent-based-simulation) or check out our [Quick Start Guide](../README.md#quick-start) to begin your agent-based modeling journey!
+**Ready to explore complex systems?** Start with the [Basic Simulation Example](#example-1-basic-agent-based-simulation) or the [Getting started guide](../getting-started/first-simulation.md).

--- a/docs/features/ai_machine_learning.md
+++ b/docs/features/ai_machine_learning.md
@@ -1,5 +1,7 @@
 # AI & Machine Learning
 
+> **Deprecated:** Legacy feature documentation scheduled for consolidation in a future docs reorganization. Prefer [Installation](../getting-started/installation.md) and the [documentation hub](../README.md) for current navigation.
+
 ![Feature](https://img.shields.io/badge/feature-AI%20%26%20ML-purple)
 
 ## Table of Contents

--- a/docs/features/customization_flexibility.md
+++ b/docs/features/customization_flexibility.md
@@ -1,5 +1,7 @@
 # Customization & Flexibility
 
+> **Deprecated:** Legacy feature documentation scheduled for consolidation in a future docs reorganization. Prefer [Installation](../getting-started/installation.md) and the [documentation hub](../README.md) for current navigation.
+
 ![Feature](https://img.shields.io/badge/feature-customization-green)
 
 ## Table of Contents

--- a/docs/features/data_system.md
+++ b/docs/features/data_system.md
@@ -1,5 +1,7 @@
 # Data System
 
+> **Deprecated:** Legacy feature documentation scheduled for consolidation in a future docs reorganization. Prefer [Installation](../getting-started/installation.md) and the [documentation hub](../README.md) for current navigation.
+
 ![Feature](https://img.shields.io/badge/feature-data%20system-blue)
 
 ## Table of Contents

--- a/docs/features/data_visualization.md
+++ b/docs/features/data_visualization.md
@@ -1,5 +1,7 @@
 # Data & Visualization
 
+> **Deprecated:** Legacy feature documentation scheduled for consolidation in a future docs reorganization. Prefer [Installation](../getting-started/installation.md) and the [documentation hub](../README.md) for current navigation.
+
 ![Feature](https://img.shields.io/badge/feature-data%20%26%20viz-orange)
 
 ## Table of Contents

--- a/docs/features/research_tools.md
+++ b/docs/features/research_tools.md
@@ -1,5 +1,7 @@
 # Research Tools
 
+> **Deprecated:** Legacy feature documentation scheduled for consolidation in a future docs reorganization. Prefer [Installation](../getting-started/installation.md) and the [documentation hub](../README.md) for current navigation.
+
 ![Feature](https://img.shields.io/badge/feature-research%20tools-red)
 
 ## Table of Contents

--- a/docs/features/spatial_indexing_performance.md
+++ b/docs/features/spatial_indexing_performance.md
@@ -1,5 +1,7 @@
 # Spatial Indexing & Performance
 
+> **Deprecated:** Legacy feature documentation scheduled for consolidation in a future docs reorganization. Prefer [Installation](../getting-started/installation.md) and the [documentation hub](../README.md) for current navigation.
+
 ![Feature](https://img.shields.io/badge/feature-spatial%20%26%20performance-brightgreen)
 
 ## Table of Contents

--- a/docs/getting-started/first-simulation.md
+++ b/docs/getting-started/first-simulation.md
@@ -1,0 +1,64 @@
+# First simulation
+
+## Command line
+
+```bash
+python run_simulation.py --environment development --steps 1000
+```
+
+Results are written under `simulations/` (database files, logs, and analysis output).
+
+## Experiments and analysis tools
+
+```bash
+# Parameter sweeps
+python farm/core/cli.py --mode experiment --environment development --experiment-name test --iterations 3
+
+# Visualize existing results
+python farm/core/cli.py --mode visualize --db-path simulations/simulation.db
+
+# Generate analysis reports
+python farm/core/cli.py --mode analyze --db-path simulations/simulation.db
+```
+
+See [Experiment QuickStart](../ExperimentQuickStart.md) for parameter studies.
+
+## API server
+
+```bash
+uvicorn farm.api.server:app --host 0.0.0.0 --port 5000
+```
+
+Use the `uvicorn` command directly. Running `python -m farm.api.server` enables `reload=True`, which requires an import string and exits with a warning.
+
+Defaults:
+
+- Port 5000
+- Structured logs in `logs/application.json.log` and `logs/application.log`
+
+Key endpoints:
+
+- `POST /api/simulation/new` — create and run a simulation
+- `GET /api/simulation/<sim_id>/step/<step>` — fetch a step
+- `GET /api/simulation/<sim_id>/analysis` — run analysis
+- `GET /api/simulation/<sim_id>/export` — export data
+- `WS /ws/<client_id>` — WebSocket client channel
+
+See [Deployment](../deployment.md) for production notes.
+
+## Benchmarks
+
+```bash
+python -m benchmarks.run_benchmarks --list
+python -m benchmarks.run_benchmarks --spec benchmarks/specs/memory_db_baseline.yaml
+```
+
+See [benchmarks/README.md](../../benchmarks/README.md).
+
+## Testing
+
+```bash
+pytest -q
+# or
+python run_tests.py
+```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,43 @@
+# Installation
+
+## Prerequisites
+
+- Python 3.8 or higher (3.9+ recommended)
+- pip and Git
+- Redis (optional, for enhanced agent memory)
+
+## Setup
+
+```bash
+git clone https://github.com/Dooders/AgentFarm.git
+cd AgentFarm
+
+python -m venv venv
+source venv/bin/activate  # Windows: venv\Scripts\activate
+
+pip install -r requirements.txt
+pip install -e .
+```
+
+Editable install (`pip install -e .`) is required for `farm` imports.
+
+## Optional: Redis
+
+Redis is used for some agent memory features and can improve performance.
+
+- Ubuntu/Debian: `sudo apt-get install redis-server`
+- macOS: `brew install redis`
+- Windows: [redis.io/download](https://redis.io/download)
+
+Start the server with `redis-server`.
+
+## Verify
+
+```bash
+pytest -q
+```
+
+## Next steps
+
+- [Run your first simulation](first-simulation.md)
+- [Contributing](../../CONTRIBUTING.md)

--- a/docs/guides/neural-recombination.md
+++ b/docs/guides/neural-recombination.md
@@ -1,0 +1,53 @@
+# Neural recombination (distillation, PTQ, QAT)
+
+After distilling student Q-networks you can apply **8-bit post-training quantization (PTQ)** and, if accuracy is not good enough, **quantization-aware training (QAT)**. Implementation details and PyTorch version notes live in [`farm/core/decision/training/quantize_ptq.py`](../../farm/core/decision/training/quantize_ptq.py) and [`farm/core/decision/training/quantize_qat.py`](../../farm/core/decision/training/quantize_qat.py).
+
+For the full step-by-step pipeline, see the [Neural Recombination Runbook](../howto/neural_recombination_runbook.md).
+
+## Typical flow
+
+1. **Distill** float students (`student_A.pt` / `student_B.pt`):
+
+   ```bash
+   python scripts/run_distillation.py --help
+   ```
+
+2. **PTQ** (default: dynamic weight-only `qint8`; static mode needs calibration states):
+
+   ```bash
+   python scripts/quantize_distilled.py \
+       --checkpoint-dir checkpoints/distillation \
+       --output-dir checkpoints/quantized
+   ```
+
+   For static PTQ, use `--states-file` or synthetic `--n-states` / `--seed`; calibration volume uses `--calibration-batches` and `--calibration-batch-size` (defaults 10 / 64). Match distillation architecture with `--input-dim`, `--output-dim`, `--parent-hidden` (defaults **8**, **4**, **64**).
+
+3. **Validate** float students (optional): `python scripts/validate_distillation.py --help`
+
+4. **Validate quantized vs float** (CPU): `python scripts/validate_quantized.py --help`. The validator loads quantized checkpoints as full-model pickles, so pass `--allow-unsafe-unpickle` only for trusted artifacts. The JSON report includes median/mean/p95 single-sample latency, optional **throughput** (`--throughput-batch-size`), **memory** RSS snapshots, float–quant **MSE/KL/top-k** agreement, and optional **teacher** metrics if `parent_*.pt` is found under `--float-dir` / `--teacher-dir` or via `--teacher-*-ckpt`.
+
+5. **Evaluate a crossover child vs both parents** (offline Q metrics, versioned JSON): `python scripts/validate_recombination.py --help`. Baselines: **child vs parent A**, **child vs parent B**, optional **parent A vs parent B** (`--include-parent-baseline`), plus **oracle** agreement in the report summary. Use the same `--states-file` / `--seed` / `--n-states` pattern as other validation scripts. For **quantized** full-model checkpoints (PTQ or post-QAT `torch.save` exports), add `--parent-a-quantized`, `--parent-b-quantized`, and/or `--child-quantized` together with `--allow-unsafe-unpickle`; those roles are loaded with `load_quantized_checkpoint` and run on **CPU**.
+
+6. **Search many crossover + fine-tune combinations** (leaderboard + manifest): `python scripts/run_crossover_search.py --help`. Presets include `minimal` / `default`, plus **`minimal-qat`** / **`default-qat`** (adds a `short_qat` / `ptq_dynamic` regime). Use **`--workers N`** for process-parallel children (float `BaseQNetwork` parents only). Quick check: `make crossover-search-smoke`. Design notes: [crossover search space](../design/crossover_search_space.md), strategy semantics: [crossover strategies](../design/crossover_strategies.md).
+
+## Crossover from PTQ parent paths (Python)
+
+[`initialize_child_from_crossover`](../../farm/core/decision/training/crossover.py) can auto-detect a **dynamic** PTQ sidecar next to a `.pt` file (same JSON shape as `PostTrainingQuantizer.save_checkpoint`) and load via `load_quantized_checkpoint`. That path uses full-model unpickling (`weights_only=False`); pass **`allow_unsafe_unpickle=True` only for trusted checkpoints**. Static PTQ sidecars are not auto-loaded here—use float state dicts or in-memory modules. Details: [crossover strategies](../design/crossover_strategies.md).
+
+## Optional QAT
+
+After PTQ, if action agreement or Q-error is unacceptable: weight-only fake quant on linear layers, same int8 export format as PTQ after convert.
+
+```bash
+python scripts/qat_distilled.py \
+    --checkpoint-dir checkpoints/distillation \
+    --output-dir checkpoints/qat
+```
+
+Use `--teacher-a-ckpt` / `--student-a-ckpt` (and `*-b-*` for pair B) when paths are not under a single `--checkpoint-dir`; see `python scripts/qat_distilled.py --help` for epochs, learning rate, and `--no-convert` (float QAT checkpoint only). Quantized QAT checkpoints work with `scripts/validate_quantized.py` like PTQ outputs.
+
+## Tests
+
+```bash
+pytest tests/decision/test_ptq.py tests/decision/test_validate_quantized.py tests/decision/test_qat.py tests/decision/test_crossover_search.py
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ env = run_simulation(
           Compose adaptive agents, environments, and rules. Track interactions,
           resources, and emergent dynamics over time.
         </p>
-        <a class="feature__link" href="{{ '/features/agent_based_modeling_analysis/' | relative_url }}">Modeling</a>
+        <a class="feature__link" href="{{ '/module_overview/' | relative_url }}">Architecture</a>
       </div>
 
       <div class="feature">
@@ -95,7 +95,7 @@ env = run_simulation(
           KD-tree, Quadtree, and Spatial Hash Grid backends with dirty-region
           tracking — thousands of agents, fast.
         </p>
-        <a class="feature__link" href="{{ '/features/spatial_indexing_performance/' | relative_url }}">Performance</a>
+        <a class="feature__link" href="{{ '/spatial/spatial_indexing/' | relative_url }}">Spatial indexing</a>
       </div>
 
       <div class="feature">
@@ -104,7 +104,7 @@ env = run_simulation(
           Repository-backed databases, behavioral clustering, causal analysis,
           and experiment-level comparisons.
         </p>
-        <a class="feature__link" href="{{ '/features/data_system/' | relative_url }}">Data system</a>
+        <a class="feature__link" href="{{ '/data/data_api/' | relative_url }}">Data API</a>
         <a class="feature__link" href="{{ '/genetics_analysis/' | relative_url }}">Genetics</a>
       </div>
 
@@ -153,7 +153,7 @@ env = run_simulation(
         <li class="quickstart__step">
           <div>
             <h4>Open the docs</h4>
-            <p>Browse the <a href="{{ '/README/' | relative_url }}">documentation index</a> for guides, API, and case studies.</p>
+            <p>Browse <a href="{{ '/getting-started/installation/' | relative_url }}">getting started</a> and the <a href="{{ '/README/' | relative_url }}">documentation hub</a>.</p>
           </div>
         </li>
       </ol>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First pass of the documentation overhaul: make the README a scannable intro and move detailed content into dedicated docs pages.

## Changes

- **README.md** — reduced from ~278 to ~40 lines (intro, feature bullets, quick start, doc links)
- **docs/README.md** — replaced 222-line index with a ~35-line navigation hub
- **New pages**
  - `docs/getting-started/installation.md`
  - `docs/getting-started/first-simulation.md` (CLI, API, benchmarks, testing)
  - `docs/guides/neural-recombination.md` (distillation/PTQ/QAT content moved from README)
- **docs/features/** — deprecation banners on all 8 legacy feature pages
- **Jekyll** — updated `_config.yml` nav and `docs/index.md` home page links

## What's next (Phase 2)

- Directory moves (`concepts/`, `reference/`, `research/`)
- Trim or archive `docs/features/*`
- Link checker in CI

## Testing

Docs-only change; no code behavior modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-499e93ac-c6af-4344-8672-24a4f4fe03e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-499e93ac-c6af-4344-8672-24a4f4fe03e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

