### PR TITLE
Implement learning-positive inheritance A/B plan and enhance ecology analysis

### DIFF
--- a/.cursor/plans/learning-positive_inheritance_a_b_0098cc01.plan.md
+++ b/.cursor/plans/learning-positive_inheritance_a_b_0098cc01.plan.md
@@ -1,0 +1,74 @@
+---
+name: Learning-positive inheritance A/B
+overview: "Run the #904 P0–P4 inheritance-ladder A/B in the learning-positive regime validated by the precondition gate (small population, 3000-step horizon), by extending the existing A/B harness with population knobs and grading on early-age net RL reward."
+todos:
+  - id: population-knobs
+    content: Add --population/--max-population to run_inheritance_mode_ab.py and thread through the sweep runner via a shared regime-config helper
+    status: completed
+  - id: multi-arm-early-life
+    content: Extend analyze_early_life_fitness.py to grade multiple treatment arms against the P0 baseline
+    status: completed
+  - id: tests
+    content: Add unit tests for population plumbing and multi-arm early-life aggregation
+    status: completed
+  - id: pilot
+    content: "Run pilot: balanced profile x 2 seeds x 5 arms at 3000 steps; verify telemetry, offspring counts, wall time"
+    status: in_progress
+  - id: full-sweep
+    content: Run full 90-run sweep (5 arms x 3 profiles x 6 seeds) with resume + disk DB
+    status: pending
+  - id: aggregate
+    content: "Aggregate: compare_inheritance_arms + early-life verdict; apply decision rule"
+    status: pending
+  - id: record
+    content: "Write results summary doc and update issue #904"
+    status: pending
+isProject: false
+---
+
+# Learning-positive inheritance-ladder A/B (#904)
+
+## Goal
+
+Run the matched P0–P4 experiment in the regime the precondition gate validated — not the default config where within-life learning is ~null. The gate established the honest effect size (~+15–30 net early reward), so the A/B is graded on **early-age net RL reward at ages {10, 25, 50}** with the project robustness gate (paired per-seed 95% CI excludes zero AND sign agreement >= 0.75).
+
+## Regime (decided)
+
+- **Arms (5):** `baldwinian` (P0 baseline), `lamarckian` (P1), `p2`, `p3`, `p4` — one matched sweep, default warm-start knobs (damping 0.5, replay limit 256, blend 0.5, gate 1.0)
+- **Population:** 8 independent agents only (0 system/control), `max_population=32`. Unlike the gate, **reproduction stays ON** (inheritance happens at reproduction), so the cap prevents the colony explosion the gate avoided by blocking `reproduce`
+- **Horizon:** `--num-steps 3000`, `--warmup-steps 200` (unchanged; offspring for early-life scoring are born after warmup), `--snapshot-interval 100`
+- **Matrix:** 3 profiles (`conservative`/`balanced`/`buffered`) x 6 seeds (`42 7 19 101 137 256`) x 5 arms = **90 runs**, `--disk-database` (required by early-life analysis) + `--resume`, `PYTHONHASHSEED=0`
+
+## Gap 1: harness has no population knobs
+
+[scripts/run_inheritance_mode_ab.py](scripts/run_inheritance_mode_ab.py) exposes `--num-steps/--profiles/--seeds` but population comes from the environment YAML (development = 30 mixed agents, cap 50). Add `--population` and `--max-population` flags, threaded through `run_stable_profile_seed_sweep._execute_sweep` into the `SimulationConfig`, mirroring `build_regime_config()` in [scripts/measure_transferable_signal.py](scripts/measure_transferable_signal.py) (independent-only, zero out system/control/order/chaos). Extract that config shaping into one shared helper so the gate and the A/B use the identical regime definition (DRY).
+
+## Gap 2: early-life analysis is 2-arm only
+
+[scripts/analyze_early_life_fitness.py](scripts/analyze_early_life_fitness.py) computes exactly the graded metrics (`rl_reward_at_age` at 10/25/50, survival, decision success) but compares one baseline vs one treatment. Extend it to accept multiple treatment arms (P1–P4 each paired against P0), reusing its existing per-seed pairing and `_verdict` logic. Output one summary table: arm x profile x metric with robust flags.
+
+## Execution phases
+
+**Phase A — pilot (before burning ~90 long runs):** 1 profile (`balanced`) x 2 seeds x all 5 arms at full 3000 steps. Verify: (1) independent-only population works with the intrinsic-evolution runner (speciation/selection machinery), (2) warm-start telemetry shows `warmstart_rate > 0` for P1–P4 and a sensible P4 `gate_hit_rate`, (3) enough post-warmup offspring exist for early-life scoring, (4) per-run wall time is acceptable (pin torch threads like the gate runner if needed).
+
+**Phase B — full sweep:**
+
+```bash
+PYTHONHASHSEED=0 python scripts/run_inheritance_mode_ab.py \
+  --arms baldwinian lamarckian p2 p3 p4 \
+  --population 8 --max-population 32 \
+  --num-steps 3000 --snapshot-interval 100 \
+  --output-dir experiments/inheritance_ab_learning_positive \
+  --disk-database --resume
+```
+
+**Phase C — aggregate and grade:**
+1. `compare_inheritance_arms.py` (P0 baseline, P1–P4 treatments) — population/speciation/stability/mechanism readouts
+2. Extended `analyze_early_life_fitness.py` — the **primary verdict**: net RL reward at ages {10, 25, 50} per arm, sized against the ~+15–30 budget the gate measured
+3. Apply the decision rule: keep a richer payload only if it robustly beats P0 on early-life net-RL-reward without degrading stability
+
+**Phase D — record:** results summary under `docs/research/experiments/intrinsic_evolution/`, check off the checklist item on #904 with a comment. (Cross-ecology transfer test is the *next* checklist item — out of scope here, but the harvested runs should be kept for it.)
+
+## Tests
+
+Unit tests for the new population-override plumbing and the multi-arm early-life aggregation (extend `tests/scripts/`), following the existing `test_measure_transferable_signal.py` pattern.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ Baseline packaged release at `0.1.0`. Detailed history is captured in the dated 
 
 ## Entries
 
+### 2026-07-03
+
+#### Performance
+
+- **Reduced default P3 replay-buffer transfer limit** — `P3_REPLAY_BUFFER_LIMIT` lowered from 256 → 64 in `farm/core/policy_inheritance.py`. At `max_population=32` with active reproduction churn the original 256-transition cap caused P3 to run ~3× slower than P2 because each birth event triggers a synchronous replay-slice serialize + deserialize; the new default cuts that overhead ~4× while still seeding the child's buffer with enough recent experience. Larger slices remain available via `IntrinsicEvolutionPolicy(warmstart_replay_buffer_limit=N)` or `--warmstart-replay-buffer-limit N`. Closes [#962](https://github.com/Dooders/AgentFarm/issues/962).
+
+---
+
 ### 2026-06-17
 
 #### Added

