### PR TITLE
Add Twitter/X account launch plan and posting automation

### DIFF
--- a/docs/communications/tweet_schedule.json
+++ b/docs/communications/tweet_schedule.json
@@ -1,0 +1,329 @@
+{
+  "campaign": {
+    "name": "AgentFarm launch",
+    "start_date": "2026-07-20",
+    "timezone": "UTC",
+    "slot_hours": {
+      "morning": 9,
+      "midday": 13,
+      "evening": 18
+    }
+  },
+  "tweets": [
+    {
+      "day": 1,
+      "slot": "morning",
+      "text": "Introducing AgentFarm 🌱 an open-source platform for growing digital ecologies: multi-agent simulations where agents perceive, learn, reproduce, and pass on heritable genomes. Built in Python, measured in SQLite, published honestly. https://github.com/Dooders/AgentFarm"
+    },
+    {
+      "day": 1,
+      "slot": "midday",
+      "text": "Why \"farm\"? Because we don't script behaviors — we plant agents in a resource-constrained world and see what grows. Selection pressure comes from the ecology itself: finite food, costly reproduction, real death."
+    },
+    {
+      "day": 1,
+      "slot": "evening",
+      "text": "What you'll get here: build notes, design principles, experiment results (including the failures), and ways to run it all yourself. Everything is Apache-2.0. https://github.com/Dooders/AgentFarm"
+    },
+    {
+      "day": 2,
+      "slot": "morning",
+      "text": "From zero to a living world in four commands: clone → venv → pip install → python run_simulation.py --environment development --steps 1000. Your first ecosystem lands in simulations/*.db. https://dooders.github.io/AgentFarm/"
+    },
+    {
+      "day": 2,
+      "slot": "midday",
+      "text": "Every AgentFarm step runs the same pipeline: refresh perception → agents act → world resolves combat, sharing, reproduction → observations update → everything persists to SQLite → the dead are cleaned up. Simple loop, complex outcomes."
+    },
+    {
+      "day": 2,
+      "slot": "evening",
+      "text": "A simulation you can't interrogate afterwards is just a screensaver. Every run writes agent states, actions, reproduction events, and learning telemetry to a queryable database. The sim is the experiment; the DB is the lab notebook."
+    },
+    {
+      "day": 3,
+      "slot": "morning",
+      "text": "An AgentFarm agent is not a monolith. It's an AgentCore plus pluggable components — movement, perception, combat, learning — and a swappable behavior policy. Want a new species? Compose one; don't fork the engine."
+    },
+    {
+      "day": 3,
+      "slot": "midday",
+      "text": "Agents see through egocentric multi-channel tensors: allies, enemies, resources, visibility, trails, damage heat — each a layer in a (channels × H × W) window centered on the agent. A tiny convolutional retina."
+    },
+    {
+      "day": 3,
+      "slot": "evening",
+      "text": "Actions are a registry, not an enum: move, gather, attack, share, reproduce — and yours. Register a new action at import time and every agent's action space grows to fit. No core edits required."
+    },
+    {
+      "day": 4,
+      "slot": "morning",
+      "text": "The world is a 2D grid with regenerating resources and a spatial index underneath — KD-tree, quadtree, or spatial hash. Proximity queries use dirty-region tracking, so only changed cells get reindexed."
+    },
+    {
+      "day": 4,
+      "slot": "midday",
+      "text": "Determinism is a feature, not an accident. Seeds are explicit, PYTHONHASHSEED is pinned, and identical configs replay identical worlds. If you can't reproduce it, you can't study it."
+    },
+    {
+      "day": 4,
+      "slot": "evening",
+      "text": "Ecology is the fitness function. No hand-written score tells agents how to live — energy budgets, resource scarcity, and reproduction costs do the selecting. What survives is what worked."
+    },
+    {
+      "day": 5,
+      "slot": "morning",
+      "text": "Each agent can carry a DQN decision stack — and its hyperparameters (learning rate, epsilon, network width…) live on a typed chromosome that offspring inherit, cross over, and mutate. Learning parameters become heritable traits."
+    },
+    {
+      "day": 5,
+      "slot": "midday",
+      "text": "Two timescales of adaptation in one sim: within a lifetime, agents learn by RL; across generations, genomes evolve by selection. Watching them interact is the whole research program."
+    },
+    {
+      "day": 5,
+      "slot": "evening",
+      "text": "We call it intrinsic evolution: no external fitness function, no generational reset, no evaluation phase. Agents that eat, survive, and reproduce pass on their genes mid-simulation. Selection just happens. https://dooders.github.io/AgentFarm/research/experiments-catalog/"
+    },
+    {
+      "day": 6,
+      "slot": "morning",
+      "text": "The analysis stack mirrors a real lab: SimulationDatabase → repositories → analyzers → reports and plots. Population, spatial, combat, and learning modules ship in the box."
+    },
+    {
+      "day": 6,
+      "slot": "midday",
+      "text": "Charts we stare at daily: population curves, resource-vs-agent phase plots, per-generation gene distributions, reward trajectories by age. All generated from the run DB, all reproducible from the seed."
+    },
+    {
+      "day": 6,
+      "slot": "evening",
+      "text": "Weekend idea: run 1,000 steps, open the .db in any SQLite browser, and ask your own questions. The schema covers agent states, actions, and reproduction events. Your queries are as first-class as ours."
+    },
+    {
+      "day": 7,
+      "slot": "morning",
+      "text": "Week 1 recap: AgentFarm = composable agents + ecological selection + learning under pressure + everything persisted for analysis. Open-source, Python-first, Apache-2.0. https://github.com/Dooders/AgentFarm"
+    },
+    {
+      "day": 7,
+      "slot": "midday",
+      "text": "The docs have role-based entry points: researchers start at the experiments catalog, developers at architecture, operators at deployment. https://dooders.github.io/AgentFarm/"
+    },
+    {
+      "day": 7,
+      "slot": "evening",
+      "text": "Question for the timeline: what emergent behavior would convince YOU a simulated ecology is doing something real? We collect answers — some become experiments."
+    },
+    {
+      "day": 8,
+      "slot": "morning",
+      "text": "Intention #1: AgentFarm is an instrument, not a demo. Instruments must be calibrated, reproducible, and honest about their noise floor. That drives every design decision — from pinned seeds to typed configs."
+    },
+    {
+      "day": 8,
+      "slot": "midday",
+      "text": "Intention #2: negative results are results. Our devlog publishes the experiments that failed, the effects that turned out to be single-seed artifacts, and the nulls that held up. https://dooders.github.io/AgentFarm/research/devlog/"
+    },
+    {
+      "day": 8,
+      "slot": "evening",
+      "text": "Intention #3: extensible by strangers. If adding a new observation channel, action, or behavior requires editing engine internals, we've failed. Registries and interfaces exist so your fork stays small."
+    },
+    {
+      "day": 9,
+      "slot": "morning",
+      "text": "Design principle: composition over inheritance. Agents gain abilities by adding components (movement, perception, combat, learning), not by descending from a god-class. Deep hierarchies fossilize; components stay swappable."
+    },
+    {
+      "day": 9,
+      "slot": "midday",
+      "text": "Concrete payoff: a memory-augmented agent is AgentCore + a memory component + the same behavior interface. No parallel class tree, no diamond problem, no re-testing the whole ancestry."
+    },
+    {
+      "day": 9,
+      "slot": "evening",
+      "text": "Single Responsibility in practice: the environment orchestrates, the resource manager owns resources, the spatial index owns proximity, the metrics tracker observes. When one thing changes, one module changes."
+    },
+    {
+      "day": 10,
+      "slot": "morning",
+      "text": "Open–Closed Principle, applied: new actions and observation channels register themselves at import time. The engine never learns their names. Adding a pheromone channel touches zero core files."
+    },
+    {
+      "day": 10,
+      "slot": "midday",
+      "text": "Dependency Inversion, applied: the core depends on DatabaseProtocol and RepositoryProtocol, not SQLite. Tests inject in-memory fakes; production wires the real thing. Swappable persistence for free."
+    },
+    {
+      "day": 10,
+      "slot": "evening",
+      "text": "The test suite is ~6,500 tests and counting. Protocol-based seams are why that's tractable — most tests never touch a real database, filesystem, or network."
+    },
+    {
+      "day": 11,
+      "slot": "morning",
+      "text": "KISS survives contact with research code only if you defend it. Our rule: the simulation loop reads like six lines of pseudocode. All cleverness lives behind interfaces where it can be replaced."
+    },
+    {
+      "day": 11,
+      "slot": "midday",
+      "text": "Every run is a SimulationConfig: typed, nested, YAML-loaded, validated before step one. Population, resources, learning, observation — all declared, all diffable, all reproducible. Configs are experiments."
+    },
+    {
+      "day": 11,
+      "slot": "evening",
+      "text": "DRY, but not prematurely: sweeps don't copy configs, they declare variations. The ExperimentRunner takes a base config + a list of overrides and fans out the runs."
+    },
+    {
+      "day": 12,
+      "slot": "morning",
+      "text": "Hard-won lesson: one seed is an anecdote. Our CohortRunner wraps any experiment in N independent seeded runs and aggregates mean, deviation, and convergence stats. Single-run discoveries rarely survive it."
+    },
+    {
+      "day": 12,
+      "slot": "midday",
+      "text": "True story: an early result showed learning-rate flips between resource regimes. Exciting! A 6-seed sweep later: single-seed artifact. Gone. The devlog post stays up because that's the point. https://dooders.github.io/AgentFarm/research/devlog/2026-05-12-seed-sweep-reality-check/"
+    },
+    {
+      "day": 12,
+      "slot": "evening",
+      "text": "Reproducibility stack: pinned PYTHONHASHSEED → explicit RNG seeds → deterministic spatial updates → versioned configs → archived run DBs. Any figure in our devlog can be regenerated from a command line."
+    },
+    {
+      "day": 13,
+      "slot": "morning",
+      "text": "Simulation perf principle: never recompute what didn't change. Dirty-region tracking on the spatial index means a mostly-idle world reindexes almost nothing per step."
+    },
+    {
+      "day": 13,
+      "slot": "midday",
+      "text": "Observations can be sparse or dense, CPU or GPU, at your chosen dtype — because a thousand agents each holding a multi-channel float tensor adds up fast. ObservationConfig makes the trade-off explicit."
+    },
+    {
+      "day": 13,
+      "slot": "evening",
+      "text": "We benchmark the spatial backends against each other (KD-tree vs quadtree vs hash) with committed, verified benchmark artifacts — so perf claims in the docs are checkable, like everything else."
+    },
+    {
+      "day": 14,
+      "slot": "morning",
+      "text": "Week 2 recap — the principles: composition over inheritance · open–closed registries · protocol-based DI · typed config as experiment · multi-seed or it didn't happen · benchmarked perf claims."
+    },
+    {
+      "day": 14,
+      "slot": "midday",
+      "text": "Structured logging everywhere (structlog): every event carries context — step, agent, values — machine-parseable and human-readable. When a sim misbehaves at step 8,412, grep is a research tool."
+    },
+    {
+      "day": 14,
+      "slot": "evening",
+      "text": "None of this is exotic. It's boring discipline applied to research code, where discipline is rarest and pays most. Steal any of it for your own projects — that's what the license is for."
+    },
+    {
+      "day": 15,
+      "slot": "morning",
+      "text": "Research week 🧵 We gave every agent its own heritable hyperparameter genome and removed the fitness function entirely. Survival and reproduction in a shared resource world do all the selecting. https://dooders.github.io/AgentFarm/research/devlog/2026-04-23-evolving-hyperparameter-genomes-foraging-learning-agents/"
+    },
+    {
+      "day": 15,
+      "slot": "midday",
+      "text": "Result: gene distributions drift, split, and stabilize across a 10,000-step run — no evaluator, no generations, no reset. The ecology alone produces evolutionary dynamics."
+    },
+    {
+      "day": 15,
+      "slot": "evening",
+      "text": "The question behind it: how much adaptive behavior can emerge from ecology alone — finite resources, costly reproduction, inherited priors — without a human writing \"fitness\"? That's AgentFarm's north star."
+    },
+    {
+      "day": 16,
+      "slot": "morning",
+      "text": "Experiment: three identical populations, one knob changed — stability of the resource supply. Most behavioral genes drift the same way regardless. But learning rate and ensemble size split cleanly along the buffer. https://dooders.github.io/AgentFarm/research/devlog/2026-05-04-resource-buffer-shapes-intrinsic-evolution/"
+    },
+    {
+      "day": 16,
+      "slot": "midday",
+      "text": "Interpretation: the environment doesn't just select behaviors — it selects learning styles. Stable worlds and volatile worlds favor measurably different learners."
+    },
+    {
+      "day": 16,
+      "slot": "evening",
+      "text": "Then we ran the humility check: 6 seeds per profile. The headline gene flips didn't replicate; the divergence patterns did, as magnitude trends. Both facts are in the devlog. https://dooders.github.io/AgentFarm/research/devlog/2026-05-12-seed-sweep-reality-check/"
+    },
+    {
+      "day": 17,
+      "slot": "morning",
+      "text": "A user asked: are your agents actually learning, or just wandering? Fair. Instrumenting the decision stack surfaced FOUR real bugs — a training throttle, a dead epsilon schedule, a config that dropped knobs, a hidden-size that did nothing. https://dooders.github.io/AgentFarm/research/devlog/2026-05-16-is-the-dqn-actually-learning/"
+    },
+    {
+      "day": 17,
+      "slot": "midday",
+      "text": "After the fixes: ~9× more training updates, +23% agent lifespan. But the late-life vs early-life decision-quality gap stayed small. The bottleneck moved from our code to the environment's signal-to-noise. Bugs fixed ≠ question answered."
+    },
+    {
+      "day": 17,
+      "slot": "evening",
+      "text": "The meta-lesson: in RL + simulation, \"it runs\" and \"it learns\" are separated by instrumentation. Log the training volume. Plot decision quality by age. Assume nothing."
+    },
+    {
+      "day": 18,
+      "slot": "morning",
+      "text": "Should offspring inherit their parents' learned neural weights (Lamarckian) or just the genome, learning from scratch (Baldwinian)? We built a paired A/B harness — 36 matched runs, 3 resource regimes. https://dooders.github.io/AgentFarm/research/devlog/2026-05-21-baldwinian-vs-lamarckian-ab-harness/"
+    },
+    {
+      "day": 18,
+      "slot": "midday",
+      "text": "Result: Lamarckian warm-start applied ~85% of the time, runs genuinely diverged… and no regime cleared our robustness gate. Baldwinian stays the default. A publishable null, published."
+    },
+    {
+      "day": 18,
+      "slot": "evening",
+      "text": "We re-scored the same runs at the newborn level to check we weren't measuring at the wrong altitude. Two small behavioral shifts, no fitness gain. The null held. https://dooders.github.io/AgentFarm/research/devlog/2026-06-04-are-we-measuring-at-the-wrong-level/"
+    },
+    {
+      "day": 19,
+      "slot": "morning",
+      "text": "What if the reward function itself were a heritable, per-agent trait? We ran 20 paired seeds where each agent optimizes its own randomly-drawn objective vs a hand-tuned control. https://dooders.github.io/AgentFarm/research/devlog/2026-06-09-every-agent-a-different-goal/"
+    },
+    {
+      "day": 19,
+      "slot": "midday",
+      "text": "Result: goal-diverse populations carried ~40% fewer agents and collapsed behavior toward gathering (+17pp). Objective diversity persisted all run — and un-curated diversity lowered collective fitness."
+    },
+    {
+      "day": 19,
+      "slot": "evening",
+      "text": "Why it matters beyond ALife: multi-agent systems where each unit optimizes a private objective are everywhere — markets, swarms, orgs. Here's a controlled world where you can watch that go wrong."
+    },
+    {
+      "day": 20,
+      "slot": "morning",
+      "text": "The big one: a 90-run ladder testing five inheritance payloads, from bare genome to full learned-policy transfer, graded on offspring early-life reward. Hypothesis: richer inheritance → better start. https://dooders.github.io/AgentFarm/research/devlog/2026-07-08-inheritance-ladder-warm-start-clamps-offspring/"
+    },
+    {
+      "day": 20,
+      "slot": "midday",
+      "text": "Result: every robust effect was a LOSS. The richer the inherited payload, the worse the offspring did — warm-started agents clamp to low, ecology-blind trajectories while cold-start offspring track the world."
+    },
+    {
+      "day": 20,
+      "slot": "evening",
+      "text": "We re-ran the identical ladder at low density to kill the confound. It held: zero robust positives. ~200 runs, one honest conclusion: for this design, inherited policies hurt. Now we ask why, with data. https://dooders.github.io/AgentFarm/research/devlog/2026-07-09-lowchurn-inheritance-still-loses/"
+    },
+    {
+      "day": 21,
+      "slot": "morning",
+      "text": "Week 3 recap: ecology-only evolution works · environments select learning styles · four DQN bugs found & fixed · inheritance nulls that held · goal diversity that backfired. All reproducible from the repo. https://dooders.github.io/AgentFarm/research/devlog/"
+    },
+    {
+      "day": 21,
+      "slot": "midday",
+      "text": "Where AgentFarm goes next: richer inherited payloads, memory-augmented agents, better decision-quality metrics, and more multi-seed rigor. The experiments catalog is the living roadmap. https://dooders.github.io/AgentFarm/research/experiments-catalog/"
+    },
+    {
+      "day": 21,
+      "slot": "evening",
+      "text": "Want in? Run a sim, open an issue, replicate a devlog result, or pick up a starter task. Research code that strangers can extend is the whole point — come extend it 🌱 https://github.com/Dooders/AgentFarm"
+    }
+  ]
+}

