### PR TITLE
Add intrinsic-evolution matrix orchestrator and research plan

### DIFF
--- a/docs/research/experiments/intrinsic_evolution/research_plan_population_matrix.md
+++ b/docs/research/experiments/intrinsic_evolution/research_plan_population_matrix.md
@@ -1,0 +1,183 @@
+# Research Plan: Is intrinsic evolution non-uniform, and does larger population size sharpen the signal?
+
+This plan turns a feasibility question — *would a long intrinsic-evolution run
+be valuable, or return a mostly uniform result, and would a larger grid with
+more agents help?* — into a replicated, evidence-gated experiment. It reuses the
+existing runner
+([`IntrinsicEvolutionExperiment`](../../../../farm/runners/intrinsic_evolution_experiment.py))
+and analyzers rather than adding new simulation logic.
+
+The orchestrator is
+[`scripts/run_intrinsic_evolution_matrix.py`](../../../../scripts/run_intrinsic_evolution_matrix.py),
+which fans the matrix across CPU cores by calling
+[`scripts/run_stable_profile_seed_sweep.py`](../../../../scripts/run_stable_profile_seed_sweep.py)
+once per (cell, seed).
+
+## 1. Motivation
+
+The recorded 10,000-step run ([RESULTS.md](RESULTS.md)) already shows durable
+polymorphism (a sustained speciation index of 0.4–0.6, four coexisting niches,
+77% founder-lineage extinction). So the system is not obviously uniform. But the
+project's own methods note
+([seed-sweep reality check](../../devlog/2026-05-12-seed-sweep-reality-check.md))
+established that single-seed, per-gene claims do not replicate, because
+within-seed genetic drift variance exceeds the between-condition differences.
+
+That reframes the question. The scientific target is **not** "run one simulation
+longer." It is "raise the effective population size (`Ne`) so drift stops
+dominating, and replicate across enough seeds to pass the evidence gate." A
+single 30-day run is `n = 1`; the same compute buys a whole replicated factorial.
+
+## 2. Hypotheses
+
+Directions and the null are pre-registered so the analysis is confirmatory, not
+a search for a story.
+
+- **H1 — non-uniformity.** With initial-diversity seeding on and selection
+  pressure at least `low`, per-gene span-normalized diversity at the end stays
+  near its ~0.28 starting value and does not collapse toward the drift-only
+  floor (~0.02). The `pressure = none` arm is the drift-only null.
+- **H2 — `Ne` sharpens the signal.** Moving from the `simulation` profile
+  (~300 cap) to the `research` profile (~500 cap) narrows the across-seed 95% CIs
+  on per-gene shifts and raises within-condition sign agreement, without flipping
+  the direction of robust shifts.
+- **H3 — selection shapes structure.** Higher pressure raises founder-lineage
+  extinction and effective-selection-strength telemetry, and drives no single
+  gene to a monoculture — consistent with the frequency-dependent reading in
+  [selection pressure and intrinsic goals](../../devlog/2026-07-29-selection-pressure-and-intrinsic-goals.md).
+- **H4 — gene flow.** Crossover-on changes speciation-index variance and/or mode
+  entropy relative to mutation-only (unresolved for the buffered profile;
+  conservative showed a real reduction in
+  [gene flow and the buffer](../../devlog/2026-05-18-gene-flow-and-the-buffer.md)).
+
+Primary claims are restricted to the loci that moved robustly before
+(`gamma`, `learning_rate`, `attack_weight`, `share_weight`, `attack_mult_stable`,
+`per_alpha`). The remaining ~25 genes are treated as near-neutral secondary
+readouts, since prior work shows most gene variance is behaviorally near-neutral.
+
+## 3. Design
+
+A replicated factorial over three axes.
+
+| Axis | Levels | Rationale |
+| --- | --- | --- |
+| Selection pressure | `none`, `low`, `high` | `none` is the drift-only null for H1/H3 |
+| Gene flow | `mutation`, `crossover` | Tests H4 |
+| Population / `Ne` | `sim` (100×100, cap 300), `research` (150×150, cap 500) | Tests H2 — the core lever |
+
+That is 3 × 2 × 2 = 12 cells × **8 seeds** = **96 runs** at 10,000 logged steps
+after a 200-step warmup. Eight seeds clears the project's ≥5-seed gate and
+tightens the CIs.
+
+Population is set by the environment profile plus `max_population`, **not** by
+resource supply. A VM probe confirmed a hard ceiling of 50 agents in the
+`development` environment regardless of a 6× resource boost
+([`development.yaml`](../../../../farm/config/environments/development.yaml)). A
+bigger grid alone spreads agents thinner and *increases* drift, so the
+population axis must move the environment profile (grid + starting agents +
+`max_population`) together.
+
+### Phases
+
+- **Phase 1 — calibration (≈4–6 runs).** Pilot one `sim` and one `research`
+  cell to (1) re-measure seconds/step on the chosen VM, (2) confirm no arm goes
+  extinct before ~2,000 steps at `high` pressure, and (3) confirm the population
+  stabilizes above ~150 (i.e., `max_population`, not resource scarcity, is the
+  effective ceiling). Gate: proceed only if both hold; otherwise scale resource
+  regeneration up and re-pilot.
+- **Phase 2 — confirmatory matrix (96 runs).** The full factorial above.
+- **Phase 3 — depth (≈6 runs, exploratory).** Extend the most polymorphic
+  Phase-2 cell to 50,000 steps for 6 seeds to test whether niches keep turning
+  over (interesting) or eventually fix (uniform-at-last). This is the only place
+  long horizons are justified.
+
+## 4. Compute budget
+
+Planning constant from the VM probe and the
+[GCP spot-VM guide](../../../guides/gcp-spot-vm-sweep.md): ~0.02 s per alive
+agent per step, roughly linear in population.
+
+| Population | Steps | Core-hours / run |
+| --- | ---: | ---: |
+| ~300 (`sim`) | 10,000 | ~17 |
+| ~500 (`research`) | 10,000 | ~28 |
+| ~300 (depth) | 50,000 | ~83 |
+
+Phase 2 ≈ (48 × 17) + (48 × 28) ≈ 2,160 core-hours. Phase 3 ≈ 500 core-hours.
+With a pilot and ~20% Spot-preemption margin, the total is **~3,300 core-hours**.
+A single 8-vCPU Spot VM over 30 days provides 30 × 24 × 8 ≈ 5,760 core-hours, so
+the plan fits with ~40% headroom (a larger VM finishes proportionally sooner).
+Runs are single-threaded with BLAS pinned to one thread, so parallelism is one
+process per vCPU. `--dry-run` prints an upper-bound estimate; re-measure with the
+Phase-1 pilot before trusting the total for scheduling.
+
+## 5. Execution
+
+Run the whole matrix with the orchestrator; each (cell, seed) is an independent,
+resumable subprocess:
+
+```bash
+source venv/bin/activate
+python scripts/run_intrinsic_evolution_matrix.py \
+    --populations sim research \
+    --pressures none low high \
+    --gene-flow mutation crossover \
+    --seeds 42 7 19 101 137 256 512 999 \
+    --num-steps 10000 --warmup-steps 200 --snapshot-interval 200 \
+    --jobs 8 --disk-database --resume \
+    --output-dir experiments/intrinsic_matrix
+```
+
+Operational rules (from the GCP guide): run detached so it survives SSH drops;
+`PYTHONHASHSEED=0` and BLAS thread-pinning are set for every child automatically;
+disk-backed SQLite for the long runs; `--resume` so a Spot preemption redoes at
+most the interrupted runs; delete the VM at teardown. Preview first with
+`--dry-run`.
+
+## 6. Analysis and evidence gates
+
+- Per-run plots and lineage/speciation artifacts:
+  [`scripts/analyze_intrinsic_evolution.py`](../../../../scripts/analyze_intrinsic_evolution.py).
+- Per-cell aggregation (mean, variance, 95% Student-t CI, speciation slope and
+  direction, sign agreement):
+  [`scripts/analyze_stable_profile_seed_sweep.py`](../../../../scripts/analyze_stable_profile_seed_sweep.py),
+  once per cell directory.
+- Cross-condition mode/transition classification with conservative gates:
+  [`scripts/analyze_transition_regime.py`](../../../../scripts/analyze_transition_regime.py).
+
+A directional claim counts only if its 95% CI excludes zero **and**
+within-condition sign agreement is ≥ 0.75 across the 8 seeds — the project's
+existing gate. Between-condition claims (e.g. "`Ne` sharpens the signal") require
+the CI on the *difference* to exclude zero, not merely each arm on its own. H1's
+"not uniform" is operationalized as: per-gene span-normalized end diversity stays
+≥ ~0.20 in the selection arms while the `none` arm trends toward the ~0.02 drift
+floor.
+
+## 7. Deliverables and success criteria
+
+- `experiments/intrinsic_matrix/` with per-cell run artifacts, `matrix_manifest.json`,
+  aggregated `seed_sweep_summary.{json,md}` per cell, and comparison plots.
+- A devlog-style writeup (matching `docs/research/devlog/`) answering the
+  headline question with CIs and the robustness gate applied.
+- Success = a defensible, replicated statement of the form: "under pressure `P`
+  and population `Ne`, the system sustains `k` niches with speciation index in
+  `[a, b]`, founder survival `f`, and robust gene shifts in {…}; the `none` arm
+  collapses to drift" — or a documented null if the gates fail.
+
+## 8. Risk register
+
+| Risk | Mitigation |
+| --- | --- |
+| Early extinction at `high` pressure × sparse resources | Phase-1 gate; scale resource regeneration with grid before Phase 2 |
+| Spot preemption mid-run | `--resume` + disk DB; at most the interrupted runs are redone |
+| Near-neutral genes limit richness | Pre-register primary claims on the ~6 loci that moved before; rest are secondary |
+| DB disk growth over long/depth runs | Snapshot interval 200; disk DB with periodic pruning |
+| Reproducibility | Fixed seed list, `PYTHONHASHSEED=0`, per-cell `run_manifest.json` + `matrix_manifest.json` |
+
+## Related docs
+
+- [Intrinsic evolution experiment doc](intrinsic_evolution.md)
+- [Results (10,000 steps)](RESULTS.md)
+- [Transition-regime workflow](transition_regime.md)
+- [Seed-sweep reality check (methods)](../../devlog/2026-05-12-seed-sweep-reality-check.md)
+- [GCP spot-VM sweep runbook](../../../guides/gcp-spot-vm-sweep.md)