--- a/docs/research/experiments/intrinsic_evolution/inheritance_mode_ab.md
+++ b/docs/research/experiments/intrinsic_evolution/inheritance_mode_ab.md
@@ -29,6 +29,48 @@ Issue: [#849](https://github.com/Dooders/AgentFarm/issues/849)
 - Initial diversity: independent mutation (`rate=1.0`, `scale=0.25`)
 - Speciation: GMM, `max_k=4`
 
+## Ecology regime and divergence from the gate
+
+The inheritance A/B runs with **reproduction enabled** and a starting
+population of 8 independent agents. The two ecology variants differ in how
+much the colony can grow:
+
+### Saturated ecology (default, `--population 8 --max-population 32`)
+
+`max_population=32` gives 4× growth headroom. In pilot runs, every seed
+fills to the cap early (32/32) and runs as a **crowded, high-churn ecology**
+for most of the horizon (see [Issue #963]).
+
+This diverges from the precondition gate
+([transferable-signal-budget devlog]), which ran with **reproduction
+disabled** in a fixed-8 uncrowded setting. The gate measured a modest
+within-life decision-quality signal (~+15–30 net reward at age 10) in an
+*uncrowded, no-repro* environment; the A/B measures offspring early-life
+fitness in a *saturated colony* where resources and spatial competition
+differ.
+
+Practical implication: interpret early-life scores alongside the
+**ecology context** table in the analysis output (`ecology_by_arm` in the
+JSON, "Ecology context" section in the Markdown). A `saturation_ratio` of
+1.0 means every arm ran fully saturated; any comparison is then ecology-matched
+by construction, but the regime differs from the gate.
+
+### Low-churn ecology (`--population 8 --max-population 8 --low-churn`)
+
+Setting `max_population = population` (via `--low-churn`) prevents the colony
+from growing beyond its starting size. Reproduction can only replace dead
+agents, keeping ecology density comparable to the gate regime.
+
+Use this variant when the research question is: *"does the inherited payload
+help offspring survive in an uncrowded environment similar to the one where
+the parent learned?"*
+
+Use the saturated variant when the research question is: *"does inheritance
+help under realistic evolutionary pressure in a full colony?"*
+
+[Issue #963]: https://github.com/Dooders/AgentFarm/issues/963
+[transferable-signal-budget devlog]: ../../devlog/2026-06-20-transferable-signal-budget/
+
 ## Run commands
 
 **Note:** Results under `experiments/inheritance_ab_pre_fix/` were collected
@@ -36,11 +78,22 @@ before a decision-path fix (2026-05-22) that prevented policy weights from
 influencing actions. That aggregate is invalid; use a fresh output directory
 after the fix lands.
 
-### 1) Run both arms
+### 1a) Run both arms — saturated ecology (default)
 
 ```bash
 PYTHONHASHSEED=0 python scripts/run_inheritance_mode_ab.py \
   --output-dir experiments/inheritance_ab \
+  --disk-database \
+  --resume
+```
+
+### 1b) Run both arms — low-churn ecology variant
+
+```bash
+PYTHONHASHSEED=0 python scripts/run_inheritance_mode_ab.py \
+  --output-dir experiments/inheritance_ab_low_churn \
+  --population 8 \
+  --low-churn \
   --disk-database \
   --resume
 ```

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -1044,11 +1044,6 @@ class AgentCore:
             if lock_shapes
             else ()
         )
-        per_gene_rate_multipliers = (
-            {gene_name: 0.0 for gene_name in locked_genes}
-            if locked_genes
-            else None
-        )
         child_chromosome = mutate_chromosome(
             base,
             mutation_rate=policy.mutation_rate,
@@ -1056,17 +1051,12 @@ class AgentCore:
             mutation_mode=policy.mutation_mode,
             boundary_mode=policy.boundary_mode,
             interior_bias_fraction=policy.interior_bias_fraction,
-            per_gene_rate_multipliers=per_gene_rate_multipliers,
             rng=rng,
         )
-        if not locked_genes:
-            return child_chromosome
-        return child_chromosome.with_overrides(
-            {
-                gene_name: parent_chromosome.get_value(gene_name)
-                for gene_name in locked_genes
-            }
-        )
+        overrides = {
+            gene_name: parent_chromosome.get_value(gene_name) for gene_name in locked_genes
+        }
+        return child_chromosome.with_overrides(overrides) if overrides else child_chromosome
 
     def _select_coparent(self, policy, rng) -> Optional["AgentCore"]:
         """Pick a co-parent for crossover according to the policy.

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -62,6 +62,10 @@ _WARMSTART_DISPATCH = {
     "p4": apply_p4_policy_warmstart,
 }
 
+# Shape-sensitive loci are pinned to the parent's value whenever a warm-start
+# inheritance mode is active, so policy tensors remain load-compatible.
+_WARMSTART_SHAPE_LOCKED_GENES = ("dqn_hidden_size",)
+
 
 def _warmstart_kwargs_for_mode(mode: str, policy: Any) -> Dict[str, Any]:
     """Build the per-mode tuning kwargs for a warm-start hook from ``policy``.
@@ -1029,14 +1033,39 @@ class AgentCore:
                     rng=rng,
                 )
 
-        return mutate_chromosome(
+        inheritance_mode = getattr(policy, "inheritance_mode", "baldwinian")
+        lock_shapes = inheritance_mode in _WARMSTART_DISPATCH
+        locked_genes = (
+            tuple(
+                gene_name
+                for gene_name in _WARMSTART_SHAPE_LOCKED_GENES
+                if parent_chromosome.get_gene(gene_name) is not None
+            )
+            if lock_shapes
+            else ()
+        )
+        per_gene_rate_multipliers = (
+            {gene_name: 0.0 for gene_name in locked_genes}
+            if locked_genes
+            else None
+        )
+        child_chromosome = mutate_chromosome(
             base,
             mutation_rate=policy.mutation_rate,
             mutation_scale=policy.mutation_scale,
             mutation_mode=policy.mutation_mode,
             boundary_mode=policy.boundary_mode,
             interior_bias_fraction=policy.interior_bias_fraction,
+            per_gene_rate_multipliers=per_gene_rate_multipliers,
             rng=rng,
+        )
+        if not locked_genes:
+            return child_chromosome
+        return child_chromosome.with_overrides(
+            {
+                gene_name: parent_chromosome.get_value(gene_name)
+                for gene_name in locked_genes
+            }
         )
 
     def _select_coparent(self, policy, rng) -> Optional["AgentCore"]:

--- a/farm/core/agent/core.py
+++ b/farm/core/agent/core.py
@@ -1035,15 +1035,19 @@ class AgentCore:
 
         inheritance_mode = getattr(policy, "inheritance_mode", "baldwinian")
         lock_shapes = inheritance_mode in _WARMSTART_DISPATCH
+        parent_gene_names = {gene.name for gene in parent_chromosome.genes}
         locked_genes = (
             tuple(
                 gene_name
                 for gene_name in _WARMSTART_SHAPE_LOCKED_GENES
-                if parent_chromosome.get_gene(gene_name) is not None
+                if gene_name in parent_gene_names
             )
             if lock_shapes
             else ()
         )
+        overrides = {
+            gene_name: parent_chromosome.get_value(gene_name) for gene_name in locked_genes
+        }
         child_chromosome = mutate_chromosome(
             base,
             mutation_rate=policy.mutation_rate,
@@ -1053,9 +1057,6 @@ class AgentCore:
             interior_bias_fraction=policy.interior_bias_fraction,
             rng=rng,
         )
-        overrides = {
-            gene_name: parent_chromosome.get_value(gene_name) for gene_name in locked_genes
-        }
         return child_chromosome.with_overrides(overrides) if overrides else child_chromosome
 
     def _select_coparent(self, policy, rng) -> Optional["AgentCore"]:

--- a/farm/core/policy_inheritance.py
+++ b/farm/core/policy_inheritance.py
@@ -69,7 +69,16 @@ WARMSTART_REASON_EXTENDED_STATE_UNSUPPORTED = "extended_state_unsupported"
 P2_PLASTICITY_DAMPING = 0.5
 
 # Replay-buffer slice size cap used by the P3 variant.
-P3_REPLAY_BUFFER_LIMIT = 256
+# Kept at 64 (down from the original 256) to bound per-offspring serialization
+# overhead at population-cap churn rates.  At max_population=32 with active
+# reproduction, each birth triggers a synchronous replay-slice serialize +
+# deserialize; 256 transitions proved ~3× slower than P2 in the learning-
+# positive pilot (#962).  64 preserves enough recent experience to seed the
+# child's replay buffer while capping the transfer cost to roughly the same
+# wall-clock band as P2.  Override via IntrinsicEvolutionPolicy
+# (warmstart_replay_buffer_limit) or the --warmstart-replay-buffer-limit CLI
+# flag when a larger slice is justified by the experiment's horizon.
+P3_REPLAY_BUFFER_LIMIT = 64
 
 # Blend coefficient used by the P4 variant:
 #   θ_child = P4_BLEND_ALPHA * θ_parent + (1 - P4_BLEND_ALPHA) * θ_init
@@ -339,6 +348,12 @@ def apply_p3_policy_warmstart(
     Copies the parent's policy weights, optimizer state (Adam moments), and
     a bounded slice of the parent's replay buffer so the offspring continues
     the parent's learning trajectory instead of restarting from scratch.
+
+    ``replay_buffer_limit`` caps the number of transitions serialized and
+    transferred per offspring.  Keep it small (default :data:`P3_REPLAY_BUFFER_LIMIT`
+    = 64) for long-horizon sweeps or high-reproduction-churn regimes; larger
+    values increase wall-clock time proportionally because the transfer is
+    synchronous per birth event.
 
     Returns ``None`` on success; returns a ``WARMSTART_REASON_*`` string on
     any skip.

--- a/farm/core/policy_inheritance.py
+++ b/farm/core/policy_inheritance.py
@@ -350,10 +350,10 @@ def apply_p3_policy_warmstart(
     the parent's learning trajectory instead of restarting from scratch.
 
     ``replay_buffer_limit`` caps the number of transitions serialized and
-    transferred per offspring.  Keep it small (default :data:`P3_REPLAY_BUFFER_LIMIT`
-    = 64) for long-horizon sweeps or high-reproduction-churn regimes; larger
-    values increase wall-clock time proportionally because the transfer is
-    synchronous per birth event.
+    transferred per offspring. Keep it small (default :data:`P3_REPLAY_BUFFER_LIMIT`)
+    for long-horizon sweeps or high-reproduction-churn regimes; larger values
+    increase wall-clock time proportionally because the transfer is synchronous per
+    birth event.
 
     Returns ``None`` on success; returns a ``WARMSTART_REASON_*`` string on
     any skip.

--- a/farm/runners/intrinsic_evolution_experiment.py
+++ b/farm/runners/intrinsic_evolution_experiment.py
@@ -943,6 +943,7 @@ class IntrinsicEvolutionExperiment:
             final_gene_statistics=latest_gene_statistics,
             startup_transient_metrics=startup_transient_metrics,
         )
+        resolved_ic["max_population"] = int(run_config.population.max_population)
         self._persist(
             result,
             initial_diversity_config=run_config.initial_diversity,

--- a/scripts/_learning_positive_regime.py
+++ b/scripts/_learning_positive_regime.py
@@ -1,0 +1,104 @@
+"""Shared learning-positive regime helpers (#904 / transferable-signal gate).
+
+Centralizes population and ecology shaping so the precondition gate
+(``measure_transferable_signal.py``) and the inheritance A/B harness
+(``run_stable_profile_seed_sweep.py``) apply identical regime definitions.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Dict, Optional
+
+from farm.config import SimulationConfig
+from farm.runners.intrinsic_evolution_experiment import STABLE_SUB_PROFILES
+
+# Mapping from STABLE_SUB_PROFILES override keys to SimulationConfig fields.
+_PROFILE_FIELD_MAP = {
+    "initial_agent_resource_level": ("agent_behavior", "initial_resource_level"),
+    "initial_resource_count": ("resources", "initial_resources"),
+    "resource_regen_rate": ("resources", "resource_regen_rate"),
+    "resource_regen_amount": ("resources", "resource_regen_amount"),
+}
+
+# Defaults used by the #904 learning-positive inheritance A/B (mirrors gate).
+DEFAULT_LEARNING_POSITIVE_POPULATION = 8
+DEFAULT_LEARNING_POSITIVE_MAX_POPULATION = 32
+
+
+def apply_independent_population(
+    config: SimulationConfig,
+    population: int,
+    max_population: int,
+) -> None:
+    """Small independent-only population (learning-positive regime).
+
+    Zeros out system/control/order/chaos agents so every slot is an
+    independent learning agent — the same shape used by the transferable-signal
+    gate and the inheritance-ladder A/B.
+    """
+    pop = config.population
+    pop.system_agents = 0
+    pop.independent_agents = int(population)
+    pop.control_agents = 0
+    for attr in ("order_agents", "chaos_agents"):
+        if hasattr(pop, attr):
+            setattr(pop, attr, 0)
+    pop.max_population = int(max_population)
+
+
+def apply_stable_profile_ecology(
+    config: SimulationConfig,
+    profile: str,
+) -> Dict[str, Any]:
+    """Apply STABLE_SUB_PROFILES[profile] ecology to a SimulationConfig."""
+    overrides = STABLE_SUB_PROFILES[profile]
+    for key, value in overrides.items():
+        mapping = _PROFILE_FIELD_MAP.get(key)
+        if mapping is None:
+            print(
+                f"apply_stable_profile_ecology: ignoring unknown profile key {key!r}",
+                file=sys.stderr,
+            )
+            continue
+        section_name, field_name = mapping
+        section = getattr(config, section_name, None)
+        if section is not None and hasattr(section, field_name):
+            setattr(section, field_name, value)
+    return dict(overrides)
+
+
+def use_disk_database(config: SimulationConfig) -> None:
+    """Force disk-backed, persisted SQLite (never in-memory)."""
+    config.database.use_in_memory_db = False
+    if hasattr(config.database, "persist_db_on_completion"):
+        config.database.persist_db_on_completion = True
+
+
+def maybe_apply_learning_positive_population(
+    config: SimulationConfig,
+    population: Optional[int],
+    max_population: Optional[int],
+) -> None:
+    """Apply population override when ``population`` is set; no-op otherwise."""
+    if population is None:
+        return
+    cap = max_population if max_population is not None else population * 4
+    apply_independent_population(config, population, cap)
+
+
+def build_learning_positive_regime_config(
+    profile: str,
+    *,
+    environment: str = "development",
+    population: int = DEFAULT_LEARNING_POSITIVE_POPULATION,
+    max_population: int = DEFAULT_LEARNING_POSITIVE_MAX_POPULATION,
+    force_disk_database: bool = True,
+) -> SimulationConfig:
+    """Learning-positive training regime: small population + stable ecology."""
+    config = SimulationConfig.from_centralized_config(environment=environment)
+    apply_independent_population(config, population, max_population)
+    if force_disk_database:
+        use_disk_database(config)
+    apply_stable_profile_ecology(config, profile)
+    return config

--- a/scripts/_learning_positive_regime.py
+++ b/scripts/_learning_positive_regime.py
@@ -23,7 +23,13 @@ _PROFILE_FIELD_MAP = {
 
 # Defaults used by the #904 learning-positive inheritance A/B (mirrors gate).
 DEFAULT_LEARNING_POSITIVE_POPULATION = 8
+# Saturated-ecology variant: 4× the starting population so the colony fills
+# quickly and runs as a crowded, high-churn ecology for most of the horizon.
 DEFAULT_LEARNING_POSITIVE_MAX_POPULATION = 32
+# Low-churn variant: cap equals the starting population so reproduction can
+# only replace dead agents — it cannot expand the colony.  Keeps ecology
+# density comparable to the gate regime (fixed-8, no-repro).
+DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION = DEFAULT_LEARNING_POSITIVE_POPULATION
 
 
 def apply_independent_population(

--- a/scripts/analyze_early_life_fitness.py
+++ b/scripts/analyze_early_life_fitness.py
@@ -728,8 +728,7 @@ def _build_multi_arm_markdown(
     for age in ages:
         lines += [f"## Net RL reward at age {age} (primary gate)", ""]
         lines += [
-            "| Profile | Arm | Baseline mean | Treatment mean | Mean Δ | 95% CI | "
-            "Sign agr. | Verdict |",
+            "| Profile | Arm | Baseline mean | Treatment mean | Mean Δ | 95% CI | Sign agr. | Verdict |",
             "| --- | --- | --- | --- | --- | --- | --- | --- |",
         ]
         for arm in treatment_arms:

--- a/scripts/analyze_early_life_fitness.py
+++ b/scripts/analyze_early_life_fitness.py
@@ -564,10 +564,12 @@ def _build_markdown(
                 )
         lines += [
             "",
-            "_Saturation ratio = final population / max_population cap. "
-            "1.0 = fully saturated (crowded ecology); "
-            "values near initial_population/max_population indicate a sparse ecology "
-            "closer to the gate regime (fixed-8, no-repro)._",
+            (
+                "_Saturation ratio = final population / max_population cap. "
+                + "1.0 = fully saturated (crowded ecology); "
+                + "values near initial_population/max_population indicate a sparse ecology "
+                + "closer to the gate regime (fixed-8, no-repro)._"
+            ),
             "",
         ]
 

--- a/scripts/analyze_early_life_fitness.py
+++ b/scripts/analyze_early_life_fitness.py
@@ -164,6 +164,45 @@ def _read_warmstart_rate(run_dir: Path) -> Optional[float]:
     return float(applied) / total if total > 0 else float("nan")
 
 
+def _read_ecology_context(run_dir: Path) -> Dict[str, Any]:
+    """Read ecology density context from run metadata.
+
+    Returns a dict with keys:
+    - ``final_population``: population alive at the end of the run.
+    - ``configured_max_population``: max_population cap set in the run config.
+    - ``saturation_ratio``: final_population / configured_max_population
+      (1.0 = fully saturated; close to initial_population/max_population = sparse).
+
+    Returns an empty dict when metadata is absent or malformed.
+    """
+    meta_path = run_dir / "intrinsic_evolution_metadata.json"
+    if not meta_path.exists():
+        return {}
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    context: Dict[str, Any] = {}
+    final_pop = meta.get("final_population")
+    if final_pop is not None:
+        context["final_population"] = int(final_pop)
+    # max_population lives in resolved_initial_conditions (set by the runner).
+    resolved = meta.get("resolved_initial_conditions") or {}
+    max_pop = resolved.get("max_population")
+    if max_pop is None:
+        # Fallback: check the policy block.
+        policy = meta.get("policy") or {}
+        max_pop = policy.get("max_population")
+    if max_pop is not None:
+        context["configured_max_population"] = int(max_pop)
+    if "final_population" in context and "configured_max_population" in context:
+        denom = context["configured_max_population"]
+        context["saturation_ratio"] = (
+            context["final_population"] / denom if denom > 0 else float("nan")
+        )
+    return context
+
+
 def _parent_of(genome_id: Optional[str]) -> Optional[str]:
     """Return parent id only for single-parent genome IDs.
 
@@ -352,6 +391,36 @@ def _discover_arm_runs(
 
 # ── Paired deltas ────────────────────────────────────────────────────────────────
 
+def _summarize_ecology(eco_list: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Aggregate per-run ecology context dicts into a profile-level summary.
+
+    Keys in the summary:
+    - ``n_runs``: number of runs with ecology data.
+    - ``mean_final_population``: mean final population across runs.
+    - ``mean_saturation_ratio``: mean final_pop / max_pop (1.0 = saturated).
+    - ``configured_max_population``: configured cap (all runs should agree;
+      the first available value is used).
+
+    Returns an empty dict when ``eco_list`` is empty.
+    """
+    if not eco_list:
+        return {}
+    final_pops = [e["final_population"] for e in eco_list if "final_population" in e]
+    sat_ratios = [e["saturation_ratio"] for e in eco_list
+                  if "saturation_ratio" in e and math.isfinite(e["saturation_ratio"])]
+    max_pop = next(
+        (e["configured_max_population"] for e in eco_list
+         if "configured_max_population" in e),
+        None,
+    )
+    return {
+        "n_runs": len(eco_list),
+        "mean_final_population": _mean(final_pops) if final_pops else float("nan"),
+        "mean_saturation_ratio": _mean(sat_ratios) if sat_ratios else float("nan"),
+        "configured_max_population": max_pop,
+    }
+
+
 def _verdict(deltas: Sequence[float]) -> Dict[str, Any]:
     """Robustness verdict for a list of paired deltas (one per seed)."""
     vals = [d for d in deltas if not math.isnan(d)]
@@ -443,6 +512,8 @@ def _build_markdown(
     ages: Sequence[int],
     baseline_arm: str,
     treatment_arm: str,
+    *,
+    ecology_by_arm: Optional[Dict[str, Dict[str, Dict[str, Any]]]] = None,
 ) -> str:
     profiles = [p for p in PROFILE_ORDER if p in paired]
     lines: List[str] = [
@@ -453,6 +524,30 @@ def _build_markdown(
         "95% CI excludes zero AND within-profile sign agreement >= 0.75.",
         "",
     ]
+
+    if ecology_by_arm:
+        lines += ["## Ecology context", ""]
+        lines += [
+            "| Profile | Arm | Mean final pop | Max pop cap | Saturation ratio |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+        for profile in profiles:
+            for arm in (baseline_arm, treatment_arm):
+                eco = ecology_by_arm.get(arm, {}).get(profile, {})
+                lines.append(
+                    f"| {profile} | {arm} "
+                    f"| {_fmt(eco.get('mean_final_population'), 1)} "
+                    f"| {eco.get('configured_max_population', 'n/a')} "
+                    f"| {_fmt(eco.get('mean_saturation_ratio'), 2)} |"
+                )
+        lines += [
+            "",
+            "_Saturation ratio = final population / max_population cap. "
+            "1.0 = fully saturated (crowded ecology); "
+            "values near initial_population/max_population indicate a sparse ecology "
+            "closer to the gate regime (fixed-8, no-repro)._",
+            "",
+        ]
 
     if warmstart_rates:
         lines += ["## Warm-start coverage (treatment arm)", ""]
@@ -546,6 +641,8 @@ def _build_multi_arm_markdown(
     ages: Sequence[int],
     baseline_arm: str,
     treatment_arms: Sequence[str],
+    *,
+    ecology_by_arm: Optional[Dict[str, Dict[str, Dict[str, Any]]]] = None,
 ) -> str:
     lines: List[str] = [
         f"# Early-life offspring fitness: ladder vs {baseline_arm} (#904)",
@@ -555,6 +652,35 @@ def _build_multi_arm_markdown(
         "95% CI excludes zero AND within-profile sign agreement >= 0.75.",
         "",
     ]
+
+    all_arms = [baseline_arm] + list(treatment_arms)
+    if ecology_by_arm:
+        profiles_eco = [
+            p for p in PROFILE_ORDER
+            if any(p in ecology_by_arm.get(a, {}) for a in all_arms)
+        ]
+        if profiles_eco:
+            lines += ["## Ecology context", ""]
+            lines += [
+                "| Profile | Arm | Mean final pop | Max pop cap | Saturation ratio |",
+                "| --- | --- | --- | --- | --- |",
+            ]
+            for profile in profiles_eco:
+                for arm in all_arms:
+                    eco = ecology_by_arm.get(arm, {}).get(profile, {})
+                    lines.append(
+                        f"| {profile} | {arm} "
+                        f"| {_fmt(eco.get('mean_final_population'), 1)} "
+                        f"| {eco.get('configured_max_population', 'n/a')} "
+                        f"| {_fmt(eco.get('mean_saturation_ratio'), 2)} |"
+                    )
+            lines += [
+                "",
+                "_Saturation ratio = final population / max_population cap. "
+                "1.0 = fully saturated; values near initial/max indicate a sparse "
+                "ecology closer to the gate regime (fixed-8, no-repro)._",
+                "",
+            ]
 
     if warmstart_by_arm:
         lines += ["## Warm-start coverage (treatment arms)", ""]
@@ -612,10 +738,21 @@ def _load_arm(
     label: str,
     profiles: Sequence[str],
     ages: Sequence[int],
-) -> Tuple[Dict[str, Dict[int, Dict[str, Any]]], Dict[str, List[float]]]:
+) -> Tuple[Dict[str, Dict[int, Dict[str, Any]]], Dict[str, List[float]], Dict[str, List[Dict[str, Any]]]]:
+    """Load per-run early-life data for one arm.
+
+    Returns
+    -------
+    per_profile : mapping profile -> seed -> run data dict
+    warmstart   : mapping profile -> list of per-run warm-start rates
+    ecology     : mapping profile -> list of per-run ecology context dicts
+                  (keys: ``final_population``, ``configured_max_population``,
+                  ``saturation_ratio``).
+    """
     runs = _discover_arm_runs(arm_dir, profiles)
     per_profile: Dict[str, Dict[int, Dict[str, Any]]] = defaultdict(dict)
     warmstart: Dict[str, List[float]] = defaultdict(list)
+    ecology: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
     for profile, seed_dirs in runs.items():
         for seed, run_dir in seed_dirs:
             db = _find_db(run_dir)
@@ -631,11 +768,20 @@ def _load_arm(
             rate = _read_warmstart_rate(run_dir)
             if rate is not None and not math.isnan(rate):
                 warmstart[profile].append(rate)
+            eco = _read_ecology_context(run_dir)
+            if eco:
+                ecology[profile].append(eco)
             print(
                 f"  [{label}] {profile} seed={seed}: "
                 f"{data['n_offspring']} offspring, warmup={warmup}"
+                + (
+                    f", final_pop={eco.get('final_population', '?')}"
+                    f"/{eco.get('configured_max_population', '?')}"
+                    if eco
+                    else ""
+                )
             )
-    return dict(per_profile), dict(warmstart)
+    return dict(per_profile), dict(warmstart), dict(ecology)
 
 
 def _resolve_treatment_arms(args: argparse.Namespace) -> List[str]:
@@ -659,9 +805,11 @@ def _run_single_pair_analysis(
         return 1
 
     print(f"Loading baseline arm ({baseline_arm})...")
-    baseline, _ = _load_arm(baseline_dir, baseline_arm, profiles, ages)
+    baseline, _, baseline_ecology = _load_arm(baseline_dir, baseline_arm, profiles, ages)
     print(f"Loading treatment arm ({treatment_arm})...")
-    treatment, warmstart_raw = _load_arm(treatment_dir, treatment_arm, profiles, ages)
+    treatment, warmstart_raw, treatment_ecology = _load_arm(
+        treatment_dir, treatment_arm, profiles, ages
+    )
 
     warmstart_rates = {p: _mean(v) for p, v in warmstart_raw.items() if v}
 
@@ -677,12 +825,23 @@ def _run_single_pair_analysis(
         print("No paired profiles found; nothing to compare.", file=sys.stderr)
         return 1
 
+    ecology_by_arm = {
+        baseline_arm: {
+            p: _summarize_ecology(baseline_ecology.get(p, []))
+            for p in paired
+        },
+        treatment_arm: {
+            p: _summarize_ecology(treatment_ecology.get(p, []))
+            for p in paired
+        },
+    }
     summary = {
         "baseline_arm": baseline_arm,
         "treatment_arm": treatment_arm,
         "ages": list(ages),
         "profiles_analyzed": [p for p in PROFILE_ORDER if p in paired],
         "warmstart_rates": warmstart_rates,
+        "ecology_by_arm": ecology_by_arm,
         "paired": paired,
         "rl_reward_curves": {
             "baseline": {
@@ -713,7 +872,8 @@ def _run_single_pair_analysis(
     )
     md_path = output_dir / "early_life_summary.md"
     md_path.write_text(
-        _build_markdown(paired, warmstart_rates, ages, baseline_arm, treatment_arm),
+        _build_markdown(paired, warmstart_rates, ages, baseline_arm, treatment_arm,
+                        ecology_by_arm=ecology_by_arm),
         encoding="utf-8",
     )
     print(f"\nDone. Outputs in: {output_dir}")
@@ -740,16 +900,28 @@ def _run_multi_arm_analysis(
             return 1
 
     print(f"Loading baseline arm ({baseline_arm})...")
-    baseline, _ = _load_arm(baseline_dir, baseline_arm, profiles, ages)
+    baseline, _, baseline_ecology = _load_arm(baseline_dir, baseline_arm, profiles, ages)
 
     paired_by_arm: Dict[str, Dict[str, Dict[str, Any]]] = {}
     warmstart_by_arm: Dict[str, Dict[str, float]] = {}
+    ecology_by_arm: Dict[str, Dict[str, Dict[str, Any]]] = {
+        baseline_arm: {
+            p: _summarize_ecology(baseline_ecology.get(p, []))
+            for p in baseline
+        }
+    }
     profiles_analyzed: List[str] = []
 
     for arm in treatment_arms:
         print(f"Loading treatment arm ({arm})...")
-        treatment, warmstart_raw = _load_arm(ab_dir / arm, arm, profiles, ages)
+        treatment, warmstart_raw, treatment_ecology = _load_arm(
+            ab_dir / arm, arm, profiles, ages
+        )
         warmstart_by_arm[arm] = {p: _mean(v) for p, v in warmstart_raw.items() if v}
+        ecology_by_arm[arm] = {
+            p: _summarize_ecology(treatment_ecology.get(p, []))
+            for p in treatment
+        }
         paired: Dict[str, Dict[str, Any]] = {}
         for profile in profiles:
             b = baseline.get(profile, {})
@@ -773,6 +945,7 @@ def _run_multi_arm_analysis(
         "ages": list(ages),
         "profiles_analyzed": [p for p in PROFILE_ORDER if p in profiles_analyzed],
         "warmstart_by_arm": warmstart_by_arm,
+        "ecology_by_arm": ecology_by_arm,
         "paired_by_arm": paired_by_arm,
         "robust_hits": _collect_robust_hits(paired_by_arm, ages),
     }
@@ -785,7 +958,8 @@ def _run_multi_arm_analysis(
     md_path = output_dir / "early_life_ladder_summary.md"
     md_path.write_text(
         _build_multi_arm_markdown(
-            paired_by_arm, warmstart_by_arm, ages, baseline_arm, treatment_arms
+            paired_by_arm, warmstart_by_arm, ages, baseline_arm, treatment_arms,
+            ecology_by_arm=ecology_by_arm,
         ),
         encoding="utf-8",
     )

--- a/scripts/analyze_early_life_fitness.py
+++ b/scripts/analyze_early_life_fitness.py
@@ -54,12 +54,19 @@ two-parent offspring are excluded from that metric.
 
 Usage
 -----
-::
+Single treatment (legacy)::
 
     python scripts/analyze_early_life_fitness.py \\
         --ab-dir experiments/inheritance_ab \\
         --baseline-arm baldwinian \\
         --treatment-arm lamarckian
+
+Multi-arm ladder (#904) — each treatment paired against baseline::
+
+    python scripts/analyze_early_life_fitness.py \\
+        --ab-dir experiments/inheritance_ab_learning_positive \\
+        --baseline-arm baldwinian \\
+        --treatment-arms lamarckian p2 p3 p4
 """
 
 from __future__ import annotations
@@ -508,87 +515,158 @@ def _build_markdown(
     return "\n".join(lines)
 
 
-# ── Driver ─────────────────────────────────────────────────────────────────────
-
-def _json_safe(obj: Any) -> Any:
-    """Recursively replace non-finite floats with ``None`` for portable JSON.
-
-    ``json.dumps`` emits bare ``NaN``/``Infinity`` tokens by default, which are
-    invalid in strict JSON (and break JS / non-Python consumers). Mapping them
-    to ``null`` keeps the file parseable everywhere.
-    """
-    if isinstance(obj, float):
-        return obj if math.isfinite(obj) else None
-    if isinstance(obj, dict):
-        return {k: _json_safe(v) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple)):
-        return [_json_safe(v) for v in obj]
-    return obj
+# Primary #904 gate metric: net RL reward at fixed offspring ages.
+PRIMARY_GATE_METRIC = "rl_reward_at_age"
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="Measure early-life offspring fitness across A/B inheritance arms.",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
-    parser.add_argument("--ab-dir", type=str, required=True,
-                        help="Root dir containing the two arm sub-directories.")
-    parser.add_argument("--baseline-arm", type=str, default="baldwinian")
-    parser.add_argument("--treatment-arm", type=str, default="lamarckian")
-    parser.add_argument("--output-dir", type=str, default=None,
-                        help="Defaults to <ab-dir>/early_life.")
-    parser.add_argument("--profiles", nargs="+", default=list(PROFILE_ORDER),
-                        choices=list(PROFILE_ORDER), metavar="PROFILE")
-    parser.add_argument("--ages", nargs="+", type=int, default=list(DEFAULT_AGES))
-    args = parser.parse_args()
+def _collect_robust_hits(
+    paired_by_arm: Dict[str, Dict[str, Dict[str, Any]]],
+    ages: Sequence[int],
+    *,
+    metric: str = PRIMARY_GATE_METRIC,
+) -> List[str]:
+    hits: List[str] = []
+    for arm, paired in paired_by_arm.items():
+        profiles = [p for p in PROFILE_ORDER if p in paired]
+        for profile in profiles:
+            for age in ages:
+                verdicts = paired[profile]["ages"].get(age, {}).get("verdicts", {})
+                v = verdicts.get(metric, {})
+                if v.get("robust"):
+                    hits.append(
+                        f"{arm} / {profile} / N={age} "
+                        f"(Δ {_fmt(v.get('mean_delta'), 3)})"
+                    )
+    return hits
 
-    ab_dir = Path(args.ab_dir)
-    baseline_dir = ab_dir / args.baseline_arm
-    treatment_dir = ab_dir / args.treatment_arm
+
+def _build_multi_arm_markdown(
+    paired_by_arm: Dict[str, Dict[str, Dict[str, Any]]],
+    warmstart_by_arm: Dict[str, Dict[str, float]],
+    ages: Sequence[int],
+    baseline_arm: str,
+    treatment_arms: Sequence[str],
+) -> str:
+    lines: List[str] = [
+        f"# Early-life offspring fitness: ladder vs {baseline_arm} (#904)",
+        "",
+        "Each treatment arm is paired against the baseline per (profile, seed). "
+        "Primary gate metric: **net RL reward at age N**. Robustness rule: "
+        "95% CI excludes zero AND within-profile sign agreement >= 0.75.",
+        "",
+    ]
+
+    if warmstart_by_arm:
+        lines += ["## Warm-start coverage (treatment arms)", ""]
+        header = "| Profile | " + " | ".join(treatment_arms) + " |"
+        lines += [header, "| --- | " + " | ".join("---" for _ in treatment_arms) + " |"]
+        profiles = [p for p in PROFILE_ORDER if any(p in paired_by_arm[a] for a in treatment_arms)]
+        for profile in profiles:
+            cells = [
+                _fmt(warmstart_by_arm.get(arm, {}).get(profile, float("nan")), 3)
+                for arm in treatment_arms
+            ]
+            lines.append(f"| {profile} | " + " | ".join(cells) + " |")
+        lines.append("")
+
+    for age in ages:
+        lines += [f"## Net RL reward at age {age} (primary gate)", ""]
+        lines += [
+            "| Profile | Arm | Baseline mean | Treatment mean | Mean Δ | 95% CI | "
+            "Sign agr. | Verdict |",
+            "| --- | --- | --- | --- | --- | --- | --- | --- |",
+        ]
+        for arm in treatment_arms:
+            paired = paired_by_arm.get(arm, {})
+            for profile in [p for p in PROFILE_ORDER if p in paired]:
+                age_block = paired[profile]["ages"].get(age, {})
+                v = age_block.get("verdicts", {}).get(PRIMARY_GATE_METRIC, {})
+                verdict = "robust" if v.get("robust") else "no robust effect"
+                lines.append(
+                    f"| {profile} | {arm} "
+                    f"| {_fmt(age_block.get('baseline_means', {}).get(PRIMARY_GATE_METRIC), 3)} "
+                    f"| {_fmt(age_block.get('treatment_means', {}).get(PRIMARY_GATE_METRIC), 3)} "
+                    f"| {_fmt(v.get('mean_delta'), 3)} "
+                    f"| {_fmt(v.get('ci95'), 3)} "
+                    f"| {_fmt(v.get('sign_agreement'), 2)} "
+                    f"| {verdict} |"
+                )
+        lines.append("")
+
+    lines += ["## Headline", ""]
+    robust_hits = _collect_robust_hits(paired_by_arm, ages)
+    if robust_hits:
+        lines.append("Robust early-life RL-reward gains vs baseline:")
+        lines += [f"- {hit}" for hit in robust_hits]
+    else:
+        lines.append(
+            "**No robust early-life RL-reward gain** for any treatment arm vs "
+            f"{baseline_arm}. Richer payloads do not clear the #904 gate on this metric."
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _load_arm(
+    arm_dir: Path,
+    label: str,
+    profiles: Sequence[str],
+    ages: Sequence[int],
+) -> Tuple[Dict[str, Dict[int, Dict[str, Any]]], Dict[str, List[float]]]:
+    runs = _discover_arm_runs(arm_dir, profiles)
+    per_profile: Dict[str, Dict[int, Dict[str, Any]]] = defaultdict(dict)
+    warmstart: Dict[str, List[float]] = defaultdict(list)
+    for profile, seed_dirs in runs.items():
+        for seed, run_dir in seed_dirs:
+            db = _find_db(run_dir)
+            if db is None:
+                print(f"  [{label}] {run_dir}: no .db, skipping", file=sys.stderr)
+                continue
+            warmup = _read_warmup(run_dir)
+            data = _extract_run_early_life(db, warmup, ages)
+            if data is None:
+                print(f"  [{label}] {run_dir}: no offspring, skipping", file=sys.stderr)
+                continue
+            per_profile[profile][seed] = data
+            rate = _read_warmstart_rate(run_dir)
+            if rate is not None and not math.isnan(rate):
+                warmstart[profile].append(rate)
+            print(
+                f"  [{label}] {profile} seed={seed}: "
+                f"{data['n_offspring']} offspring, warmup={warmup}"
+            )
+    return dict(per_profile), dict(warmstart)
+
+
+def _resolve_treatment_arms(args: argparse.Namespace) -> List[str]:
+    if getattr(args, "treatment_arms", None):
+        return list(args.treatment_arms)
+    return [args.treatment_arm]
+
+
+def _run_single_pair_analysis(
+    ab_dir: Path,
+    baseline_arm: str,
+    treatment_arm: str,
+    profiles: Sequence[str],
+    ages: Sequence[int],
+    output_dir: Path,
+) -> int:
+    baseline_dir = ab_dir / baseline_arm
+    treatment_dir = ab_dir / treatment_arm
     if not baseline_dir.is_dir() or not treatment_dir.is_dir():
         print(f"Expected arm dirs {baseline_dir} and {treatment_dir}", file=sys.stderr)
         return 1
 
-    output_dir = Path(args.output_dir) if args.output_dir else ab_dir / "early_life"
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    ages = sorted(set(int(a) for a in args.ages))
-
-    def _load_arm(arm_dir: Path, label: str) -> Tuple[
-        Dict[str, Dict[int, Dict[str, Any]]], Dict[str, List[float]]
-    ]:
-        runs = _discover_arm_runs(arm_dir, args.profiles)
-        per_profile: Dict[str, Dict[int, Dict[str, Any]]] = defaultdict(dict)
-        warmstart: Dict[str, List[float]] = defaultdict(list)
-        for profile, seed_dirs in runs.items():
-            for seed, run_dir in seed_dirs:
-                db = _find_db(run_dir)
-                if db is None:
-                    print(f"  [{label}] {run_dir}: no .db, skipping", file=sys.stderr)
-                    continue
-                warmup = _read_warmup(run_dir)
-                data = _extract_run_early_life(db, warmup, ages)
-                if data is None:
-                    print(f"  [{label}] {run_dir}: no offspring, skipping",
-                          file=sys.stderr)
-                    continue
-                per_profile[profile][seed] = data
-                rate = _read_warmstart_rate(run_dir)
-                if rate is not None and not math.isnan(rate):
-                    warmstart[profile].append(rate)
-                print(f"  [{label}] {profile} seed={seed}: "
-                      f"{data['n_offspring']} offspring, warmup={warmup}")
-        return dict(per_profile), dict(warmstart)
-
-    print(f"Loading baseline arm ({args.baseline_arm})...")
-    baseline, _ = _load_arm(baseline_dir, args.baseline_arm)
-    print(f"Loading treatment arm ({args.treatment_arm})...")
-    treatment, warmstart_raw = _load_arm(treatment_dir, args.treatment_arm)
+    print(f"Loading baseline arm ({baseline_arm})...")
+    baseline, _ = _load_arm(baseline_dir, baseline_arm, profiles, ages)
+    print(f"Loading treatment arm ({treatment_arm})...")
+    treatment, warmstart_raw = _load_arm(treatment_dir, treatment_arm, profiles, ages)
 
     warmstart_rates = {p: _mean(v) for p, v in warmstart_raw.items() if v}
 
     paired: Dict[str, Dict[str, Any]] = {}
-    for profile in args.profiles:
+    for profile in profiles:
         b = baseline.get(profile, {})
         t = treatment.get(profile, {})
         if not b or not t:
@@ -600,9 +678,9 @@ def main() -> int:
         return 1
 
     summary = {
-        "baseline_arm": args.baseline_arm,
-        "treatment_arm": args.treatment_arm,
-        "ages": ages,
+        "baseline_arm": baseline_arm,
+        "treatment_arm": treatment_arm,
+        "ages": list(ages),
         "profiles_analyzed": [p for p in PROFILE_ORDER if p in paired],
         "warmstart_rates": warmstart_rates,
         "paired": paired,
@@ -627,21 +705,179 @@ def main() -> int:
             },
         },
     }
+    output_dir.mkdir(parents=True, exist_ok=True)
     summary_path = output_dir / "early_life_summary.json"
     summary_path.write_text(
         json.dumps(_json_safe(summary), indent=2, allow_nan=False, default=str),
         encoding="utf-8",
     )
-
-    md = _build_markdown(paired, warmstart_rates, ages, args.baseline_arm,
-                         args.treatment_arm)
     md_path = output_dir / "early_life_summary.md"
-    md_path.write_text(md, encoding="utf-8")
-
+    md_path.write_text(
+        _build_markdown(paired, warmstart_rates, ages, baseline_arm, treatment_arm),
+        encoding="utf-8",
+    )
     print(f"\nDone. Outputs in: {output_dir}")
     print(f"  summary JSON : {summary_path}")
     print(f"  summary MD   : {md_path}")
     return 0
+
+
+def _run_multi_arm_analysis(
+    ab_dir: Path,
+    baseline_arm: str,
+    treatment_arms: Sequence[str],
+    profiles: Sequence[str],
+    ages: Sequence[int],
+    output_dir: Path,
+) -> int:
+    baseline_dir = ab_dir / baseline_arm
+    if not baseline_dir.is_dir():
+        print(f"Expected baseline dir {baseline_dir}", file=sys.stderr)
+        return 1
+    for arm in treatment_arms:
+        if not (ab_dir / arm).is_dir():
+            print(f"Expected treatment dir {ab_dir / arm}", file=sys.stderr)
+            return 1
+
+    print(f"Loading baseline arm ({baseline_arm})...")
+    baseline, _ = _load_arm(baseline_dir, baseline_arm, profiles, ages)
+
+    paired_by_arm: Dict[str, Dict[str, Dict[str, Any]]] = {}
+    warmstart_by_arm: Dict[str, Dict[str, float]] = {}
+    profiles_analyzed: List[str] = []
+
+    for arm in treatment_arms:
+        print(f"Loading treatment arm ({arm})...")
+        treatment, warmstart_raw = _load_arm(ab_dir / arm, arm, profiles, ages)
+        warmstart_by_arm[arm] = {p: _mean(v) for p, v in warmstart_raw.items() if v}
+        paired: Dict[str, Dict[str, Any]] = {}
+        for profile in profiles:
+            b = baseline.get(profile, {})
+            t = treatment.get(profile, {})
+            if not b or not t:
+                continue
+            paired[profile] = _pair_profile(b, t, ages)
+        if paired:
+            paired_by_arm[arm] = paired
+            for profile in paired:
+                if profile not in profiles_analyzed:
+                    profiles_analyzed.append(profile)
+
+    if not paired_by_arm:
+        print("No paired profiles found across treatment arms.", file=sys.stderr)
+        return 1
+
+    summary = {
+        "baseline_arm": baseline_arm,
+        "treatment_arms": list(treatment_arms),
+        "ages": list(ages),
+        "profiles_analyzed": [p for p in PROFILE_ORDER if p in profiles_analyzed],
+        "warmstart_by_arm": warmstart_by_arm,
+        "paired_by_arm": paired_by_arm,
+        "robust_hits": _collect_robust_hits(paired_by_arm, ages),
+    }
+    output_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = output_dir / "early_life_ladder_summary.json"
+    summary_path.write_text(
+        json.dumps(_json_safe(summary), indent=2, allow_nan=False, default=str),
+        encoding="utf-8",
+    )
+    md_path = output_dir / "early_life_ladder_summary.md"
+    md_path.write_text(
+        _build_multi_arm_markdown(
+            paired_by_arm, warmstart_by_arm, ages, baseline_arm, treatment_arms
+        ),
+        encoding="utf-8",
+    )
+    print(f"\nDone. Outputs in: {output_dir}")
+    print(f"  ladder JSON : {summary_path}")
+    print(f"  ladder MD   : {md_path}")
+    return 0
+
+def _json_safe(obj: Any) -> Any:
+    """Recursively replace non-finite floats with ``None`` for portable JSON.
+
+    ``json.dumps`` emits bare ``NaN``/``Infinity`` tokens by default, which are
+    invalid in strict JSON (and break JS / non-Python consumers). Mapping them
+    to ``null`` keeps the file parseable everywhere.
+    """
+    if isinstance(obj, float):
+        return obj if math.isfinite(obj) else None
+    if isinstance(obj, dict):
+        return {k: _json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_json_safe(v) for v in obj]
+    return obj
+
+
+# ── Driver ─────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Measure early-life offspring fitness across A/B inheritance arms.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--ab-dir",
+        type=str,
+        required=True,
+        help="Root dir containing arm sub-directories.",
+    )
+    parser.add_argument("--baseline-arm", type=str, default="baldwinian")
+    parser.add_argument(
+        "--treatment-arm",
+        type=str,
+        default="lamarckian",
+        help="Single treatment arm (legacy two-arm mode).",
+    )
+    parser.add_argument(
+        "--treatment-arms",
+        nargs="+",
+        default=None,
+        metavar="ARM",
+        help=(
+            "Multiple treatment arms, each paired against baseline (#904 ladder). "
+            "When set, overrides --treatment-arm."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="Defaults to <ab-dir>/early_life.",
+    )
+    parser.add_argument(
+        "--profiles",
+        nargs="+",
+        default=list(PROFILE_ORDER),
+        choices=list(PROFILE_ORDER),
+        metavar="PROFILE",
+    )
+    parser.add_argument("--ages", nargs="+", type=int, default=list(DEFAULT_AGES))
+    args = parser.parse_args()
+
+    ab_dir = Path(args.ab_dir)
+    output_dir = Path(args.output_dir) if args.output_dir else ab_dir / "early_life"
+    ages = sorted(set(int(a) for a in args.ages))
+    treatment_arms = _resolve_treatment_arms(args)
+
+    if len(treatment_arms) == 1:
+        return _run_single_pair_analysis(
+            ab_dir,
+            args.baseline_arm,
+            treatment_arms[0],
+            args.profiles,
+            ages,
+            output_dir,
+        )
+    return _run_multi_arm_analysis(
+        ab_dir,
+        args.baseline_arm,
+        treatment_arms,
+        args.profiles,
+        ages,
+        output_dir,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/analyze_early_life_fitness.py
+++ b/scripts/analyze_early_life_fitness.py
@@ -671,9 +671,7 @@ def _build_multi_arm_markdown(
     lines: List[str] = [
         f"# Early-life offspring fitness: ladder vs {baseline_arm} (#904)",
         "",
-        "Each treatment arm is paired against the baseline per (profile, seed). "
-        "Primary gate metric: **net RL reward at age N**. Robustness rule: "
-        "95% CI excludes zero AND within-profile sign agreement >= 0.75.",
+        "Each treatment arm is paired against the baseline per (profile, seed). Primary gate metric: **net RL reward at age N**. Robustness rule: 95% CI excludes zero AND within-profile sign agreement >= 0.75.",
         "",
     ]
 

--- a/scripts/analyze_early_life_fitness.py
+++ b/scripts/analyze_early_life_fitness.py
@@ -190,6 +190,8 @@ def _read_ecology_context(run_dir: Path) -> Dict[str, Any]:
         try:
             context["final_population"] = int(final_pop)
         except (TypeError, ValueError):
+            # Metadata can be malformed across runs; ignore this field and
+            # leave final_population unset so downstream logic can proceed.
             pass
     # max_population lives in resolved_initial_conditions (set by the runner).
     resolved = meta.get("resolved_initial_conditions")

--- a/scripts/analyze_early_life_fitness.py
+++ b/scripts/analyze_early_life_fitness.py
@@ -698,9 +698,11 @@ def _build_multi_arm_markdown(
                     )
             lines += [
                 "",
-                "_Saturation ratio = final population / max_population cap. "
-                "1.0 = fully saturated; values near initial/max indicate a sparse "
-                "ecology closer to the gate regime (fixed-8, no-repro)._",
+                (
+                    "_Saturation ratio = final population / max_population cap. "
+                    "1.0 = fully saturated; values near initial/max indicate a sparse "
+                    "ecology closer to the gate regime (fixed-8, no-repro)._"
+                ),
                 "",
             ]
 

--- a/scripts/analyze_early_life_fitness.py
+++ b/scripts/analyze_early_life_fitness.py
@@ -208,7 +208,11 @@ def _read_ecology_context(run_dir: Path) -> Dict[str, Any]:
         try:
             context["configured_max_population"] = int(max_pop)
         except (TypeError, ValueError):
-            pass
+            # Best-effort metadata parsing: ignore malformed max_population.
+            # The caller can still use any other valid context fields.
+            context["configured_max_population"] = context.get(
+                "configured_max_population"
+            )
     if "final_population" in context and "configured_max_population" in context:
         denom = context["configured_max_population"]
         context["saturation_ratio"] = (

--- a/scripts/analyze_early_life_fitness.py
+++ b/scripts/analyze_early_life_fitness.py
@@ -180,21 +180,33 @@ def _read_ecology_context(run_dir: Path) -> Dict[str, Any]:
         return {}
     try:
         meta = json.loads(meta_path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(meta, dict):
         return {}
     context: Dict[str, Any] = {}
     final_pop = meta.get("final_population")
     if final_pop is not None:
-        context["final_population"] = int(final_pop)
+        try:
+            context["final_population"] = int(final_pop)
+        except (TypeError, ValueError):
+            pass
     # max_population lives in resolved_initial_conditions (set by the runner).
-    resolved = meta.get("resolved_initial_conditions") or {}
+    resolved = meta.get("resolved_initial_conditions")
+    if not isinstance(resolved, dict):
+        resolved = {}
     max_pop = resolved.get("max_population")
     if max_pop is None:
         # Fallback: check the policy block.
-        policy = meta.get("policy") or {}
+        policy = meta.get("policy")
+        if not isinstance(policy, dict):
+            policy = {}
         max_pop = policy.get("max_population")
     if max_pop is not None:
-        context["configured_max_population"] = int(max_pop)
+        try:
+            context["configured_max_population"] = int(max_pop)
+        except (TypeError, ValueError):
+            pass
     if "final_population" in context and "configured_max_population" in context:
         denom = context["configured_max_population"]
         context["saturation_ratio"] = (

--- a/scripts/analyze_early_life_fitness.py
+++ b/scripts/analyze_early_life_fitness.py
@@ -394,6 +394,13 @@ def _discover_arm_runs(
 def _summarize_ecology(eco_list: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Aggregate per-run ecology context dicts into a profile-level summary.
 
+    Parameters
+    ----------
+    eco_list:
+        List of per-run ecology dicts, each with optional keys
+        ``final_population``, ``configured_max_population``, and
+        ``saturation_ratio`` (as returned by :func:`_read_ecology_context`).
+
     Keys in the summary:
     - ``n_runs``: number of runs with ecology data.
     - ``mean_final_population``: mean final population across runs.
@@ -406,8 +413,11 @@ def _summarize_ecology(eco_list: List[Dict[str, Any]]) -> Dict[str, Any]:
     if not eco_list:
         return {}
     final_pops = [e["final_population"] for e in eco_list if "final_population" in e]
-    sat_ratios = [e["saturation_ratio"] for e in eco_list
-                  if "saturation_ratio" in e and math.isfinite(e["saturation_ratio"])]
+    sat_ratios = [
+        e["saturation_ratio"]
+        for e in eco_list
+        if "saturation_ratio" in e and math.isfinite(e["saturation_ratio"])
+    ]
     max_pop = next(
         (e["configured_max_population"] for e in eco_list
          if "configured_max_population" in e),

--- a/scripts/measure_transferable_signal.py
+++ b/scripts/measure_transferable_signal.py
@@ -82,6 +82,7 @@ from farm.config import SimulationConfig  # noqa: E402
 from farm.core.agent.core import AgentCore  # noqa: E402
 from farm.core.decision.decision import DecisionModule  # noqa: E402
 from farm.core.simulation import run_simulation  # noqa: E402
+from farm.runners.intrinsic_evolution_experiment import STABLE_SUB_PROFILES  # noqa: E402
 from scripts._learning_positive_regime import (  # noqa: E402
     apply_independent_population,
     apply_stable_profile_ecology,

--- a/scripts/measure_transferable_signal.py
+++ b/scripts/measure_transferable_signal.py
@@ -82,8 +82,11 @@ from farm.config import SimulationConfig  # noqa: E402
 from farm.core.agent.core import AgentCore  # noqa: E402
 from farm.core.decision.decision import DecisionModule  # noqa: E402
 from farm.core.simulation import run_simulation  # noqa: E402
-from farm.runners.intrinsic_evolution_experiment import (  # noqa: E402
-    STABLE_SUB_PROFILES,
+from scripts._learning_positive_regime import (  # noqa: E402
+    apply_independent_population,
+    apply_stable_profile_ecology,
+    build_learning_positive_regime_config,
+    use_disk_database,
 )
 from scripts.analyze_stable_profile_seed_sweep import (  # noqa: E402
     PROFILE_ORDER,
@@ -96,17 +99,6 @@ from scripts.analyze_stable_profile_seed_sweep import (  # noqa: E402
 
 DEFAULT_SEEDS: List[int] = [42, 7, 19, 101, 137, 256]
 DEFAULT_PROFILES: List[str] = ["conservative", "balanced", "buffered"]
-
-# Mapping from STABLE_SUB_PROFILES override keys to SimulationConfig fields.
-# Mirrors InitialConditionsConfig application in
-# farm/runners/intrinsic_evolution_experiment.py so the gate runs in the same
-# ecology the #848 experiment will use.
-_PROFILE_FIELD_MAP = {
-    "initial_agent_resource_level": ("agent_behavior", "initial_resource_level"),
-    "initial_resource_count": ("resources", "initial_resources"),
-    "resource_regen_rate": ("resources", "resource_regen_rate"),
-    "resource_regen_amount": ("resources", "resource_regen_amount"),
-}
 
 
 def _configure_torch_threads() -> None:
@@ -466,39 +458,6 @@ def install_instrumentation() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _apply_profile_overrides(config: SimulationConfig, profile: str) -> Dict[str, Any]:
-    """Apply STABLE_SUB_PROFILES[profile] ecology to a SimulationConfig."""
-    overrides = STABLE_SUB_PROFILES[profile]
-    for key, value in overrides.items():
-        mapping = _PROFILE_FIELD_MAP.get(key)
-        if mapping is None:
-            # Unknown key — forward-compat: skip rather than crash.  Log so
-            # callers notice when STABLE_SUB_PROFILES gains keys not yet in
-            # _PROFILE_FIELD_MAP.
-            print(
-                f"_apply_profile_overrides: ignoring unknown profile key {key!r}",
-                file=sys.stderr,
-            )
-            continue
-        section_name, field_name = mapping
-        section = getattr(config, section_name, None)
-        if section is not None and hasattr(section, field_name):
-            setattr(section, field_name, value)
-    return dict(overrides)
-
-
-def _use_disk_database(config: SimulationConfig) -> None:
-    """Force disk-backed, persisted SQLite (never in-memory).
-
-    In-memory SQLite schema is per-connection and proved fragile over long
-    runs (lost ``agent_actions`` table mid-flush), so all simulation data is
-    persisted to disk.
-    """
-    config.database.use_in_memory_db = False
-    if hasattr(config.database, "persist_db_on_completion"):
-        config.database.persist_db_on_completion = True
-
-
 def build_regime_config(
     profile: str,
     *,
@@ -516,18 +475,13 @@ def build_regime_config(
     and exhausts RAM. The gate measures within-life learning, which is
     independent of reproduction.
     """
-    config = SimulationConfig.from_centralized_config(environment=environment)
-    pop = config.population
-    pop.system_agents = 0
-    pop.independent_agents = int(population)
-    pop.control_agents = 0
-    for attr in ("order_agents", "chaos_agents"):
-        if hasattr(pop, attr):
-            setattr(pop, attr, 0)
-    pop.max_population = int(max_population)
-    _use_disk_database(config)
-    _apply_profile_overrides(config, profile)
-    return config
+    return build_learning_positive_regime_config(
+        profile,
+        environment=environment,
+        population=population,
+        max_population=max_population,
+        force_disk_database=True,
+    )
 
 
 def build_eval_config(
@@ -540,16 +494,9 @@ def build_eval_config(
     cannot spawn a colony during a rollout.
     """
     config = SimulationConfig.from_centralized_config(environment=environment)
-    pop = config.population
-    pop.system_agents = 0
-    pop.independent_agents = 1
-    pop.control_agents = 0
-    for attr in ("order_agents", "chaos_agents"):
-        if hasattr(pop, attr):
-            setattr(pop, attr, 0)
-    pop.max_population = 1
-    _use_disk_database(config)
-    _apply_profile_overrides(config, profile)
+    apply_independent_population(config, population=1, max_population=1)
+    use_disk_database(config)
+    apply_stable_profile_ecology(config, profile)
     # Frozen-policy rollouts: disable deferred gradient steps so injected
     # snapshot weights stay fixed for the full held-out episode.
     config.performance.max_learning_updates_per_step = -1

--- a/scripts/run_inheritance_mode_ab.py
+++ b/scripts/run_inheritance_mode_ab.py
@@ -36,6 +36,9 @@ from scripts._warmstart_cli import (  # noqa: E402
     add_warmstart_tuning_arguments,
     warmstart_tuning_kwargs,
 )
+from scripts._learning_positive_regime import (  # noqa: E402
+    DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION,
+)
 from scripts import analyze_stable_profile_seed_sweep as analyzer_mod  # noqa: E402
 from scripts import run_stable_profile_seed_sweep as runner_mod  # noqa: E402
 from scripts.run_stable_profile_seed_sweep import (  # noqa: E402
@@ -115,6 +118,19 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Population cap when --population is set (default: population * 4).",
     )
+    parser.add_argument(
+        "--low-churn",
+        action="store_true",
+        default=False,
+        help=(
+            "Low-churn ecology variant: set max_population = population so the "
+            "colony cannot grow beyond its starting size. Reproduction replaces "
+            "dead agents rather than expanding the colony, keeping ecology density "
+            "comparable to the gate regime (fixed-8, no-repro). "
+            "Ignored when --population is not set. "
+            "Takes precedence over --max-population when both are given."
+        ),
+    )
     parser.add_argument("--mutation-rate", type=float, default=0.15)
     parser.add_argument("--mutation-scale", type=float, default=0.10)
     parser.add_argument("--selection-pressure", type=str, default="low")
@@ -159,6 +175,11 @@ def _build_runner_args(
     args: argparse.Namespace, arm: str, arm_output_dir: Path
 ) -> argparse.Namespace:
     preset = ARM_PRESETS[arm]
+    # Resolve max_population: --low-churn takes precedence when --population is
+    # set, capping the colony at its starting size (replacement-only ecology).
+    resolved_max_population = args.max_population
+    if getattr(args, "low_churn", False) and args.population is not None:
+        resolved_max_population = DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION
     return argparse.Namespace(
         environment=args.environment,
         profiles=list(args.profiles),
@@ -168,7 +189,7 @@ def _build_runner_args(
         warmup_steps=args.warmup_steps,
         snapshot_interval=args.snapshot_interval,
         population=args.population,
-        max_population=args.max_population,
+        max_population=resolved_max_population,
         mutation_rate=args.mutation_rate,
         mutation_scale=args.mutation_scale,
         selection_pressure=args.selection_pressure,
@@ -258,8 +279,14 @@ def _print_dry_run(args: argparse.Namespace, output_dir: Path) -> None:
     print(f"  profiles   : {args.profiles}")
     print(f"  seeds      : {args.seeds}")
     if args.population is not None:
-        cap = args.max_population if args.max_population is not None else args.population * 4
-        print(f"  population : {args.population} independent-only (max {cap})")
+        low_churn = getattr(args, "low_churn", False)
+        if low_churn:
+            cap = DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION
+            ecology = "low-churn (max = start)"
+        else:
+            cap = args.max_population if args.max_population is not None else args.population * 4
+            ecology = "saturated"
+        print(f"  population : {args.population} independent-only (max {cap}, ecology={ecology})")
     print(f"  total runs : {total}")
     print()
     for arm in args.arms:
@@ -296,6 +323,7 @@ def main() -> int:
         "snapshot_interval": args.snapshot_interval,
         "population": args.population,
         "max_population": args.max_population,
+        "low_churn": getattr(args, "low_churn", False),
         "arm_manifests": {},
     }
 

--- a/scripts/run_inheritance_mode_ab.py
+++ b/scripts/run_inheritance_mode_ab.py
@@ -36,9 +36,6 @@ from scripts._warmstart_cli import (  # noqa: E402
     add_warmstart_tuning_arguments,
     warmstart_tuning_kwargs,
 )
-from scripts._learning_positive_regime import (  # noqa: E402
-    DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION,
-)
 from scripts import analyze_stable_profile_seed_sweep as analyzer_mod  # noqa: E402
 from scripts import run_stable_profile_seed_sweep as runner_mod  # noqa: E402
 from scripts.run_stable_profile_seed_sweep import (  # noqa: E402
@@ -55,6 +52,12 @@ ARM_PRESETS: Dict[str, Dict[str, Any]] = {
     "p4": {"inheritance_mode": "p4"},
 }
 DEFAULT_ARMS: List[str] = ["baldwinian", "lamarckian"]
+
+
+def _resolve_max_population(args: argparse.Namespace) -> int | None:
+    if getattr(args, "low_churn", False) and args.population is not None:
+        return args.population
+    return args.max_population
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -175,11 +178,6 @@ def _build_runner_args(
     args: argparse.Namespace, arm: str, arm_output_dir: Path
 ) -> argparse.Namespace:
     preset = ARM_PRESETS[arm]
-    # Resolve max_population: --low-churn takes precedence when --population is
-    # set, capping the colony at its starting size (replacement-only ecology).
-    resolved_max_population = args.max_population
-    if getattr(args, "low_churn", False) and args.population is not None:
-        resolved_max_population = DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION
     return argparse.Namespace(
         environment=args.environment,
         profiles=list(args.profiles),
@@ -189,7 +187,7 @@ def _build_runner_args(
         warmup_steps=args.warmup_steps,
         snapshot_interval=args.snapshot_interval,
         population=args.population,
-        max_population=resolved_max_population,
+        max_population=_resolve_max_population(args),
         mutation_rate=args.mutation_rate,
         mutation_scale=args.mutation_scale,
         selection_pressure=args.selection_pressure,
@@ -281,7 +279,7 @@ def _print_dry_run(args: argparse.Namespace, output_dir: Path) -> None:
     if args.population is not None:
         low_churn = getattr(args, "low_churn", False)
         if low_churn:
-            cap = DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION
+            cap = _resolve_max_population(args)
             ecology = "low-churn (max = start)"
         else:
             cap = args.max_population if args.max_population is not None else args.population * 4

--- a/scripts/run_inheritance_mode_ab.py
+++ b/scripts/run_inheritance_mode_ab.py
@@ -18,7 +18,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 for _thread_var in (
     "OMP_NUM_THREADS",
@@ -54,7 +54,7 @@ ARM_PRESETS: Dict[str, Dict[str, Any]] = {
 DEFAULT_ARMS: List[str] = ["baldwinian", "lamarckian"]
 
 
-def _resolve_max_population(args: argparse.Namespace) -> int | None:
+def _resolve_max_population(args: argparse.Namespace) -> Optional[int]:
     if getattr(args, "low_churn", False) and args.population is not None:
         return args.population
     return args.max_population

--- a/scripts/run_inheritance_mode_ab.py
+++ b/scripts/run_inheritance_mode_ab.py
@@ -14,10 +14,19 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import time
 from pathlib import Path
 from typing import Any, Dict, List
+
+for _thread_var in (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+):
+    os.environ.setdefault(_thread_var, "1")
 
 _repo_root = Path(__file__).resolve().parent.parent
 if str(_repo_root) not in sys.path:
@@ -32,6 +41,7 @@ from scripts import run_stable_profile_seed_sweep as runner_mod  # noqa: E402
 from scripts.run_stable_profile_seed_sweep import (  # noqa: E402
     DEFAULT_PROFILES,
     DEFAULT_SEEDS,
+    _configure_torch_threads,
 )
 
 ARM_PRESETS: Dict[str, Dict[str, Any]] = {
@@ -90,6 +100,21 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--num-steps", type=int, default=1000)
     parser.add_argument("--warmup-steps", type=int, default=200)
     parser.add_argument("--snapshot-interval", type=int, default=50)
+    parser.add_argument(
+        "--population",
+        type=int,
+        default=None,
+        help=(
+            "Learning-positive regime: independent-only population of this size. "
+            "Forwarded to the seed sweep runner."
+        ),
+    )
+    parser.add_argument(
+        "--max-population",
+        type=int,
+        default=None,
+        help="Population cap when --population is set (default: population * 4).",
+    )
     parser.add_argument("--mutation-rate", type=float, default=0.15)
     parser.add_argument("--mutation-scale", type=float, default=0.10)
     parser.add_argument("--selection-pressure", type=str, default="low")
@@ -142,6 +167,8 @@ def _build_runner_args(
         num_steps=args.num_steps,
         warmup_steps=args.warmup_steps,
         snapshot_interval=args.snapshot_interval,
+        population=args.population,
+        max_population=args.max_population,
         mutation_rate=args.mutation_rate,
         mutation_scale=args.mutation_scale,
         selection_pressure=args.selection_pressure,
@@ -230,6 +257,9 @@ def _print_dry_run(args: argparse.Namespace, output_dir: Path) -> None:
     print(f"  arms       : {args.arms}")
     print(f"  profiles   : {args.profiles}")
     print(f"  seeds      : {args.seeds}")
+    if args.population is not None:
+        cap = args.max_population if args.max_population is not None else args.population * 4
+        print(f"  population : {args.population} independent-only (max {cap})")
     print(f"  total runs : {total}")
     print()
     for arm in args.arms:
@@ -245,6 +275,7 @@ def main() -> int:
         _print_dry_run(args, output_dir)
         return 0
 
+    _configure_torch_threads()
     output_dir.mkdir(parents=True, exist_ok=True)
     runner_mod.configure_logging(
         environment=args.environment,
@@ -261,6 +292,10 @@ def main() -> int:
         "profiles": args.profiles,
         "seeds": args.seeds,
         "num_steps": args.num_steps,
+        "warmup_steps": args.warmup_steps,
+        "snapshot_interval": args.snapshot_interval,
+        "population": args.population,
+        "max_population": args.max_population,
         "arm_manifests": {},
     }
 
@@ -312,6 +347,13 @@ def main() -> int:
         )
         compare_lines.append(f"    --output-dir {output_dir / 'aggregate'}")
         print("\n".join(compare_lines))
+        print(
+            "\nEarly-life verdict (primary #904 metric):\n"
+            f"  python scripts/analyze_early_life_fitness.py \\\n"
+            f"    --ab-dir {output_dir} \\\n"
+            f"    --baseline-arm {baseline_arm} \\\n"
+            f"    --treatment-arms {' '.join(treatment_arms)}"
+        )
 
     return 0 if total_fail == 0 else 1
 

--- a/scripts/run_stable_profile_seed_sweep.py
+++ b/scripts/run_stable_profile_seed_sweep.py
@@ -115,7 +115,8 @@ def _configure_torch_threads() -> None:
             # already initialized; keep default inter-op threads in that case.
             pass
     except ImportError:
-        pass
+        # Torch is optional in some environments; if unavailable, skip thread pinning.
+        return
 
 
 def _read_completed_steps(run_dir: Path) -> Optional[int]:

--- a/scripts/run_stable_profile_seed_sweep.py
+++ b/scripts/run_stable_profile_seed_sweep.py
@@ -45,11 +45,23 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import shutil
 import sys
 import time
 import traceback
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+# Long learning-positive runs train many tiny per-agent DQNs. Pin BLAS/OpenMP
+# pools before numpy/torch import (same fix as measure_transferable_signal.py).
+for _thread_var in (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+):
+    os.environ.setdefault(_thread_var, "1")
 
 _repo_root = Path(__file__).resolve().parent.parent
 if str(_repo_root) not in sys.path:
@@ -62,6 +74,9 @@ from farm.core.hyperparameter_chromosome import (  # noqa: E402
     MutationMode,
 )
 from farm.core.initial_diversity import InitialDiversityConfig, SeedingMode  # noqa: E402
+from scripts._learning_positive_regime import (  # noqa: E402
+    maybe_apply_learning_positive_population,
+)
 from scripts._warmstart_cli import (  # noqa: E402
     add_warmstart_tuning_arguments,
     warmstart_tuning_kwargs,
@@ -85,6 +100,52 @@ COPARENT_STRATEGIES: List[str] = [
     "random_alive_same_type",
 ]
 INHERITANCE_MODES: List[str] = ["baldwinian", "lamarckian", "p2", "p3", "p4"]
+
+
+def _configure_torch_threads() -> None:
+    """Pin Torch thread counts to 1 for tiny-network DQN training."""
+    try:
+        import torch
+
+        torch.set_num_threads(1)
+        try:
+            torch.set_num_interop_threads(1)
+        except RuntimeError:
+            pass
+    except ImportError:
+        pass
+
+
+def _read_completed_steps(run_dir: Path) -> Optional[int]:
+    """Return ``num_steps_completed`` from metadata, or ``None`` if absent/invalid."""
+    meta_path = run_dir / "intrinsic_evolution_metadata.json"
+    if not meta_path.is_file():
+        return None
+    try:
+        with meta_path.open(encoding="utf-8") as fh:
+            meta = json.load(fh)
+        completed = meta.get("num_steps_completed")
+        if completed is None:
+            return None
+        return int(completed)
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        return None
+
+
+def _prepare_run_dir_for_resume(run_dir: Path, num_steps: int, resume: bool) -> None:
+    """Drop partial artifacts from interrupted runs so ``--resume`` can restart cleanly."""
+    if not resume or not run_dir.is_dir():
+        return
+    completed = _read_completed_steps(run_dir)
+    if completed is not None and completed >= num_steps:
+        return
+    if any(run_dir.iterdir()):
+        print(
+            f"  Removing incomplete run dir {run_dir} "
+            f"(completed={completed}, target={num_steps})",
+            file=sys.stderr,
+        )
+        shutil.rmtree(run_dir)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -122,6 +183,22 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--num-steps", type=int, default=1000)
     parser.add_argument("--warmup-steps", type=int, default=200)
     parser.add_argument("--snapshot-interval", type=int, default=50)
+    parser.add_argument(
+        "--population",
+        type=int,
+        default=None,
+        help=(
+            "When set, override to an independent-only learning-positive "
+            "population of this size (0 system/control agents). Requires "
+            "--max-population or defaults to population * 4."
+        ),
+    )
+    parser.add_argument(
+        "--max-population",
+        type=int,
+        default=None,
+        help="Population cap when --population is set (default: population * 4).",
+    )
     parser.add_argument("--mutation-rate", type=float, default=0.15)
     parser.add_argument("--mutation-scale", type=float, default=0.10)
     parser.add_argument("--selection-pressure", type=str, default="low")
@@ -235,6 +312,11 @@ def _build_run(profile: str, seed: int, args: argparse.Namespace, run_dir: Path)
     overrides = STABLE_SUB_PROFILES[profile]
 
     base_config = SimulationConfig.from_centralized_config(environment=args.environment)
+    maybe_apply_learning_positive_population(
+        base_config,
+        getattr(args, "population", None),
+        getattr(args, "max_population", None),
+    )
     if getattr(args, "disk_database", False):
         base_config.database.use_in_memory_db = False
         base_config.database.persist_db_on_completion = True
@@ -307,17 +389,14 @@ def _maybe_resume_skip(
     """
     if not getattr(args, "resume", False):
         return None
-    meta_path = run_dir / "intrinsic_evolution_metadata.json"
-    if not meta_path.is_file():
+    completed = _read_completed_steps(run_dir)
+    if completed is None:
+        return None
+    if completed < int(args.num_steps):
         return None
     try:
-        with meta_path.open(encoding="utf-8") as fh:
+        with (run_dir / "intrinsic_evolution_metadata.json").open(encoding="utf-8") as fh:
             meta = json.load(fh)
-        completed = meta.get("num_steps_completed")
-        if completed is None:
-            return None
-        if int(completed) < int(args.num_steps):
-            return None
         record.update(
             status="skipped_done",
             elapsed_seconds=0.0,
@@ -362,6 +441,7 @@ def _run_one(
         )
         return True, record
 
+    _prepare_run_dir_for_resume(run_dir, args.num_steps, getattr(args, "resume", False))
     run_dir.mkdir(parents=True, exist_ok=True)
 
     logger.info("seed_sweep_run_start", profile=profile, seed=seed, run_dir=str(run_dir))
@@ -425,6 +505,9 @@ def _print_dry_run_plan(args: argparse.Namespace, output_dir: Path) -> None:
     print(f"  seeds      : {args.seeds}")
     print(f"  num_steps  : {args.num_steps} (warmup {args.warmup_steps}, "
           f"snapshot/{args.snapshot_interval})")
+    if getattr(args, "population", None) is not None:
+        cap = args.max_population if args.max_population is not None else args.population * 4
+        print(f"  population : {args.population} independent-only (max {cap})")
     print(f"  disk_db    : {getattr(args, 'disk_database', False)}")
     print(f"  inheritance: {_inheritance_settings_dict(args)}")
     print(f"  crossover  : {_crossover_settings_dict(args)}")
@@ -469,6 +552,7 @@ def main() -> int:
         _print_dry_run_plan(args, output_dir)
         return 0
 
+    _configure_torch_threads()
     output_dir.mkdir(parents=True, exist_ok=True)
     configure_logging(
         environment=args.environment,
@@ -497,6 +581,8 @@ def main() -> int:
         "num_steps": args.num_steps,
         "warmup_steps": args.warmup_steps,
         "snapshot_interval": args.snapshot_interval,
+        "population": getattr(args, "population", None),
+        "max_population": getattr(args, "max_population", None),
         "mutation_rate": args.mutation_rate,
         "mutation_scale": args.mutation_scale,
         "selection_pressure": args.selection_pressure,

--- a/scripts/run_stable_profile_seed_sweep.py
+++ b/scripts/run_stable_profile_seed_sweep.py
@@ -111,6 +111,8 @@ def _configure_torch_threads() -> None:
         try:
             torch.set_num_interop_threads(1)
         except RuntimeError:
+            # Best-effort tuning: this can fail when Torch's thread pools are
+            # already initialized; keep default inter-op threads in that case.
             pass
     except ImportError:
         pass

--- a/tests/scripts/test_early_life_fitness.py
+++ b/tests/scripts/test_early_life_fitness.py
@@ -28,7 +28,9 @@ from scripts.analyze_early_life_fitness import (  # noqa: E402
     _json_safe,
     _pair_profile,
     _parent_of,
+    _read_ecology_context,
     _resolve_treatment_arms,
+    _summarize_ecology,
     _verdict,
 )
 
@@ -243,6 +245,95 @@ class TestMultiArmHelpers(unittest.TestCase):
         out = _pair_profile(baseline, treatment, ages=[10])
         delta = out["ages"][10]["per_seed_delta"][42]["rl_reward_at_age"]
         self.assertAlmostEqual(delta, 2.0)
+
+
+class TestReadEcologyContext(unittest.TestCase):
+    """Tests for _read_ecology_context — ecology density context from metadata."""
+
+    def test_missing_metadata_returns_empty(self):
+        with TemporaryDirectory() as tmp:
+            self.assertEqual(_read_ecology_context(Path(tmp)), {})
+
+    def test_reads_final_population_and_max_population(self):
+        with TemporaryDirectory() as tmp:
+            meta = {
+                "final_population": 30,
+                "resolved_initial_conditions": {"max_population": 32},
+            }
+            (Path(tmp) / "intrinsic_evolution_metadata.json").write_text(
+                json.dumps(meta), encoding="utf-8"
+            )
+            ctx = _read_ecology_context(Path(tmp))
+        self.assertEqual(ctx["final_population"], 30)
+        self.assertEqual(ctx["configured_max_population"], 32)
+        self.assertAlmostEqual(ctx["saturation_ratio"], 30 / 32)
+
+    def test_saturation_ratio_1_when_fully_saturated(self):
+        with TemporaryDirectory() as tmp:
+            meta = {
+                "final_population": 8,
+                "resolved_initial_conditions": {"max_population": 8},
+            }
+            (Path(tmp) / "intrinsic_evolution_metadata.json").write_text(
+                json.dumps(meta), encoding="utf-8"
+            )
+            ctx = _read_ecology_context(Path(tmp))
+        self.assertAlmostEqual(ctx["saturation_ratio"], 1.0)
+
+    def test_malformed_json_returns_empty(self):
+        with TemporaryDirectory() as tmp:
+            (Path(tmp) / "intrinsic_evolution_metadata.json").write_text(
+                "not json", encoding="utf-8"
+            )
+            self.assertEqual(_read_ecology_context(Path(tmp)), {})
+
+    def test_partial_metadata_no_saturation_ratio(self):
+        """If max_population is absent, saturation_ratio should not be set."""
+        with TemporaryDirectory() as tmp:
+            meta = {"final_population": 12}
+            (Path(tmp) / "intrinsic_evolution_metadata.json").write_text(
+                json.dumps(meta), encoding="utf-8"
+            )
+            ctx = _read_ecology_context(Path(tmp))
+        self.assertEqual(ctx["final_population"], 12)
+        self.assertNotIn("saturation_ratio", ctx)
+
+
+class TestSummarizeEcology(unittest.TestCase):
+    """Tests for _summarize_ecology — aggregate ecology context dicts."""
+
+    def test_empty_list_returns_empty(self):
+        self.assertEqual(_summarize_ecology([]), {})
+
+    def test_aggregates_mean_final_population(self):
+        eco_list = [
+            {"final_population": 30, "configured_max_population": 32,
+             "saturation_ratio": 30 / 32},
+            {"final_population": 32, "configured_max_population": 32,
+             "saturation_ratio": 1.0},
+        ]
+        summary = _summarize_ecology(eco_list)
+        self.assertEqual(summary["n_runs"], 2)
+        self.assertAlmostEqual(summary["mean_final_population"], 31.0)
+        self.assertAlmostEqual(summary["mean_saturation_ratio"], (30 / 32 + 1.0) / 2)
+        self.assertEqual(summary["configured_max_population"], 32)
+
+    def test_uses_first_configured_max_population(self):
+        eco_list = [
+            {"configured_max_population": 8},
+            {"configured_max_population": 8},
+        ]
+        summary = _summarize_ecology(eco_list)
+        self.assertEqual(summary["configured_max_population"], 8)
+
+    def test_missing_saturation_excluded_from_mean(self):
+        eco_list = [
+            {"final_population": 5},  # no saturation_ratio
+            {"final_population": 7, "saturation_ratio": 0.875},
+        ]
+        summary = _summarize_ecology(eco_list)
+        # mean_saturation_ratio computed from only the one run with it
+        self.assertAlmostEqual(summary["mean_saturation_ratio"], 0.875)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_early_life_fitness.py
+++ b/tests/scripts/test_early_life_fitness.py
@@ -8,6 +8,7 @@ vs. action cohorts, and parent-anchored reward gap).
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import sqlite3
@@ -21,9 +22,13 @@ if _repo_root not in sys.path:
     sys.path.insert(0, _repo_root)
 
 from scripts.analyze_early_life_fitness import (  # noqa: E402
+    PRIMARY_GATE_METRIC,
+    _collect_robust_hits,
     _extract_run_early_life,
     _json_safe,
+    _pair_profile,
     _parent_of,
+    _resolve_treatment_arms,
     _verdict,
 )
 
@@ -195,6 +200,49 @@ class TestExtractRunEarlyLife(unittest.TestCase):
     def test_no_offspring_returns_none(self):
         # With a warmup past every birth, there are no offspring.
         self.assertIsNone(_extract_run_early_life(self.db_path, warmup=100, ages=[3]))
+
+
+class TestMultiArmHelpers(unittest.TestCase):
+    def test_resolve_treatment_arms_prefers_list(self):
+        args = argparse.Namespace(treatment_arm="lamarckian", treatment_arms=["p2", "p3"])
+        self.assertEqual(_resolve_treatment_arms(args), ["p2", "p3"])
+
+    def test_resolve_treatment_arms_single_fallback(self):
+        args = argparse.Namespace(treatment_arm="lamarckian", treatment_arms=None)
+        self.assertEqual(_resolve_treatment_arms(args), ["lamarckian"])
+
+    def test_collect_robust_hits(self):
+        paired_by_arm = {
+            "p2": {
+                "balanced": {
+                    "ages": {
+                        10: {
+                            "verdicts": {
+                                PRIMARY_GATE_METRIC: {
+                                    "robust": True,
+                                    "mean_delta": 1.5,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        hits = _collect_robust_hits(paired_by_arm, ages=[10])
+        self.assertEqual(len(hits), 1)
+        self.assertIn("p2", hits[0])
+        self.assertIn("balanced", hits[0])
+
+    def test_pair_profile_delta_shape(self):
+        baseline = {
+            42: {"per_age": {10: {"rl_reward_at_age": 5.0, "survival_rate": 1.0}}},
+        }
+        treatment = {
+            42: {"per_age": {10: {"rl_reward_at_age": 7.0, "survival_rate": 1.0}}},
+        }
+        out = _pair_profile(baseline, treatment, ages=[10])
+        delta = out["ages"][10]["per_seed_delta"][42]["rl_reward_at_age"]
+        self.assertAlmostEqual(delta, 2.0)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_early_life_fitness.py
+++ b/tests/scripts/test_early_life_fitness.py
@@ -16,6 +16,7 @@ import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 _repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 if _repo_root not in sys.path:
@@ -287,6 +288,13 @@ class TestReadEcologyContext(unittest.TestCase):
             )
             self.assertEqual(_read_ecology_context(Path(tmp)), {})
 
+    def test_read_error_returns_empty(self):
+        with TemporaryDirectory() as tmp:
+            meta_path = Path(tmp) / "intrinsic_evolution_metadata.json"
+            meta_path.write_text("{}", encoding="utf-8")
+            with patch.object(Path, "read_text", side_effect=OSError("denied")):
+                self.assertEqual(_read_ecology_context(Path(tmp)), {})
+
     def test_partial_metadata_no_saturation_ratio(self):
         """If max_population is absent, saturation_ratio should not be set."""
         with TemporaryDirectory() as tmp:
@@ -296,6 +304,21 @@ class TestReadEcologyContext(unittest.TestCase):
             )
             ctx = _read_ecology_context(Path(tmp))
         self.assertEqual(ctx["final_population"], 12)
+        self.assertNotIn("saturation_ratio", ctx)
+
+    def test_invalid_nested_metadata_types_are_ignored(self):
+        with TemporaryDirectory() as tmp:
+            meta = {
+                "final_population": "not-an-int",
+                "resolved_initial_conditions": [],
+                "policy": {"max_population": "32"},
+            }
+            (Path(tmp) / "intrinsic_evolution_metadata.json").write_text(
+                json.dumps(meta), encoding="utf-8"
+            )
+            ctx = _read_ecology_context(Path(tmp))
+        self.assertEqual(ctx["configured_max_population"], 32)
+        self.assertNotIn("final_population", ctx)
         self.assertNotIn("saturation_ratio", ctx)
 
 

--- a/tests/scripts/test_early_life_fitness.py
+++ b/tests/scripts/test_early_life_fitness.py
@@ -307,10 +307,16 @@ class TestSummarizeEcology(unittest.TestCase):
 
     def test_aggregates_mean_final_population(self):
         eco_list = [
-            {"final_population": 30, "configured_max_population": 32,
-             "saturation_ratio": 30 / 32},
-            {"final_population": 32, "configured_max_population": 32,
-             "saturation_ratio": 1.0},
+            {
+                "final_population": 30,
+                "configured_max_population": 32,
+                "saturation_ratio": 30 / 32,
+            },
+            {
+                "final_population": 32,
+                "configured_max_population": 32,
+                "saturation_ratio": 1.0,
+            },
         ]
         summary = _summarize_ecology(eco_list)
         self.assertEqual(summary["n_runs"], 2)

--- a/tests/scripts/test_learning_positive_regime.py
+++ b/tests/scripts/test_learning_positive_regime.py
@@ -16,6 +16,9 @@ if _repo_root not in sys.path:
 from farm.config import SimulationConfig  # noqa: E402
 from farm.runners.intrinsic_evolution_experiment import STABLE_SUB_PROFILES  # noqa: E402
 from scripts._learning_positive_regime import (  # noqa: E402
+    DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION,
+    DEFAULT_LEARNING_POSITIVE_MAX_POPULATION,
+    DEFAULT_LEARNING_POSITIVE_POPULATION,
     apply_independent_population,
     apply_stable_profile_ecology,
     build_learning_positive_regime_config,
@@ -80,6 +83,35 @@ class TestPopulationCliForwarding(unittest.TestCase):
         self.assertEqual(args.max_population, 32)
 
 
+class TestLowChurnConstants(unittest.TestCase):
+    """Validate ecology-variant defaults are self-consistent (#963)."""
+
+    def test_low_churn_max_population_equals_default_population(self):
+        self.assertEqual(
+            DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION,
+            DEFAULT_LEARNING_POSITIVE_POPULATION,
+        )
+
+    def test_saturated_max_population_exceeds_population(self):
+        self.assertGreater(
+            DEFAULT_LEARNING_POSITIVE_MAX_POPULATION,
+            DEFAULT_LEARNING_POSITIVE_POPULATION,
+        )
+
+    def test_low_churn_via_apply_independent_population(self):
+        config = SimulationConfig.from_centralized_config(environment="testing")
+        apply_independent_population(
+            config,
+            population=DEFAULT_LEARNING_POSITIVE_POPULATION,
+            max_population=DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION,
+        )
+        # cap == start => no growth room
+        self.assertEqual(
+            config.population.max_population,
+            config.population.independent_agents,
+        )
+
+
 class TestResumeHelpers(unittest.TestCase):
     def test_read_completed_steps_missing(self):
         with TemporaryDirectory() as tmp:
@@ -107,3 +139,4 @@ class TestResumeHelpers(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/tests/scripts/test_learning_positive_regime.py
+++ b/tests/scripts/test_learning_positive_regime.py
@@ -1,0 +1,109 @@
+"""Tests for scripts/_learning_positive_regime.py population/ecology helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+_repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+from farm.config import SimulationConfig  # noqa: E402
+from farm.runners.intrinsic_evolution_experiment import STABLE_SUB_PROFILES  # noqa: E402
+from scripts._learning_positive_regime import (  # noqa: E402
+    apply_independent_population,
+    apply_stable_profile_ecology,
+    build_learning_positive_regime_config,
+    maybe_apply_learning_positive_population,
+)
+from scripts.run_inheritance_mode_ab import _build_parser, _build_runner_args  # noqa: E402
+from scripts.run_stable_profile_seed_sweep import (  # noqa: E402
+    _build_parser as _sweep_parser,
+    _prepare_run_dir_for_resume,
+    _read_completed_steps,
+)
+
+
+class TestIndependentPopulation(unittest.TestCase):
+    def test_apply_independent_population_zeros_non_independent(self):
+        config = SimulationConfig.from_centralized_config(environment="testing")
+        apply_independent_population(config, population=8, max_population=32)
+        self.assertEqual(config.population.independent_agents, 8)
+        self.assertEqual(config.population.system_agents, 0)
+        self.assertEqual(config.population.control_agents, 0)
+        self.assertEqual(config.population.max_population, 32)
+
+    def test_maybe_apply_noop_when_unset(self):
+        config = SimulationConfig.from_centralized_config(environment="testing")
+        before = config.population.independent_agents
+        maybe_apply_learning_positive_population(config, None, None)
+        self.assertEqual(config.population.independent_agents, before)
+
+    def test_maybe_apply_defaults_max_population(self):
+        config = SimulationConfig.from_centralized_config(environment="testing")
+        maybe_apply_learning_positive_population(config, 8, None)
+        self.assertEqual(config.population.independent_agents, 8)
+        self.assertEqual(config.population.max_population, 32)
+
+
+class TestLearningPositiveRegimeConfig(unittest.TestCase):
+    def test_build_config_applies_ecology_and_disk(self):
+        config = build_learning_positive_regime_config(
+            "balanced", environment="testing", population=8, max_population=32
+        )
+        overrides = STABLE_SUB_PROFILES["balanced"]
+        self.assertFalse(config.database.use_in_memory_db)
+        self.assertEqual(
+            config.resources.initial_resources, overrides["initial_resource_count"]
+        )
+
+
+class TestPopulationCliForwarding(unittest.TestCase):
+    def test_inheritance_ab_forwards_population(self):
+        args = _build_parser().parse_args(
+            ["--population", "8", "--max-population", "32"]
+        )
+        runner_args = _build_runner_args(args, "p2", __import__("pathlib").Path("/tmp/out"))
+        self.assertEqual(runner_args.population, 8)
+        self.assertEqual(runner_args.max_population, 32)
+
+    def test_seed_sweep_accepts_population_flags(self):
+        args = _sweep_parser().parse_args(
+            ["--population", "8", "--max-population", "32"]
+        )
+        self.assertEqual(args.population, 8)
+        self.assertEqual(args.max_population, 32)
+
+
+class TestResumeHelpers(unittest.TestCase):
+    def test_read_completed_steps_missing(self):
+        with TemporaryDirectory() as tmp:
+            self.assertIsNone(_read_completed_steps(Path(tmp)))
+
+    def test_prepare_run_dir_removes_incomplete(self):
+        with TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "seed_7"
+            run_dir.mkdir()
+            (run_dir / "partial.db").write_text("x", encoding="utf-8")
+            _prepare_run_dir_for_resume(run_dir, num_steps=3000, resume=True)
+            self.assertFalse(run_dir.exists())
+
+    def test_prepare_run_dir_keeps_complete(self):
+        with TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "seed_42"
+            run_dir.mkdir()
+            meta = {"num_steps_completed": 3000, "final_population": 32}
+            (run_dir / "intrinsic_evolution_metadata.json").write_text(
+                json.dumps(meta), encoding="utf-8"
+            )
+            _prepare_run_dir_for_resume(run_dir, num_steps=3000, resume=True)
+            self.assertTrue(run_dir.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_learning_positive_regime.py
+++ b/tests/scripts/test_learning_positive_regime.py
@@ -20,7 +20,6 @@ from scripts._learning_positive_regime import (  # noqa: E402
     DEFAULT_LEARNING_POSITIVE_MAX_POPULATION,
     DEFAULT_LEARNING_POSITIVE_POPULATION,
     apply_independent_population,
-    apply_stable_profile_ecology,
     build_learning_positive_regime_config,
     maybe_apply_learning_positive_population,
 )

--- a/tests/scripts/test_measure_transferable_signal.py
+++ b/tests/scripts/test_measure_transferable_signal.py
@@ -27,6 +27,7 @@ _repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__f
 if _repo_root not in sys.path:
     sys.path.insert(0, _repo_root)
 
+from scripts._learning_positive_regime import apply_stable_profile_ecology  # noqa: E402
 from scripts.measure_transferable_signal import (  # noqa: E402
     _PolicySnapshots,
     _entropy,
@@ -38,7 +39,6 @@ from scripts.measure_transferable_signal import (  # noqa: E402
     build_eval_config,
     build_regime_config,
     compute_drift,
-    _apply_profile_overrides,
 )
 from farm.config import SimulationConfig  # noqa: E402
 from farm.runners.intrinsic_evolution_experiment import STABLE_SUB_PROFILES  # noqa: E402
@@ -321,7 +321,7 @@ def test_eval_policy_weighted_falls_through_greedy_overrides():
 
 def test_apply_profile_overrides_sets_ecology():
     config = SimulationConfig.from_centralized_config(environment="testing")
-    _apply_profile_overrides(config, "buffered")
+    apply_stable_profile_ecology(config, "buffered")
     overrides = STABLE_SUB_PROFILES["buffered"]
     assert config.agent_behavior.initial_resource_level == overrides[
         "initial_agent_resource_level"

--- a/tests/scripts/test_run_inheritance_mode_ab_args.py
+++ b/tests/scripts/test_run_inheritance_mode_ab_args.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import os
 import sys
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 
 _repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 if _repo_root not in sys.path:
@@ -29,6 +31,7 @@ from scripts.run_inheritance_mode_ab import (  # noqa: E402
     DEFAULT_ARMS,
     _build_parser,
     _build_runner_args,
+    _print_dry_run,
 )
 
 
@@ -132,18 +135,12 @@ class TestLowChurnFlag(unittest.TestCase):
 
     def test_low_churn_sets_max_population_to_population(self):
         """With --low-churn, runner_args.max_population = population (no growth)."""
-        from scripts._learning_positive_regime import (
-            DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION,
-        )
         args = _build_parser().parse_args(
-            ["--population", "8", "--low-churn"]
+            ["--population", "16", "--low-churn"]
         )
         runner_args = _build_runner_args(args, "baldwinian", Path("/tmp/out"))
-        self.assertEqual(
-            runner_args.max_population,
-            DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION,
-        )
-        self.assertEqual(runner_args.population, 8)
+        self.assertEqual(runner_args.max_population, 16)
+        self.assertEqual(runner_args.population, 16)
 
     def test_low_churn_no_population_does_not_override_max_population(self):
         """--low-churn is ignored when --population is not set."""
@@ -155,17 +152,11 @@ class TestLowChurnFlag(unittest.TestCase):
 
     def test_low_churn_overrides_explicit_max_population(self):
         """--low-churn takes precedence over --max-population when population is set."""
-        from scripts._learning_positive_regime import (
-            DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION,
-        )
         args = _build_parser().parse_args(
-            ["--population", "8", "--max-population", "64", "--low-churn"]
+            ["--population", "12", "--max-population", "64", "--low-churn"]
         )
         runner_args = _build_runner_args(args, "baldwinian", Path("/tmp/out"))
-        self.assertEqual(
-            runner_args.max_population,
-            DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION,
-        )
+        self.assertEqual(runner_args.max_population, 12)
 
     def test_saturated_default_preserves_explicit_max_population(self):
         """Without --low-churn, an explicit --max-population is forwarded unchanged."""
@@ -174,6 +165,13 @@ class TestLowChurnFlag(unittest.TestCase):
         )
         runner_args = _build_runner_args(args, "baldwinian", Path("/tmp/out"))
         self.assertEqual(runner_args.max_population, 32)
+
+    def test_low_churn_dry_run_reports_population_as_cap(self):
+        args = _build_parser().parse_args(["--population", "16", "--low-churn"])
+        stdout = StringIO()
+        with redirect_stdout(stdout):
+            _print_dry_run(args, Path("/tmp/out"))
+        self.assertIn("population : 16 independent-only (max 16, ecology=low-churn (max = start))", stdout.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_run_inheritance_mode_ab_args.py
+++ b/tests/scripts/test_run_inheritance_mode_ab_args.py
@@ -171,7 +171,10 @@ class TestLowChurnFlag(unittest.TestCase):
         stdout = StringIO()
         with redirect_stdout(stdout):
             _print_dry_run(args, Path("/tmp/out"))
-        self.assertIn("population : 16 independent-only (max 16, ecology=low-churn (max = start))", stdout.getvalue())
+        output = stdout.getvalue()
+        self.assertIn("population : 16 independent-only", output)
+        self.assertIn("max 16", output)
+        self.assertIn("ecology=low-churn (max = start)", output)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_run_inheritance_mode_ab_args.py
+++ b/tests/scripts/test_run_inheritance_mode_ab_args.py
@@ -119,5 +119,62 @@ class TestWarmstartTuningForwarding(unittest.TestCase):
         self.assertEqual(runner_args.warmstart_fitness_gate_min_resources, 5.0)
 
 
+class TestLowChurnFlag(unittest.TestCase):
+    """Tests for the --low-churn ecology variant (Issue #963)."""
+
+    def test_low_churn_flag_accepted(self):
+        args = _build_parser().parse_args(["--low-churn"])
+        self.assertTrue(args.low_churn)
+
+    def test_low_churn_default_is_false(self):
+        args = _build_parser().parse_args([])
+        self.assertFalse(args.low_churn)
+
+    def test_low_churn_sets_max_population_to_population(self):
+        """With --low-churn, runner_args.max_population = population (no growth)."""
+        from scripts._learning_positive_regime import (
+            DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION,
+        )
+        args = _build_parser().parse_args(
+            ["--population", "8", "--low-churn"]
+        )
+        runner_args = _build_runner_args(args, "baldwinian", Path("/tmp/out"))
+        self.assertEqual(
+            runner_args.max_population,
+            DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION,
+        )
+        self.assertEqual(runner_args.population, 8)
+
+    def test_low_churn_no_population_does_not_override_max_population(self):
+        """--low-churn is ignored when --population is not set."""
+        args = _build_parser().parse_args(["--low-churn"])
+        runner_args = _build_runner_args(args, "baldwinian", Path("/tmp/out"))
+        # population is None => max_population remains None (not overridden).
+        self.assertIsNone(runner_args.population)
+        self.assertIsNone(runner_args.max_population)
+
+    def test_low_churn_overrides_explicit_max_population(self):
+        """--low-churn takes precedence over --max-population when population is set."""
+        from scripts._learning_positive_regime import (
+            DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION,
+        )
+        args = _build_parser().parse_args(
+            ["--population", "8", "--max-population", "64", "--low-churn"]
+        )
+        runner_args = _build_runner_args(args, "baldwinian", Path("/tmp/out"))
+        self.assertEqual(
+            runner_args.max_population,
+            DEFAULT_LEARNING_POSITIVE_LOW_CHURN_MAX_POPULATION,
+        )
+
+    def test_saturated_default_preserves_explicit_max_population(self):
+        """Without --low-churn, an explicit --max-population is forwarded unchanged."""
+        args = _build_parser().parse_args(
+            ["--population", "8", "--max-population", "32"]
+        )
+        runner_args = _build_runner_args(args, "baldwinian", Path("/tmp/out"))
+        self.assertEqual(runner_args.max_population, 32)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -122,6 +122,42 @@ def test_reproduce_with_policy_mutates_learning_rate_and_passes_child_config():
     assert offspring.hyperparameter_chromosome.get_value("learning_rate") == pytest.approx(0.012, abs=1e-9)
 
 
+def test_derive_child_chromosome_locks_dqn_hidden_size_in_warmstart_modes():
+    """Warm-start modes keep topology genes fixed to avoid policy shape mismatches."""
+    parent = _build_parent_agent_for_reproduction()
+    parent.environment.intrinsic_evolution_policy = IntrinsicEvolutionPolicy(
+        inheritance_mode="lamarckian",
+        mutation_rate=1.0,
+        mutation_scale=0.2,
+    )
+    parent_hidden = parent.hyperparameter_chromosome.get_value("dqn_hidden_size")
+
+    with patch("farm.core.hyperparameter_chromosome.random.random", return_value=0.0), patch(
+        "farm.core.hyperparameter_chromosome.random.gauss", return_value=1000.0
+    ):
+        child = AgentCore._derive_child_chromosome(parent, parent.hyperparameter_chromosome)
+
+    assert child.get_value("dqn_hidden_size") == parent_hidden
+
+
+def test_derive_child_chromosome_allows_dqn_hidden_size_mutation_in_baldwinian():
+    """Baldwinian mode keeps existing behavior and allows topology mutation."""
+    parent = _build_parent_agent_for_reproduction()
+    parent.environment.intrinsic_evolution_policy = IntrinsicEvolutionPolicy(
+        inheritance_mode="baldwinian",
+        mutation_rate=1.0,
+        mutation_scale=0.2,
+    )
+    parent_hidden = parent.hyperparameter_chromosome.get_value("dqn_hidden_size")
+
+    with patch("farm.core.hyperparameter_chromosome.random.random", return_value=0.0), patch(
+        "farm.core.hyperparameter_chromosome.random.gauss", return_value=1000.0
+    ):
+        child = AgentCore._derive_child_chromosome(parent, parent.hyperparameter_chromosome)
+
+    assert child.get_value("dqn_hidden_size") != parent_hidden
+
+
 def test_reproduce_lamarckian_policy_applies_warmstart_and_tracks_counter():
     """Lamarckian mode should invoke warm-start and increment applied counter."""
     parent = _build_parent_agent_for_reproduction()

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -122,11 +122,12 @@ def test_reproduce_with_policy_mutates_learning_rate_and_passes_child_config():
     assert offspring.hyperparameter_chromosome.get_value("learning_rate") == pytest.approx(0.012, abs=1e-9)
 
 
-def test_derive_child_chromosome_locks_dqn_hidden_size_in_warmstart_modes():
+@pytest.mark.parametrize("inheritance_mode", ("lamarckian", "p2", "p3", "p4"))
+def test_derive_child_chromosome_locks_dqn_hidden_size_in_warmstart_modes(inheritance_mode):
     """Warm-start modes keep topology genes fixed to avoid policy shape mismatches."""
     parent = _build_parent_agent_for_reproduction()
     parent.environment.intrinsic_evolution_policy = IntrinsicEvolutionPolicy(
-        inheritance_mode="lamarckian",
+        inheritance_mode=inheritance_mode,
         mutation_rate=1.0,
         mutation_scale=0.2,
     )

--- a/tests/test_agent_reproduction_hyperparameters.py
+++ b/tests/test_agent_reproduction_hyperparameters.py
@@ -132,11 +132,15 @@ def test_derive_child_chromosome_locks_dqn_hidden_size_in_warmstart_modes():
     )
     parent_hidden = parent.hyperparameter_chromosome.get_value("dqn_hidden_size")
 
-    with patch("farm.core.hyperparameter_chromosome.random.random", return_value=0.0), patch(
+    with patch(
+        "farm.core.hyperparameter_chromosome.random.random", return_value=0.0
+    ) as patched_random, patch(
         "farm.core.hyperparameter_chromosome.random.gauss", return_value=1000.0
-    ):
+    ) as patched_gauss:
         child = AgentCore._derive_child_chromosome(parent, parent.hyperparameter_chromosome)
 
+    assert patched_random.called
+    assert patched_gauss.called
     assert child.get_value("dqn_hidden_size") == parent_hidden
 
 
@@ -150,11 +154,15 @@ def test_derive_child_chromosome_allows_dqn_hidden_size_mutation_in_baldwinian()
     )
     parent_hidden = parent.hyperparameter_chromosome.get_value("dqn_hidden_size")
 
-    with patch("farm.core.hyperparameter_chromosome.random.random", return_value=0.0), patch(
+    with patch(
+        "farm.core.hyperparameter_chromosome.random.random", return_value=0.0
+    ) as patched_random, patch(
         "farm.core.hyperparameter_chromosome.random.gauss", return_value=1000.0
-    ):
+    ) as patched_gauss:
         child = AgentCore._derive_child_chromosome(parent, parent.hyperparameter_chromosome)
 
+    assert patched_random.called
+    assert patched_gauss.called
     assert child.get_value("dqn_hidden_size") != parent_hidden
 
 


### PR DESCRIPTION
This pull request implements and documents improvements for the "learning-positive inheritance" A/B experiments (#904) in the AgentFarm project. The most significant changes are the reduction of the default P3 replay-buffer transfer limit to improve performance, the introduction of a shared regime configuration helper to ensure consistent population and ecology settings across scripts, and updates to documentation to reflect new experiment variants and clarify ecological regimes. Additionally, the code now ensures that shape-sensitive loci are locked during inheritance in warm-start modes, and the codebase is refactored to centralize and DRY regime configuration logic.

**Performance Improvements**
- Reduced the default `P3_REPLAY_BUFFER_LIMIT` from 256 to 64 in `farm/core/policy_inheritance.py`, significantly improving P3 performance under high reproduction churn by reducing synchronous replay-buffer transfer overhead. Larger limits are still configurable. [[1]](diffhunk://#diff-e7b1139b26913335b3cfc007bf25b568d7e77169a69aea2c132964c8a4a9a46aL72-R81)], [[2]](diffhunk://#diff-e7b1139b26913335b3cfc007bf25b568d7e77169a69aea2c132964c8a4a9a46aR352-R357)], [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR37-R44)])

**Experiment Regime Configuration**
- Added `scripts/_learning_positive_regime.py`, providing shared helpers to configure population, ecology, and database settings for learning-positive experiments, ensuring both the precondition gate and inheritance A/B harness use identical regime definitions. ([[scripts/_learning_positive_regime.pyR1-R110](diffhunk://#diff-bb032e219dbdae050c71a78cb912e6796a6ea0b690df83729e90b7b7b1ba521aR1-R110)])
- Refactored `scripts/measure_transferable_signal.py` to use these shared helpers, removing duplicated logic and centralizing configuration. [[1]](diffhunk://#diff-f825668d9356d2d409e9219cba5588434780a98e3b3820ecd24046d5f13c148dL85-R89)], [[2]](diffhunk://#diff-f825668d9356d2d409e9219cba5588434780a98e3b3820ecd24046d5f13c148dL100-L110)], [[3]](diffhunk://#diff-f825668d9356d2d409e9219cba5588434780a98e3b3820ecd24046d5f13c148dL469-L501)], [[4]](diffhunk://#diff-f825668d9356d2d409e9219cba5588434780a98e3b3820ecd24046d5f13c148dL519-R484)])

**Documentation Updates**
- Updated experiment plan and documentation to describe the new saturated and low-churn ecology variants, including run commands and practical guidance for interpreting results in different ecological contexts. ([.cursor/plans/learning-positive_inheritance_a_b_0098cc01.plan.md] [[1]](diffhunk://#diff-393417ebcbd97e9f5b04fe09337b0c59bdfe50e3d734c005e2b536063d02e259R1-R74) [docs/research/experiments/intrinsic_evolution/inheritance_mode_ab.md] [[2]](diffhunk://#diff-bedaa3c09ca09f2b7da555ca007fd0fcd28ab017312cd387c38aae53346b1d79R32-R81) [[3]](diffhunk://#diff-bedaa3c09ca09f2b7da555ca007fd0fcd28ab017312cd387c38aae53346b1d79R90-R100)

**Genetic Inheritance Logic**
- Ensured that shape-sensitive loci (e.g., `dqn_hidden_size`) are locked to the parent's value when using warm-start inheritance modes, maintaining tensor compatibility. ([farm/core/agent/core.py] [[1]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393R65-R68) [[2]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393L1032-R1051) [[3]](diffhunk://#diff-d9125bde750efb64aa0292d9c2880b1bef4aa769c22fb16a3e5b84715d3bc393R1060)

**Changelog**
- Added a changelog entry summarizing the performance fix for P3 and referencing the related issue. ([[CHANGELOG.mdR37-R44](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR37-R44)])

These changes collectively improve experiment reproducibility, performance, and clarity for future research and analysis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reproduction chromosome logic and default P3 transfer size, which can shift experiment outcomes and runtime; scope is research tooling and inheritance paths rather than production auth/data APIs.
> 
> **Overview**
> This PR wires up the **#904 learning-positive inheritance ladder** (P0–P4) so sweeps use the same small independent-only population/ecology as the transferable-signal gate, while reproduction stays on for real inheritance tests.
> 
> **Experiment harness & regime** — New `scripts/_learning_positive_regime.py` centralizes independent-only population shaping, stable-profile ecology, and disk DB defaults. `run_inheritance_mode_ab.py` and `run_stable_profile_seed_sweep.py` gain `--population`, `--max-population`, and `--low-churn` (cap = start size for gate-like density). Both runners pin BLAS/Torch threads for long sweeps; resume now drops incomplete run dirs before restart.
> 
> **Analysis** — `analyze_early_life_fitness.py` supports `--treatment-arms` for ladder grading vs Baldwinian, emits ladder JSON/MD with **ecology context** (`saturation_ratio`, final vs max pop), and surfaces the primary #904 metric (net RL reward at ages 10/25/50) with robust-hit headlines.
> 
> **Inheritance correctness & performance** — Warm-start modes (`lamarckian`, `p2`–`p4`) **lock `dqn_hidden_size`** on the parent after mutation so policy warm-start stays shape-compatible; Baldwinian still allows topology mutation. Default **`P3_REPLAY_BUFFER_LIMIT` drops 256 → 64** to cut per-birth synchronous replay transfer cost under saturated colonies (#962).
> 
> **Docs** — Inheritance A/B doc explains saturated vs low-churn ecology vs the no-repro gate; plan and changelog entries track the work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e77031cbe1ebf73eb7145742e16d3f450c168d7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->