--- a/docs/communications/twitter-plan.md
+++ b/docs/communications/twitter-plan.md
@@ -374,6 +374,86 @@ Legend: 🌅 morning slot · ☀️ midday slot · 🌆 evening slot.
 
 ---
 
+## Automating the posts
+
+The schedule is duplicated in machine-readable form at
+[`tweet_schedule.json`](tweet_schedule.json), and
+[`scripts/post_scheduled_tweet.py`](../../scripts/post_scheduled_tweet.py)
+posts whichever tweet is due at the current UTC time. The intended trigger is
+a **Cursor Automation** with a cron schedule.
+
+### 1. Get X API access
+
+As of 2026 there is **no free tier** for new X developers — the API is
+pay-per-use (roughly $0.015 per plain post, $0.20 per post containing a URL;
+legacy Basic/Pro tiers are closed to new signups). For this campaign
+(63 tweets, ~24 with links) expect on the order of **$5–6 total**.
+
+1. Sign up at [developer.x.com](https://developer.x.com) with the
+   `@AgentFarm…` account and add a small credit balance.
+2. Create a Project + App. Under **User authentication settings**, enable
+   **Read and Write** permissions (OAuth 1.0a).
+3. From the app's **Keys and tokens** page, collect four values:
+   API Key, API Key Secret, Access Token, Access Token Secret
+   (the access token must be generated *after* enabling write permissions,
+   and must belong to the AgentFarm account).
+
+### 2. Store the credentials as Cursor secrets
+
+In [cursor.com/dashboard/cloud-agents](https://cursor.com/dashboard/cloud-agents)
+→ **Secrets**, add four **Runtime Secrets** (runtime secrets are injected as
+environment variables but redacted from transcripts and tool results):
+
+| Secret name | Value |
+|-------------|-------|
+| `X_API_KEY` | API Key |
+| `X_API_SECRET` | API Key Secret |
+| `X_ACCESS_TOKEN` | Access Token |
+| `X_ACCESS_TOKEN_SECRET` | Access Token Secret |
+
+Scope them to this repository so only AgentFarm agents receive them.
+
+### 3. Create the Cursor Automation
+
+At [cursor.com/automations/new](https://cursor.com/automations/new)
+(or via the `/automate` skill in a local agent session):
+
+- **Trigger:** Scheduled, cron `0 9,13,18 * * *` (UTC) — one firing per slot.
+- **Repository:** `Dooders/AgentFarm`, branch `main` (a repository must be
+  selected; cron automations default to "no repository", which would hide
+  the script and secrets scoped to this repo).
+- **Prompt:**
+
+  > Run `python scripts/post_scheduled_tweet.py` from the repository root.
+  > If it prints "No tweet due", stop — that is expected outside campaign
+  > slots. If it exits non-zero for any other reason, report the full error
+  > output. Do not edit any files, do not open a PR, and do not retry a
+  > successful post.
+
+- **Tools:** disable *Pull request creation* — this automation only posts.
+
+The script is stateless by design: each cron firing posts exactly the tweet
+whose slot covers the current time (a 2-hour lateness window per slot, and
+slots are ≥4 hours apart, so a run can never double-post). If a firing is
+missed entirely, that slot's tweet is skipped rather than posted late.
+
+### Verifying before launch
+
+```bash
+# Show the whole expanded schedule
+python scripts/post_scheduled_tweet.py --list
+
+# Preview what a given slot would post, without credentials
+python scripts/post_scheduled_tweet.py --dry-run --at 2026-07-20T09:00:00
+
+# One real end-to-end post (uses the four X_* env vars)
+python scripts/post_scheduled_tweet.py --at 2026-07-20T09:00:00
+```
+
+To shift the campaign, edit `campaign.start_date` (and `slot_hours` for
+different posting times) in `tweet_schedule.json` — the script derives every
+slot from those values.
+
 ## After week 3
 
 Sustainable cadence once the launch backlog is exhausted:

--- a/docs/communications/twitter-plan.md
+++ b/docs/communications/twitter-plan.md
@@ -1,0 +1,386 @@
+# AgentFarm Twitter/X account plan
+
+Launch plan for the AgentFarm account: profile assets, voice, and a 3-week
+schedule of three tweets per day covering the project, its intentions, design
+principles, and research results.
+
+All content below is grounded in the repository and docs site
+([dooders.github.io/AgentFarm](https://dooders.github.io/AgentFarm/)).
+Adjust dates, links, and screenshots at posting time.
+
+---
+
+## Profile
+
+### Handle suggestions
+
+- `@AgentFarmSim` (preferred — "AgentFarm" alone is likely taken)
+- `@AgentFarmDev`
+- `@FarmOfAgents`
+
+### Display name
+
+**AgentFarm**
+
+### Bio (160-character limit)
+
+Primary:
+
+> Open-source agent-based simulation & RL research platform. Digital ecology: evolving genomes, learning agents, honest results — negative ones too. 🧪 Apache-2.0
+
+Alternates:
+
+> Simulating digital ecologies: learning agents, heritable genomes, emergent dynamics. Open-source research platform in Python. Devlog + code below. 🌱
+
+> We grow agents. Multi-agent sims, DQN decision stacks, evolvable hyperparameters, and a devlog that publishes the null results too. Python · Apache-2.0
+
+### Location / website fields
+
+- Location: `simulations/*.db`
+- Website: `https://dooders.github.io/AgentFarm/`
+
+### Pinned tweet
+
+Use Day 1, Tweet 1 (the launch thread opener) as the pinned tweet.
+
+---
+
+## Profile picture prompt
+
+For an image-generation model, square output (400×400 minimum, generate at 1024×1024):
+
+> Minimal flat vector logo mark for a software project called "AgentFarm".
+> A stylized square field-grid seen from above, like farmland plots crossed
+> with a simulation grid. A few of the grid cells contain small glowing dots
+> (agents) in warm amber, one cell sprouts a tiny abstract seedling made of
+> circuit-like lines. Color palette: deep forest green and dark teal
+> background, amber/gold accent dots, thin off-white grid lines. Geometric,
+> modern, high contrast, no text, no gradients heavier than subtle, reads
+> clearly at 48×48 pixels. Centered emblem with generous margin.
+
+## Banner image prompt
+
+For an image-generation model, 3:1 ratio (X banner is 1500×500):
+
+> Wide panoramic illustration of a digital ecosystem simulation, flat vector
+> style with a dark scientific-dashboard aesthetic. A top-down 2D grid world
+> stretches across the banner: clusters of glowing amber resource nodes,
+> dozens of small agent dots in teal and green with faint motion trails,
+> sparse territory boundaries. On the right third, subtle translucent
+> overlays of line charts and population curves rising and falling, as if the
+> world is being measured while it runs. Deep navy/charcoal background, thin
+> grid lines, restrained color (teal, green, amber). Leave the left ~25%
+> visually quiet so the profile picture and name overlay cleanly. No text.
+
+---
+
+## Voice and style rules
+
+- **Honest instrument, not hype machine.** We publish negative results in the
+  devlog; the account does the same. Never oversell.
+- Plain language first, jargon second. Define terms inline when cheap.
+- Every claim about results links to a devlog post or experiment doc.
+- Threads for research stories; single tweets for tips and principles.
+- Hashtags: at most two per tweet, drawn from `#ALife`, `#ReinforcementLearning`,
+  `#AgentBasedModeling`, `#OpenSource`, `#ComplexSystems`, `#Python`.
+- Media: screenshots of charts from `farm/analysis` output, devlog figures
+  (`docs/research/devlog/figures/`), and short sim GIFs beat text-only tweets.
+
+Suggested posting slots (adjust to audience analytics): **9:00**, **13:00**,
+**18:00** local time.
+
+---
+
+## Three-week schedule (3 tweets/day)
+
+Legend: 🌅 morning slot · ☀️ midday slot · 🌆 evening slot.
+`[link: …]` marks where to attach a URL; `[media: …]` marks a suggested image.
+
+### Week 1 — What AgentFarm is
+
+**Day 1 (Mon) — Launch**
+
+- 🌅 Introducing AgentFarm 🌱 — an open-source platform for growing digital
+  ecologies: multi-agent simulations where agents perceive, learn, reproduce,
+  and pass on heritable genomes. Built in Python, measured in SQLite, published
+  honestly. Follow along. [link: repo] [media: banner art or sim GIF]
+- ☀️ Why "farm"? Because we don't script behaviors — we plant agents in a
+  resource-constrained world and see what grows. Selection pressure comes from
+  the ecology itself: finite food, costly reproduction, real death.
+- 🌆 What you'll get from this account: build notes, design principles,
+  experiment results (including the failures), and ways to run it all
+  yourself. Everything is Apache-2.0. [link: repo]
+
+**Day 2 (Tue) — Getting started**
+
+- 🌅 From zero to a living world in four commands:
+  clone → venv → `pip install -r requirements.txt` → `python run_simulation.py
+  --environment development --steps 1000`.
+  Your first ecosystem lands in `simulations/*.db`. [link: quick start docs]
+- ☀️ Every AgentFarm step runs the same pipeline: refresh perception channels →
+  agents act → world resolves combat/sharing/reproduction → observations
+  update → everything persists to SQLite → the dead are cleaned up. Simple
+  loop, complex outcomes.
+- 🌆 A simulation you can't interrogate afterwards is just a screensaver.
+  Every run writes agent states, actions, reproduction events, and learning
+  telemetry to a queryable database. The sim is the experiment; the DB is the
+  lab notebook.
+
+**Day 3 (Wed) — Agents**
+
+- 🌅 An AgentFarm agent is not a monolith. It's an AgentCore plus pluggable
+  components — movement, perception, combat, learning — and a swappable
+  behavior policy. Want a new species? Compose one; don't fork the engine.
+- ☀️ Agents see the world through egocentric multi-channel tensors: allies,
+  enemies, resources, visibility, trails, damage heat — each a layer in a
+  (channels × H × W) window centered on the agent. Just like a tiny
+  convolutional retina. [media: observation channel figure]
+- 🌆 Actions are a registry, not an enum: move, gather, attack, share,
+  reproduce, pass — and yours. Register a new action at import time and every
+  agent's action space grows to fit. No core edits required.
+
+**Day 4 (Thu) — The world**
+
+- 🌅 The world is a 2D grid with regenerating resources and a spatial index
+  underneath — KD-tree, quadtree, or spatial hash, your pick. Proximity
+  queries with dirty-region tracking mean only changed cells get reindexed.
+- ☀️ Determinism is a feature, not an accident. `run_simulation.py` pins
+  `PYTHONHASHSEED`, seeds are explicit, and identical configs replay identical
+  worlds. If you can't reproduce it, you can't study it. [link: deterministic
+  simulations guide]
+- 🌆 Ecology is the fitness function. No hand-written "score" tells agents how
+  to live — energy budgets, resource scarcity, and reproduction costs do the
+  selecting. What survives is what worked.
+
+**Day 5 (Fri) — Learning & evolution**
+
+- 🌅 Each agent can carry a DQN decision stack — and its hyperparameters
+  (learning rate, epsilon, network width…) live on a typed chromosome that
+  offspring inherit, cross over, and mutate. Learning parameters become
+  heritable traits. [link: hyperparameter chromosome design]
+- ☀️ Two timescales of adaptation in one sim: within a lifetime, agents learn
+  by RL; across generations, genomes evolve by selection. Watching them
+  interact is the whole research program.
+- 🌆 We call it intrinsic evolution: no external fitness function, no
+  generational reset, no evaluation phase. Agents that eat, survive, and
+  reproduce pass on their genes mid-simulation. Selection just… happens.
+  [link: intrinsic evolution experiment]
+
+**Day 6 (Sat) — Data & analysis**
+
+- 🌅 The analysis stack mirrors a real lab: SimulationDatabase → repositories →
+  analyzers → reports and plots. Population, spatial, combat, and learning
+  modules ship in the box. [media: analysis chart]
+- ☀️ Charts we stare at daily: population curves, resource-vs-agent phase
+  plots, per-generation gene distributions, reward trajectories by age. All
+  generated from the run DB, all reproducible from the seed.
+- 🌆 Weekend idea: run 1,000 steps, open the `.db` in any SQLite browser, and
+  ask your own questions. The schema covers agent states, actions, and
+  reproduction events. Your queries are as first-class as ours.
+
+**Day 7 (Sun) — Recap & docs**
+
+- 🌅 Week 1 recap: AgentFarm = composable agents + ecological selection +
+  learning under pressure + everything persisted for analysis. Open-source,
+  Python-first, Apache-2.0. [link: repo]
+- ☀️ The docs site has role-based entry points: researchers start at the
+  experiments catalog, developers at architecture, operators at deployment.
+  [link: docs site]
+- 🌆 Question for the timeline: what emergent behavior would convince YOU a
+  simulated ecology is doing something real? We collect answers — some become
+  experiments.
+
+### Week 2 — Intentions & design principles
+
+**Day 8 (Mon) — Why we build this way**
+
+- 🌅 Intention #1: AgentFarm is an *instrument*, not a demo. Instruments must
+  be calibrated, reproducible, and honest about their noise floor. That
+  drives every design decision — from pinned seeds to typed configs.
+- ☀️ Intention #2: negative results are results. Our devlog publishes the
+  experiments that failed, the "effects" that were single-seed artifacts, and
+  the nulls that held up. Science rots without them. [link: devlog]
+- 🌆 Intention #3: extensible by strangers. If adding a new observation
+  channel, action, or behavior requires editing engine internals, we've
+  failed. Registries and interfaces exist so your fork stays small.
+
+**Day 9 (Tue) — Composition over inheritance**
+
+- 🌅 Design principle: composition over inheritance. Agents gain abilities by
+  adding components (movement, perception, combat, learning), not by
+  descending from a god-class. Deep hierarchies fossilize; components stay
+  swappable.
+- ☀️ Concrete payoff: a memory-augmented agent is AgentCore + a memory
+  component + the same behavior interface. No parallel class tree, no
+  diamond problem, no re-testing the whole ancestry.
+- 🌆 Single Responsibility in practice: the environment orchestrates, the
+  resource manager owns resources, the spatial index owns proximity, the
+  metrics tracker observes. When one thing changes, one module changes.
+
+**Day 10 (Wed) — Open for extension**
+
+- 🌅 Open–Closed Principle, applied: new actions and observation channels
+  register themselves at import time. The engine never learns their names.
+  Adding a "pheromone" channel touches zero core files.
+- ☀️ Dependency Inversion, applied: the core depends on `DatabaseProtocol` and
+  `RepositoryProtocol`, not SQLite. Tests inject in-memory fakes; production
+  wires the real thing. Swappable persistence for free. [link: DI docs]
+- 🌆 The test suite is ~6,500 tests and counting. Protocol-based seams are why
+  that's tractable — most tests never touch a real database, filesystem, or
+  network.
+
+**Day 11 (Thu) — Simplicity & configuration**
+
+- 🌅 KISS survives contact with research code only if you defend it. Our rule:
+  the simulation loop reads like the six-line pseudocode in the docs. All
+  cleverness lives behind interfaces where it can be replaced.
+- ☀️ Every run is a `SimulationConfig`: typed, nested, YAML-loaded, and
+  validated before step one. Population, resources, learning, observation —
+  all declared, all diffable, all reproducible. Configs are experiments.
+- 🌆 DRY, but not prematurely: sweeps don't copy configs, they declare
+  variations. The ExperimentRunner takes a base config + a list of overrides
+  and fans out the runs. [link: experiment runner guide]
+
+**Day 12 (Fri) — Reproducibility**
+
+- 🌅 Hard-won lesson: one seed is an anecdote. Our CohortRunner wraps any
+  experiment in N independent seeded runs and aggregates mean, deviation, and
+  convergence stats. Single-run "discoveries" rarely survive it.
+- ☀️ True story: an early result showed learning-rate "flips" between resource
+  regimes. Exciting! A 6-seed sweep later: single-seed artifact. Gone. The
+  devlog post stays up because that's the point. [link: seed-sweep devlog]
+- 🌆 Reproducibility stack: pinned `PYTHONHASHSEED` → explicit RNG seeds →
+  deterministic spatial updates → versioned configs → archived run DBs. Any
+  figure in our devlog can be regenerated from a command line.
+
+**Day 13 (Sat) — Performance**
+
+- 🌅 Simulation perf principle: never recompute what didn't change.
+  Dirty-region tracking on the spatial index means a mostly-idle world
+  reindexes almost nothing per step.
+- ☀️ Observations can be sparse or dense, CPU or GPU, at your chosen dtype —
+  because a thousand agents each holding a multi-channel float tensor adds up
+  fast. `ObservationConfig` makes the trade-off explicit.
+- 🌆 We benchmark the spatial backends against each other (KD-tree vs quadtree
+  vs hash) with committed, verified benchmark artifacts — so perf claims in
+  the docs are checkable, like everything else. [link: benchmarks]
+
+**Day 14 (Sun) — Engineering culture recap**
+
+- 🌅 Week 2 recap — the principles: composition over inheritance ·
+  open–closed registries · protocol-based DI · typed config as experiment ·
+  multi-seed or it didn't happen · benchmarked perf claims.
+- ☀️ Structured logging everywhere (`structlog`): every event carries context —
+  step, agent, values — machine-parseable and human-readable. When a sim
+  misbehaves at step 8,412, grep is a research tool.
+- 🌆 None of this is exotic. It's boring discipline applied to research code,
+  where discipline is rarest and pays most. Steal any of it for your own
+  projects — that's what the license is for.
+
+### Week 3 — Research stories & community
+
+**Day 15 (Mon) — Intrinsic evolution arc**
+
+- 🌅 Research thread week 🧵 Day 1: we gave every agent its own heritable
+  hyperparameter genome and removed the fitness function entirely. Survival
+  and reproduction in a shared resource world do all the selecting.
+  [link: intrinsic evolution devlog]
+- ☀️ Result: gene distributions drift, split, and stabilize across a
+  10,000-step run — no evaluator, no generations, no reset. The ecology alone
+  produces evolutionary dynamics. [media: gene trajectory figure]
+- 🌆 The question behind it: how much adaptive behavior can emerge from
+  ecology alone — finite resources, costly reproduction, inherited priors —
+  without a human writing "fitness"? That's AgentFarm's north star.
+
+**Day 16 (Tue) — The environment picks the genes**
+
+- 🌅 Experiment: three identical populations, one knob changed — the stability
+  of the resource supply. Most behavioral genes drift the same way regardless.
+  But learning rate and ensemble size split cleanly along the resource buffer.
+  [link: resource-buffer devlog]
+- ☀️ Interpretation: the environment doesn't just select behaviors — it
+  selects *learning styles*. Stable worlds and volatile worlds favor
+  measurably different learners.
+- 🌆 Then we ran the humility check: 6 seeds per profile. The headline
+  gene "flips" didn't replicate; the divergence patterns did, as magnitude
+  trends. Both facts are in the devlog. [link: seed-sweep devlog]
+
+**Day 17 (Wed) — Is the DQN actually learning?**
+
+- 🌅 A user asked: "are your agents actually learning, or just wandering?"
+  Fair. We instrumented the decision stack and found FOUR real bugs — a
+  global training throttle, a never-applied epsilon schedule, a config field
+  that dropped knobs, a hidden-size that did nothing. [link: DQN devlog]
+- ☀️ After the fixes: ~9× more training updates, +23% agent lifespan. But
+  the late-life vs early-life decision-quality gap stayed small. The
+  bottleneck moved from our code to the environment's signal-to-noise. Bugs
+  fixed ≠ question answered.
+- 🌆 The meta-lesson: in RL + simulation, "it runs" and "it learns" are
+  separated by instrumentation. Log the training volume. Plot decision
+  quality by age. Assume nothing.
+
+**Day 18 (Thu) — Baldwinian vs Lamarckian**
+
+- 🌅 Should offspring inherit their parents' learned neural weights
+  (Lamarckian) or just the genome, learning from scratch (Baldwinian)?
+  We built a paired A/B harness — 36 matched runs, 3 resource regimes — to
+  find out. [link: inheritance A/B devlog]
+- ☀️ Result: Lamarckian warm-start applied ~85% of the time, runs genuinely
+  diverged… and no regime cleared our robustness gate. Baldwinian stays the
+  default. A publishable null, published.
+- 🌆 We then re-scored the same runs at the newborn level to check we weren't
+  measuring at the wrong altitude. Two small behavioral shifts, no fitness
+  gain. The null held. [link: measurement-level devlog]
+
+**Day 19 (Fri) — When every agent wants something different**
+
+- 🌅 What if the reward function itself were a heritable, per-agent trait?
+  We ran 20 paired seeds where each agent optimizes its own randomly-drawn
+  objective vs a hand-tuned control. [link: goal-diversity devlog]
+- ☀️ Result: goal-diverse populations carried ~40% fewer agents and collapsed
+  behavior toward gathering (+17pp). Objective diversity persisted all run —
+  and un-curated diversity *lowered* collective fitness. Big effects, all
+  significant.
+- 🌆 Why it matters beyond ALife: multi-agent systems where each unit
+  optimizes a private objective are everywhere (markets, swarms, orgs).
+  Here's a controlled world where you can watch that go wrong.
+
+**Day 20 (Sat) — The inheritance ladder**
+
+- 🌅 The big one: a 90-run ladder testing five inheritance payloads, from bare
+  genome up to full learned-policy transfer. Graded on offspring early-life
+  reward. Hypothesis: richer inheritance → better start. [link: inheritance
+  ladder devlog]
+- ☀️ Result: every robust effect was a LOSS. The richer the inherited payload,
+  the worse the offspring did — warm-started agents clamped to low,
+  ecology-blind trajectories while cold-start offspring tracked the world.
+  We re-ran under low density to kill the confound. It held.
+- 🌆 Three devlog posts, ~200 runs, and the honest conclusion: for this
+  design, inherited policies hurt. That's not failure — that's the instrument
+  working. Now we get to ask *why*, with data.
+
+**Day 21 (Sun) — What's next & how to join**
+
+- 🌅 Week 3 recap: ecology-only evolution works · environments select learning
+  styles · four DQN bugs found & fixed · inheritance nulls that held up ·
+  goal diversity that backfired. All reproducible from the repo. [link:
+  devlog index]
+- ☀️ Where AgentFarm goes next: richer inherited payloads, memory-augmented
+  agents, better decision-quality metrics, and more multi-seed rigor.
+  The experiments catalog is the living roadmap. [link: experiments catalog]
+- 🌆 Want in? Run a sim, open an issue, replicate a devlog result, or pick up
+  a starter task. Research code that strangers can extend is the whole
+  point — come extend it. 🌱 [link: CONTRIBUTING.md]
+
+---
+
+## After week 3
+
+Sustainable cadence once the launch backlog is exhausted:
+
+- **1/day minimum:** alternate devlog announcements, design notes, and
+  figures from ongoing runs.
+- **Per devlog post:** a 3–5 tweet thread summarizing question → method →
+  result → link.
+- **Monthly:** a recap thread and a "replicate this figure" challenge with
+  the exact command line.

--- a/scripts/post_scheduled_tweet.py
+++ b/scripts/post_scheduled_tweet.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Post the currently-due tweet from the AgentFarm launch schedule.
+
+Reads ``docs/communications/tweet_schedule.json``, determines which tweet is
+scheduled for the current UTC time, and posts it to X (Twitter) via the v2
+``POST /2/tweets`` endpoint using OAuth 1.0a user-context authentication.
+
+Designed to be triggered by a scheduler (e.g. a Cursor Automation with a cron
+trigger of ``0 9,13,18 * * *``). Each invocation posts at most one tweet: the
+one whose scheduled time falls within the lateness window before "now". This
+keeps the script stateless — no posted-tweet ledger is needed as long as the
+scheduler fires once per slot.
+
+Credentials are read from environment variables (see ``OAuthCredentials``).
+Uses only the Python standard library so it runs without the project venv.
+
+Usage:
+    python scripts/post_scheduled_tweet.py                # post the due tweet
+    python scripts/post_scheduled_tweet.py --dry-run      # print, don't post
+    python scripts/post_scheduled_tweet.py --at 2026-07-20T09:00:00  # test a slot
+    python scripts/post_scheduled_tweet.py --list         # show the full schedule
+
+Exit codes: 0 = posted (or dry-run), 2 = no tweet due, 1 = error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets as _secrets
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Mapping, Optional, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SCHEDULE_PATH = REPO_ROOT / "docs" / "communications" / "tweet_schedule.json"
+POST_TWEET_URL = "https://api.x.com/2/tweets"
+
+#: A tweet is considered "due" from its scheduled time until this much later.
+#: Slots are at least 4 hours apart, so a 2-hour window can never match two.
+DEFAULT_LATENESS = timedelta(hours=2)
+
+#: X counts any URL as a fixed t.co length regardless of the actual URL.
+TCO_URL_LENGTH = 23
+MAX_WEIGHTED_LENGTH = 280
+
+#: Unicode ranges that weigh 1 unit in X's character counting; everything
+#: else (CJK, emoji, ...) weighs 2. Mirrors the twitter-text v3 config.
+_LIGHT_WEIGHT_RANGES = ((0, 4351), (8192, 8205), (8208, 8223), (8242, 8247))
+
+
+@dataclass(frozen=True)
+class ScheduledTweet:
+    day: int
+    slot: str
+    text: str
+    scheduled_at: datetime
+
+
+@dataclass(frozen=True)
+class OAuthCredentials:
+    """OAuth 1.0a user-context credentials for the account being posted to."""
+
+    api_key: str
+    api_secret: str
+    access_token: str
+    access_token_secret: str
+
+    ENV_VARS = ("X_API_KEY", "X_API_SECRET", "X_ACCESS_TOKEN", "X_ACCESS_TOKEN_SECRET")
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] = os.environ) -> "OAuthCredentials":
+        missing = [name for name in cls.ENV_VARS if not env.get(name)]
+        if missing:
+            raise KeyError(f"Missing required environment variables: {', '.join(missing)}")
+        return cls(*(env[name] for name in cls.ENV_VARS))
+
+
+def load_schedule(path: Path = DEFAULT_SCHEDULE_PATH) -> list[ScheduledTweet]:
+    """Load and expand the schedule JSON into concrete scheduled datetimes."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    campaign = data["campaign"]
+    start = datetime.fromisoformat(campaign["start_date"]).replace(tzinfo=timezone.utc)
+    slot_hours: dict[str, int] = campaign["slot_hours"]
+
+    tweets = []
+    for entry in data["tweets"]:
+        scheduled_at = start + timedelta(days=entry["day"] - 1, hours=slot_hours[entry["slot"]])
+        tweets.append(
+            ScheduledTweet(day=entry["day"], slot=entry["slot"], text=entry["text"], scheduled_at=scheduled_at)
+        )
+    return sorted(tweets, key=lambda t: t.scheduled_at)
+
+
+def resolve_due_tweet(
+    tweets: Sequence[ScheduledTweet],
+    now: datetime,
+    lateness: timedelta = DEFAULT_LATENESS,
+) -> Optional[ScheduledTweet]:
+    """Return the tweet whose slot covers ``now``, or None if nothing is due."""
+    for tweet in tweets:
+        if tweet.scheduled_at <= now < tweet.scheduled_at + lateness:
+            return tweet
+    return None
+
+
+def weighted_tweet_length(text: str) -> int:
+    """Estimate X's weighted character count for ``text``.
+
+    URLs count as a fixed 23 units; codepoints in the light-weight ranges
+    count 1, all others 2. Multi-codepoint emoji are overcounted slightly,
+    which errs on the safe side of the 280 limit.
+    """
+    total = 0
+    for token in text.split(" "):
+        if token.startswith(("http://", "https://")):
+            total += TCO_URL_LENGTH
+        else:
+            for char in token:
+                cp = ord(char)
+                total += 1 if any(lo <= cp <= hi for lo, hi in _LIGHT_WEIGHT_RANGES) else 2
+    # Add back the separating spaces consumed by split().
+    total += text.count(" ")
+    return total
+
+
+def _percent_encode(value: str) -> str:
+    return urllib.parse.quote(value, safe="~")
+
+
+def build_oauth1_signature(
+    method: str,
+    url: str,
+    params: Mapping[str, str],
+    api_secret: str,
+    access_token_secret: str,
+) -> str:
+    """Compute an RFC 5849 HMAC-SHA1 signature over ``params``."""
+    encoded = sorted((_percent_encode(k), _percent_encode(v)) for k, v in params.items())
+    param_string = "&".join(f"{k}={v}" for k, v in encoded)
+    base_string = "&".join((method.upper(), _percent_encode(url), _percent_encode(param_string)))
+    signing_key = f"{_percent_encode(api_secret)}&{_percent_encode(access_token_secret)}"
+    digest = hmac.new(signing_key.encode(), base_string.encode(), hashlib.sha1).digest()
+    return base64.b64encode(digest).decode()
+
+
+def build_oauth1_header(
+    method: str,
+    url: str,
+    credentials: OAuthCredentials,
+    nonce: Optional[str] = None,
+    timestamp: Optional[str] = None,
+) -> str:
+    """Build the ``Authorization`` header for a JSON-body request.
+
+    JSON bodies are not form-encoded, so per OAuth 1.0a only the oauth_*
+    parameters (and any query parameters, of which this endpoint has none)
+    participate in the signature.
+    """
+    oauth_params = {
+        "oauth_consumer_key": credentials.api_key,
+        "oauth_nonce": nonce or _secrets.token_hex(16),
+        "oauth_signature_method": "HMAC-SHA1",
+        "oauth_timestamp": timestamp or str(int(time.time())),
+        "oauth_token": credentials.access_token,
+        "oauth_version": "1.0",
+    }
+    signature = build_oauth1_signature(
+        method, url, oauth_params, credentials.api_secret, credentials.access_token_secret
+    )
+    oauth_params["oauth_signature"] = signature
+    header_params = ", ".join(
+        f'{_percent_encode(k)}="{_percent_encode(v)}"' for k, v in sorted(oauth_params.items())
+    )
+    return f"OAuth {header_params}"
+
+
+def post_tweet(text: str, credentials: OAuthCredentials) -> str:
+    """Post ``text`` via POST /2/tweets and return the created tweet id."""
+    body = json.dumps({"text": text}).encode("utf-8")
+    request = urllib.request.Request(
+        POST_TWEET_URL,
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": build_oauth1_header("POST", POST_TWEET_URL, credentials),
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"X API returned {error.code}: {detail}") from error
+    return payload["data"]["id"]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--schedule", type=Path, default=DEFAULT_SCHEDULE_PATH, help="Path to the schedule JSON.")
+    parser.add_argument("--dry-run", action="store_true", help="Resolve and print the due tweet without posting.")
+    parser.add_argument("--at", type=str, default=None, help="Override 'now' with an ISO datetime (assumed UTC).")
+    parser.add_argument(
+        "--lateness-hours",
+        type=float,
+        default=DEFAULT_LATENESS.total_seconds() / 3600,
+        help="How long after its slot a tweet is still considered due.",
+    )
+    parser.add_argument("--list", action="store_true", help="Print the expanded schedule and exit.")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    tweets = load_schedule(args.schedule)
+
+    if args.list:
+        for tweet in tweets:
+            print(f"{tweet.scheduled_at:%Y-%m-%d %H:%M} UTC  day {tweet.day:>2} {tweet.slot:<8} {tweet.text[:60]}…")
+        return 0
+
+    if args.at:
+        now = datetime.fromisoformat(args.at)
+        now = now.replace(tzinfo=timezone.utc) if now.tzinfo is None else now.astimezone(timezone.utc)
+    else:
+        now = datetime.now(timezone.utc)
+
+    due = resolve_due_tweet(tweets, now, timedelta(hours=args.lateness_hours))
+    if due is None:
+        print(f"No tweet due at {now:%Y-%m-%d %H:%M} UTC.")
+        return 2
+
+    length = weighted_tweet_length(due.text)
+    print(f"Due: day {due.day} / {due.slot} (scheduled {due.scheduled_at:%Y-%m-%d %H:%M} UTC, ~{length} chars)")
+    print(due.text)
+
+    if length > MAX_WEIGHTED_LENGTH:
+        print(f"ERROR: tweet exceeds the {MAX_WEIGHTED_LENGTH}-character limit ({length}). Not posting.")
+        return 1
+
+    if args.dry_run:
+        print("Dry run — not posting.")
+        return 0
+
+    try:
+        credentials = OAuthCredentials.from_env()
+    except KeyError as error:
+        print(f"ERROR: {error}")
+        return 1
+
+    try:
+        tweet_id = post_tweet(due.text, credentials)
+    except RuntimeError as error:
+        print(f"ERROR: {error}")
+        return 1
+
+    print(f"Posted tweet id {tweet_id}: https://x.com/i/status/{tweet_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_post_scheduled_tweet.py
+++ b/tests/scripts/test_post_scheduled_tweet.py
@@ -1,0 +1,224 @@
+"""Tests for ``scripts/post_scheduled_tweet.py`` and the tweet schedule data.
+
+Covers schedule loading/validation, due-slot resolution, weighted length
+estimation, the OAuth 1.0a signature (against the documented X/Twitter test
+vector), and the posting flow with a stubbed HTTP layer.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from contextlib import redirect_stdout
+from datetime import datetime, timedelta, timezone
+
+_repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+import pytest  # noqa: E402
+
+from scripts.post_scheduled_tweet import (  # noqa: E402
+    DEFAULT_SCHEDULE_PATH,
+    MAX_WEIGHTED_LENGTH,
+    OAuthCredentials,
+    build_oauth1_signature,
+    load_schedule,
+    main,
+    resolve_due_tweet,
+    weighted_tweet_length,
+)
+
+pytestmark = pytest.mark.unit
+
+UTC = timezone.utc
+
+
+class TestScheduleData:
+    """The committed schedule JSON is valid and complete."""
+
+    def test_campaign_has_63_tweets_over_21_days(self):
+        tweets = load_schedule(DEFAULT_SCHEDULE_PATH)
+        assert len(tweets) == 63
+        assert {t.day for t in tweets} == set(range(1, 22))
+        for day in range(1, 22):
+            slots = {t.slot for t in tweets if t.day == day}
+            assert slots == {"morning", "midday", "evening"}, f"day {day} missing slots"
+
+    def test_schedule_is_sorted_and_unique(self):
+        tweets = load_schedule(DEFAULT_SCHEDULE_PATH)
+        times = [t.scheduled_at for t in tweets]
+        assert times == sorted(times)
+        assert len(set(times)) == len(times)
+
+    def test_all_tweets_within_character_limit(self):
+        for tweet in load_schedule(DEFAULT_SCHEDULE_PATH):
+            length = weighted_tweet_length(tweet.text)
+            assert length <= MAX_WEIGHTED_LENGTH, (
+                f"day {tweet.day}/{tweet.slot} is {length} weighted chars: {tweet.text!r}"
+            )
+
+    def test_all_tweets_nonempty(self):
+        for tweet in load_schedule(DEFAULT_SCHEDULE_PATH):
+            assert tweet.text.strip()
+
+
+class TestResolveDueTweet:
+    def _tweets(self):
+        return load_schedule(DEFAULT_SCHEDULE_PATH)
+
+    def test_exact_slot_time_is_due(self):
+        tweets = self._tweets()
+        first = tweets[0]
+        assert resolve_due_tweet(tweets, first.scheduled_at) == first
+
+    def test_within_lateness_window_is_due(self):
+        tweets = self._tweets()
+        first = tweets[0]
+        due = resolve_due_tweet(tweets, first.scheduled_at + timedelta(hours=1, minutes=59))
+        assert due == first
+
+    def test_after_window_is_not_due(self):
+        tweets = self._tweets()
+        first = tweets[0]
+        due = resolve_due_tweet(tweets, first.scheduled_at + timedelta(hours=2))
+        assert due != first
+
+    def test_before_campaign_nothing_due(self):
+        tweets = self._tweets()
+        assert resolve_due_tweet(tweets, tweets[0].scheduled_at - timedelta(minutes=1)) is None
+
+    def test_after_campaign_nothing_due(self):
+        tweets = self._tweets()
+        assert resolve_due_tweet(tweets, tweets[-1].scheduled_at + timedelta(hours=3)) is None
+
+    def test_each_slot_time_resolves_to_its_own_tweet(self):
+        tweets = self._tweets()
+        for tweet in tweets:
+            assert resolve_due_tweet(tweets, tweet.scheduled_at) == tweet
+
+
+class TestWeightedTweetLength:
+    def test_plain_ascii(self):
+        assert weighted_tweet_length("hello world") == 11
+
+    def test_url_counts_as_23(self):
+        assert weighted_tweet_length("see https://github.com/Dooders/AgentFarm/very/long/path") == 4 + 23
+
+    def test_emoji_counts_as_two(self):
+        assert weighted_tweet_length("hi 🌱") == 3 + 2
+
+
+class TestOAuth1Signature:
+    def test_documented_twitter_test_vector(self):
+        """Signature matches the worked example from the X developer docs."""
+        params = {
+            "status": "Hello Ladies + Gentlemen, a signed OAuth request!",
+            "include_entities": "true",
+            "oauth_consumer_key": "xvz1evFS4wEEPTGEFPHBog",
+            "oauth_nonce": "kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg",
+            "oauth_signature_method": "HMAC-SHA1",
+            "oauth_timestamp": "1318622958",
+            "oauth_token": "370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb",
+            "oauth_version": "1.0",
+        }
+        signature = build_oauth1_signature(
+            "POST",
+            "https://api.twitter.com/1.1/statuses/update.json",
+            params,
+            api_secret="kAcSOqF21Fu85e7zjz7ZN2U4ZRhfV3WpwPAoE3Z7kBw",
+            access_token_secret="LswwdoUaIvS8ltyTt5jkRh4J50vUPVVHtR2YPi5kE",
+        )
+        assert signature == "hCtSmYh+iHYCEqBWrE7C7hYmtUk="
+
+
+class TestCredentials:
+    def test_from_env_missing_vars_raises(self):
+        with pytest.raises(KeyError, match="X_API_KEY"):
+            OAuthCredentials.from_env(env={})
+
+    def test_from_env_reads_all_four(self):
+        env = {
+            "X_API_KEY": "k",
+            "X_API_SECRET": "s",
+            "X_ACCESS_TOKEN": "t",
+            "X_ACCESS_TOKEN_SECRET": "ts",
+        }
+        creds = OAuthCredentials.from_env(env=env)
+        assert (creds.api_key, creds.api_secret, creds.access_token, creds.access_token_secret) == (
+            "k",
+            "s",
+            "t",
+            "ts",
+        )
+
+
+class TestMainCli:
+    def _run(self, argv):
+        out = io.StringIO()
+        with redirect_stdout(out):
+            code = main(argv)
+        return code, out.getvalue()
+
+    def test_dry_run_at_first_slot(self):
+        code, output = self._run(["--dry-run", "--at", "2026-07-20T09:00:00"])
+        assert code == 0
+        assert "Dry run" in output
+        assert "day 1 / morning" in output
+
+    def test_no_tweet_due_returns_2(self):
+        code, output = self._run(["--dry-run", "--at", "2026-07-19T00:00:00"])
+        assert code == 2
+        assert "No tweet due" in output
+
+    def test_list_prints_all_slots(self):
+        code, output = self._run(["--list"])
+        assert code == 0
+        assert output.count("morning") == 21
+
+    def test_posting_uses_stubbed_http(self, monkeypatch, tmp_path):
+        for name, value in zip(OAuthCredentials.ENV_VARS, ("k", "s", "t", "ts")):
+            monkeypatch.setenv(name, value)
+
+        captured = {}
+
+        class _FakeResponse:
+            def read(self):
+                return json.dumps({"data": {"id": "12345"}}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        def fake_urlopen(request, timeout=None):
+            captured["url"] = request.full_url
+            captured["body"] = json.loads(request.data.decode())
+            captured["auth"] = request.get_header("Authorization")
+            return _FakeResponse()
+
+        monkeypatch.setattr("scripts.post_scheduled_tweet.urllib.request.urlopen", fake_urlopen)
+
+        code, output = self._run(["--at", "2026-07-20T13:30:00"])
+        assert code == 0
+        assert "Posted tweet id 12345" in output
+        assert captured["url"] == "https://api.x.com/2/tweets"
+        assert captured["auth"].startswith("OAuth ")
+        assert "oauth_signature=" in captured["auth"]
+        assert "farm" in captured["body"]["text"].lower()
+
+    def test_now_defaults_to_current_time(self, monkeypatch):
+        fixed = datetime(2026, 7, 20, 18, 5, tzinfo=UTC)
+
+        class _FakeDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return fixed
+
+        monkeypatch.setattr("scripts.post_scheduled_tweet.datetime", _FakeDatetime)
+        code, output = self._run(["--dry-run"])
+        assert code == 0
+        assert "day 1 / evening" in output


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a launch plan for an AgentFarm Twitter/X account plus the tooling to post the schedule automatically via a Cursor Automation.

### Content plan (`docs/communications/twitter-plan.md`)

- **Profile assets**: bio (with alternates), handle suggestions, and detailed image-generation prompts for the profile picture and 1500×500 banner.
- **Voice guidelines**: honest-instrument tone matching the devlog's practice of publishing negative results, link-every-claim rule, hashtag limits.
- **3-week schedule** of 3 tweets/day (63 tweets): Week 1 — what AgentFarm is; Week 2 — intentions and design principles; Week 3 — research story threads grounded in real devlog posts.
- **Automation setup guide**: X API pay-per-use access (~$5–6 for the whole campaign), storing the four OAuth keys as Cursor Runtime Secrets, and configuring a scheduled Cursor Automation (`0 9,13,18 * * *`) with a ready-to-paste prompt.

### Posting automation

- `docs/communications/tweet_schedule.json` — machine-readable schedule: campaign start date, slot hours, and all 63 tweets.
- `scripts/post_scheduled_tweet.py` — stateless CLI that resolves which tweet is due at the current UTC time and posts it via `POST /2/tweets` with OAuth 1.0a (stdlib only, no new dependencies). Supports `--dry-run`, `--at`, and `--list`; enforces the 280 weighted-character limit; a 2-hour lateness window with ≥4-hour slot spacing makes double-posting impossible.
- `tests/scripts/test_post_scheduled_tweet.py` — 21 unit tests: schedule completeness (63 tweets × 21 days × 3 slots, all within the character limit), slot resolution, weighted length rules, the OAuth 1.0a HMAC-SHA1 signature against the documented X test vector, and the posting flow with a stubbed HTTP layer.

## Testing

- ✅ `pytest tests/scripts` — 165 passed (21 new).
- ✅ `ruff check scripts/post_scheduled_tweet.py tests/scripts/test_post_scheduled_tweet.py` — clean.
- ✅ `python scripts/check_docs_links.py` — all 307 markdown files pass.
- ✅ Manual CLI dry-runs: `--dry-run --at 2026-07-24T09:15:00` resolves day 5/morning; outside any slot exits 2 with "No tweet due"; `--list` prints all 63 slots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5b3858a-98d8-493a-94b6-f5a6847e24fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5b3858a-98d8-493a-94b6-f5a6847e24fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