--- a/farm/editor/package-lock.json
+++ b/farm/editor/package-lock.json
@@ -3159,9 +3159,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/scripts/run_intrinsic_evolution_matrix.py
+++ b/scripts/run_intrinsic_evolution_matrix.py
@@ -86,15 +86,15 @@ _THREAD_VARS = (
     "NUMEXPR_NUM_THREADS",
 )
 
-# Named population levels. Each maps to a (environment profile, approximate
-# max_population) pair. The max_population figure is only used to produce an
-# upper-bound cost estimate in --dry-run; the true standing population is set
-# by the simulation and is typically well below the cap.
-POPULATION_LEVELS: dict[str, tuple[str, int]] = {
-    "dev": ("development", 50),
-    "sim": ("simulation", 300),
-    "research": ("research", 500),
-    "production": ("production", 1000),
+# Named population levels. Each maps to (environment, optional profile overlay,
+# approximate max_population). Grid size and max_population come from the profile
+# when set (see farm/config/profiles/). The max_population figure is only used
+# to produce an upper-bound cost estimate in --dry-run.
+POPULATION_LEVELS: dict[str, tuple[str, str | None, int]] = {
+    "dev": ("development", None, 50),
+    "sim": ("development", "simulation", 300),
+    "research": ("development", "research", 500),
+    "production": ("production", None, 1000),
 }
 
 PRESSURES: tuple[str, ...] = ("none", "low", "high")
@@ -147,12 +147,17 @@ def build_matrix(
 
 def build_command(job: Job, args: argparse.Namespace, cell_dir: Path) -> list[str]:
     """Resolve the seed-sweep subprocess command for a single job."""
-    environment, _ = POPULATION_LEVELS[job.population]
+    environment, profile, _ = POPULATION_LEVELS[job.population]
     command: list[str] = [
         sys.executable,
         str(_SEED_SWEEP_SCRIPT),
         "--environment",
         environment,
+    ]
+    if profile is not None:
+        command.extend(["--profile", profile])
+    command.extend(
+        [
         "--profiles",
         "balanced",
         "--seeds",
@@ -169,7 +174,8 @@ def build_command(job: Job, args: argparse.Namespace, cell_dir: Path) -> list[st
         str(cell_dir),
         "--log-level",
         args.log_level,
-    ]
+        ]
+    )
     if job.gene_flow == "crossover":
         command.append("--crossover-enabled")
     if args.disk_database:
@@ -187,7 +193,7 @@ def estimate_core_hours(job: Job, args: argparse.Namespace) -> float:
     this is deliberately conservative. Re-measure with a Phase-1 pilot before
     trusting the total for scheduling.
     """
-    _, approx_max_pop = POPULATION_LEVELS[job.population]
+    _, _, approx_max_pop = POPULATION_LEVELS[job.population]
     total_steps = args.num_steps + args.warmup_steps
     seconds = args.sec_per_agent_step * approx_max_pop * total_steps
     return seconds / 3600.0

--- a/scripts/run_intrinsic_evolution_matrix.py
+++ b/scripts/run_intrinsic_evolution_matrix.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Fan out the intrinsic-evolution research matrix across CPU cores.
+
+This orchestrator implements the confirmatory factorial described in
+``docs/research/experiments/intrinsic_evolution/research_plan_population_matrix.md``:
+a replicated sweep over three axes — selection pressure, gene flow, and
+population size (effective population, ``Ne``) — with many seeds per cell.
+
+It does **not** re-implement any simulation logic.  Each (cell, seed) job is a
+subprocess call to :mod:`scripts.run_stable_profile_seed_sweep`, which builds and
+runs a single :class:`~farm.runners.intrinsic_evolution_experiment.IntrinsicEvolutionExperiment`.
+Running one seed per subprocess keeps every job independent and single-threaded,
+which is what makes ``--jobs`` (one process per vCPU) and ``--resume`` behave
+predictably on a Spot VM.
+
+Axes
+----
+- ``--pressures``: density-dependent reproduction-cost presets. ``none`` is the
+  drift-only null used to test whether selection (not drift) shapes outcomes.
+- ``--gene-flow``: ``mutation`` (inherit parent chromosome, mutated) vs
+  ``crossover`` (pick a co-parent and cross before mutating).
+- ``--populations``: a named ``(environment, approx max_population)`` pair. The
+  population axis is driven by the environment profile because population is
+  bounded by grid size and ``max_population``, not by resource supply — see the
+  plan doc and ``farm/config/environments/*.yaml``.
+
+Layout
+------
+Per-cell artifacts land under::
+
+    {output_dir}/pop-{pop}__pressure-{pressure}__geneflow-{geneflow}/
+        stable_balanced/seed_{seed}/...
+
+A top-level ``matrix_manifest.json`` records every job's resolved command,
+status, and wall time.
+
+Examples
+--------
+Print the planned matrix and an (upper-bound) cost estimate without running::
+
+    python scripts/run_intrinsic_evolution_matrix.py --dry-run
+
+Fast smoke check (tiny run, not scientific evidence)::
+
+    python scripts/run_intrinsic_evolution_matrix.py \\
+        --populations dev --pressures low --gene-flow mutation \\
+        --seeds 42 --num-steps 5 --warmup-steps 0 --snapshot-interval 5 \\
+        --jobs 1 --output-dir /tmp/intrinsic_matrix_smoke
+
+Full Phase-2 confirmatory matrix (12 cells x 8 seeds = 96 runs)::
+
+    python scripts/run_intrinsic_evolution_matrix.py \\
+        --populations sim research \\
+        --pressures none low high \\
+        --gene-flow mutation crossover \\
+        --seeds 42 7 19 101 137 256 512 999 \\
+        --num-steps 10000 --warmup-steps 200 --snapshot-interval 200 \\
+        --output-dir experiments/intrinsic_matrix
+
+Aggregate each cell afterwards with::
+
+    python scripts/analyze_stable_profile_seed_sweep.py --sweep-dir <cell_dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SEED_SWEEP_SCRIPT = _REPO_ROOT / "scripts" / "run_stable_profile_seed_sweep.py"
+
+# Thread-pool env vars pinned to 1 for every child: these are many tiny
+# per-agent DQNs, so oversubscribed BLAS pools slow the whole matrix down.
+_THREAD_VARS = (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+)
+
+# Named population levels. Each maps to a (environment profile, approximate
+# max_population) pair. The max_population figure is only used to produce an
+# upper-bound cost estimate in --dry-run; the true standing population is set
+# by the simulation and is typically well below the cap.
+POPULATION_LEVELS: dict[str, tuple[str, int]] = {
+    "dev": ("development", 50),
+    "sim": ("simulation", 300),
+    "research": ("research", 500),
+    "production": ("production", 1000),
+}
+
+PRESSURES: tuple[str, ...] = ("none", "low", "high")
+GENE_FLOWS: tuple[str, ...] = ("mutation", "crossover")
+
+DEFAULT_SEEDS: tuple[int, ...] = (42, 7, 19, 101, 137, 256, 512, 999)
+
+
+@dataclass(frozen=True)
+class Job:
+    """A single (cell, seed) unit of work."""
+
+    population: str
+    pressure: str
+    gene_flow: str
+    seed: int
+
+    @property
+    def cell_name(self) -> str:
+        return f"pop-{self.population}__pressure-{self.pressure}__geneflow-{self.gene_flow}"
+
+
+@dataclass
+class JobResult:
+    """Outcome of running a single :class:`Job`."""
+
+    job: dict[str, object]
+    cell_dir: str
+    command: list[str]
+    status: str
+    returncode: int | None
+    elapsed_seconds: float | None
+
+
+def build_matrix(
+    populations: list[str],
+    pressures: list[str],
+    gene_flows: list[str],
+    seeds: list[int],
+) -> list[Job]:
+    """Cartesian product of the four axes, in a stable, readable order."""
+    jobs: list[Job] = []
+    for population in populations:
+        for pressure in pressures:
+            for gene_flow in gene_flows:
+                for seed in seeds:
+                    jobs.append(Job(population, pressure, gene_flow, seed))
+    return jobs
+
+
+def build_command(job: Job, args: argparse.Namespace, cell_dir: Path) -> list[str]:
+    """Resolve the seed-sweep subprocess command for a single job."""
+    environment, _ = POPULATION_LEVELS[job.population]
+    command: list[str] = [
+        sys.executable,
+        str(_SEED_SWEEP_SCRIPT),
+        "--environment",
+        environment,
+        "--profiles",
+        "balanced",
+        "--seeds",
+        str(job.seed),
+        "--selection-pressure",
+        job.pressure,
+        "--num-steps",
+        str(args.num_steps),
+        "--warmup-steps",
+        str(args.warmup_steps),
+        "--snapshot-interval",
+        str(args.snapshot_interval),
+        "--output-dir",
+        str(cell_dir),
+        "--log-level",
+        args.log_level,
+    ]
+    if job.gene_flow == "crossover":
+        command.append("--crossover-enabled")
+    if args.disk_database:
+        command.append("--disk-database")
+    if args.resume:
+        command.append("--resume")
+    return command
+
+
+def estimate_core_hours(job: Job, args: argparse.Namespace) -> float:
+    """Upper-bound single-run cost estimate in core-hours.
+
+    Uses ``sec_per_agent_step`` x (max_population) x (num_steps + warmup). The
+    max_population cap is an over-estimate of the true standing population, so
+    this is deliberately conservative. Re-measure with a Phase-1 pilot before
+    trusting the total for scheduling.
+    """
+    _, approx_max_pop = POPULATION_LEVELS[job.population]
+    total_steps = args.num_steps + args.warmup_steps
+    seconds = args.sec_per_agent_step * approx_max_pop * total_steps
+    return seconds / 3600.0
+
+
+def _child_env() -> dict[str, str]:
+    env = dict(os.environ)
+    for var in _THREAD_VARS:
+        env.setdefault(var, "1")
+    env.setdefault("PYTHONHASHSEED", "0")
+    return env
+
+
+def run_job(job: Job, args: argparse.Namespace) -> JobResult:
+    """Execute one (cell, seed) job as a subprocess and capture its outcome."""
+    cell_dir = Path(args.output_dir) / job.cell_name
+    cell_dir.mkdir(parents=True, exist_ok=True)
+    command = build_command(job, args, cell_dir)
+
+    log_path = cell_dir / f"seed_{job.seed}.log"
+    t0 = time.time()
+    with log_path.open("w", encoding="utf-8") as log_handle:
+        completed = subprocess.run(
+            command,
+            cwd=str(_REPO_ROOT),
+            env=_child_env(),
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+    elapsed = time.time() - t0
+    status = "ok" if completed.returncode == 0 else "error"
+    return JobResult(
+        job=asdict(job),
+        cell_dir=str(cell_dir),
+        command=command,
+        status=status,
+        returncode=completed.returncode,
+        elapsed_seconds=round(elapsed, 3),
+    )
+
+
+def _print_dry_run(jobs: list[Job], args: argparse.Namespace) -> None:
+    cells = sorted({job.cell_name for job in jobs})
+    total_core_hours = sum(estimate_core_hours(job, args) for job in jobs)
+    print("Intrinsic-evolution matrix — DRY RUN")
+    print(f"  output_dir        : {args.output_dir}")
+    print(f"  populations       : {args.populations}")
+    print(f"  pressures         : {args.pressures}")
+    print(f"  gene_flow         : {args.gene_flow}")
+    print(f"  seeds             : {args.seeds}")
+    print(f"  steps/warmup/snap : {args.num_steps} / {args.warmup_steps} / {args.snapshot_interval}")
+    print(f"  jobs (workers)    : {args.jobs}")
+    print(f"  disk_database     : {args.disk_database}")
+    print(f"  cells             : {len(cells)}")
+    print(f"  total runs        : {len(jobs)}")
+    print(
+        f"  est. core-hours   : ~{total_core_hours:.0f} "
+        f"(upper bound @ {args.sec_per_agent_step:.3f} s/agent/step, cap-based)"
+    )
+    print()
+    print("Cells:")
+    for cell in cells:
+        print(f"  {cell}")
+    print()
+    print("Example command (first job):")
+    first = jobs[0]
+    example = build_command(first, args, Path(args.output_dir) / first.cell_name)
+    print("  " + " ".join(example))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fan out the intrinsic-evolution research matrix (pressure x gene-flow "
+            "x population x seed) across CPU cores, one seed per subprocess."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--populations",
+        nargs="+",
+        default=["sim", "research"],
+        choices=list(POPULATION_LEVELS),
+        metavar="POP",
+        help="Named population levels (environment profiles).",
+    )
+    parser.add_argument(
+        "--pressures",
+        nargs="+",
+        default=list(PRESSURES),
+        choices=list(PRESSURES),
+        metavar="PRESSURE",
+        help="Selection-pressure presets. 'none' is the drift-only null.",
+    )
+    parser.add_argument(
+        "--gene-flow",
+        nargs="+",
+        default=list(GENE_FLOWS),
+        choices=list(GENE_FLOWS),
+        metavar="MODE",
+        help="Inheritance modes: mutation-only and/or crossover.",
+    )
+    parser.add_argument(
+        "--seeds",
+        nargs="+",
+        type=int,
+        default=list(DEFAULT_SEEDS),
+        metavar="SEED",
+        help="Replicate seeds (>=5 recommended for the evidence gate).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="experiments/intrinsic_matrix",
+        help="Base directory for all cell/seed artifacts.",
+    )
+    parser.add_argument("--num-steps", type=int, default=10000)
+    parser.add_argument("--warmup-steps", type=int, default=200)
+    parser.add_argument("--snapshot-interval", type=int, default=200)
+    parser.add_argument(
+        "--jobs",
+        type=int,
+        default=os.cpu_count() or 1,
+        help="Number of concurrent subprocesses (default: CPU count).",
+    )
+    parser.add_argument(
+        "--disk-database",
+        action="store_true",
+        default=True,
+        help="Use disk-backed SQLite in each run (recommended for long horizons).",
+    )
+    parser.add_argument(
+        "--memory-database",
+        dest="disk_database",
+        action="store_false",
+        help="Opt into :memory: DB (development default) instead of disk DB.",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip (cell, seed) runs already completed to --num-steps.",
+    )
+    parser.add_argument(
+        "--sec-per-agent-step",
+        type=float,
+        default=0.02,
+        help="Planning constant for --dry-run cost estimate (s per alive agent per step).",
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="WARNING",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the planned matrix and cost estimate, then exit.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    if not _SEED_SWEEP_SCRIPT.is_file():
+        print(f"error: seed-sweep runner not found at {_SEED_SWEEP_SCRIPT}", file=sys.stderr)
+        return 2
+
+    jobs = build_matrix(args.populations, args.pressures, args.gene_flow, args.seeds)
+    if not jobs:
+        print("error: empty matrix (check --populations/--pressures/--gene-flow/--seeds)", file=sys.stderr)
+        return 2
+
+    if args.dry_run:
+        _print_dry_run(jobs, args)
+        return 0
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    workers = max(1, int(args.jobs))
+    print(
+        f"Launching {len(jobs)} runs across {workers} worker(s) "
+        f"into {output_dir} ...",
+        file=sys.stderr,
+    )
+
+    results: list[JobResult] = []
+    n_ok = 0
+    n_fail = 0
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        future_to_job = {pool.submit(run_job, job, args): job for job in jobs}
+        for future in as_completed(future_to_job):
+            result = future.result()
+            results.append(result)
+            if result.status == "ok":
+                n_ok += 1
+            else:
+                n_fail += 1
+            print(
+                f"  [{n_ok + n_fail}/{len(jobs)}] {result.status:5s} "
+                f"rc={result.returncode} {result.elapsed_seconds}s "
+                f"{result.cell_dir} seed={result.job['seed']}",
+                file=sys.stderr,
+            )
+
+    manifest = {
+        "output_dir": str(output_dir),
+        "populations": args.populations,
+        "pressures": args.pressures,
+        "gene_flow": args.gene_flow,
+        "seeds": args.seeds,
+        "num_steps": args.num_steps,
+        "warmup_steps": args.warmup_steps,
+        "snapshot_interval": args.snapshot_interval,
+        "disk_database": args.disk_database,
+        "workers": workers,
+        "n_ok": n_ok,
+        "n_fail": n_fail,
+        "results": [asdict(result) for result in results],
+    }
+    manifest_path = output_dir / "matrix_manifest.json"
+    with manifest_path.open("w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2)
+
+    print(f"\nDone: {n_ok} ok, {n_fail} failed. Manifest: {manifest_path}", file=sys.stderr)
+    if n_ok:
+        cells = sorted({result.cell_dir for result in results if result.status == "ok"})
+        print("\nAggregate each cell with:", file=sys.stderr)
+        for cell in cells:
+            print(
+                f"  python scripts/analyze_stable_profile_seed_sweep.py --sweep-dir {cell}",
+                file=sys.stderr,
+            )
+
+    return 0 if n_fail == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_stable_profile_seed_sweep.py
+++ b/scripts/run_stable_profile_seed_sweep.py
@@ -162,6 +162,13 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--environment", type=str, default="development")
     parser.add_argument(
+        "--profile",
+        type=str,
+        default=None,
+        choices=["benchmark", "simulation", "research"],
+        help="Optional centralized config profile (grid size, max_population, etc.).",
+    )
+    parser.add_argument(
         "--profiles",
         nargs="+",
         default=DEFAULT_PROFILES,
@@ -314,7 +321,10 @@ def _build_run(profile: str, seed: int, args: argparse.Namespace, run_dir: Path)
     """Construct (but do not execute) a single (profile, seed) experiment."""
     overrides = STABLE_SUB_PROFILES[profile]
 
-    base_config = SimulationConfig.from_centralized_config(environment=args.environment)
+    base_config = SimulationConfig.from_centralized_config(
+        environment=args.environment,
+        profile=args.profile,
+    )
     maybe_apply_learning_positive_population(
         base_config,
         getattr(args, "population", None),
@@ -522,6 +532,37 @@ def _print_dry_run_plan(args: argparse.Namespace, output_dir: Path) -> None:
         print(f"  stable_{profile}: {overrides}")
 
 
+def _load_existing_manifest_runs(manifest_path: Path) -> List[Dict[str, Any]]:
+    """Return prior ``runs`` entries from an existing sweep manifest, if any."""
+    if not manifest_path.is_file():
+        return []
+    try:
+        with manifest_path.open(encoding="utf-8") as fh:
+            existing = json.load(fh)
+        runs = existing.get("runs", [])
+        if isinstance(runs, list):
+            return runs
+    except (json.JSONDecodeError, OSError, TypeError):
+        pass
+    return []
+
+
+def _merge_sweep_records(
+    existing_runs: List[Dict[str, Any]],
+    new_records: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Merge per-run records keyed by (profile, seed), preferring newer entries."""
+    by_key: Dict[Tuple[Any, Any], Dict[str, Any]] = {}
+    for record in existing_runs:
+        by_key[(record.get("profile"), record.get("seed"))] = record
+    for record in new_records:
+        by_key[(record.get("profile"), record.get("seed"))] = record
+    return sorted(
+        by_key.values(),
+        key=lambda record: (str(record.get("profile")), int(record.get("seed", 0))),
+    )
+
+
 def _execute_sweep(
     args: argparse.Namespace, output_dir: Path, logger: Any
 ) -> Tuple[List[Dict[str, Any]], int, int]:
@@ -576,10 +617,25 @@ def main() -> int:
 
     sweep_records, n_ok, n_fail = _execute_sweep(args, output_dir, logger)
 
+    manifest_path = output_dir / "sweep_manifest.json"
+    merged_runs = _merge_sweep_records(
+        _load_existing_manifest_runs(manifest_path),
+        sweep_records,
+    )
+    merged_seeds = sorted(
+        {int(record["seed"]) for record in merged_runs if record.get("seed") is not None}
+    )
+    merged_n_ok = sum(
+        1 for record in merged_runs if record.get("status") in ("ok", "skipped_done")
+    )
+    merged_n_fail = sum(1 for record in merged_runs if record.get("status") == "error")
+
     manifest = {
         "sweep_type": "stable_profile_seed_sweep",
+        "environment": args.environment,
+        "profile": args.profile,
         "profiles": args.profiles,
-        "seeds": args.seeds,
+        "seeds": merged_seeds,
         "disk_database": getattr(args, "disk_database", False),
         "num_steps": args.num_steps,
         "warmup_steps": args.warmup_steps,
@@ -592,11 +648,10 @@ def main() -> int:
         "inheritance": _inheritance_settings_dict(args),
         "crossover": _crossover_settings_dict(args),
         "sub_profile_overrides": {p: STABLE_SUB_PROFILES[p] for p in args.profiles},
-        "runs": sweep_records,
-        "n_ok": n_ok,
-        "n_fail": n_fail,
+        "runs": merged_runs,
+        "n_ok": merged_n_ok,
+        "n_fail": merged_n_fail,
     }
-    manifest_path = output_dir / "sweep_manifest.json"
     with manifest_path.open("w", encoding="utf-8") as fh:
         json.dump(manifest, fh, indent=2, default=str)
 

--- a/scripts/run_stable_profile_seed_sweep.py
+++ b/scripts/run_stable_profile_seed_sweep.py
@@ -542,8 +542,12 @@ def _load_existing_manifest_runs(manifest_path: Path) -> List[Dict[str, Any]]:
         runs = existing.get("runs", [])
         if isinstance(runs, list):
             return runs
-    except (json.JSONDecodeError, OSError, TypeError):
-        pass
+    except (json.JSONDecodeError, OSError, TypeError) as exc:
+        # Best-effort manifest reuse: if unreadable/invalid, continue with a fresh run list.
+        print(
+            f"Warning: unable to load existing sweep manifest at {manifest_path}: {exc}",
+            file=sys.stderr,
+        )
     return []
 
 


### PR DESCRIPTION
This pull request introduces a new research plan document for population matrix experiments and enhances the `run_stable_profile_seed_sweep.py` script with improved configuration and manifest management. The main changes are grouped into documentation and code improvements:

**Documentation:**

* Added a comprehensive research plan (`research_plan_population_matrix.md`) outlining hypotheses, experimental design, compute budgeting, execution steps, analysis methods, and risk management for intrinsic evolution experiments with varying population sizes and selection pressures.

**Code improvements in `run_stable_profile_seed_sweep.py`:**

* **Configuration enhancements:**
  - Added a new `--profile` argument to centralize experiment configuration (grid size, population cap, etc.), and updated the simulation config loading to use this profile. [[1]](diffhunk://#diff-0c1a489d433979494f32421f58b59f1ea8b7da23264a71a83cebf915b9c95187R164-R170) [[2]](diffhunk://#diff-0c1a489d433979494f32421f58b59f1ea8b7da23264a71a83cebf915b9c95187L317-R327)

* **Sweep manifest management:**
  - Implemented functions to load existing sweep manifests and merge run records by (profile, seed), preferring newer results. This allows for robust resumption and aggregation of results across interrupted or repeated runs.
  - Updated manifest writing to include merged run records and aggregate statistics (`n_ok`, `n_fail`, `seeds`), ensuring the manifest reflects the complete sweep state even after partial reruns. [[1]](diffhunk://#diff-0c1a489d433979494f32421f58b59f1ea8b7da23264a71a83cebf915b9c95187R624-R642) [[2]](diffhunk://#diff-0c1a489d433979494f32421f58b59f1ea8b7da23264a71a83cebf915b9c95187L595-L599)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to research docs and experiment CLI/orchestration; simulation behavior is unchanged except when callers opt into new profile overlays.
> 
> **Overview**
> Adds a **replicated factorial research plan** for intrinsic evolution (pressure × gene flow × population `Ne`, 8 seeds) and a new **`run_intrinsic_evolution_matrix.py`** orchestrator that fans out each (cell, seed) as a subprocess to the existing seed-sweep runner—no new simulation code. The orchestrator maps named population levels to environment/profile pairs, supports `--dry-run` core-hour estimates, parallel workers, disk DB, `--resume`, and writes **`matrix_manifest.json`**.
> 
> **`run_stable_profile_seed_sweep.py`** gains **`--profile`** (`benchmark` / `simulation` / `research`) passed into `SimulationConfig.from_centralized_config` so matrix runs can vary grid and `max_population`. Sweep **`sweep_manifest.json`** now **merges** prior run records by `(profile, seed)` when rewriting the manifest, and records `environment` / `profile` plus aggregate `n_ok` / `n_fail` over the merged set—supporting partial reruns and matrix-level resume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d61af45ecba1aeefd10f1fef74b9173a5de27a1d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->