### PR TITLE
Bump ws dependency from 8.18.3 to 8.21.3

### DIFF
--- a/farm/editor/package-lock.json
+++ b/farm/editor/package-lock.json
@@ -6591,9 +6591,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"version": "8.21.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+			"integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {


### PR DESCRIPTION
This pull request updates the `ws` package dependency in the `farm/editor/package-lock.json` file to a newer version. This is a routine maintenance change to keep dependencies up to date.

Dependency updates:

* Upgraded the `ws` package from version `8.18.3` to `8.21.3` to ensure the latest features, security patches, and bug fixes are included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only patch/minor bump of a dev transitive dependency with no application code changes.
> 
> **Overview**
> Updates the resolved **`ws`** WebSocket library in `farm/editor/package-lock.json` from **8.18.3** to **8.21.3**. No `package.json` or application source changes—only the lockfile entry (version, tarball URL, and integrity hash).
> 
> This is routine dependency maintenance for a **dev** transitive dependency (pulled in via tooling such as jsdom), not a direct app dependency bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac9d832a8010cd798c4252dc24097faab4076828. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->